### PR TITLE
Pdfjs zoom keys

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -253,7 +253,7 @@ class AbstractZoom(QObject):
                 self._set_factor_internal(factor, smart=True)
             except SmartZoomException:
                 return self.set_factor(factor)
-            log.misc.debug("Smart zoomed to: {}%".format(
+            log.misc.debug("Smart zoomed to: {:.1f}%".format(
                 self.factor(smart=True) * 100))
             return
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -769,7 +769,7 @@ class CommandDispatcher:
         """
         tab = self._current_widget()
         try:
-            perc = tab.zoom.offset(-count)
+            perc = tab.zoom.offset(-count, smart=smart)
         except ValueError as e:
             raise cmdexc.CommandError(e)
         message.info("Zoom level: {}%".format(perc))

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -744,26 +744,28 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)
-    def zoom_in(self, count=1):
+    def zoom_in(self, count=1, smart=False):
         """Increase the zoom level for the current tab.
 
         Args:
             count: How many steps to zoom in.
+            smart: Try to use smart zoom (see `zoom` for more).
         """
         tab = self._current_widget()
         try:
-            perc = tab.zoom.offset(count)
+            perc = tab.zoom.offset(count, smart=smart)
         except ValueError as e:
             raise cmdexc.CommandError(e)
         message.info("Zoom level: {}%".format(perc))
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)
-    def zoom_out(self, count=1):
+    def zoom_out(self, count=1, smart=False):
         """Decrease the zoom level for the current tab.
 
         Args:
             count: How many steps to zoom out.
+            smart: Try to use smart zoom (see `zoom` for more).
         """
         tab = self._current_widget()
         try:
@@ -774,7 +776,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)
-    def zoom(self, zoom: int=None, count=None):
+    def zoom(self, zoom: int=None, count=None, smart=False):
         """Set the zoom level for the current tab.
 
         The zoom can be given as argument or as [count]. If neither is
@@ -784,6 +786,8 @@ class CommandDispatcher:
         Args:
             zoom: The zoom percentage to set.
             count: The zoom percentage to set.
+            smart: Try to use smart zoom. Smart zoom tries to delegate the
+                   zooming to the current page (supported e.g. for pdfjs).
         """
         level = count if count is not None else zoom
         if level is None:
@@ -791,7 +795,7 @@ class CommandDispatcher:
         tab = self._current_widget()
 
         try:
-            tab.zoom.set_factor(float(level) / 100)
+            tab.zoom.set_factor(float(level) / 100, smart=smart)
         except ValueError:
             raise cmdexc.CommandError("Can't zoom {}%!".format(level))
         message.info("Zoom level: {}%".format(level))

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -229,3 +229,21 @@ def is_pdfjs_page(webview):
         any(script.attribute('src').endswith(suffix) for script in scripts)
         for suffix in suffixes)
     return has_scripts
+
+
+def get_zoom_script():
+    """Get a JS snippet that will return the current pdfjs zoom factor."""
+    cmd = ('(window.PDFView || window.PDFViewerApplication)'
+            '.pdfViewer.currentScale')
+    return cmd
+
+
+def set_zoom_script(factor):
+    """Get a JS snippet that will set the current pdfjs zoom factor.
+
+    Args:
+        factor: Zoom factor as float.
+    """
+    cmd = ('(window.PDFView || window.PDFViewerApplication)'
+            '.pdfViewer.currentScaleValue = {!r}'.format(factor))
+    return cmd

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -24,6 +24,7 @@ import os
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.utils import utils, javascript
+from qutebrowser.browser.webkit import webview as webkit_webview
 
 
 class PDFJSNotFound(Exception):
@@ -201,3 +202,29 @@ def is_available():
         return False
     else:
         return True
+
+
+def is_pdfjs_page(webview):
+    """Check whether the given webview displays a pdfjs site.
+
+    This currently only works for WebKit views, as pdfjs is not implemented for
+    WebEngine.
+
+    Args:
+        webview: The browser.webkit.webview.WebView instance. Only works for
+                 WebKit!
+
+    Return:
+        True if the view displays pdfjs, False otherwise.
+    """
+    assert isinstance(webview, webkit_webview.WebView)
+    frame = webview.page().mainFrame()
+    has_viewer = frame.findFirstElement('#viewer.pdfViewer')
+    if has_viewer.isNull():
+        return False
+    scripts = frame.findAllElements('script')
+    suffixes = ['/pdf.js', 'viewer.js']
+    has_scripts = all(
+        any(script.attribute('src').endswith(suffix) for script in scripts)
+        for suffix in suffixes)
+    return has_scripts

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -234,7 +234,7 @@ def is_pdfjs_page(webview):
 def get_zoom_script():
     """Get a JS snippet that will return the current pdfjs zoom factor."""
     cmd = ('(window.PDFView || window.PDFViewerApplication)'
-            '.pdfViewer.currentScale')
+           '.pdfViewer.currentScale')
     return cmd
 
 
@@ -245,5 +245,5 @@ def set_zoom_script(factor):
         factor: Zoom factor as float.
     """
     cmd = ('(window.PDFView || window.PDFViewerApplication)'
-            '.pdfViewer.currentScaleValue = {!r}'.format(factor))
+           '.pdfViewer.currentScaleValue = {!r}'.format(factor))
     return cmd

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -24,7 +24,6 @@ import os
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.utils import utils, javascript
-from qutebrowser.browser.webkit import webview as webkit_webview
 
 
 class PDFJSNotFound(Exception):
@@ -217,7 +216,9 @@ def is_pdfjs_page(webview):
     Return:
         True if the view displays pdfjs, False otherwise.
     """
-    assert isinstance(webview, webkit_webview.WebView)
+    # import late to avoid errors when QWebView is not available
+    from PyQt5.QtWebKitWidgets import QWebView
+    assert isinstance(webview, QWebView)
     frame = webview.page().mainFrame()
     has_viewer = frame.findFirstElement('#viewer.pdfViewer')
     if has_viewer.isNull():

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -363,10 +363,12 @@ class WebEngineZoom(browsertab.AbstractZoom):
 
     """QtWebEngine implementations related to zooming."""
 
-    def _set_factor_internal(self, factor):
+    def _set_factor_internal(self, factor, *, smart=False):
+        if smart:
+            raise browsertab.SmartZoomException
         self._widget.setZoomFactor(factor)
 
-    def factor(self):
+    def factor(self, *, smart=False):
         return self._widget.zoomFactor()
 
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -353,7 +353,8 @@ class WebKitZoom(browsertab.AbstractZoom):
     def _set_factor_internal(self, factor):
         widget = self._widget
         if pdfjs.is_pdfjs_page(widget):
-            cmd = 'PDFView.pdfViewer.currentScaleValue = {!r}'.format(factor)
+            cmd = ('(window.PDFView || window.PDFViewerApplication)'
+                   '.pdfViewer.currentScaleValue = {!r}'.format(factor))
             widget.page().mainFrame().evaluateJavaScript(cmd)
         else:
             widget.setZoomFactor(factor)
@@ -361,7 +362,8 @@ class WebKitZoom(browsertab.AbstractZoom):
     def factor(self):
         widget = self._widget
         if pdfjs.is_pdfjs_page(widget):
-            cmd = 'PDFView.pdfViewer.currentScaleValue'
+            cmd = ('(window.PDFView || window.PDFViewerApplication)'
+                   '.pdfViewer.currentScaleValue')
             return widget.page().mainFrame().evaluateJavaScript(cmd)
         else:
             return widget.zoomFactor()

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -350,20 +350,22 @@ class WebKitZoom(browsertab.AbstractZoom):
 
     """QtWebKit implementations related to zooming."""
 
-    def _set_factor_internal(self, factor):
+    def _set_factor_internal(self, factor, *, smart=False):
         widget = self._widget
-        if pdfjs.is_pdfjs_page(widget):
+        if smart and pdfjs.is_pdfjs_page(widget):
             cmd = ('(window.PDFView || window.PDFViewerApplication)'
                    '.pdfViewer.currentScaleValue = {!r}'.format(factor))
             widget.page().mainFrame().evaluateJavaScript(cmd)
+        elif smart:
+            raise browsertab.SmartZoomException
         else:
             widget.setZoomFactor(factor)
 
-    def factor(self):
+    def factor(self, *, smart=False):
         widget = self._widget
-        if pdfjs.is_pdfjs_page(widget):
+        if smart and pdfjs.is_pdfjs_page(widget):
             cmd = ('(window.PDFView || window.PDFViewerApplication)'
-                   '.pdfViewer.currentScaleValue')
+                   '.pdfViewer.currentScale')
             return widget.page().mainFrame().evaluateJavaScript(cmd)
         else:
             return widget.zoomFactor()

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -30,7 +30,7 @@ from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtPrintSupport import QPrinter
 
-from qutebrowser.browser import browsertab
+from qutebrowser.browser import browsertab, pdfjs
 from qutebrowser.browser.webkit import webview, tabhistory, webkitelem
 from qutebrowser.utils import qtutils, objreg, usertypes, utils, log
 
@@ -351,10 +351,20 @@ class WebKitZoom(browsertab.AbstractZoom):
     """QtWebKit implementations related to zooming."""
 
     def _set_factor_internal(self, factor):
-        self._widget.setZoomFactor(factor)
+        widget = self._widget
+        if pdfjs.is_pdfjs_page(widget):
+            cmd = 'PDFView.pdfViewer.currentScaleValue = {!r}'.format(factor)
+            widget.page().mainFrame().evaluateJavaScript(cmd)
+        else:
+            widget.setZoomFactor(factor)
 
     def factor(self):
-        return self._widget.zoomFactor()
+        widget = self._widget
+        if pdfjs.is_pdfjs_page(widget):
+            cmd = 'PDFView.pdfViewer.currentScaleValue'
+            return widget.page().mainFrame().evaluateJavaScript(cmd)
+        else:
+            return widget.zoomFactor()
 
 
 class WebKitScroller(browsertab.AbstractScroller):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -353,8 +353,7 @@ class WebKitZoom(browsertab.AbstractZoom):
     def _set_factor_internal(self, factor, *, smart=False):
         widget = self._widget
         if smart and pdfjs.is_pdfjs_page(widget):
-            cmd = ('(window.PDFView || window.PDFViewerApplication)'
-                   '.pdfViewer.currentScaleValue = {!r}'.format(factor))
+            cmd = pdfjs.set_zoom_script(factor)
             widget.page().mainFrame().evaluateJavaScript(cmd)
         elif smart:
             raise browsertab.SmartZoomException
@@ -364,8 +363,7 @@ class WebKitZoom(browsertab.AbstractZoom):
     def factor(self, *, smart=False):
         widget = self._widget
         if smart and pdfjs.is_pdfjs_page(widget):
-            cmd = ('(window.PDFView || window.PDFViewerApplication)'
-                   '.pdfViewer.currentScale')
+            cmd = pdfjs.get_zoom_script()
             return widget.page().mainFrame().evaluateJavaScript(cmd)
         else:
             return widget.zoomFactor()

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -243,6 +243,11 @@ class NeighborList(collections.abc.Sequence):
         if value is None:
             value = self.fuzzyval
         index = self._find_closest(value, offset)
+        snapped = value not in self._items
+        if snapped and offset > 0:
+            offset -= 1
+        elif snapped and offset < 0:
+            offset += 1
         try:
             if index + offset >= 0:
                 return self._items[index + offset]

--- a/tests/end2end/features/zoom.feature
+++ b/tests/end2end/features/zoom.feature
@@ -95,3 +95,8 @@ Feature: Zooming in and out
         And I run :zoom --smart 200
         Then "Smart zoomed to: 200.0%" should be logged
         And the zoom should be 100%
+
+    Scenario: Smart zoom on non-smart page
+        When I run :zoom --smart 150
+        Then the message "Zoom level: 150%" should be shown
+        Then the zoom should be 150%

--- a/tests/end2end/features/zoom.feature
+++ b/tests/end2end/features/zoom.feature
@@ -85,3 +85,13 @@ Feature: Zooming in and out
         And I run :zoom-in
         Then the message "Zoom level: 120%" should be shown
         And the zoom should be 120%
+
+    @qtwebengine_todo: pdfjs is not implemented yet
+    Scenario: Zooming with pdfjs
+        Given pdfjs is available
+        When I set content -> enable-pdfjs to true
+        And I open data/misc/test.pdf
+        And I run :zoom 100
+        And I run :zoom --smart 200
+        Then "Smart zoomed to: 200.0%" should be logged
+        And the zoom should be 100%

--- a/tests/end2end/features/zoom.feature
+++ b/tests/end2end/features/zoom.feature
@@ -96,6 +96,18 @@ Feature: Zooming in and out
         Then "Smart zoomed to: 200.0%" should be logged
         And the zoom should be 100%
 
+    @qtwebengine_todo: pdfjs is not implemented yet
+    Scenario: Zooming in with pdfjs
+        Given pdfjs is available
+        When I set content -> enable-pdfjs to true
+        And I open data/misc/test.pdf
+        And I run :zoom 100
+        # Make sure we start at 100%, not "Page fit" or something like that
+        And I run :zoom --smart 100
+        And I run :zoom-in --smart
+        Then "Smart zoomed to: 110.0%" should be logged
+        And the zoom should be 100%
+
     Scenario: Smart zoom on non-smart page
         When I run :zoom --smart 150
         Then the message "Zoom level: 150%" should be shown

--- a/tests/unit/browser/test_pdfjs.py
+++ b/tests/unit/browser/test_pdfjs.py
@@ -72,3 +72,26 @@ def test_fix_urls():
 ])
 def test_remove_prefix(path, expected):
     assert pdfjs._remove_prefix(path) == expected
+
+
+@pytest.mark.parametrize('html, expected', [
+    ('<html><h1>No pdfjs!</h1></html>', False),
+    ('''
+    <html>
+    <head>
+    <script src="/pdf.js"></script>
+    <script src="/viewer.js"></script>
+    </head>
+    <body>
+    <div class="pdfViewer" id="viewer"></div>
+    </body>
+    </html>
+    ''', True),
+])
+def test_is_pdfjs_page(qtbot, html, expected):
+    # Skip only this test
+    qt_widgets = pytest.importorskip('PyQt5.QtWebKitWidgets')
+    view = qt_widgets.QWebView()
+    qtbot.add_widget(view)
+    view.setHtml(html)
+    assert pdfjs.is_pdfjs_page(view) == expected

--- a/tests/unit/utils/usertypes/test_neighborlist.py
+++ b/tests/unit/utils/usertypes/test_neighborlist.py
@@ -318,3 +318,32 @@ class TestSnapIn:
         neighborlist.fuzzyval = 0
         assert neighborlist.previtem() == 1
         assert neighborlist._idx == 2
+
+
+class TestPeek:
+
+    """Test the peek features."""
+
+    @pytest.fixture
+    def neighborlist(self):
+        return usertypes.NeighborList([20, 9, 1, 5])
+
+    def test_bigger(self, neighborlist):
+        assert neighborlist.peek_at(7, 1) == 9
+        assert neighborlist._idx is None
+        assert neighborlist.peek_at(7, 2) == 1
+        assert neighborlist._idx is None
+
+    def test_smaller(self, neighborlist):
+        assert neighborlist.peek_at(3, -1) == 1
+        assert neighborlist._idx is None
+        assert neighborlist.peek_at(3, -2) == 9
+        assert neighborlist._idx is None
+
+    def test_equal_bigger(self, neighborlist):
+        assert neighborlist.peek_at(20, 1) == 9
+        assert neighborlist._idx is None
+
+    def test_equal_smaller(self, neighborlist):
+        assert neighborlist.peek_at(5, -1) == 1
+        assert neighborlist._idx is None

--- a/tests/unit/utils/usertypes/test_neighborlist.py
+++ b/tests/unit/utils/usertypes/test_neighborlist.py
@@ -326,7 +326,18 @@ class TestPeek:
 
     @pytest.fixture
     def neighborlist(self):
-        return usertypes.NeighborList([20, 9, 1, 5])
+        return usertypes.NeighborList(
+            [20, 9, 1, 5], mode=usertypes.NeighborList.Modes.edge)
+
+    def test_empty(self):
+        neighborlist = usertypes.NeighborList([])
+        with pytest.raises(IndexError):
+            neighborlist.peek_at(1, 1)
+
+    def test_fuzzyval(self, neighborlist):
+        neighborlist.fuzzyval = 7
+        assert neighborlist.peek_at(None, 1) == 9
+        assert neighborlist._idx is None
 
     def test_bigger(self, neighborlist):
         assert neighborlist.peek_at(7, 1) == 9
@@ -347,3 +358,19 @@ class TestPeek:
     def test_equal_smaller(self, neighborlist):
         assert neighborlist.peek_at(5, -1) == 1
         assert neighborlist._idx is None
+
+    def test_edge_right(self, neighborlist):
+        assert neighborlist.peek_at(5, 5) == 5
+
+    def test_edge_left(self, neighborlist):
+        assert neighborlist.peek_at(20, -5) == 20
+
+    def test_exception_left(self):
+        neighborlist = usertypes.NeighborList([20, 9, 1, 5])
+        with pytest.raises(IndexError):
+            neighborlist.peek_at(20, -5)
+
+    def test_exception_right(self):
+        neighborlist = usertypes.NeighborList([20, 9, 1, 5])
+        with pytest.raises(IndexError):
+            neighborlist.peek_at(5, 5)


### PR DESCRIPTION
Fixes #1916.

This sends zoom commands to pdfjs (if a pdfjs page is displayed), which
zooms only the content (and leaves the controls unzoomed), which is
probably what you want when you zoom pdf sites.

The API was actually easier than I expected :laughing:

The check uses a simple heuristic to determine if a pdfjs page is displayed (it checks for the `#viewer.pdfViewer` element and for the `/pdf.js` and `viewer.js` scripts). It's currently only implemented for WebKit, as we only support pdfjs for WebKit, though I guess that it might be possible to do it in a similar way for WebEngine if needed. If the heuristic is bad or impacts performance too much, we could try and set a flag on the WebView when pdfjs is loaded (in the unsupported content handler), but this way it should work for any pdf.js instance (it also works for the demo).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2001)
<!-- Reviewable:end -->
