### PR TITLE
treat E: and E:\ the same when downloading

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1334,6 +1334,9 @@ class CommandDispatcher:
                                       scope='window', window=self._win_id)
         target = None
         if dest is not None:
+            dest = downloads.transform_path(dest)
+            if dest is None:
+                raise cmdexc.CommandError("Invalid target filename")
             target = downloads.FileDownloadTarget(dest)
 
         tab = self._current_widget()

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -583,6 +583,8 @@ class AbstractDownloadItem(QObject):
         """
         global last_used_directory
         filename = os.path.expanduser(filename)
+        if sys.platform == "win32":
+            filename = utils.expand_windows_drive(filename)
         self._ensure_can_set_filename(filename)
 
         self._filename = create_full_filename(self.basename, filename)

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -583,8 +583,6 @@ class AbstractDownloadItem(QObject):
         """
         global last_used_directory
         filename = os.path.expanduser(filename)
-        if sys.platform == "win32":
-            filename = utils.expand_windows_drive(filename)
         self._ensure_can_set_filename(filename)
 
         self._filename = create_full_filename(self.basename, filename)

--- a/qutebrowser/browser/webkit/mhtml.py
+++ b/qutebrowser/browser/webkit/mhtml.py
@@ -554,8 +554,6 @@ def start_download_checked(target, tab):
     dest = utils.force_encoding(target.filename, encoding)
 
     dest = os.path.expanduser(dest)
-    if sys.platform == "win32":
-        dest = utils.expand_windows_drive(dest)
 
     # See if we already have an absolute path
     path = downloads.create_full_filename(default_name, dest)

--- a/qutebrowser/browser/webkit/mhtml.py
+++ b/qutebrowser/browser/webkit/mhtml.py
@@ -554,6 +554,8 @@ def start_download_checked(target, tab):
     dest = utils.force_encoding(target.filename, encoding)
 
     dest = os.path.expanduser(dest)
+    if sys.platform == "win32":
+        dest = utils.expand_windows_drive(dest)
 
     # See if we already have an absolute path
     path = downloads.create_full_filename(default_name, dest)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -184,8 +184,6 @@ class MainWindow(QWidget):
 
         self._keyhint = keyhintwidget.KeyHintView(self.win_id, self)
         self._add_overlay(self._keyhint, self._keyhint.update_geometry)
