### PR TITLE
New qute:history page.

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -248,6 +248,19 @@ def qute_history(url):
         return 'text/html', jinja.render('history.html', title='History')
 
 
+@add_handler('javascript')
+def qute_javascript(url):
+    """Handler for qute:javascript.
+
+    Return content of file given as query parameter.
+    """
+    path = url.path()
+    if path:
+        return 'text/html', utils.read_file("javascript" + path, binary=False)
+    else:
+        raise QuteSchemeError("No file specified", ValueError())
+
+
 @add_handler('pyeval')
 def qute_pyeval(_url):
     """Handler for qute:pyeval."""

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -211,7 +211,7 @@ def qute_history(url):
                     last_item = item
                     continue
                 if item_newer:
-                    yield {"next": int(last_item.atime)}
+                    yield {"next": int(last_item.atime if last_item else -1)}
                     return
 
             # Use item's url as title if there's no title.

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -29,7 +29,7 @@ import sys
 import time
 import urllib.parse
 
-from PyQt5.QtCore import QUrl, QUrlQuery
+from PyQt5.QtCore import QUrlQuery
 
 import qutebrowser
 from qutebrowser.utils import (version, utils, jinja, log, message, docutils,
@@ -203,7 +203,7 @@ def qute_history(url):
                 if item_newer:
                     continue
             else:
-                # history_dict is not reversed, we are going forward in history.
+                # history_dict isn't reversed, we are going forward in history.
                 # so:
                 #     abort if item is newer than start_time
                 #     skip if item is older than start_time+24hrs

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -216,8 +216,11 @@ def qute_history(url):
 
     if url.path() == '/data':
         # Use start_time in query or current time.
-        start_time = QUrlQuery(url).queryItemValue("start_time")
-        start_time = float(start_time) if start_time else time.time()
+        try:
+            start_time = QUrlQuery(url).queryItemValue("start_time")
+            start_time = float(start_time) if start_time else time.time()
+        except ValueError as e:
+            raise QuteSchemeError("Query parameter start_time is invalid", e)
 
         if sys.hexversion >= 0x03050000:
             # On Python >= 3.5 we can reverse the ordereddict in-place and thus

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -169,20 +169,20 @@ def qute_history(url):
     def history_iter(start_time, reverse=False):
         """Iterate through the history and get items we're interested.
 
-        Keyword arguments:
-        reverse -- whether to reverse the history_dict before iterating.
-        start_time -- select history starting from this timestamp.
+        Arguments:
+            reverse -- whether to reverse the history_dict before iterating.
+            start_time -- select history starting from this timestamp.
         """
         history = objreg.get('web-history').history_dict.values()
         if reverse:
             history = reversed(history)
 
-        end_time = start_time - 86400.0  # end is 24hrs earlier than start
+        end_time = start_time - 24*60*60  # end is 24hrs earlier than start
 
         for item in history:
             # Abort/continue as early as possible
             item_newer = item.atime > start_time
-            item_older = item.atime < end_time
+            item_older = item.atime <= end_time
             if reverse:
                 # history_dict is reversed, we are going back in history.
                 # so:
@@ -202,12 +202,9 @@ def qute_history(url):
                 if item_newer:
                     return
 
-            # Skip items not within start_time and end_time
             # Skip redirects
             # Skip qute:// links
-            is_in_window = item.atime > end_time and item.atime <= start_time
-            is_internal = item.url.scheme() == 'qute'
-            if item.redirect or is_internal or not is_in_window:
+            if item.redirect or item.url.scheme() == 'qute':
                 continue
 
             # Use item's url as title if there's no title.
@@ -217,7 +214,7 @@ def qute_history(url):
 
             yield {"url": item_url, "title": item_title, "time": item_time}
 
-    if QUrl(url).path() == '/data':
+    if url.path() == '/data':
         # Use start_time in query or current time.
         start_time = QUrlQuery(url).queryItemValue("start_time")
         start_time = float(start_time) if start_time else time.time()

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -25,6 +25,7 @@ Module attributes:
 """
 
 import json
+import os
 import sys
 import time
 import urllib.parse
@@ -256,7 +257,8 @@ def qute_javascript(url):
     """
     path = url.path()
     if path:
-        return 'text/html', utils.read_file("javascript" + path, binary=False)
+        path = "javascript" + os.sep.join(path.split('/'))
+        return 'text/html', utils.read_file(path, binary=False)
     else:
         raise QuteSchemeError("No file specified", ValueError())
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -227,13 +227,13 @@ def qute_history(url):
             # apply an additional performance improvement in history_iter.
             # On my machine, this gets us down from 550ms to 72us with 500k old
             # items.
-            history = list(history_iter(start_time, reverse=True))
+            history = history_iter(start_time, reverse=True)
         else:
             # On Python 3.4, we can't do that, so we'd need to copy the entire
             # history to a list. There, filter first and then reverse it here.
             history = reversed(list(history_iter(start_time, reverse=False)))
 
-        return 'text/html', json.dumps(history)
+        return 'text/html', json.dumps(list(history))
     else:
         return 'text/html', jinja.render('history.html', title='History')
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -218,7 +218,7 @@ def qute_history(url):
             # Use item's url as title if there's no title.
             item_url = item.url.toDisplayString()
             item_title = item.title if item.title else item_url
-            item_time = int(item.atime)
+            item_time = int(item.atime * 1000)
 
             yield {"url": item_url, "title": item_title, "time": item_time}
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -222,7 +222,7 @@ def qute_history(url):
             yield {"url": item_url, "title": item_title, "time": item_time}
 
         # if we reached here, we had reached the end of history
-        yield {"next": -1}
+        yield {"next": int(last_item.atime if last_item else -1)}
 
     if url.path() == '/data':
         # Use start_time in query or current time.

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -33,6 +33,7 @@ import urllib.parse
 from PyQt5.QtCore import QUrlQuery
 
 import qutebrowser
+from qutebrowser.config import config
 from qutebrowser.utils import (version, utils, jinja, log, message, docutils,
                                objreg)
 from qutebrowser.misc import objects
@@ -246,7 +247,8 @@ def qute_history(url):
 
         return 'text/html', json.dumps(list(history))
     else:
-        return 'text/html', jinja.render('history.html', title='History')
+        return 'text/html', jinja.render('history.html', title='History',
+                session_interval=config.get('ui', 'history-session-interval'))
 
 
 @add_handler('javascript')

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -291,6 +291,12 @@ def data(readonly=False):
         )),
 
         ('ui', sect.KeyValue(
+            ('history-session-interval',
+             SettingValue(typ.Int(), '30'),
+             "The maximum time in minutes between two history items for them "
+             "to be considered being from the same session. Use -1 to "
+             "disable separation."),
+
             ('zoom-levels',
              SettingValue(typ.List(typ.Perc(minval=0)),
                           '25%,33%,50%,67%,75%,90%,100%,110%,125%,150%,175%,'

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -65,11 +65,13 @@ table {
 </noscript>
 <div id="hist-container"></div>
 <span id="eof" style="display: none">end</span>
-<a href="#" id="load">Show more</a>
+<a href="#" id="load" style="display: none">Show more</a>
 <script type="text/javascript" src="qute://javascript/history.js"></script>
 <script type="text/javascript">
     window.onload = function() {
-        document.getElementById('load').addEventListener('click', function(ev) {
+        var loadLink = document.getElementById('load');
+        loadLink.style.display = null;
+        loadLink.addEventListener('click', function(ev) {
             ev.preventDefault();
             window.loadHistory();
         });

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -16,43 +16,165 @@ td.time {
     white-space: nowrap;
 }
 
+table {
+    margin-bottom: 30px;
+}
+
 .date {
-    color: #888;
-    font-size: 14pt;
-    padding-left: 25px;
-}
-
-.pagination-link {
-    display: inline-block;
-    margin-bottom: 10px;
-    margin-top: 10px;
-    padding-right: 10px;
-}
-
-.pagination-link > a {
-    color: #333;
+    color: #555;
+    font-size: 12pt;
+    padding-bottom: 15px;
     font-weight: bold;
+    text-align: left;
+}
+
+.session-separator {
+    color: #aaa;
+    height: 40px;
+    text-align: center;
+}
+
+{% endblock %}
+
+{% block script %}
+/**
+ * Container for global stuff
+ */
+var global = {
+    // The last history item that was seen.
+    lastItem: null,
+    // The cutoff interval for session-separator (30 minutes)
+    SESSION_CUTOFF: 30*60
+};
+
+/**
+ * Finds or creates the session table>tbody to which item with given date
+ * should be added.
+ *
+ * @param {Date} date - the date of the item being added.
+ */
+var getSessionNode = function(date) {
+    var histContainer = document.getElementById('hist-container');
+
+    // Find/create table
+    var tableId = "hist-" + date.getDate() + date.getMonth() + date.getYear();
+    var table = document.getElementById(tableId);
+    if (table === null) {
+        table = document.createElement("table");
+        table.id = tableId;
+
+        caption = document.createElement("caption");
+        caption.className = "date";
+        var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
+        caption.innerHTML = date.toLocaleDateString('en-US', options);
+        table.appendChild(caption);
+
+        // Add table to page
+        histContainer.appendChild(table);
+    }
+
+    // Find/create tbody
+    var tbody = table.lastChild;
+    if (tbody.tagName !== "TBODY") { // this is the caption
+        tbody = document.createElement("tbody");
+        table.appendChild(tbody);
+    }
+
+    // Create session-separator and new tbody if necessary
+    if (tbody.lastChild !== null && global.lastItem !== null) {
+        lastItemDate = new Date(parseInt(global.lastItem.time)*1000);
+        var interval = (lastItemDate.getTime() - date.getTime())/1000.00;
+        if (interval > global.SESSION_CUTOFF) {
+            // Add session-separator
+            var sessionSeparator = document.createElement('td');
+            sessionSeparator.className = "session-separator";
+            sessionSeparator.colSpan = 2;
+            sessionSeparator.innerHTML = "&#167;"
+            table.appendChild(document.createElement('tr'));
+            table.lastChild.appendChild(sessionSeparator);
+
+            // Create new tbody
+            tbody = document.createElement("tbody");
+            table.appendChild(tbody);
+        }
+    }
+
+    return tbody;
+}
+
+/**
+ * Given a history item, create and return <tr> for it.
+ * param {string} itemUrl - The url for this item
+ * param {string} itemTitle - The title for this item
+ * param {string} itemTime - The formatted time for this item
+ */
+var makeHistoryRow = function(itemUrl, itemTitle, itemTime) {
+    var row = document.createElement('tr');
+
+    var title = document.createElement('td');
+    title.className = "title";
+    var link = document.createElement('a');
+    link.href = itemUrl;
+    link.innerHTML = itemTitle;
+    title.appendChild(link);
+
+    var time = document.createElement('td');
+    time.className = "time";
+    time.innerHTML = itemTime;
+
+    row.appendChild(title);
+    row.appendChild(time);
+
+    return row;
+}
+
+var getJSON = function(url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'json';
+    xhr.onload = function() {
+      var status = xhr.status;
+      callback(status, xhr.response);
+    };
+    xhr.send();
+};
+
+/**
+ * Load new history.
+ */
+var loadHistory = function() {
+    url = "qute://history/data";
+    if (global.lastItem !== null) {
+        startTime = parseInt(global.lastItem.time) - 1;
+        url = "qute://history/data?start_time=" + startTime.toString();
+    }
+
+    getJSON(url, function(status, history) {
+        if (history !== undefined) {
+            for (item of history) {
+                atime = new Date(parseInt(item.time)*1000);
+                var session = getSessionNode(atime);
+                var row = makeHistoryRow(item.url, item.title, atime.toLocaleTimeString());
+                session.appendChild(row)
+                global.lastItem = item;
+            }
+        }
+    });
 }
 {% endblock %}
 
 {% block content %}
+<h1>Browsing history</h1>
+<div id="hist-container"></div>
+<script>
+window.onload = function() {
+    loadHistory();
 
-<h1>Browsing history <span class="date">{{curr_date.strftime("%a, %d %B %Y")}}</span></h1>
-
-<table>
-    <tbody>
-    {% for url, title, time in history %}
-        <tr>
-            <td class="title"><a href="{{url}}">{{title}}</a></td>
-            <td class="time">{{time}}</td>
-        </tr>
-    {% endfor %}
-    </tbody>
-</table>
-
-<span class="pagination-link"><a href="qute://history/?date={{prev_date.strftime("%Y-%m-%d")}}" rel="prev">Previous</a></span>
-{% if today >= next_date %}
-<span class="pagination-link"><a href="qute://history/?date={{next_date.strftime("%Y-%m-%d")}}" rel="next">Next</a></span>
-{% endif %}
-
+    window.onscroll = function(ev) {
+        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
+            loadHistory();
+        }
+    };
+};
+</script>
 {% endblock %}

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -68,6 +68,8 @@ table {
 <a href="#" id="load" style="display: none">Show more</a>
 <script type="text/javascript" src="qute://javascript/history.js"></script>
 <script type="text/javascript">
+    window.SESSION_INTERVAL = {{session_interval}} * 60 * 1000;
+
     window.onload = function() {
         var loadLink = document.getElementById('load');
         loadLink.style.display = null;

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -65,16 +65,22 @@ table {
 </noscript>
 <div id="hist-container"></div>
 <span id="eof" style="display: none">end</span>
-<a href="#" onclick="loadHistory();"id="load">Show more</a>
+<a href="#" id="load">Show more</a>
 <script type="text/javascript" src="qute://javascript/history.js"></script>
 <script type="text/javascript">
     window.onload = function() {
-        loadHistory();
+        document.getElementById('load').addEventListener('click', function(ev) {
+            ev.preventDefault();
+            window.loadHistory();
+        });
+
         window.onscroll = function(ev) {
             if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
-                loadHistory();
+                window.loadHistory();
             }
         };
+
+        window.loadHistory();
     };
 </script>
 {% endblock %}

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -28,6 +28,19 @@ table {
     text-align: left;
 }
 
+#load {
+    color: #555;
+    font-weight: bold;
+    text-decoration: none;
+}
+
+#eof {
+    color: #aaa;
+    margin-bottom: 30px;
+    text-align: center;
+    width: 100%;
+}
+
 .session-separator {
     color: #aaa;
     height: 40px;
@@ -43,6 +56,8 @@ table {
 var global = {
     // The last history item that was seen.
     lastItem: null,
+    // The next time to load
+    nextTime: null,
     // The cutoff interval for session-separator (30 minutes)
     SESSION_CUTOFF: 30*60
 };
@@ -144,14 +159,25 @@ var getJSON = function(url, callback) {
  */
 var loadHistory = function() {
     url = "qute://history/data";
-    if (global.lastItem !== null) {
-        startTime = parseInt(global.lastItem.time) - 1;
+    if (global.nextTime !== null) {
+        startTime = global.nextTime;
         url = "qute://history/data?start_time=" + startTime.toString();
     }
 
     getJSON(url, function(status, history) {
         if (history !== undefined) {
             for (item of history) {
+                if (item.next === -1) {
+                    // Reached end of history
+                    window.onscroll = null;
+                    document.getElementById('eof').style.display = "block"
+                    document.getElementById('load').style.display = "none"
+                    continue;
+                } else if (item.next !== undefined) {
+                    global.nextTime = parseInt(item.next);
+                    continue;
+                }
+
                 atime = new Date(parseInt(item.time)*1000);
                 var session = getSessionNode(atime);
                 var row = makeHistoryRow(item.url, item.title, atime.toLocaleTimeString());
@@ -166,10 +192,11 @@ var loadHistory = function() {
 {% block content %}
 <h1>Browsing history</h1>
 <div id="hist-container"></div>
+<span id="eof" style="display: none">end</span>
+<a href="#" onclick="loadHistory();"id="load">Show more</a>
 <script>
 window.onload = function() {
     loadHistory();
-
     window.onscroll = function(ev) {
         if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
             loadHistory();

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -47,9 +47,22 @@ table {
     text-align: center;
 }
 
+.error {
+    background-color: #ffbbbb;
+    border-radius: 5px;
+    font-weight: bold;
+    padding: 10px;
+    text-align: center;
+    width: 100%;
+    border: 1px solid #ff7777;
+}
+
 {% endblock %}
 {% block content %}
 <h1>Browsing history</h1>
+<noscript>
+    <div class="error">Javascript is required to view this page.</div>
+</noscript>
 <div id="hist-container"></div>
 <span id="eof" style="display: none">end</span>
 <a href="#" onclick="loadHistory();"id="load">Show more</a>

--- a/qutebrowser/html/history.html
+++ b/qutebrowser/html/history.html
@@ -48,160 +48,20 @@ table {
 }
 
 {% endblock %}
-
-{% block script %}
-/**
- * Container for global stuff
- */
-var global = {
-    // The last history item that was seen.
-    lastItem: null,
-    // The next time to load
-    nextTime: null,
-    // The cutoff interval for session-separator (30 minutes)
-    SESSION_CUTOFF: 30*60
-};
-
-/**
- * Finds or creates the session table>tbody to which item with given date
- * should be added.
- *
- * @param {Date} date - the date of the item being added.
- */
-var getSessionNode = function(date) {
-    var histContainer = document.getElementById('hist-container');
-
-    // Find/create table
-    var tableId = "hist-" + date.getDate() + date.getMonth() + date.getYear();
-    var table = document.getElementById(tableId);
-    if (table === null) {
-        table = document.createElement("table");
-        table.id = tableId;
-
-        caption = document.createElement("caption");
-        caption.className = "date";
-        var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
-        caption.innerHTML = date.toLocaleDateString('en-US', options);
-        table.appendChild(caption);
-
-        // Add table to page
-        histContainer.appendChild(table);
-    }
-
-    // Find/create tbody
-    var tbody = table.lastChild;
-    if (tbody.tagName !== "TBODY") { // this is the caption
-        tbody = document.createElement("tbody");
-        table.appendChild(tbody);
-    }
-
-    // Create session-separator and new tbody if necessary
-    if (tbody.lastChild !== null && global.lastItem !== null) {
-        lastItemDate = new Date(parseInt(global.lastItem.time)*1000);
-        var interval = (lastItemDate.getTime() - date.getTime())/1000.00;
-        if (interval > global.SESSION_CUTOFF) {
-            // Add session-separator
-            var sessionSeparator = document.createElement('td');
-            sessionSeparator.className = "session-separator";
-            sessionSeparator.colSpan = 2;
-            sessionSeparator.innerHTML = "&#167;"
-            table.appendChild(document.createElement('tr'));
-            table.lastChild.appendChild(sessionSeparator);
-
-            // Create new tbody
-            tbody = document.createElement("tbody");
-            table.appendChild(tbody);
-        }
-    }
-
-    return tbody;
-}
-
-/**
- * Given a history item, create and return <tr> for it.
- * param {string} itemUrl - The url for this item
- * param {string} itemTitle - The title for this item
- * param {string} itemTime - The formatted time for this item
- */
-var makeHistoryRow = function(itemUrl, itemTitle, itemTime) {
-    var row = document.createElement('tr');
-
-    var title = document.createElement('td');
-    title.className = "title";
-    var link = document.createElement('a');
-    link.href = itemUrl;
-    link.innerHTML = itemTitle;
-    title.appendChild(link);
-
-    var time = document.createElement('td');
-    time.className = "time";
-    time.innerHTML = itemTime;
-
-    row.appendChild(title);
-    row.appendChild(time);
-
-    return row;
-}
-
-var getJSON = function(url, callback) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
-    xhr.responseType = 'json';
-    xhr.onload = function() {
-      var status = xhr.status;
-      callback(status, xhr.response);
-    };
-    xhr.send();
-};
-
-/**
- * Load new history.
- */
-var loadHistory = function() {
-    url = "qute://history/data";
-    if (global.nextTime !== null) {
-        startTime = global.nextTime;
-        url = "qute://history/data?start_time=" + startTime.toString();
-    }
-
-    getJSON(url, function(status, history) {
-        if (history !== undefined) {
-            for (item of history) {
-                if (item.next === -1) {
-                    // Reached end of history
-                    window.onscroll = null;
-                    document.getElementById('eof').style.display = "block"
-                    document.getElementById('load').style.display = "none"
-                    continue;
-                } else if (item.next !== undefined) {
-                    global.nextTime = parseInt(item.next);
-                    continue;
-                }
-
-                atime = new Date(parseInt(item.time)*1000);
-                var session = getSessionNode(atime);
-                var row = makeHistoryRow(item.url, item.title, atime.toLocaleTimeString());
-                session.appendChild(row)
-                global.lastItem = item;
-            }
-        }
-    });
-}
-{% endblock %}
-
 {% block content %}
 <h1>Browsing history</h1>
 <div id="hist-container"></div>
 <span id="eof" style="display: none">end</span>
 <a href="#" onclick="loadHistory();"id="load">Show more</a>
-<script>
-window.onload = function() {
-    loadHistory();
-    window.onscroll = function(ev) {
-        if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
-            loadHistory();
-        }
+<script type="text/javascript" src="qute://javascript/history.js"></script>
+<script type="text/javascript">
+    window.onload = function() {
+        loadHistory();
+        window.onscroll = function(ev) {
+            if ((window.innerHeight + window.scrollY) >= document.body.scrollHeight) {
+                loadHistory();
+            }
+        };
     };
-};
 </script>
 {% endblock %}

--- a/qutebrowser/javascript/history.js
+++ b/qutebrowser/javascript/history.js
@@ -1,0 +1,138 @@
+/**
+ * Container for global stuff
+ */
+var global = {
+    // The last history item that was seen.
+    lastItem: null,
+    // The next time to load
+    nextTime: null,
+    // The cutoff interval for session-separator (30 minutes)
+    SESSION_CUTOFF: 30*60
+};
+
+/**
+ * Finds or creates the session table>tbody to which item with given date
+ * should be added.
+ *
+ * @param {Date} date - the date of the item being added.
+ */
+var getSessionNode = function(date) {
+    var histContainer = document.getElementById('hist-container');
+
+    // Find/create table
+    var tableId = "hist-" + date.getDate() + date.getMonth() + date.getYear();
+    var table = document.getElementById(tableId);
+    if (table === null) {
+        table = document.createElement("table");
+        table.id = tableId;
+
+        caption = document.createElement("caption");
+        caption.className = "date";
+        var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
+        caption.innerHTML = date.toLocaleDateString('en-US', options);
+        table.appendChild(caption);
+
+        // Add table to page
+        histContainer.appendChild(table);
+    }
+
+    // Find/create tbody
+    var tbody = table.lastChild;
+    if (tbody.tagName !== "TBODY") { // this is the caption
+        tbody = document.createElement("tbody");
+        table.appendChild(tbody);
+    }
+
+    // Create session-separator and new tbody if necessary
+    if (tbody.lastChild !== null && global.lastItem !== null) {
+        lastItemDate = new Date(parseInt(global.lastItem.time)*1000);
+        var interval = (lastItemDate.getTime() - date.getTime())/1000.00;
+        if (interval > global.SESSION_CUTOFF) {
+            // Add session-separator
+            var sessionSeparator = document.createElement('td');
+            sessionSeparator.className = "session-separator";
+            sessionSeparator.colSpan = 2;
+            sessionSeparator.innerHTML = "&#167;";
+            table.appendChild(document.createElement('tr'));
+            table.lastChild.appendChild(sessionSeparator);
+
+            // Create new tbody
+            tbody = document.createElement("tbody");
+            table.appendChild(tbody);
+        }
+    }
+
+    return tbody;
+}
+
+/**
+ * Given a history item, create and return <tr> for it.
+ * param {string} itemUrl - The url for this item
+ * param {string} itemTitle - The title for this item
+ * param {string} itemTime - The formatted time for this item
+ */
+var makeHistoryRow = function(itemUrl, itemTitle, itemTime) {
+    var row = document.createElement('tr');
+
+    var title = document.createElement('td');
+    title.className = "title";
+    var link = document.createElement('a');
+    link.href = itemUrl;
+    link.innerHTML = itemTitle;
+    title.appendChild(link);
+
+    var time = document.createElement('td');
+    time.className = "time";
+    time.innerHTML = itemTime;
+
+    row.appendChild(title);
+    row.appendChild(time);
+
+    return row;
+}
+
+var getJSON = function(url, callback) {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', url, true);
+    xhr.responseType = 'json';
+    xhr.onload = function() {
+        var status = xhr.status;
+        callback(status, xhr.response);
+    };
+    xhr.send();
+};
+
+/**
+ * Load new history.
+ */
+var loadHistory = function() {
+    url = "qute://history/data";
+    if (global.nextTime !== null) {
+        startTime = global.nextTime;
+        url = "qute://history/data?start_time=" + startTime.toString();
+    }
+
+    getJSON(url, function(status, history) {
+        if (history !== undefined) {
+            for (item of history) {
+                if (item.next === -1) {
+                    // Reached end of history
+                    window.onscroll = null;
+                    document.getElementById('eof').style.display = "block";
+                    document.getElementById('load').style.display = "none";
+                    continue;
+                } else if (item.next !== undefined) {
+                    global.nextTime = parseInt(item.next);
+                    continue;
+                }
+
+                atime = new Date(parseInt(item.time)*1000);
+                var session = getSessionNode(atime);
+                var row = makeHistoryRow(item.url, item.title, atime.toLocaleTimeString());
+                session.appendChild(row);
+                global.lastItem = item;
+            }
+        }
+    });
+}
+

--- a/qutebrowser/javascript/history.js
+++ b/qutebrowser/javascript/history.js
@@ -20,14 +20,14 @@
 "use strict";
 
 window.loadHistory = (function() {
-    // The time of last history item.
-    var lastTime = null;
+    // Date of last seen item.
+    var lastItemDate = null;
 
     // The time to load next.
     var nextTime = null;
 
-    // The cutoff interval for session-separator (30 minutes)
-    var SESSION_CUTOFF = 30 * 60;
+    // The cutoff interval for session-separator (30 minutes in milliseconds).
+    var SESSION_CUTOFF = 30 * 60 * 1000;
 
     // The URL to fetch data from.
     var DATA_URL = "qute://history/data";
@@ -77,9 +77,8 @@ window.loadHistory = (function() {
         }
 
         // Create session-separator and new tbody if necessary
-        if (tbody.lastChild !== null && lastTime !== null) {
-            var lastItemDate = new Date(lastTime * 1000);
-            var interval = (lastItemDate.getTime() - date.getTime()) / 1000.00;
+        if (tbody.lastChild !== null && lastItemDate !== null) {
+            var interval = lastItemDate.getTime() - date.getTime();
             if (interval > SESSION_CUTOFF) {
                 // Add session-separator
                 var sessionSeparator = document.createElement("td");
@@ -158,12 +157,11 @@ window.loadHistory = (function() {
 
         for (var i = 0, len = history.length - 1; i < len; i++) {
             var item = history[i];
-            var atime = new Date(item.time * 1000);
-            var session = getSessionNode(atime);
-            var row = makeHistoryRow(item.url, item.title,
-                atime.toLocaleTimeString());
-            session.appendChild(row);
-            lastTime = item.time;
+            var currentItemDate = new Date(item.time);
+            getSessionNode(currentItemDate).appendChild(makeHistoryRow(
+                item.url, item.title, currentItemDate.toLocaleTimeString()
+            ));
+            lastItemDate = currentItemDate;
         }
 
         var next = history[history.length - 1].next;

--- a/qutebrowser/javascript/history.js
+++ b/qutebrowser/javascript/history.js
@@ -26,9 +26,6 @@ window.loadHistory = (function() {
     // The time to load next.
     var nextTime = null;
 
-    // The cutoff interval for session-separator (30 minutes in milliseconds).
-    var SESSION_CUTOFF = 30 * 60 * 1000;
-
     // The URL to fetch data from.
     var DATA_URL = "qute://history/data";
 
@@ -77,9 +74,10 @@ window.loadHistory = (function() {
         }
 
         // Create session-separator and new tbody if necessary
-        if (tbody.lastChild !== null && lastItemDate !== null) {
+        if (tbody.lastChild !== null && lastItemDate !== null &&
+                window.SESSION_INTERVAL > 0) {
             var interval = lastItemDate.getTime() - date.getTime();
-            if (interval > SESSION_CUTOFF) {
+            if (interval > window.SESSION_INTERVAL) {
                 // Add session-separator
                 var sessionSeparator = document.createElement("td");
                 sessionSeparator.className = "session-separator";

--- a/qutebrowser/javascript/history.js
+++ b/qutebrowser/javascript/history.js
@@ -152,7 +152,7 @@ window.loadHistory = (function() {
      * @returns {void}
      */
     function receiveHistory(status, history) {
-        if (history === undefined) {
+        if (history === null) {
             return;
         }
 

--- a/qutebrowser/javascript/history.js
+++ b/qutebrowser/javascript/history.js
@@ -46,8 +46,8 @@ window.loadHistory = (function() {
      */
     function getSessionNode(date) {
         // Find/create table
-        var tableId = "hist-".concat(date.getDate(), date.getMonth(),
-            date.getYear());
+        var tableId = ["hist", date.getDate(), date.getMonth(),
+            date.getYear()].join("-");
         var table = document.getElementById(tableId);
         if (table === null) {
             table = document.createElement("table");

--- a/qutebrowser/javascript/history.js
+++ b/qutebrowser/javascript/history.js
@@ -1,138 +1,194 @@
 /**
- * Container for global stuff
- */
-var global = {
-    // The last history item that was seen.
-    lastItem: null,
-    // The next time to load
-    nextTime: null,
-    // The cutoff interval for session-separator (30 minutes)
-    SESSION_CUTOFF: 30*60
-};
-
-/**
- * Finds or creates the session table>tbody to which item with given date
- * should be added.
+ * Copyright 2017 Imran Sobir
  *
- * @param {Date} date - the date of the item being added.
+ * This file is part of qutebrowser.
+ *
+ * qutebrowser is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * qutebrowser is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
  */
-var getSessionNode = function(date) {
-    var histContainer = document.getElementById('hist-container');
 
-    // Find/create table
-    var tableId = "hist-" + date.getDate() + date.getMonth() + date.getYear();
-    var table = document.getElementById(tableId);
-    if (table === null) {
-        table = document.createElement("table");
-        table.id = tableId;
+"use strict";
 
-        caption = document.createElement("caption");
-        caption.className = "date";
-        var options = {weekday: 'long', year: 'numeric', month: 'long', day: 'numeric'};
-        caption.innerHTML = date.toLocaleDateString('en-US', options);
-        table.appendChild(caption);
+window.loadHistory = (function() {
+    // The time of last history item.
+    var lastTime = null;
 
-        // Add table to page
-        histContainer.appendChild(table);
-    }
+    // The time to load next.
+    var nextTime = null;
 
-    // Find/create tbody
-    var tbody = table.lastChild;
-    if (tbody.tagName !== "TBODY") { // this is the caption
-        tbody = document.createElement("tbody");
-        table.appendChild(tbody);
-    }
+    // The cutoff interval for session-separator (30 minutes)
+    var SESSION_CUTOFF = 30 * 60;
 
-    // Create session-separator and new tbody if necessary
-    if (tbody.lastChild !== null && global.lastItem !== null) {
-        lastItemDate = new Date(parseInt(global.lastItem.time)*1000);
-        var interval = (lastItemDate.getTime() - date.getTime())/1000.00;
-        if (interval > global.SESSION_CUTOFF) {
-            // Add session-separator
-            var sessionSeparator = document.createElement('td');
-            sessionSeparator.className = "session-separator";
-            sessionSeparator.colSpan = 2;
-            sessionSeparator.innerHTML = "&#167;";
-            table.appendChild(document.createElement('tr'));
-            table.lastChild.appendChild(sessionSeparator);
+    // The URL to fetch data from.
+    var DATA_URL = "qute://history/data";
 
-            // Create new tbody
+    // Various fixed elements
+    var EOF_MESSAGE = document.getElementById("eof");
+    var LOAD_LINK = document.getElementById("load");
+    var HIST_CONTAINER = document.getElementById("hist-container");
+
+    /**
+     * Finds or creates the session table>tbody to which item with given date
+     * should be added.
+     *
+     * @param {Date} date - the date of the item being added.
+     * @returns {Element} the element to which new rows should be added.
+     */
+    function getSessionNode(date) {
+        // Find/create table
+        var tableId = "hist-".concat(date.getDate(), date.getMonth(),
+            date.getYear());
+        var table = document.getElementById(tableId);
+        if (table === null) {
+            table = document.createElement("table");
+            table.id = tableId;
+
+            // Caption contains human-readable date
+            var caption = document.createElement("caption");
+            caption.className = "date";
+            var options = {
+                "weekday": "long",
+                "year": "numeric",
+                "month": "long",
+                "day": "numeric",
+            };
+            caption.innerHTML = date.toLocaleDateString("en-US", options);
+            table.appendChild(caption);
+
+            // Add table to page
+            HIST_CONTAINER.appendChild(table);
+        }
+
+        // Find/create tbody
+        var tbody = table.lastChild;
+        if (tbody.tagName !== "TBODY") {
             tbody = document.createElement("tbody");
             table.appendChild(tbody);
         }
-    }
 
-    return tbody;
-}
+        // Create session-separator and new tbody if necessary
+        if (tbody.lastChild !== null && lastTime !== null) {
+            var lastItemDate = new Date(lastTime * 1000);
+            var interval = (lastItemDate.getTime() - date.getTime()) / 1000.00;
+            if (interval > SESSION_CUTOFF) {
+                // Add session-separator
+                var sessionSeparator = document.createElement("td");
+                sessionSeparator.className = "session-separator";
+                sessionSeparator.colSpan = 2;
+                sessionSeparator.innerHTML = "&#167;";
+                table.appendChild(document.createElement("tr"));
+                table.lastChild.appendChild(sessionSeparator);
 
-/**
- * Given a history item, create and return <tr> for it.
- * param {string} itemUrl - The url for this item
- * param {string} itemTitle - The title for this item
- * param {string} itemTime - The formatted time for this item
- */
-var makeHistoryRow = function(itemUrl, itemTitle, itemTime) {
-    var row = document.createElement('tr');
-
-    var title = document.createElement('td');
-    title.className = "title";
-    var link = document.createElement('a');
-    link.href = itemUrl;
-    link.innerHTML = itemTitle;
-    title.appendChild(link);
-
-    var time = document.createElement('td');
-    time.className = "time";
-    time.innerHTML = itemTime;
-
-    row.appendChild(title);
-    row.appendChild(time);
-
-    return row;
-}
-
-var getJSON = function(url, callback) {
-    var xhr = new XMLHttpRequest();
-    xhr.open('GET', url, true);
-    xhr.responseType = 'json';
-    xhr.onload = function() {
-        var status = xhr.status;
-        callback(status, xhr.response);
-    };
-    xhr.send();
-};
-
-/**
- * Load new history.
- */
-var loadHistory = function() {
-    url = "qute://history/data";
-    if (global.nextTime !== null) {
-        startTime = global.nextTime;
-        url = "qute://history/data?start_time=" + startTime.toString();
-    }
-
-    getJSON(url, function(status, history) {
-        if (history !== undefined) {
-            for (item of history) {
-                if (item.next === -1) {
-                    // Reached end of history
-                    window.onscroll = null;
-                    document.getElementById('eof').style.display = "block";
-                    document.getElementById('load').style.display = "none";
-                    continue;
-                } else if (item.next !== undefined) {
-                    global.nextTime = parseInt(item.next);
-                    continue;
-                }
-
-                atime = new Date(parseInt(item.time)*1000);
-                var session = getSessionNode(atime);
-                var row = makeHistoryRow(item.url, item.title, atime.toLocaleTimeString());
-                session.appendChild(row);
-                global.lastItem = item;
+                // Create new tbody
+                tbody = document.createElement("tbody");
+                table.appendChild(tbody);
             }
         }
-    });
-}
 
+        return tbody;
+    }
+
+    /**
+     * Given a history item, create and return <tr> for it.
+     *
+     * @param {string} itemUrl - The url for this item.
+     * @param {string} itemTitle - The title for this item.
+     * @param {string} itemTime - The formatted time for this item.
+     * @returns {Element} the completed tr.
+     */
+    function makeHistoryRow(itemUrl, itemTitle, itemTime) {
+        var row = document.createElement("tr");
+
+        var title = document.createElement("td");
+        title.className = "title";
+        var link = document.createElement("a");
+        link.href = itemUrl;
+        link.innerHTML = itemTitle;
+        title.appendChild(link);
+
+        var time = document.createElement("td");
+        time.className = "time";
+        time.innerHTML = itemTime;
+
+        row.appendChild(title);
+        row.appendChild(time);
+
+        return row;
+    }
+
+    /**
+     * Get JSON from given URL.
+     *
+     * @param {string} url - the url to fetch data from.
+     * @param {function} callback - the function to callback with data.
+     * @returns {void}
+     */
+    function getJSON(url, callback) {
+        var xhr = new XMLHttpRequest();
+        xhr.open("GET", url, true);
+        xhr.responseType = "json";
+        xhr.onload = function() {
+            var status = xhr.status;
+            callback(status, xhr.response);
+        };
+        xhr.send();
+    }
+
+    /**
+     * Receive history data from qute://history/data.
+     *
+     * @param {Number} status - The status of the query.
+     * @param {Array} history - History data.
+     * @returns {void}
+     */
+    function receiveHistory(status, history) {
+        if (history === undefined) {
+            return;
+        }
+
+        for (var i = 0, len = history.length - 1; i < len; i++) {
+            var item = history[i];
+            var atime = new Date(item.time * 1000);
+            var session = getSessionNode(atime);
+            var row = makeHistoryRow(item.url, item.title,
+                atime.toLocaleTimeString());
+            session.appendChild(row);
+            lastTime = item.time;
+        }
+
+        var next = history[history.length - 1].next;
+        if (next === -1) {
+            // Reached end of history
+            window.onscroll = null;
+            EOF_MESSAGE.style.display = "block";
+            LOAD_LINK.style.display = "none";
+        } else {
+            nextTime = next;
+        }
+    }
+
+    /**
+     * Load new history.
+     * @return {void}
+     */
+    function loadHistory() {
+        if (nextTime === null) {
+            getJSON(DATA_URL, receiveHistory);
+        } else {
+            var url = DATA_URL.concat("?start_time=", nextTime.toString());
+            getJSON(url, receiveHistory);
+        }
+    }
+
+    return loadHistory;
+})();

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -77,7 +77,7 @@ Feature: Page history
     Scenario: Listing history
         When I open data/numbers/3.txt
         And I open data/numbers/4.txt
-        And I open qute:history
+        And I open qute://history/data
         Then the page should contain the plaintext "3.txt"
         Then the page should contain the plaintext "4.txt"
 

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -110,10 +110,10 @@ class TestHistoryHandler:
         fake_web_history.save()
 
     @pytest.mark.parametrize("start_time_offset, expected_item_count", [
-        (0, 5),
-        (24*60*60, 5),
-        (48*60*60, 5),
-        (72*60*60, 1)
+        (0, 4),
+        (24*60*60, 4),
+        (48*60*60, 4),
+        (72*60*60, 0)
     ])
     def test_qutehistory_data(self, start_time_offset, expected_item_count):
         """Ensure qute://history/data returns correct items."""
@@ -121,12 +121,13 @@ class TestHistoryHandler:
         url = QUrl("qute://history/data?start_time=" + str(start_time))
         _mimetype, data = qutescheme.qute_history(url)
         items = json.loads(data)
+        items = [item for item in items if 'time' in item]  # skip 'next' item
 
         assert len(items) == expected_item_count
 
         # test times
         end_time = start_time - 24*60*60
-        for item in items[:expected_item_count-1]:
+        for item in items:
             assert item['time'] <= start_time
             assert item['time'] > end_time
 
@@ -142,6 +143,7 @@ class TestHistoryHandler:
         url = QUrl("qute://history/data?start_time=" + str(start_time))
         _mimetype, data = qutescheme.qute_history(url)
         items = json.loads(data)
+        items = [item for item in items if 'next' in item]  # 'next' items
 
         if next_time == -1:
             assert items[-1]["next"] == -1

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -92,4 +92,4 @@ class TestHistoryHandler:
             fake_web_history._add_entry(entry)
 
         url = QUrl("qute://history/data?start_time={}".format(self.now))
-        _mimetype, data = benchmark(qutescheme.qute_history, url)
+        _mimetype, _data = benchmark(qutescheme.qute_history, url)

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -47,7 +47,7 @@ class TestJavascriptHandler:
             for filename, content in self.js_files:
                 if path == os.path.join('javascript', filename):
                     return content
-            raise IOError("File not found {}!".format(path))
+            raise OSError("File not found {}!".format(path))
 
         monkeypatch.setattr('qutebrowser.utils.utils.read_file', _read_file)
 
@@ -61,7 +61,7 @@ class TestJavascriptHandler:
     def test_qutejavascript_error(self):
         url = QUrl("qute://javascript/404.js")
 
-        with pytest.raises(IOError):
+        with pytest.raises(OSError):
             qutescheme.qute_javascript(url)
 
     def test_qutejavascript_empty_query(self):

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -42,7 +42,7 @@ class TestJavascriptHandler:
     def patch_read_file(self, monkeypatch):
         """Patch utils.read_file to return few fake JS files."""
         def _read_file(path, binary=False):
-            """Faked utils.read_file"""
+            """Faked utils.read_file."""
             assert not binary
             for filename, content in self.js_files:
                 if path == os.path.join('javascript', filename):
@@ -75,13 +75,15 @@ class TestHistoryHandler:
 
     """Test the qute://history endpoint."""
 
+    # Current time
+    now = time.time()
+
     @pytest.fixture
     def entries(self):
         """Create fake history entries."""
         # create 12 history items spaced 6 hours apart, starting from now
         entry_count = 12
         interval = 6 * 60 * 60
-        self.now = time.time()
 
         items = []
         for i in range(entry_count):

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -130,8 +130,8 @@ class TestHistoryHandler:
         # test times
         end_time = start_time - 24*60*60
         for item in items:
-            assert item['time'] <= start_time
-            assert item['time'] > end_time
+            assert item['time'] <= start_time * 1000
+            assert item['time'] > end_time * 1000
 
     @pytest.mark.parametrize("start_time_offset, next_time", [
         (0, 24*60*60),

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -58,11 +58,11 @@ class TestJavascriptHandler:
 
         assert data == content
 
-    def test_qutejavascript_error(self):
+    def test_qutejavascript_404(self):
         url = QUrl("qute://javascript/404.js")
 
-        with pytest.raises(OSError):
-            qutescheme.qute_javascript(url)
+        with pytest.raises(qutescheme.QuteSchemeOSError):
+            qutescheme.data_for_url(url)
 
     def test_qutejavascript_empty_query(self):
         url = QUrl("qute://javascript")


### PR DESCRIPTION
Improvements to qute:history as outlined in #2333.

The history page now shows history from the past 24 hours. More items are
automatically loaded and appended when scrolled to the bottom. Items are also
separated if there's a 30 minute gap between them.
