### PR TITLE
WIP: Fix for issue #1596 - Make emergency backup

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1389,10 +1389,10 @@ class CommandDispatcher:
             text = elem.evaluateJavaScript('this.value')
         ed = editor.ExternalEditor(self._win_id, self._tabbed_browser)
         ed.editing_finished.connect(functools.partial(
-            self.on_editing_finished, elem))
+            self.on_editing_finished, ed, page, elem))
         ed.edit(text)
 
-    def on_editing_finished(self, elem, text):
+    def on_editing_finished(self, ed, page, elem, text):
         """Write the editor text into the form field and clean up tempfile.
 
         Callback for GUIProcess when the editor was closed.
@@ -1409,9 +1409,14 @@ class CommandDispatcher:
             else:
                 log.misc.debug("Filling element {} via javascript.".format(
                     elem.debug_text()))
-                text = webelem.javascript_escape(text)
-                elem.evaluateJavaScript("this.value='{}'".format(text))
-        except webelem.IsNullError:
+                text_for_js = webelem.javascript_escape(text)
+                elem.evaluateJavaScript("this.value='{}'".format(text_for_js))
+
+            if elem.webFrame() != page.currentFrame():
+                ed.emergency_save()
+
+        except (webelem.IsNullError):
+            ed.emergency_save()
             raise cmdexc.CommandError("Element vanished while editing!")
 
     @cmdutils.register(instance='command-dispatcher',

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -69,3 +69,14 @@ Feature: Opening external editors
         And I run :hint all
         And I run :follow-hint s
         Then the javascript message "text: foobar" should be logged
+
+    Scenario: Taking away the text input while external editor is active
+        When I set up a fake editor returning "foobar" after 2 seconds
+        And I open data/editor.html
+        And I run :hint all
+        And I run :follow-hint a
+        And I wait for "Clicked editable element!" in the log
+        And I run :open-editor
+        And I run :reload
+        And I wait for "Read back: foobar" in the log
+        Then the error "Failed to set externally edited text*" should be shown

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -57,3 +57,21 @@ def set_up_editor(quteproc, httpbin, tmpdir, text):
     """.format(text=text)))
     editor = '"{}" "{}" {{}}'.format(sys.executable, script)
     quteproc.set_setting('general', 'editor', editor)
+
+
+@bdd.when(bdd.parsers.parse('I set up a fake editor returning "{text}" after'
+                            '{secs} seconds'))
+def set_up_editor_slow(quteproc, httpbin, tmpdir, text, secs):
+    """Set up general->editor to a small python script inserting a text."""
+    script = tmpdir / 'script.py'
+    script.write(textwrap.dedent("""
+        import sys
+        import time
+
+        time.sleep({secs})
+
+        with open(sys.argv[1], 'w', encoding='utf-8') as f:
+            f.write({text!r})
+    """.format(text=text, secs=secs)))
+    editor = '"{}" "{}" {{}}'.format(sys.executable, script)
+    quteproc.set_setting('general', 'editor', editor)


### PR DESCRIPTION
When editing a form field or similar in an external editor (Ctrl+E) and the
corresponding field vanishes, then the edited text will be lost. This fixes the
problem by creating a more permanent temp file in such cases and telling the
user about it, so they can manually restore the lost contents if needed.

Note that this will spam your /tmp (or whereever your system temp is) if it
happens a lot, since those files will never be cleaned up by qutebrowser.
