### PR TITLE
[WIP] pdfjs single download

### DIFF
--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -21,8 +21,6 @@
 
 import os
 
-from PyQt5.QtCore import QUrl
-
 from qutebrowser.browser.webkit import webelem
 from qutebrowser.utils import utils, objreg
 

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -41,28 +41,26 @@ class PDFJSNotFound(Exception):
         super().__init__(message)
 
 
-def generate_pdfjs_page(url, data):
+def generate_pdfjs_page(data):
     """Return the html content of a page that displays url with pdfjs.
 
     Returns a string.
 
     Args:
-        url: The url of the pdf as QUrl.
-        data: Initial data of the pdf file as bytes.
+        data: Data of the pdf file as bytes.
     """
     viewer = get_pdfjs_res('web/viewer.html').decode('utf-8')
-    script = _generate_pdfjs_script(url, data)
+    script = _generate_pdfjs_script(data)
     html_page = viewer.replace('</body>',
                                '</body><script>\n{}\n</script>'.format(script))
     return html_page
 
 
-def _generate_pdfjs_script(url, data):
+def _generate_pdfjs_script(data):
     """Generate the script that shows the pdf with pdf.js.
 
     Args:
-        url: The url of the pdf page as QUrl.
-        data: Initial data of the pdf file as bytes.
+        data: Data of the pdf file as bytes.
     """
     init_ident = objreg.get('js-bridge').insert_pdf(data)
     return (

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -24,7 +24,7 @@ import os
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.browser.webkit import webelem
-from qutebrowser.utils import utils
+from qutebrowser.utils import utils, objreg
 
 
 class PDFJSNotFound(Exception):
@@ -41,31 +41,41 @@ class PDFJSNotFound(Exception):
         super().__init__(message)
 
 
-def generate_pdfjs_page(url):
+def generate_pdfjs_page(url, data):
     """Return the html content of a page that displays url with pdfjs.
 
     Returns a string.
 
     Args:
         url: The url of the pdf as QUrl.
+        data: Initial data of the pdf file as bytes.
     """
     viewer = get_pdfjs_res('web/viewer.html').decode('utf-8')
-    script = _generate_pdfjs_script(url)
+    script = _generate_pdfjs_script(url, data)
     html_page = viewer.replace('</body>',
-                               '</body><script>{}</script>'.format(script))
+                               '</body><script>\n{}\n</script>'.format(script))
     return html_page
 
 
-def _generate_pdfjs_script(url):
+def _generate_pdfjs_script(url, data):
     """Generate the script that shows the pdf with pdf.js.
 
     Args:
         url: The url of the pdf page as QUrl.
+        data: Initial data of the pdf file as bytes.
     """
+    init_ident = objreg.get('js-bridge').insert_pdf(data)
     return (
         'PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS.info;\n'
-        'PDFView.open("{url}");\n'
-    ).format(url=webelem.javascript_escape(url.toString(QUrl.FullyEncoded)))
+        'var _init_params = {{\n'
+        '    data: new Uint8Array(window.qute.get_pdf("{init}")),\n'
+        '}};\n'
+        'PDFJS.getDocument(_init_params).then(\n'
+        '    function (doc) {{ PDFView.load(doc); }}\n'
+        ');\n'
+    ).format(
+        init=webelem.javascript_escape(init_ident),
+    )
 
 
 def fix_urls(asset):

--- a/qutebrowser/browser/webkit/network/qutescheme.py
+++ b/qutebrowser/browser/webkit/network/qutescheme.py
@@ -27,6 +27,7 @@ import functools
 import configparser
 import mimetypes
 import urllib.parse
+import uuid
 
 from PyQt5.QtCore import pyqtSlot, QObject
 from PyQt5.QtNetwork import QNetworkReply
@@ -125,6 +126,22 @@ class JSBridge(QObject):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._pdfs = {}
+
+    def insert_pdf(self, data):
+        """Insert pdf data for later access via pdf.js.
+
+        Args:
+            data: The pdf data to store as bytes.
+
+        Return:
+            An identifier which should be passed to pdf.js.
+        """
+        identifier = str(uuid.uuid4())
+        self._pdfs[identifier] = data
+        log.pdfjs.debug("inserted {} PDF bytes as {}, {} files stored"
+                        .format(len(data), identifier, len(self._pdfs)))
+        return identifier
 
     @pyqtSlot(int, str, str, str)
     def set(self, win_id, sectname, optname, value):
