### PR TITLE
Add optional argument --only-active-window to :session-save.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -239,6 +239,7 @@ Contributors, sorted by the number of commits in descending order:
 * Jean-Louis Fuchs
 * Franz Fellner
 * Eric Drechsel
+* Daniel Fiser
 * zwarag
 * xd1le
 * rmortens
@@ -275,7 +276,6 @@ Contributors, sorted by the number of commits in descending order:
 * Dietrich Daroch
 * Derek Sivers
 * Daniel Lu
-* Daniel Fiser
 * Arseniy Seroka
 * Andy Balaam
 * Andreas Fischer

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -275,6 +275,7 @@ Contributors, sorted by the number of commits in descending order:
 * Dietrich Daroch
 * Derek Sivers
 * Daniel Lu
+* Daniel Fiser
 * Arseniy Seroka
 * Andy Balaam
 * Andreas Fischer

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -723,7 +723,7 @@ Load a session.
 
 [[session-save]]
 === session-save
-Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] ['name']+
+Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*] ['name']+
 
 Save a session.
 
@@ -735,6 +735,7 @@ Save a session.
 * +*-c*+, +*--current*+: Save the current session instead of the default.
 * +*-q*+, +*--quiet*+: Don't show confirmation message.
 * +*-f*+, +*--force*+: Force saving internal sessions (starting with an underline).
+* +*-o*+, +*--only-active-window*+: Saves only tabs of the currently active window.
 
 [[set]]
 === set

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -723,7 +723,8 @@ Load a session.
 
 [[session-save]]
 === session-save
-Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*] ['name']+
+Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*]
+             ['name']+
 
 Save a session.
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -261,7 +261,7 @@ class SessionManager(QObject):
         return name
 
     def save(self, name, last_window=False, load_next_time=False,
-                   only_window=None):
+             only_window=None):
         """Save a named session.
 
         Args:

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -436,6 +436,7 @@ class SessionManager(QObject):
             current: Save the current session instead of the default.
             quiet: Don't show confirmation message.
             force: Force saving internal sessions (starting with an underline).
+            only_active_window: Saves only tabs of the currently active window.
         """
         if (name is not default and
                 name.startswith('_') and  # pylint: disable=no-member

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -290,8 +290,7 @@ Feature: Saving and loading sessions
     And I run :session-load window_session_name
     Then the session should look like:
       windows:
-        - active: true
-          tabs:
+        - tabs:
             - history:
               - active: true
                 url: http://localhost:*/data/numbers/5.txt

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -278,6 +278,32 @@ Feature: Saving and loading sessions
     Then "Saved session quiet_session." should not be logged
     And the session quiet_session should exist
 
+  Scenario: Saving session with --only-active-window
+    When I open data/numbers/1.txt
+    And I open data/numbers/2.txt in a new tab
+    And I open data/numbers/3.txt in a new window
+    And I open data/numbers/4.txt in a new tab
+    And I open data/numbers/5.txt in a new tab
+    And I run :session-save --only-active-window window_session_name
+    And I run :window-only
+    And I run :tab-only
+    And I run :session-load window_session_name
+    Then the session should look like:
+      windows:
+        - active: true
+          tabs:
+            - history:
+              - active: true
+                url: http://localhost:*/data/numbers/5.txt
+        - tabs:
+            - history:
+                - url: http://localhost:*/data/numbers/3.txt
+            - history:
+                - url: http://localhost:*/data/numbers/4.txt
+            - history:
+                - active: true
+                  url: http://localhost:*/data/numbers/5.txt
+
   # :session-delete
 
   Scenario: Deleting a directory


### PR DESCRIPTION
The new optional argument --only-active-window makes :session-save to
save only the tabs in the currently active window.