### PR TITLE
Add 'undo-across-windows' option

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -422,9 +422,6 @@ def _init_modules(args, crash_handler):
     log.init.debug("Initializing bookmarks...")
     bookmark_manager = urlmarks.BookmarkManager(qApp)
     objreg.register('bookmark-manager', bookmark_manager)
-    log.init.debug("Initializing undo stack...")
-    undo_stack = []
-    objreg.register('undo-stack', undo_stack)
     log.init.debug("Initializing proxy...")
     proxy.init()
     log.init.debug("Initializing cookies...")

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -422,6 +422,9 @@ def _init_modules(args, crash_handler):
     log.init.debug("Initializing bookmarks...")
     bookmark_manager = urlmarks.BookmarkManager(qApp)
     objreg.register('bookmark-manager', bookmark_manager)
+    log.init.debug("Initializing undo stack...")
+    undo_stack = []
+    objreg.register('undo-stack', undo_stack)
     log.init.debug("Initializing proxy...")
     proxy.init()
     log.init.debug("Initializing cookies...")

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -781,10 +781,17 @@ class CommandDispatcher:
                 self._tabbed_browser.close_tab(tab)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def undo(self):
-        """Re-open a closed tab (optionally skipping [count] closed tabs)."""
+    def undo(self, window=False):
+        """Re-open a closed tab (optionally skipping [count] closed tabs).
+
+        Args:
+            window: Undo the last window closed rather than the last tab.
+        """
         try:
-            self._tabbed_browser.undo()
+            if window or config.get('tabs', 'tabs-are-windows'):
+                self._tabbed_browser.undo_window()
+            else:
+                self._tabbed_browser.undo()
         except IndexError:
             raise cmdexc.CommandError("Nothing to undo!")
 

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -1462,6 +1462,7 @@ KEY_DATA = collections.OrderedDict([
         ('scroll up', ['k']),
         ('scroll right', ['l']),
         ('undo', ['u', '<Ctrl-Shift-T>']),
+        ('undo -w', ['wu', 'U']),
         ('scroll-perc 0', ['gg']),
         ('scroll-perc', ['G']),
         ('search-next', ['n']),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -620,6 +620,11 @@ def data(readonly=False):
              SettingValue(typ.Int(minval=0), '3'),
              "Width of the progress indicator (0 to disable)."),
 
+            ('undo-across-windows',
+             SettingValue(typ.Bool(), 'false'),
+             "Whether the undo command should reopen the last closed tab from "
+             "any open window, rather than just the current one."),
+
             ('tabs-are-windows',
              SettingValue(typ.Bool(), 'false'),
              "Whether to open windows instead of tabs."),

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -620,11 +620,6 @@ def data(readonly=False):
              SettingValue(typ.Int(minval=0), '3'),
              "Width of the progress indicator (0 to disable)."),
 
-            ('undo-across-windows',
-             SettingValue(typ.Bool(), 'false'),
-             "Whether the undo command should reopen the last closed tab from "
-             "any open window, rather than just the current one."),
-
             ('tabs-are-windows',
              SettingValue(typ.Bool(), 'false'),
              "Whether to open windows instead of tabs."),

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -435,7 +435,7 @@ class MainWindow(QWidget):
         session_manager.save_last_window_session()
         session_manager.session_save(self.win_id,
                 name="_undo-{}".format(self.win_id),
-                force=True, only_window=True)
+                force=True, only_window=True, in_memory=True)
         session_manager._window_id_stack.append(self.win_id)
         self._save_geometry()
         log.destroy.debug("Closing window {}".format(self.win_id))

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -431,7 +431,12 @@ class MainWindow(QWidget):
 
     def _do_close(self):
         """Helper function for closeEvent."""
-        objreg.get('session-manager').save_last_window_session()
+        session_manager = objreg.get('session-manager')
+        session_manager.save_last_window_session()
+        session_manager.session_save(self.win_id,
+                name="_undo-{}".format(self.win_id),
+                force=True, only_window=True)
+        session_manager._window_id_stack.append(self.win_id)
         self._save_geometry()
         log.destroy.debug("Closing window {}".format(self.win_id))
         self.tabbed_browser.shutdown()

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -259,12 +259,14 @@ class TabbedBrowser(tabwidget.TabWidget):
         if last_close == 'ignore' and count == 1:
             return
 
+        if last_close == 'close' and count == 1:
+            self.close_window.emit()
+            return
+
         self._remove_tab(tab)
 
         if count == 1:  # We just closed the last tab above.
-            if last_close == 'close':
-                self.close_window.emit()
-            elif last_close == 'blank':
+            if last_close == 'blank':
                 self.openurl(QUrl('about:blank'), newtab=True)
             elif last_close == 'startpage':
                 url = QUrl(config.get('general', 'startpage')[0])

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -338,6 +338,13 @@ class TabbedBrowser(tabwidget.TabWidget):
 
         qtutils.deserialize(history_data, newtab.history())
 
+    def undo_window(self):
+        """Undo removing of a window."""
+        session_manager = objreg.get('session-manager')
+        win_id = session_manager._window_id_stack.pop()
+        restore_session_name = "_undo-{}".format(win_id)
+        session_manager.session_load(restore_session_name, force=True)
+
     @pyqtSlot('QUrl', bool)
     def openurl(self, url, newtab):
         """Open a URL, used as a slot.

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -343,7 +343,8 @@ class TabbedBrowser(tabwidget.TabWidget):
         session_manager = objreg.get('session-manager')
         win_id = session_manager._window_id_stack.pop()
         restore_session_name = "_undo-{}".format(win_id)
-        session_manager.session_load(restore_session_name, force=True)
+        session_manager.session_load(restore_session_name, force=True,
+                in_memory=True)
 
     @pyqtSlot('QUrl', bool)
     def openurl(self, url, newtab):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -34,7 +34,13 @@ from qutebrowser.utils import (log, usertypes, utils, qtutils, objreg,
                                urlutils, message)
 
 
-UndoEntry = collections.namedtuple('UndoEntry', ['url', 'history'])
+class UndoEntry:
+    """TODO document UndoEntry"""
+    def __init__(self, url, history, last_of_window, window_id):
+        self.url = url
+        self.history = history
+        self.last_of_window = last_of_window
+        self.window_id = window_id
 
 
 class TabDeletedError(Exception):
@@ -291,8 +297,13 @@ class TabbedBrowser(tabwidget.TabWidget):
                           window=self._win_id)
         if tab.cur_url.isValid():
             history_data = qtutils.serialize(tab.history())
-            entry = UndoEntry(tab.cur_url, history_data)
-            self._undo_stack.append(entry)
+            last_of_window = self.count() == 1
+            entry = UndoEntry(tab.cur_url, history_data, last_of_window,
+                    self._win_id)
+            if config.get('tabs', 'undo-across-windows'):
+                objreg.get('undo-stack').append(entry)
+            else:
+                self._undo_stack.append(entry)
         elif tab.cur_url.isEmpty():
             # There are some good reasons why an URL could be empty
             # (target="_blank" with a download, see [1]), so we silently ignore
@@ -328,15 +339,34 @@ class TabbedBrowser(tabwidget.TabWidget):
             use_current_tab = (only_one_tab_open and no_history and
                                last_close_url_used)
 
-        url, history_data = self._undo_stack.pop()
+        if config.get('tabs', 'undo-across-windows'):
+            undo_entry = objreg.get('undo-stack').pop()
+        else:
+            undo_entry = self._undo_stack.pop()
 
         if use_current_tab:
-            self.openurl(url, newtab=False)
+            self.openurl(undo_entry.url, newtab=False)
             newtab = self.widget(0)
+        elif undo_entry.last_of_window:
+            from qutebrowser.mainwindow import mainwindow
+            window = mainwindow.MainWindow()
+            window.show()
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                        window=window.win_id)
+            for entry in objreg.get('undo-stack'):
+                if entry.window_id == undo_entry.window_id:
+                    print("Updating entry")
+                    entry.window_id = window.win_id
+            newtab = tabbed_browser.tabopen(undo_entry.url, background=False)
         else:
-            newtab = self.tabopen(url, background=False)
+            if config.get('tabs', 'undo-across-windows'):
+                tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                            window=undo_entry.window_id)
+                newtab = tabbed_browser.tabopen(undo_entry.url, background=False)
+            else:
+                newtab = self.tabopen(undo_entry.url, background=False)
 
-        qtutils.deserialize(history_data, newtab.history())
+        qtutils.deserialize(undo_entry.history, newtab.history())
 
     @pyqtSlot('QUrl', bool)
     def openurl(self, url, newtab):

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -208,6 +208,7 @@ class SessionManager(QObject):
             win_data['active'] = True
         win_data['geometry'] = bytes(main_window.saveGeometry())
         win_data['tabs'] = []
+        win_data['undo_stack'] = main_window.tabbed_browser._undo_stack
         for i, tab in enumerate(tabbed_browser.widgets()):
             active = i == tabbed_browser.currentIndex()
             win_data['tabs'].append(self._save_tab(tab, active))
@@ -352,12 +353,14 @@ class SessionManager(QObject):
             window.show()
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=window.win_id)
+            tabbed_browser._undo_stack = win['undo_stack']
             tab_to_focus = None
             for i, tab in enumerate(win['tabs']):
                 new_tab = tabbed_browser.tabopen()
                 self._load_tab(new_tab, tab)
                 if tab.get('active', False):
                     tab_to_focus = i
+                tabbed_browser._undo_stack.pop()
             if tab_to_focus is not None:
                 tabbed_browser.setCurrentIndex(tab_to_focus)
             if win.get('active', False):

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -212,7 +212,6 @@ class SessionManager(QObject):
         win_data['tabs'] = []
         win_data['undo_stack'] = \
             self._save_undo(main_window.tabbed_browser._undo_stack)
-        print(win_data)
 
         for i, tab in enumerate(tabbed_browser.widgets()):
             active = i == tabbed_browser.currentIndex()

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -208,7 +208,6 @@ class SessionManager(QObject):
             win_data['active'] = True
         win_data['geometry'] = bytes(main_window.saveGeometry())
         win_data['tabs'] = []
-        win_data['undo_stack'] = main_window.tabbed_browser._undo_stack
         for i, tab in enumerate(tabbed_browser.widgets()):
             active = i == tabbed_browser.currentIndex()
             win_data['tabs'].append(self._save_tab(tab, active))
@@ -353,14 +352,12 @@ class SessionManager(QObject):
             window.show()
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=window.win_id)
-            tabbed_browser._undo_stack = win['undo_stack']
             tab_to_focus = None
             for i, tab in enumerate(win['tabs']):
                 new_tab = tabbed_browser.tabopen()
                 self._load_tab(new_tab, tab)
                 if tab.get('active', False):
                     tab_to_focus = i
-                tabbed_browser._undo_stack.pop()
             if tab_to_focus is not None:
                 tabbed_browser.setCurrentIndex(tab_to_focus)
             if win.get('active', False):

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -666,8 +666,8 @@ Feature: Tab management
 
     Scenario: Undo closing a window with tabs-are-windows
         Given I have a fresh instance
-        And I set tabs -> tabs-are-windows to true
         When I open data/numbers/1.txt
+        And I set tabs -> tabs-are-windows to true
         And I open data/numbers/2.txt in a new window
         And I run :close
         And I run :undo

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -667,6 +667,7 @@ Feature: Tab management
     # last-close
 
     Scenario: last-close = blank
+        Given I have a fresh instance
         When I open data/hello.txt
         And I set tabs -> last-close to blank
         And I run :tab-only

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -664,6 +664,23 @@ Feature: Tab management
               - history:
                 - url: http://localhost:*/data/numbers/3.txt
 
+    Scenario: Undo closing a window with tabs-are-windows
+        Given I have a fresh instance
+        And I set tabs -> tabs-are-windows to true
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I run :close
+        And I run :undo
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+
     # last-close
 
     Scenario: last-close = blank

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -645,6 +645,25 @@ Feature: Tab management
         Then the error "Nothing to undo!" should be shown
         And the error "Nothing to undo!" should be shown
 
+    Scenario: Undo closing a window
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I open data/numbers/3.txt in a new tab
+        And I run :close
+        And I run :undo -w
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+              - history:
+                - url: http://localhost:*/data/numbers/3.txt
+
     # last-close
 
     Scenario: last-close = blank


### PR DESCRIPTION
This aims to solve issues #1420 and #1031. When the option is set to true, the
undo of closed tabs and windows behaves like Chromium.

Pretty rough (no docs / tests yet) but just looking for initial feedback. Tests related to tabs passed.