@@ -139,6 +156,18 @@ class JSBridge(QObject):
             objreg.get('config').set('conf', sectname, optname, value)
         except (configexc.Error, configparser.Error) as e:
             message.error(win_id, e)
+
+    @pyqtSlot(str, result='QByteArray')
+    def get_pdf(self, identifier):
+        """Retrieve the pdf data by the given identifier.
+
+        This can only be done once, as the data will be removed after the first
+        access.
+        """
+        data = self._pdfs.pop(identifier)
+        log.pdfjs.debug("retrieved pdf data for {}, {} remaining items"
+                        .format(identifier, len(self._pdfs)))
+        return data
 
 
 @add_handler('pyeval')
@@ -257,7 +286,7 @@ def qute_pdfjs(_win_id, request):
         # Logging as the error might get lost otherwise since we're not showing
         # the error page if a single asset is missing. This way we don't lose
         # information, as the failed pdfjs requests are still in the log.
-        log.misc.warning(
+        log.pdfjs.warning(
             "pdfjs resource requested but not found: {}".format(e.path))
         raise QuteSchemeError("Can't find pdfjs resource '{}'".format(e.path),
                               QNetworkReply.ContentNotFoundError)

--- a/qutebrowser/browser/webkit/network/qutescheme.py
+++ b/qutebrowser/browser/webkit/network/qutescheme.py
@@ -143,6 +143,14 @@ class JSBridge(QObject):
                         .format(len(data), identifier, len(self._pdfs)))
         return identifier
 
+    def peek_pdfs(self):
+        """Return a list of saved pdfs without deleting them.
+
+        Return:
+            A list of (identifier, data) tuples, representing the pdfs.
+        """
+        return list(self._pdfs.items())
+
     @pyqtSlot(int, str, str, str)
     def set(self, win_id, sectname, optname, value):
         """Slot to set a setting from qute:settings."""

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -28,7 +28,7 @@ from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
 from PyQt5.QtWidgets import QFileDialog
 from PyQt5.QtPrintSupport import QPrintDialog
-from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
+from PyQt5.QtWebKitWidgets import QWebPage
 
 from qutebrowser.config import config
 from qutebrowser.browser import pdfjs
@@ -52,6 +52,7 @@ class BrowserPage(QWebPage):
         _win_id: The window ID this BrowserPage is associated with.
         _ignore_load_started: Whether to ignore the next loadStarted signal.
         _is_shutting_down: Whether the page is currently shutting down.
+        _pdf_download: The currently running pdf download.
 
     Signals:
         shutting_down: Emitted when the page is currently shutting down.

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -265,7 +265,7 @@ class BrowserPage(QWebPage):
         # this, otherwise the js bridge will be disabled immediately.
         self._ignore_load_started = True
         try:
-            page = pdfjs.generate_pdfjs_page(reply.url(), data)
+            page = pdfjs.generate_pdfjs_page(data)
         except pdfjs.PDFJSNotFound:
             page = jinja.render('no_pdfjs.html',
                                 url=reply.url().toDisplayString())

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -274,7 +274,7 @@ class BrowserPage(QWebPage):
         frame.setContent(page.encode('utf-8'), 'text/html', reply.url())
 
     def _enable_js_bridge(self):
-        """Enable the js bridge for pdfjs"""
+        """Enable the js bridge for pdfjs."""
         frame = self.mainFrame()
         self._add_js_bridge()
         frame.javaScriptWindowObjectCleared.connect(self._add_js_bridge)

--- a/qutebrowser/html/pdf_cancelled.html
+++ b/qutebrowser/html/pdf_cancelled.html
@@ -1,0 +1,44 @@
+{% extends "base.html" %}
+
+{% block style %}
+{{ super() }}
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -webkit-text-size-adjust: none;
+    color: #333333;
+    background-color: #EEEEEE;
+    font-size: 1.2em;
+}
+
+#content-container {
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-top: 20px;
+  border: 1px solid #CCCCCC;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.20);
+  border-radius: 5px;
+  background-color: #FFFFFF;
+  padding: 20px 20px;
+}
+
+p#bigx {
+    font-size: 500%;
+    text-align: center;
+    margin: 10px;
+    padding: 0;
+}
+
+p.url {
+    color: #111111;
+    text-align: center;
+}
+
+{% endblock %}
+
+{% block content %}
+<div id="content-container">
+    <p id="bigx">&#x2716;</p>
+    <p>The download was cancelled, the PDF can't be shown!</p>
+    <p class="url"><a href="{{ url }}">Click here to try again</a></p>
+</div>
+{% endblock %}

--- a/qutebrowser/html/pdf_loading.html
+++ b/qutebrowser/html/pdf_loading.html
@@ -1,0 +1,97 @@
+{% extends "base.html" %}
+
+{% block style %}
+{{ super() }}
+body {
+    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
+    -webkit-text-size-adjust: none;
+    color: #333333;
+    background-color: #EEEEEE;
+    font-size: 1.2em;
+}
+
+#content-container {
+  margin-left: 20px;
+  margin-right: 20px;
+  margin-top: 20px;
+  border: 1px solid #CCCCCC;
+  box-shadow: 0px 0px 6px rgba(0, 0, 0, 0.20);
+  border-radius: 5px;
+  background-color: #FFFFFF;
+  padding: 20px 20px;
+}
+
+p.url {
+    color: #111111;
+    text-align: center;
+}
+
+p#thanks {
+    color: #666666;
+    font-size: 0.8em;
+    text-align: right;
+    font-style: italic;
+}
+
+.spinner {
+    margin: 50px auto 0;
+    width: 88px;
+    text-align: center;
+}
+
+.spinner > div {
+    width: 18px;
+    height: 18px;
+    background-color: #333;
+
+    border-radius: 100%;
+    display: inline-block;
+    -webkit-animation: bouncedelay 1.4s infinite ease-in-out both;
+    animation: bouncedelay 1.4s infinite ease-in-out both;
+}
+
+.spinner .bounce1 {
+    -webkit-animation-delay: -0.48s;
+    animation-delay: -0.48s;
+}
+
+.spinner .bounce2 {
+    -webkit-animation-delay: -0.32s;
+    animation-delay: -0.32s;
+}
+
+.spinner .bounce3 {
+    -webkit-animation-delay: -0.16s;
+    animation-delay: -0.16s;
+}
+
+@-webkit-keyframes bouncedelay {
+    0%, 80%, 100% { -webkit-transform: scale(0) }
+    40% { -webkit-transform: scale(1.0) }
+}
+
+@keyframes bouncedelay {
+    0%, 80%, 100% { 
+        -webkit-transform: scale(0);
+        transform: scale(0);
+    } 40% { 
+        -webkit-transform: scale(1.0);
+        transform: scale(1.0);
+    }
+}
+{% endblock %}
+
+{% block content %}
+<div id="content-container">
+    <div class="spinner">
+        <div class="bounce1"></div>
+        <div class="bounce2"></div>
+        <div class="bounce3"></div>
+        <div class="bounce4"></div>
+    </div>
+    <p>The requested document</p>
+    <p class="url">{{ url }}</p>
+    <p>is being loaded. It will be displayed as soon as it is ready.</p>
+    <p id="thanks">Thank you for flying with qutebrowser!</p>
+</div>
+{% endblock %}

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -125,6 +125,7 @@ save = logging.getLogger('save')
 message = logging.getLogger('message')
 config = logging.getLogger('config')
 sessions = logging.getLogger('sessions')
+pdfjs = logging.getLogger('pdfjs')
 
 
 ram_handler = None

--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -85,6 +85,10 @@ def whitelist_generator():
     yield 'qutebrowser.utils.log.QtWarningFilter.filter'
     yield 'logging.LogRecord.log_color'
     yield 'qutebrowser.browser.pdfjs.is_available'
+    # Used via javascript
+    yield 'qutebrowser.browser.webkit.network.qutescheme.JSBridge.get_pdf'
+    # Used in tests
+    yield 'qutebrowser.browser.webkit.network.qutescheme.JSBridge.peek_pdfs'
     # vulture doesn't notice the hasattr() and thus thinks netrc_used is unused
     # in NetworkManager.on_authentication_required
     yield 'PyQt5.QtNetwork.QNetworkReply.netrc_used'

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -294,6 +294,7 @@ Feature: Various utility commands.
         And I open data/misc/test.pdf
         Then the javascript message "PDF * [*] (PDF.js: *)" should be logged
 