-        self._messageview = messageview.MessageView(parent=self)
-        self._add_overlay(self._messageview, self._messageview.update_geometry)
 
         self._prompt_container = prompt.PromptContainer(self.win_id, self)
         self._add_overlay(self._prompt_container,
@@ -194,6 +192,9 @@ class MainWindow(QWidget):
         objreg.register('prompt-container', self._prompt_container,
                         scope='window', window=self.win_id)
         self._prompt_container.hide()
+
+        self._messageview = messageview.MessageView(parent=self)
+        self._add_overlay(self._messageview, self._messageview.update_geometry)
 
         if geometry is not None:
             self._load_geometry(geometry)

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -23,6 +23,7 @@ import re
 import sys
 import os.path
 import html
+import pathlib
 import collections
 
 import sip
@@ -656,6 +657,10 @@ class FilenamePrompt(_BasePrompt):
         # Drive dependent working directories are not supported, e.g.
         # E:filename is invalid
         if re.match(r'[A-Z]:[^\\]', path, re.IGNORECASE):
+            return None
+        # Paths like COM1, ...
+        # See https://github.com/qutebrowser/qutebrowser/issues/82
+        if pathlib.Path(path).is_reserved():
             return None
         return path
 

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -19,11 +19,9 @@
 
 """Showing prompts above the statusbar."""
 
-import re
 import sys
 import os.path
 import html
-import pathlib
 import collections
 
 import sip
@@ -646,31 +644,13 @@ class FilenamePrompt(_BasePrompt):
         self._file_model.directoryLoaded.connect(
             lambda: self._file_model.sort(0))
 
-    def _transform_path(self, path):
-        r"""Do platform-specific transformations, like changing E: to E:\.
-
-        Returns None if the path is invalid on the current platform.
-        """
-        if sys.platform != "win32":
-            return path
-        path = utils.expand_windows_drive(path)
-        # Drive dependent working directories are not supported, e.g.
-        # E:filename is invalid
-        if re.match(r'[A-Z]:[^\\]', path, re.IGNORECASE):
-            return None
-        # Paths like COM1, ...
-        # See https://github.com/qutebrowser/qutebrowser/issues/82
-        if pathlib.Path(path).is_reserved():
-            return None
-        return path
-
     def _show_error(self, msg):
         log.prompt.error(msg)
         QToolTip.showText(self._lineedit.mapToGlobal(QPoint(0, 0)), msg)
 
     def accept(self, value=None):
         text = value if value is not None else self._lineedit.text()
-        text = self._transform_path(text)
+        text = downloads.transform_path(text)
         if text is None:
             self._show_error("Invalid filename")
             return False
@@ -725,7 +705,7 @@ class DownloadFilenamePrompt(FilenamePrompt):
 
     def accept(self, value=None):
         text = value if value is not None else self._lineedit.text()
-        text = self._transform_path(text)
+        text = downloads.transform_path(text)
         if text is None:
             self._show_error("Invalid filename")
             return False

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -19,7 +19,6 @@
 
 """Showing prompts above the statusbar."""
 
-import sys
 import os.path
 import html
 import collections

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -665,6 +665,7 @@ class FilenamePrompt(_BasePrompt):
         return path
 
     def _show_error(self, msg):
+        log.prompt.error(msg)
         QToolTip.showText(self._lineedit.mapToGlobal(QPoint(0, 0)), msg)
 
     def accept(self, value=None):

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -25,10 +25,9 @@ import collections
 
 import sip
 from PyQt5.QtCore import (pyqtSlot, pyqtSignal, Qt, QTimer, QDir, QModelIndex,
-                          QItemSelectionModel, QObject, QEventLoop, QPoint)
+                          QItemSelectionModel, QObject, QEventLoop)
 from PyQt5.QtWidgets import (QWidget, QGridLayout, QVBoxLayout, QLineEdit,
-                             QLabel, QFileSystemModel, QTreeView, QSizePolicy,
-                             QToolTip)
+                             QLabel, QFileSystemModel, QTreeView, QSizePolicy)
 
 from qutebrowser.browser import downloads
 from qutebrowser.config import style, config

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -643,15 +643,11 @@ class FilenamePrompt(_BasePrompt):
         self._file_model.directoryLoaded.connect(
             lambda: self._file_model.sort(0))
 
-    def _show_error(self, msg):
-        log.prompt.error(msg)
-        QToolTip.showText(self._lineedit.mapToGlobal(QPoint(0, 0)), msg)
-
     def accept(self, value=None):
         text = value if value is not None else self._lineedit.text()
         text = downloads.transform_path(text)
         if text is None:
-            self._show_error("Invalid filename")
+            message.error("Invalid filename")
             return False
         self.question.answer = text
         return True
@@ -703,13 +699,11 @@ class DownloadFilenamePrompt(FilenamePrompt):
         self._file_model.setFilter(QDir.AllDirs | QDir.Drives | QDir.NoDot)
 
     def accept(self, value=None):
-        text = value if value is not None else self._lineedit.text()
-        text = downloads.transform_path(text)
-        if text is None:
-            self._show_error("Invalid filename")
-            return False
-        self.question.answer = downloads.FileDownloadTarget(text)
-        return True
+        done = super().accept(value)
+        answer = self.question.answer
+        if answer is not None:
+            self.question.answer = downloads.FileDownloadTarget(answer)
+        return done
 
     def download_open(self, cmdline):
         self.question.answer = downloads.OpenFileDownloadTarget(cmdline)

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -20,6 +20,7 @@
 """Other utilities which don't fit anywhere else."""
 
 import io
+import re
 import sys
 import enum
 import json
@@ -845,3 +846,21 @@ def open_file(filename, cmdline=None):
 def unused(_arg):
     """Function which does nothing to avoid pylint complaining."""
     pass
+
+
+def expand_windows_drive(path):
+    r"""Expand a drive-path like E: into E:\.
+
+    Does nothing for other paths.
+
+    Args:
+        path: The path to expand.
+    """
+    # Usually, "E:" on Windows refers to the current working directory on drive
+    # E:\. The correct way to specifify drive E: is "E:\", but most users
+    # probably don't use the "multiple working directories" feature and expect
+    # "E:" and "E:\" to be equal.
+    if re.match(r'[A-Z]:$', path, re.IGNORECASE):
+        return path + "\\"
+    else:
+        return path

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -128,16 +128,20 @@ Feature: Downloading things from a website.
 
     @windows
     Scenario: Downloading a file to a reserved path
-        When I open data/downloads/download.bin
+        When I set storage -> prompt-download-directory to true
+        And I open data/downloads/download.bin
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='*' mode=<PromptMode.download: 5> text='Please enter a location for <b>http://localhost:*/data/downloads/download.bin</b>' title='Save file to:'>, *" in the log
         And I run :prompt-accept COM1
-        And I run :prompt-cancel
+        And I run :leave-mode
         Then "Invalid filename" should be logged
 
     @windows
     Scenario: Downloading a file to a drive-relative working directory
-        When I open data/downloads/download.bin
+        When I set storage -> prompt-download-directory to true
+        And I open data/downloads/download.bin
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='*' mode=<PromptMode.download: 5> text='Please enter a location for <b>http://localhost:*/data/downloads/download.bin</b>' title='Save file to:'>, *" in the log
         And I run :prompt-accept C:foobar
-        And I run :prompt-cancel
+        And I run :leave-mode
         Then "Invalid filename" should be logged
 
     @windows

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -133,7 +133,7 @@ Feature: Downloading things from a website.
         And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='*' mode=<PromptMode.download: 5> text='Please enter a location for <b>http://localhost:*/data/downloads/download.bin</b>' title='Save file to:'>, *" in the log
         And I run :prompt-accept COM1
         And I run :leave-mode
-        Then "Invalid filename" should be logged
+        Then the error "Invalid filename" should be shown
 
     @windows
     Scenario: Downloading a file to a drive-relative working directory
@@ -142,7 +142,7 @@ Feature: Downloading things from a website.
         And I wait for "Asking question <qutebrowser.utils.usertypes.Question default='*' mode=<PromptMode.download: 5> text='Please enter a location for <b>http://localhost:*/data/downloads/download.bin</b>' title='Save file to:'>, *" in the log
         And I run :prompt-accept C:foobar
         And I run :leave-mode
-        Then "Invalid filename" should be logged
+        Then the error "Invalid filename" should be shown
 
     @windows
     Scenario: Downloading a file to a reserved path with :download

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -140,6 +140,16 @@ Feature: Downloading things from a website.
         And I run :prompt-cancel
         Then "Invalid filename" should be logged
 
+    @windows
+    Scenario: Downloading a file to a reserved path with :download
+        When I run :download data/downloads/download.bin --dest=COM1
+        Then the error "Invalid target filename" should be shown
+
+    @windows
+    Scenario: Download a file to a drive-relative working directory with :download
+        When I run :download data/downloads/download.bin --dest=C:foobar
+        Then the error "Invalid target filename" should be shown
+
     ## :download-retry
 
     Scenario: Retrying a failed download

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -126,6 +126,20 @@ Feature: Downloading things from a website.
         Then the downloaded file ../foo should not exist
         And the downloaded file foo should exist
 
+    @windows
+    Scenario: Downloading a file to a reserved path
+        When I open data/downloads/download.bin
+        And I run :prompt-accept COM1
+        And I run :prompt-cancel
+        Then "Invalid filename" should be logged
+
+    @windows
+    Scenario: Downloading a file to a drive-relative working directory
+        When I open data/downloads/download.bin
+        And I run :prompt-accept C:foobar
+        And I run :prompt-cancel
+        Then "Invalid filename" should be logged
+
     ## :download-retry
 
     Scenario: Retrying a failed download

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -916,3 +916,16 @@ class TestOpenFile:
 
 def test_unused():
     utils.unused(None)
+
+
+@pytest.mark.parametrize('path, expected', [
+    ('E:', 'E:\\'),
+    ('e:', 'e:\\'),
+    ('E:foo', 'E:foo'),
+    ('E:\\', 'E:\\'),
+    ('E:\\foo', 'E:\\foo'),
+    ('foo:', 'foo:'),
+    ('foo:bar', 'foo:bar'),
+])
+def test_expand_windows_drive(path, expected):
+    assert utils.expand_windows_drive(path) == expected


### PR DESCRIPTION
Fixes #2305 

I'd like to add an integration test, but that would require downloading to a drive root, which would leave temporary test data on the drive and could lead to permission errors...