### PR TITLE
Relax commandline parsing a bit

### DIFF
--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -133,7 +133,8 @@ class CommandRunner(QObject):
         Yields:
             ParseResult tuples.
         """
-        if not text.strip():
+        text = text.strip().lstrip(':').strip()
+        if not text:
             raise cmdexc.NoSuchCommandError("No command given")
 
         if aliases:

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -538,6 +538,16 @@ Feature: Various utility commands.
         When I run :message-i "Hello World" (invalid command)
         Then the error "message-i: no such command" should be shown
 
+     Scenario: Multiple leading : in command
+        When I run :::::set-cmd-text ::::message-i "Hello World"
+        And I run :command-accept
+        Then the message "Hello World" should be shown
+
+    Scenario: Whitespace in command
+        When I run :   :  set-cmd-text :  :  message-i "Hello World"
+        And I run :command-accept
+        Then the message "Hello World" should be shown
+
     # We can't run :message-i as startup command, so we use
     # :set-cmd-text
 
@@ -632,7 +642,7 @@ Feature: Various utility commands.
         And I run :command-history-prev
         And I run :command-accept
         Then the message "blah" should be shown
- 
+
     Scenario: Browsing through commands 
         When I run :set-cmd-text :message-info blarg
         And I run :command-accept
@@ -644,7 +654,7 @@ Feature: Various utility commands.
         And I run :command-history-next
         And I run :command-accept
         Then the message "blarg" should be shown
- 
+
     Scenario: Calling previous command when history is empty
         Given I have a fresh instance
         When I run :set-cmd-text :


### PR DESCRIPTION
Problem 1: Entering a command of `:::save` gives an error.
Problem 2: Entering a command of `:save\n` gives an error.

Both scenarios may seem a bit silly at first, but I encountered both by
copy/pasting a command:

1. Enter `:` in qutebrowser.
2. Copy a full line from a terminal starting with `:`.
3. You will now have both of the above problems.

Solution: Trim all whitespace and `:` of a command. This is also what
Vim does, by the way.