### PR TITLE
BDD tests for common exit paths

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -633,6 +633,15 @@ class Quitter:
                             closing.
             restart: If we're planning to restart.
         """
+        # if shutdown was called because the last window was closed, we already
+        # have user confirmation
+        if not last_window:
+            reasons = mainwindow.get_all_windows_close_prompt_reasons()
+            last_win_id = objreg.last_focused_window().win_id
+            if not mainwindow.has_close_confirmation(last_win_id, reasons):
+                log.destroy.debug("Cancelling shutdown: confirmation negative")
+                return
+
         if self._shutting_down:
             return
         self._shutting_down = True

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -633,9 +633,11 @@ class Quitter:
                             closing.
             restart: If we're planning to restart.
         """
+        # if status is greater than 128, we're shutting down on a signal, so
+        # no prompt is generated
         # if shutdown was called because the last window was closed, we already
         # have user confirmation
-        if not last_window:
+        if status <= 128 and not last_window:
             reasons = mainwindow.get_all_windows_close_prompt_reasons()
             last_win_id = objreg.last_focused_window().win_id
             if not mainwindow.has_close_confirmation(last_win_id, reasons):

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -289,6 +289,17 @@ def wait_for_message(quteproc, httpbin, category, message):
     expect_message(quteproc, httpbin, category, message)
 
 
+@bdd.when(bdd.parsers.re(r'I wait for the prompt "(?P<prompt>.*)"'))
+def wait_for_prompt(quteproc, prompt):
+    """Wait for a given prompt prompt."""
+    quteproc.log_summary('Waiting for prompt "{}"'.format(prompt))
+    pattern = re.compile(r'Asking question .* text=.* title=\'{}\'.*'.format(
+        re.escape(prompt)))
+
+    line = quteproc.wait_for(message=pattern)
+    line.expected = True
+
+
 @bdd.when(bdd.parsers.parse("I wait {delay}s"))
 def wait_time(quteproc, delay):
     """Sleep for the given delay."""

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -587,6 +587,15 @@ def should_quit(qtbot, quteproc):
     quteproc.wait_for_quit()
 
 
+@bdd.then(bdd.parsers.re(r'the closing of window (?P<win_id>.*) '
+                         r'should be cancelled'))
+def should_cancel_close(quteproc, win_id):
+    """Verify that closing of a window has been cancelled."""
+    message = 'Cancelling closing of window {}'.format(win_id)
+    line = quteproc.wait_for(message=message)
+    line.expected = True
+
+
 def _get_scroll_values(quteproc):
     data = quteproc.get_session()
     pos = data['windows'][0]['tabs'][0]['history'][-1]['scroll-pos']

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -21,6 +21,7 @@
 
 import os
 import re
+import signal
 import sys
 import time
 import json
@@ -379,6 +380,16 @@ def clear_ssl_errors(request, quteproc):
         quteproc.start()
     else:
         quteproc.send_cmd(':debug-clear-ssl-errors')
+
+
+@bdd.when(bdd.parsers.parse('qutebrowser receives the signal {signame}'))
+def send_signal_to_quteproc(signame, quteproc):
+    signum = getattr(signal, signame)
+    if hasattr(quteproc.proc, 'processId'):
+        pid = quteproc.proc.processId()
+    else:
+        pid = quteproc.proc.pid()
+    os.kill(pid, signum)
 
 
 ## Then

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -63,7 +63,7 @@ Feature: Downloading things from a website.
         And I set storage -> prompt-download-directory to true
         And I open data/downloads/issue1243.html
         And I hint with args "links download" and follow a
-        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='qutebrowser-download' mode=<PromptMode.download: 5> text=* title='Save file to:'>, *" in the log
+        And I wait for the prompt "Save file to:"
         Then the error "Download error: No handler found for qute://!" should be shown
 
     Scenario: Downloading a data: link (issue 1214)
@@ -71,7 +71,7 @@ Feature: Downloading things from a website.
         And I set storage -> prompt-download-directory to true
         And I open data/downloads/issue1214.html
         And I hint with args "links download" and follow a
-        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='binary blob' mode=<PromptMode.download: 5> text=* title='Save file to:'>, *" in the log
+        And I wait for the prompt "Save file to:"
         And I run :leave-mode
         Then no crash should happen
 

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -701,3 +701,9 @@ Feature: Various utility commands.
         And I wait for the prompt "Really quit?"
         And I run :prompt-accept no
         Then the closing of window 0 should be cancelled
+
+	Scenario: Skipping confirmation when exiting on a signal
+        Given I have a fresh instance
+        And I set ui -> confirm-quit to always
+		When qutebrowser receives the signal SIGINT
+		Then qutebrowser should quit

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -331,7 +331,7 @@ Feature: Various utility commands.
         And I open data/misc/test.pdf
         And I wait for "[qute://pdfjs/*] PDF * (PDF.js: *)" in the log
         And I run :jseval document.getElementById("download").click()
