### PR TITLE
Prefer putting the bookmark in the data directory

### DIFF
--- a/doc/qutebrowser.1.asciidoc
+++ b/doc/qutebrowser.1.asciidoc
@@ -115,8 +115,8 @@ show it.
 == FILES
 
 - '~/.config/qutebrowser/qutebrowser.conf': Main config file.
-- '~/.config/qutebrowser/quickmarks': Saved quickmarks.
 - '~/.config/qutebrowser/keys.conf': Defined key bindings.
+- '~/.local/share/qutebrowser/quickmarks': Saved quickmarks.
 - '~/.local/share/qutebrowser/': Various state information.
 - '~/.cache/qutebrowser/': Temporary data.
 
@@ -126,7 +126,7 @@ environment, the directories configured there are used instead of the above
 defaults.
 
 == BUGS
-Bugs are tracked in the Github issue tracker at 
+Bugs are tracked in the Github issue tracker at
 https://github.com/The-Compiler/qutebrowser/issues.
 
 If you found a bug, use the built-in ':report' command to create a bug report

--- a/misc/userscripts/qutedmenu
+++ b/misc/userscripts/qutedmenu
@@ -14,12 +14,12 @@ create_menu() {
     # Check quickmarks
     while read -r url; do
         printf -- '%s\n' "$url"
-    done < "$QUTE_CONFIG_DIR"/quickmarks
+    done < "$$QUTE_DATA_DIR"/qutebrowser/quickmarks
 
     # Next bookmarks
     while read -r url _; do
         printf -- '%s\n' "$url"
-    done < "$QUTE_CONFIG_DIR"/bookmarks/urls
+    done < "$$QUTE_DATA_DIR"/qutebrowser/bookmarks/urls
 
     # Finally history
     while read -r _ url; do

--- a/tests/end2end/features/test_urlmarks_bdd.py
+++ b/tests/end2end/features/test_urlmarks_bdd.py
@@ -35,9 +35,9 @@ def _check_marks(quteproc, quickmarks, expected, contains):
         contains: True if the line should be there, False otherwise.
     """
     if quickmarks:
-        mark_file = os.path.join(quteproc.basedir, 'config', 'quickmarks')
+        mark_file = os.path.join(quteproc.basedir, 'data', 'quickmarks')
     else:
-        mark_file = os.path.join(quteproc.basedir, 'config', 'bookmarks',
+        mark_file = os.path.join(quteproc.basedir, 'data', 'bookmarks',
                                  'urls')
 
     quteproc.clear_data()  # So we don't match old messages


### PR DESCRIPTION
Bookmark may be considered as data. Therefore It looks sensible to think that
some users may not want their bookmarks to pollute their configuration
directory.

Use the ~/.config path if it exists so as not to break backward compatibility.
