### PR TITLE
More options to colorize tab foreground

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -162,7 +162,9 @@
 |<<colors-statusbar.url.fg.error,statusbar.url.fg.error>>|Foreground color of the URL in the statusbar on error.
 |<<colors-statusbar.url.fg.warn,statusbar.url.fg.warn>>|Foreground color of the URL in the statusbar when there's a warning.
 |<<colors-statusbar.url.fg.hover,statusbar.url.fg.hover>>|Foreground color of the URL in the statusbar for hovered links.
-|<<colors-tab.fg,tab.fg>>|Foreground color of tabs.
+|<<colors-tab.fg.odd,tab.fg.odd>>|Foreground color of unselected odd tabs.
+|<<colors-tab.fg.even,tab.fg.even>>|Foreground color of unselected even tabs.
+|<<colors-tab.fg.selected,tab.fg.selected>>|Foreground color of selected tabs.
 |<<colors-tab.bg.odd,tab.bg.odd>>|Background color of unselected odd tabs.
 |<<colors-tab.bg.even,tab.bg.even>>|Background color of unselected even tabs.
 |<<colors-tab.bg.selected,tab.bg.selected>>|Background color of selected tabs.
@@ -990,9 +992,21 @@ Foreground color of the URL in the statusbar for hovered links.
 
 Default: +pass:[aqua]+
 
-[[colors-tab.fg]]
-=== tab.fg
-Foreground color of tabs.
+[[colors-tab.fg.odd]]
+=== tab.fg.odd
+Foreground color of unselected odd tabs.
+
+Default: +pass:[white]+
+
+[[colors-tab.fg.even]]
+=== tab.fg.even
+Foreground color of unselected even tabs.
+
+Default: +pass:[white]+
+
+[[colors-tab.fg.selected]]
+=== tab.fg.selected
+Foreground color of selected tabs.
 
 Default: +pass:[white]+
 

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -645,9 +645,17 @@ DATA = collections.OrderedDict([
          SettingValue(typ.QssColor(), 'aqua'),
          "Foreground color of the URL in the statusbar for hovered links."),
 
-        ('tab.fg',
+        ('tab.fg.odd',
          SettingValue(typ.QtColor(), 'white'),
-         "Foreground color of tabs."),
+         "Foreground color of unselected odd tabs."),
+
+        ('tab.fg.even',
+         SettingValue(typ.QtColor(), 'white'),
+         "Foreground color of unselected even tabs."),
+
+        ('tab.fg.selected',
+         SettingValue(typ.QtColor(), 'white'),
+         "Foreground color of selected tabs."),
 
         ('tab.bg.odd',
          SettingValue(typ.QtColor(), 'grey'),

--- a/qutebrowser/widgets/tabwidget.py
+++ b/qutebrowser/widgets/tabwidget.py
@@ -228,14 +228,16 @@ class TabBar(QTabBar):
         for idx in range(self.count()):
             self.initStyleOption(tab, idx)
             if idx == selected:
-                color = config.get('colors', 'tab.bg.selected')
+                bg_color = config.get('colors', 'tab.bg.selected')
+                fg_color = config.get('colors', 'tab.fg.selected')
             elif idx % 2:
-                color = config.get('colors', 'tab.bg.odd')
+                bg_color = config.get('colors', 'tab.bg.odd')
+                fg_color = config.get('colors', 'tab.fg.odd')
             else:
-                color = config.get('colors', 'tab.bg.even')
-            tab.palette.setColor(QPalette.Window, color)
-            tab.palette.setColor(QPalette.WindowText,
-                                 config.get('colors', 'tab.fg'))
+                bg_color = config.get('colors', 'tab.bg.even')
+                fg_color = config.get('colors', 'tab.fg.even')
+            tab.palette.setColor(QPalette.Window, bg_color)
+            tab.palette.setColor(QPalette.WindowText, fg_color)
             indicator_color = self.tabData(idx)
             if indicator_color is None:
                 indicator_color = QColor()


### PR DESCRIPTION
This removes configure option tab.fg and adds tab.fg.odd, tab.fg.even and tab.fg.selected. This allows to change font color for selected tab and like that. I was missing that feature as I like using dark unactive tabs with active one being blue. I hope this is a good pull request and I'm doing things right as this is my first time doing this. If I'm doing something wrong, please say it and I'll try to fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/214)
<!-- Reviewable:end -->
