### PR TITLE
PAC: fix isPlainHostName()

### DIFF
--- a/qutebrowser/javascript/pac_utils.js
+++ b/qutebrowser/javascript/pac_utils.js
@@ -61,7 +61,7 @@ function convert_addr(ipchars) {
 }
 
 function isInNet(ipaddr, pattern, maskstr) {
-    var test = /^(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})\\.(\\d{1,3})$/
+    var test = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
                .exec(ipaddr);
     if (test == null) {
         ipaddr = dnsResolve(ipaddr);
@@ -92,9 +92,9 @@ function localHostOrDomainIs(host, hostdom) {
 }
 
 function shExpMatch(url, pattern) {
-   pattern = pattern.replace(/\\./g, '\\\\.');
-   pattern = pattern.replace(/\\*/g, '.*');
-   pattern = pattern.replace(/\\?/g, '.');
+   pattern = pattern.replace(/\./g, '\\.');
+   pattern = pattern.replace(/\*/g, '.*');
+   pattern = pattern.replace(/\?/g, '.');
    var newRe = new RegExp('^'+pattern+'$');
    return newRe.test(url);
 }

--- a/qutebrowser/javascript/pac_utils.js
+++ b/qutebrowser/javascript/pac_utils.js
@@ -78,7 +78,7 @@ function isInNet(ipaddr, pattern, maskstr) {
 }
 
 function isPlainHostName(host) {
-    return (host.search('\\\\.') == -1);
+    return (host.search('\\.') == -1);
 }
 
 function isResolvable(host) {

--- a/tests/unit/browser/webkit/network/test_pac.py
+++ b/tests/unit/browser/webkit/network/test_pac.py
@@ -109,6 +109,15 @@ def test_myIpAddress():
     _pac_equality_test("isResolvable(myIpAddress())", "true")
 
 
+@pytest.mark.parametrize("host, expected", [
+    ("example", "true"),
+    ("example.com", "false"),
+    ("www.example.com", "false"),
+])
+def test_isPlainHostName(host, expected):
+    _pac_equality_test("isPlainHostName('{}')".format(host), expected)
+
+
 def test_proxyBindings():
     _pac_equality_test("JSON.stringify(ProxyConfig.bindings)", "'{}'")
 


### PR DESCRIPTION
Fix isPlainHostName() implementation and add test-case for it.

Signed-off-by: Kirill A. Shutemov <kirill@shutemov.name>