### PR TITLE
qutebrowser overlay is now available in layman

### DIFF
--- a/doc/INSTALL.asciidoc
+++ b/doc/INSTALL.asciidoc
@@ -68,7 +68,6 @@ https://github.com/posativ/qutebrowser-overlay[GitHub]. To install it, add the
 overlay with http://wiki.gentoo.org/wiki/Layman[layman]:
 
 ----
-# wget https://raw.githubusercontent.com/posativ/qutebrowser-overlay/master/overlays.xml -O /etc/layman/overlays/qutebrowser.xml
 # layman -a qutebrowser
 ----
 


### PR DESCRIPTION
A minor update to the gentoo installation. The overlay is in the "official" layman list and can be directly fetched.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/426)
<!-- Reviewable:end -->
