### PR TITLE
Apply auto-follow-timeout to hints reduced to none when using auto-follow-timeout

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -745,6 +745,7 @@ class HintManager(QObject):
             self._fire(*visible)
 
     def _apply_auto_follow_timeout(self):
+        """Apply timeout set in auto-follow-timeout."""
         timeout = config.get('hints', 'auto-follow-timeout')
         keyparsers = objreg.get('keyparsers', scope='window',
                                 window=self._win_id)

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -720,6 +720,7 @@ class HintManager(QObject):
                        if label.isVisible()}
 
         if len(visible) != 1:
+            self._apply_auto_follow_timeout()
             return
 
         auto_follow = config.get('hints', 'auto-follow')
@@ -739,14 +740,16 @@ class HintManager(QObject):
             self._context.to_follow = list(visible.keys())[0]
 
         if follow:
-            # apply auto-follow-timeout
-            timeout = config.get('hints', 'auto-follow-timeout')
-            keyparsers = objreg.get('keyparsers', scope='window',
-                                    window=self._win_id)
-            normal_parser = keyparsers[usertypes.KeyMode.normal]
-            normal_parser.set_inhibited_timeout(timeout)
+            self._apply_auto_follow_timeout()
             # unpacking gets us the first (and only) key in the dict.
             self._fire(*visible)
+
+    def _apply_auto_follow_timeout(self):
+        timeout = config.get('hints', 'auto-follow-timeout')
+        keyparsers = objreg.get('keyparsers', scope='window',
+                                window=self._win_id)
+        normal_parser = keyparsers[usertypes.KeyMode.normal]
+        normal_parser.set_inhibited_timeout(timeout)
 
     def handle_partial_key(self, keystr):
         """Handle a new partial keypress."""

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -718,9 +718,12 @@ class HintManager(QObject):
             visible = {string: label
                        for string, label in self._context.labels.items()
                        if label.isVisible()}
+        if len(visible) == 0:
+            #Apply auto-follow-timeout if hints reduced to none
+            self._apply_auto_follow_timeout()
+            return
 
         if len(visible) != 1:
-            self._apply_auto_follow_timeout()
             return
 
         auto_follow = config.get('hints', 'auto-follow')

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -745,7 +745,7 @@ class HintManager(QObject):
             self._fire(*visible)
 
     def _apply_auto_follow_timeout(self):
-        """Apply timeout set in auto-follow-timeout."""
+        """Apply timeout of keyboard input delay set in auto-follow-timeout."""
         timeout = config.get('hints', 'auto-follow-timeout')
         keyparsers = objreg.get('keyparsers', scope='window',
                                 window=self._win_id)


### PR DESCRIPTION
This is a pull request for #2126.