+    # FIXME:pdfjs better way to detect that pdfjs is really not used
     Scenario: pdfjs is not used when disabled
         When I set content -> enable-pdfjs to false
         And I set storage -> prompt-download-directory to false

--- a/tests/unit/browser/test_pdfjs.py
+++ b/tests/unit/browser/test_pdfjs.py
@@ -20,7 +20,6 @@
 import textwrap
 
 import pytest
-from PyQt5.QtCore import QUrl
 
 from qutebrowser.browser import pdfjs
 from qutebrowser.browser.webkit.network import qutescheme

--- a/tests/unit/browser/test_pdfjs.py
+++ b/tests/unit/browser/test_pdfjs.py
@@ -25,24 +25,6 @@ from PyQt5.QtCore import QUrl
 from qutebrowser.browser import pdfjs
 
 
-# Note that we got double protection, once because we use QUrl.FullyEncoded and
-# because we use qutebrowser.browser.webelem.javascript_escape.  Characters
-# like " are already replaced by QUrl.
-@pytest.mark.parametrize('url, expected', [
-    ('http://foo.bar', "http://foo.bar"),
-    ('http://"', ''),
-    ('\0', '%00'),
-    ('http://foobar/");alert("attack!");',
-     'http://foobar/%22);alert(%22attack!%22);'),
-])
-def test_generate_pdfjs_script(url, expected):
-    expected_code = ('PDFJS.verbosity = PDFJS.VERBOSITY_LEVELS.info;\n'
-                     'PDFView.open("{}");\n'.format(expected))
-    url = QUrl(url)
-    actual = pdfjs._generate_pdfjs_script(url)
-    assert actual == expected_code
-
-
 def test_fix_urls():
     page = textwrap.dedent("""
         <html>

--- a/tests/unit/browser/webkit/network/test_qutescheme.py
+++ b/tests/unit/browser/webkit/network/test_qutescheme.py
@@ -54,7 +54,7 @@ class TestPDFJSHandler:
     def test_nonexisting_resource(self, handler, caplog):
         """Test with a resource that does not exist."""
         req = QNetworkRequest(QUrl('qute://pdfjs/no/file'))
-        with caplog.at_level(logging.WARNING, 'misc'):
+        with caplog.at_level(logging.WARNING, 'pdfjs'):
             reply = handler.createRequest(None, req, None)
         assert reply.error() == QNetworkReply.ContentNotFoundError
         assert len(caplog.records) == 1


### PR DESCRIPTION
Fixes #1557.

The idea is to let qutebrowser's download-manager handle the whole PDF download, and then we just pass the data to pdf.js instead of the URL. This means that we can re-use the original request/reply and don't need a second one, plus we get the usual qutebrowser download progress indicator. The downside is that we need to wait for the whole PDF to finish downloading before we can display something. If pdfjs handles the download, it will try to use range requests, requesting exactly the parts of the file that it needs to continue rendering.

Passing the file to pdfjs is done via the JSBridge to avoid serialize-the-array-as-big-string-and-embed-it-shenanigans.

Since it might be confusing for users if the PDF is downloaded instead of shown, I've added a small "Please wait" page, explaining that the file is automatically shown when the download is finished.

This is not yet finished, I'm not completely content with the way the whole "add the js bridge" stuff is handled, I want to clean up the callbacks some more. But I'd like to have some feedback first, I think this approach is the best one as far as single requests are concerned. We could probably also try to find some compromise, like load up to 2 MB via qutebrowser and let pdfjs handle the rest, [there should be a way to do this](https://github.com/mozilla/pdf.js/blob/01ab15a6f17b2f71cd1403f84aae2d09002cccda/src/display/api.js#L92-94), but I'm not sure if another request will be made (`mitmproxy` somehow screwed up, wasn't helpful)

FWIW, if you want to test it, I've used https://www.hq.nasa.gov/alsj/a17/A17_FlightPlan.pdf as it has 20MB and leaves enough time to see the download in action.
