### PR TITLE
completion: let column widths scale according to content

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -141,31 +141,30 @@ class CompletionView(QTreeView):
 
     def _resize_columns(self):
         """Resize the completion columns based on column_widths."""
+        columns = len(self._column_widths)
         width = self.size().width()
         if self.verticalScrollBar().isVisible():
             width -= self.style().pixelMetric(QStyle.PM_ScrollBarExtent) + 5
         log.completion.debug("available width = {}".format(width))
 
         widths_max = [width * perc / 100 for perc in self._column_widths]
-        widths_hints = [self.sizeHintForColumn(i)
-                for i in range(len(self._column_widths))]
-        pixel_widths = [0] * len(self._column_widths)
+        widths_hints = [self.sizeHintForColumn(i) for i in range(columns)]
+        pixel_widths = [0] * columns
         log.completion.debug("widths_hints = {}".format(widths_hints))
         log.completion.debug("widths_max = {}".format(widths_max))
 
         # enumerate all columns, starting with narrow ones
-        remaining_indexes = set(range(len(self._column_widths)))
+        remaining_indexes = set(range(columns))
         partial_width = width
-        diffs = [widths_hints[i] - widths_max[i]
-                for i in range(len(self._column_widths))]
-        for _, i in sorted(zip(diffs, range(len(self._column_widths)))):
+        diffs = [widths_hints[i] - widths_max[i] for i in range(columns)]
+        for _, i in sorted(zip(diffs, range(columns))):
             w = widths_hints[i]
             remaining_indexes.remove(i)
             if w <= widths_max[i]:
                 # let other columns reclaim the freed space
-                for j in remaining_indexes:
+                for k in remaining_indexes:
                     if partial_width > widths_max[i]:
-                        widths_max[j] += widths_max[j] / (partial_width - widths_max[i]) * (widths_max[i] - w)
+                        widths_max[k] += widths_max[k] / (partial_width - widths_max[i]) * (widths_max[i] - w)
             else:
                 w = widths_max[i]
             pixel_widths[i] = w

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -181,7 +181,7 @@ class CompletionView(QTreeView):
         log.completion.debug("occupied width = {}".format(sum(pixel_widths)))
 
         for i, w in enumerate(pixel_widths):
-            self.setColumnWidth(i, w)
+            self.setColumnWidth(i, int(w))
 
     def _next_idx(self, upwards):
         """Get the previous/next QModelIndex displayed in the view.

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -164,7 +164,8 @@ class CompletionView(QTreeView):
             if w <= widths_max[i]:
                 # let other columns reclaim the freed space
                 for j in remaining_indexes:
-                    widths_max[j] += widths_max[j] / (partial_width - widths_max[i]) * (widths_max[i] - w)
+                    if partial_width > widths_max[i]:
+                        widths_max[j] += widths_max[j] / (partial_width - widths_max[i]) * (widths_max[i] - w)
             else:
                 w = widths_max[i]
             pixel_widths[i] = w


### PR DESCRIPTION
Proposal for #693 

This takes hints from the [sizeHintForColumn](http://doc.qt.io/qt-5/qabstractitemview.html#sizeHintForColumn) method, so the prescribed percentages are not understood as fixed, but as maximum.

It might still not be ideal, because e.g. the timestamp format for history completion is configurable, but the maximum percentage for column width isn't.
