### PR TITLE
Add qute:history page

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -164,7 +164,7 @@ def qute_bookmarks(_url):
 @add_handler('history')
 def qute_history(_url):
     """Handler for qute:history. Display browsing history."""
-    history = reversed(objreg.get('web-history').history_dict.values())
+    history = reversed(list(objreg.get('web-history').history_dict.values()))
 
     fmt = config.get('completion', 'timestamp-format')
     if fmt is None:

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -164,7 +164,11 @@ def qute_bookmarks(_url):
 @add_handler('history')
 def qute_history(_url):
     """Handler for qute:history. Display browsing history."""
-    history = reversed(list(objreg.get('web-history').history_dict.values()))
+    history = objreg.get('web-history').history_dict.values()
+    try:
+        history = reversed(history)
+    except TypeError:  # Python < 3.5
+        history = reversed(list(history))
 
     fmt = config.get('completion', 'timestamp-format')
     def fmt_atime(atime):

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -168,7 +168,7 @@ def qute_history(_url):
 
     fmt = config.get('completion', 'timestamp-format')
     if fmt is None:
-        def fmt_atime(atime):
+        def fmt_atime(_atime):
             return ''
     else:
         def fmt_atime(atime):

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -167,19 +167,17 @@ def qute_history(_url):
     history = reversed(list(objreg.get('web-history').history_dict.values()))
 
     fmt = config.get('completion', 'timestamp-format')
-    if fmt is None:
-        def fmt_atime(_atime):
+    def fmt_atime(atime):
+        if fmt is None:
             return ''
-    else:
-        def fmt_atime(atime):
-            try:
-                dt = datetime.datetime.fromtimestamp(atime)
-            except (ValueError, OSError, OverflowError):
-                # Different errors which can occur for too large values...
-                log.misc.error("Got invalid timestamp {}!".format(atime))
-                return '(invalid)'
-            else:
-                return dt.strftime(fmt)
+        try:
+            dt = datetime.datetime.fromtimestamp(atime)
+        except (ValueError, OSError, OverflowError):
+            # Different errors which can occur for too large values...
+            log.misc.error("Got invalid timestamp {}!".format(atime))
+            return '(invalid)'
+        else:
+            return dt.strftime(fmt)
 
     hist_fmt = [(h.url.toDisplayString(), h.title, fmt_atime(h.atime))
                 for h in history]

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -1,0 +1,28 @@
+{% extends "base.html" %}
+
+{% block style %}
+table { border: 1px solid grey; border-collapse: collapse; width: 100%;}
+th, td { border: 1px solid grey; padding: 0px 5px; max-width: 50%;}
+td.url, td.title { word-break: break-all; }
+td.time { white-space: nowrap; }
+th { background: lightgrey; }
+{% endblock %}
+
+{% block content %}
+
+<table>
+    <tr>
+        <th style="width: 40%"><h3>Title</h3></th>
+        <th><h3>URL</h3></th>
+        <th><h3>Time visited</h3></th>
+    </tr>
+    {% for url, title, time in history %}
+    <tr>
+        <td class="title">{{title}}</td>
+        <td class="url"><a href="{{url}}">{{url}}</a></td>
+        <td class="time">{{time}}</td>
+    </tr>
+    {% endfor %}
+</table>
+
+{% endblock %}

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -11,6 +11,13 @@ Feature: Page history
         Then the history file should contain:
             http://localhost:(port)/data/numbers/1.txt
             http://localhost:(port)/data/numbers/2.txt
+
+    Scenario: Listing history
+        When I open data/numbers/3.txt
+        And I open data/numbers/4.txt
+        And I open qute:history
+        Then the page should contain the plaintext "data/numbers/3.txt"
+        And the page should contain the plaintext "data/numbers/4.txt"
             
     Scenario: History item with title
         When I open data/title.html


### PR DESCRIPTION
A working but far from perfect `qute:history` page (see #1887). Remaining issues:
- Page creation is very slow (about 4 seconds for 10,000 history URLs here).
- Titles wrap across words. This is because making titles wrap only at word boundaries can make the title column wider than it should be if a title has a very long "word" (likely some auto-generated garbage), causing it to crowd out the other columns. The ideal behavior would be to wrap at word boundaries but break a word if it is too long, but I don't think there's a css option for that.
- The timestamp format is tied to the one for completion, which might not be what we want.
- Testing is very spare, just checking for the presence of the right URLs in the history page.

Pylint warns about an unused argument in one of the defined `fmt_atime`s. I'm not sure what the best way to remove that warning is.
