### PR TITLE
browser/navigate: _find_nextprev allow for space sep rel attribs

### DIFF
--- a/qutebrowser/browser/navigate.py
+++ b/qutebrowser/browser/navigate.py
@@ -70,11 +70,11 @@ def path_up(url, count):
 def _find_prevnext(prev, elems):
     """Find a prev/next element in the given list of elements."""
     # First check for <link rel="prev(ious)|next">
-    rel_values = ('prev', 'previous') if prev else ('next')
+    rel_values = {'prev', 'previous'} if prev else {'next'}
     for e in elems:
         if e.tag_name() not in ['link', 'a'] or 'rel' not in e:
             continue
-        if e['rel'] in rel_values:
+        if set(e['rel'].split(' ')) & rel_values:
             log.hints.debug("Found {!r} with rel={}".format(e, e['rel']))
             return e
 

--- a/tests/end2end/data/navigate/rel_nofollow.html
+++ b/tests/end2end/data/navigate/rel_nofollow.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Navigate</title>
+    </head>
+    <body>
+        <p>Index page</p>
+        <a href="/data/navigate/prev.html" rel="nofollow prev">bla</a>
+        <a href="/data/navigate/next.html" rel="nofollow next">blub</a>
+    </body>
+</html>

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -53,6 +53,16 @@ Feature: Using :navigate
         And I run :navigate next
         Then data/navigate/next.html should be loaded
 
+    Scenario: Navigating to previous page with rel nofollow
+        When I open data/navigate/rel_nofollow.html
+        And I run :navigate prev
+        Then data/navigate/prev.html should be loaded
+
+    Scenario: Navigating to next page with rel nofollow
+        When I open data/navigate/rel_nofollow.html
+        And I run :navigate next
+        Then data/navigate/next.html should be loaded
+
     # increment/decrement
 
     Scenario: Incrementing number in URL


### PR DESCRIPTION
The _find_nextprev function of browser/navigate.py only checks to see if
the rell attribute equals 'prev', 'previous', or 'next'. This patch
changes this to check for a set intersection between {'prev',
'previous'} or {'next'} and the set of the space separated list of the
rel attribute.