### PR TITLE
update installation instructions for Gentoo

### DIFF
--- a/doc/INSTALL.asciidoc
+++ b/doc/INSTALL.asciidoc
@@ -49,66 +49,23 @@ or you could use an AUR helper, e.g. `yaourt -S qutebrowser-git`.
 On Gentoo
 ---------
 
-Running qutebrowser on Gentoo is unfortunately rather hard because Qt5 and
-PyQt5 are not packaged officially. https://github.com/posativ[@posativ] has
-written a howto with steps to get it running.
-
-* Add qt-overlay (`git://git.overlays.gentoo.org/proj/qt.git`) and emerge:
-
-  * `dev-qt/qtwebkit:5`
-  * `dev-qt/qtwidgets:5`
-
-  * `dev-lang/python:3.4`
-
-  * `dev-python/virtualenv` (`~1.11.6`)
-  * `dev-python/sip` (`**4.9999`)
-
-My USEs for `qtcore/qtwebkit 5`:
+A dedicated overlay is available on
+https://github.com/posativ/qutebrowser-overlay[GitHub]. To install it, add the
+overlay with http://wiki.gentoo.org/wiki/Layman[layman]:
 
 ----
-dev-qt/qtcore:5 icu
-dev-qt/qtwebkit:5 widgets printsupport multimedia gstreamer
+# wget https://raw.githubusercontent.com/posativ/qutebrowser-overlay/master/overlays.xml -O /etc/layman/overlays/qutebrowser.xml
+# layman -a qutebrowser
 ----
 
-Also make sure you have `python3_4` in your `PYTHON_TARGETS`
-(`/etc/portage/make.conf`) and rebuild your system (`emerge -uDNav @world`).
-
-I prefer the installation in a dedicated virtual environment:
-
-----
-$ virtualenv --python=python3.4 --system-site-packages ~/.pyenv/qutebrowser
-$ cd ~/.pyenv/qutebrowser
-$ source bin/activate
-----
-
-There's still no PyQt5 packaged for Gentoo so we manually install it into the
-virtual environment:
+Note, that Qt5 is available in the portage tree, but masked. You may need to do
+a lot of keywording to install qutebrowser. Also make sure you have `python3_4`
+in your `PYTHON_TARGETS` (`/etc/portage/make.conf`) and rebuild your system
+(`emerge -uDNav @world`). Afterwards, you can install qutebrowser:
 
 ----
-$ wget http://sourceforge.net/projects/pyqt/files/PyQt5/PyQt-5.3.2/PyQt-gpl-5.3.2.tar.gz
-$ tar xfz PyQt-gpl-5.3.2.tar.gz
-$ cd PyQt-gpl-5.3.2/
-$ python configure.py --qmake=/usr/lib64/qt5/bin/qmake --confirm-license
-$ make
-$ make install
+# emerge -av qutebrowser
 ----
-
-Lastly we install qutebrowser:
-
-----
-$ git clone git://the-compiler.org/qutebrowser/
-$ cd qutebrowser/
-$ python setup.py develop
-----
-
-To run qutebrowser, you can run `qutebrowser` inside the virtualenv. Or symlink
-it to a directory in your `$PATH`, e.g.:
-
-----
-$ ln -s ~/.pyenv/qutebrowser/bin/qutebrowser /usr/local/bin/
-----
-
-Your mileage may vary.
 
 On Windows
 ----------


### PR DESCRIPTION
Add new instruction using a dedicated overlay to install qutebrowser on Gentoo. The overlay includes qutebrowser and pypeg2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/290)
<!-- Reviewable:end -->
