### PR TITLE
AppArmor profile for qutebrowser

### DIFF
--- a/contrib/apparmor/usr.bin.qutebrowser
+++ b/contrib/apparmor/usr.bin.qutebrowser
@@ -3,7 +3,7 @@
 
 #include <tunables/global>
 
-/usr/bin/qutebrowser {
+profile qutebrowser /usr/{local/,}bin/qutebrowser {
 
     #include <abstractions/base>
     #include <abstractions/nameservice>
@@ -17,8 +17,8 @@
 
     capability dac_override,
 
-    /usr/bin/ r,
-    /usr/bin/qutebrowser rix,
+    /usr/{local/,}bin/ r,
+    /usr/{local/,}bin/qutebrowser rix,
     /usr/bin/python3.? r,
 
     /usr/lib/python3/ mr,


### PR DESCRIPTION
I know it has architecture-specific stuff in it ("x86_64"), but hey, it's a start.

Created a dir "contrib", as seen in https://github.com/cjdelisle/cjdns/tree/master/contrib/apparmor

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/1)
<!-- Reviewable:end -->
