### PR TITLE
hints: Show uppercase hint chars #73

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -110,6 +110,7 @@ class HintManager(QObject):
         display: {display};
         color: {config[colors][hints.fg]};
         background: {config[colors][hints.bg]};
+        text-transform: {texttransform};
         font: {config[fonts][hints]};
         border: {config[hints][border]};
         opacity: {config[hints][opacity]};
@@ -271,6 +272,12 @@ class HintManager(QObject):
             display = 'inline'
         else:
             display = 'none'
+
+        # Make text uppercase if set in config
+        if config.get("hints","uppercase") and config.get("hints","mode") == "letter":
+            texttransform = 'uppercase'
+        else:
+            texttransform = 'none'
         rect = elem.geometry()
         left = rect.x()
         top = rect.y()
@@ -279,7 +286,8 @@ class HintManager(QObject):
             left /= zoom
             top /= zoom
         return self.HINT_CSS.format(
-            left=left, top=top, config=objreg.get('config'), display=display)
+            left=left, top=top, config=objreg.get('config'), display=display,
+                        texttransform=texttransform)
 
     def _draw_label(self, elem, string):
         """Draw a hint label over an element.

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -512,6 +512,10 @@ DATA = collections.OrderedDict([
          SettingValue(typ.String(minlen=2), 'asdfghjkl'),
          "Chars used for hint strings."),
 
+        ('uppercase',
+         SettingValue(typ.Bool(), 'false'),
+         "Make chars in hint strings uppercase."),
+
         ('auto-follow',
          SettingValue(typ.Bool(), 'true'),
          "Whether to auto-follow a hint if there's only one left."),


### PR DESCRIPTION
I currently have this feature set to be false by default.  Don't have a strong preference either way as to whether it should be true by default.  My personal preference is for true.

Manual testing:
Browsed through links with both character based and numerical hints while hints.uppercase was set to true and while it was set to false.  Made sure that no errors were generated and that the hints were in uppercase font when the new option was set.

Automated testing:
Couldn't figure out how to get this to work.  Believe that I have all the correct packages installed off of apt and pip after reading your docs.  Here's my output:

```
./run_checks.py
Traceback (most recent call last):
  File "/usr/lib/python3.4/configparser.py", line 762, in get
    value = d[option]
  File "/usr/lib/python3.4/collections/__init__.py", line 790, in __getitem__
    return self.__missing__(key)            # support subclasses that define __missing__
  File "/usr/lib/python3.4/collections/__init__.py", line 782, in __missing__
    raise KeyError(key)
KeyError: 'targets'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./run_checks.py", line 333, in <module>
    sys.exit(main())
  File "./run_checks.py", line 291, in main
    checkers = _get_checkers()
  File "./run_checks.py", line 259, in _get_checkers
    for target in config.get('DEFAULT', 'targets').split(','):
  File "/usr/lib/python3.4/configparser.py", line 765, in get
    raise NoOptionError(option, section)
configparser.NoOptionError: No option 'targets' in section: 'DEFAULT'
```

I'm on: `Linux carbon 3.2.0-4-amd64 #1 SMP Debian 3.2.60-1+deb7u3 x86_64 GNU/Linux`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/213)
<!-- Reviewable:end -->