-        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='test.pdf' mode=<PromptMode.download: 5> text=* title='Save file to:'>, *" in the log
+        And I wait for the prompt "Save file to:"
         And I run :leave-mode
         Then no crash should happen
 

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -643,7 +643,17 @@ Feature: Various utility commands.
         And I set general -> private-browsing to false
         Then the message "blah" should be shown
 
-    ## :quit
+    ## :run-with-count
+
+    Scenario: :run-with-count
+        When I run :run-with-count 2 scroll down
+        Then "command called: scroll ['down'] (count=2)" should be logged
+
+    Scenario: :run-with-count with count
+        When I run :run-with-count 2 scroll down with count 3
+        Then "command called: scroll ['down'] (count=6)" should be logged
+
+    ## shutdown sequences
 
     Scenario: Exiting qutebrowser via :quit command
         Given I have a fresh instance
@@ -654,3 +664,24 @@ Feature: Various utility commands.
         Given I have a fresh instance
         When I run :q
         Then qutebrowser should quit
+
+    Scenario: Exiting qutebrowser via :close on last window
+        Given I have a fresh instance
+        When I run :close
+        Then qutebrowser should quit
+
+    Scenario: Exiting qutebrowser via :close command with confirmation
+        Given I have a fresh instance
+        And I set ui -> confirm-quit to always
+        When I run :close
+        And I wait for the prompt "Really quit?"
+        And I run :prompt-accept yes
+        Then qutebrowser should quit
+
+    Scenario: Abort exiting qutebrowser via :close command with confirmation
+        Given I have a fresh instance
+        And I set ui -> confirm-quit to always
+        When I run :close
+        And I wait for the prompt "Really quit?"
+        And I run :prompt-accept no
+        Then the closing of window 0 should be cancelled

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -665,6 +665,22 @@ Feature: Various utility commands.
         When I run :q
         Then qutebrowser should quit
 
+    Scenario: Exiting qutebrowser via :quit command with confirmation
+        Given I have a fresh instance
+        And I set ui -> confirm-quit to always
+        When I run :quit
+        And I wait for the prompt "Really quit?"
+        And I run :prompt-accept yes
+        Then qutebrowser should quit
+
+    Scenario: Abort exiting qutebrowser via :quit command with confirmation
+        Given I have a fresh instance
+        And I set ui -> confirm-quit to always
+        When I run :quit
+        And I wait for the prompt "Really quit?"
+        And I run :prompt-accept no
+        Then "Cancelling shutdown: confirmation negative" should be logged
+
     Scenario: Exiting qutebrowser via :close on last window
         Given I have a fresh instance
         When I run :close

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -642,3 +642,15 @@ Feature: Various utility commands.
         And I run :command-accept
         And I set general -> private-browsing to false
         Then the message "blah" should be shown
+
+    ## :quit
+
+    Scenario: Exiting qutebrowser via :quit command
+        Given I have a fresh instance
+        When I run :quit
+        Then qutebrowser should quit
+
+    Scenario: Exiting qutebrowser via :q alias
+        Given I have a fresh instance
+        When I run :q
+        Then qutebrowser should quit

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -395,6 +395,11 @@ class QuteProc(testprocess.Process):
         bad_msgs = [msg for msg in self._data
                     if self._is_error_logline(msg) and not msg.expected]
 
+        # give the process some time to exit if it's expected to
+        # this ensures the next is_running() gives a reasonably accurate result
+        if self.exit_expected:
+            self.proc.waitForFinished()
+
         # if a test sets this to anything else, terminate might wait forever
         if self.is_running():
             self.set_setting('ui', 'confirm-quit', 'never')

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -395,6 +395,10 @@ class QuteProc(testprocess.Process):
         bad_msgs = [msg for msg in self._data
                     if self._is_error_logline(msg) and not msg.expected]
 
+        # if a test sets this to anything else, terminate might wait forever
+        if self.is_running():
+            self.set_setting('ui', 'confirm-quit', 'never')
+
         try:
             call = self.request.node.rep_call
         except AttributeError:

--- a/tests/end2end/fixtures/testprocess.py
+++ b/tests/end2end/fixtures/testprocess.py
@@ -298,7 +298,11 @@ class Process(QObject):
     def terminate(self):
         """Clean up and shut down the process."""
         self.proc.terminate()
-        self.proc.waitForFinished()
+        if not self.proc.waitForFinished():
+            if self.is_running():
+                # if waitForFinished returns false and the process is still
+                # running we have a timeout
+                pytest.fail('timeout while terminating test process')
 
     def is_running(self):
         """Check if the process is currently running."""


### PR DESCRIPTION
Fixes #2009 and adds tests for exiting qutebrowser with the `:quit`,`:q`, and `close` commands with `ui -> confirm-quit` set to either `never` (the default) or `always`.
