### PR TITLE
Document chrome:// URLs (fixes #2292)

### DIFF
--- a/CONTRIBUTING.asciidoc
+++ b/CONTRIBUTING.asciidoc
@@ -546,6 +546,25 @@ Rebuilding the website
 
 If you want to rebuild the website, run `./scripts/asciidoc2html.py --website <outputdir>`.
 
+Chrome URLs
+~~~~~~~~~~~
+
+Qutebrowser supports several chrome urls.  A short list of them can be found here:
+
+chrome://appcache-internals/
+chrome://blob-internals/
+chrome://gpu/
+chrome://histograms/
+chrome://indexeddb-internals/
+chrome://media-internals/
+chrome://network-errors/
+chrome://serviceworker-internals/
+chrome://webrtc-internals/
+chrome://crash/
+chrome://kill/
+chrome://gpucrash/ 
+chrome://gpuhang/
+
 
 Style conventions
 -----------------


### PR DESCRIPTION
Added a list of chrome urls that work.  A couple of with (?) next to
them did nothing and didn't hang or kill the browser, so I removed them.
They only work in OSX, not windows (opened separate issue for this).