### PR TITLE
Make keyhint delay configurable.

### DIFF
--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -406,6 +406,10 @@ def data(readonly=False):
              "Globs are supported, so ';*' will blacklist all keychains"
              "starting with ';'. Use '*' to disable keyhints"),
 
+            ('keyhint-delay',
+             SettingValue(typ.Int(minval=0), '500'),
+             "Time from pressing a key to seeing the keyhint dialog (ms)"),
+
             ('prompt-radius',
              SettingValue(typ.Int(minval=0), '8'),
              "The rounding radius for the edges of prompts."),

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -67,7 +67,6 @@ class KeyHintView(QLabel):
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Minimum)
         self.hide()
         self._show_timer = usertypes.Timer(self, 'keyhint_show')
-        self._show_timer.setInterval(500)
         self._show_timer.timeout.connect(self.show)
         style.set_register_stylesheet(self)
 
@@ -108,6 +107,7 @@ class KeyHintView(QLabel):
             return
 
         # delay so a quickly typed keychain doesn't display hints
+        self._show_timer.setInterval(config.get('ui', 'keyhint-delay'))
         self._show_timer.start()
         suffix_color = html.escape(config.get('colors', 'keyhint.fg.suffix'))
 


### PR DESCRIPTION
ui.keyhint-delay controls the time from starting a keychain to showing the
keyhint dialog. Resolves #2462.

Kinda a relief to do something this easy between the completion work :grin: