### PR TITLE
return fast from DownloadItem.open_file

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -529,7 +529,11 @@ class AbstractDownloadItem(QObject):
         if filename is None:  # pragma: no cover
             log.downloads.error("No filename to open the download!")
             return
-        utils.open_file(filename, cmdline)
+        # By using a singleshot timer, we ensure that we return fast. This
+        # is important on systems where process creation takes long, as
+        # otherwise the prompt might hang around and cause bugs
+        # (see issue #2296)
+        QTimer.singleShot(0, lambda: utils.open_file(filename, cmdline))
 
     def _ensure_can_set_filename(self, filename):
         """Make sure we can still set a filename."""


### PR DESCRIPTION
Fixes #2296

By using a singleshot timer, we return fast from `DownloadItem.open_file`, which in turn closes the prompt fast, which in turn doesn't allow a second Ctrl-x to be registered, which in turn doesn't want to set the filename twice.

With this patch, I can't recreate the bug anymore, though it'd be interesting to know if it works for other people too. @troubas, could you try if you can reproduce it with this patch applied?