### PR TITLE
Add a modeline to all the *.feature files

### DIFF
--- a/tests/end2end/features/adblock.feature
+++ b/tests/end2end/features/adblock.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Ad blocking
 
     Scenario: Simple adblock update

--- a/tests/end2end/features/backforward.feature
+++ b/tests/end2end/features/backforward.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Going back and forward.
     Testing the :back/:forward commands.
 

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Caret mode
     In caret mode, the user can select and yank text using the keyboard.
 

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Using completion
 
     Scenario: No warnings when completing with one entry (#1600)

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Downloading things from a website.
 
     Background:

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Opening external editors
 
     ## :edit-url

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Using hints
 
     # https://bugreports.qt.io/browse/QTBUG-58381

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Page history
 
     Make sure the global page history is saved correctly.

--- a/tests/end2end/features/invoke.feature
+++ b/tests/end2end/features/invoke.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Invoking a new process
     Simulate what happens when running qutebrowser with an existing instance
 

--- a/tests/end2end/features/javascript.feature
+++ b/tests/end2end/features/javascript.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Javascript stuff
 
     Integration with javascript.

--- a/tests/end2end/features/keyinput.feature
+++ b/tests/end2end/features/keyinput.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Keyboard input
 
     Tests for :bind and :unbind, :clear-keychain and other keyboard input

--- a/tests/end2end/features/marks.feature
+++ b/tests/end2end/features/marks.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Setting positional marks
 
     Background:

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Various utility commands.
 
     ## :set-cmd-text

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Using :navigate
 
     Scenario: :navigate with invalid argument

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Opening pages
 
     Scenario: :open with URL

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Prompts
     Various prompts (javascript, SSL errors, authentification, etc.)
 

--- a/tests/end2end/features/scroll.feature
+++ b/tests/end2end/features/scroll.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Scrolling
     Tests the various scroll commands.
 

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Searching on a page
     Searching text on the page (like /foo) with different options.
 

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Saving and loading sessions
 
   Background:

--- a/tests/end2end/features/set.feature
+++ b/tests/end2end/features/set.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Setting settings.
 
     Background:

--- a/tests/end2end/features/spawn.feature
+++ b/tests/end2end/features/spawn.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: :spawn
 
     Scenario: Running :spawn

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Tab management
     Tests for various :tab-* commands.
 

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: quickmarks and bookmarks
 
     ## bookmarks

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Miscellaneous utility commands exposed to the user.
 
     Background:

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Yanking and pasting.
     :yank, {clipboard} and {primary} can be used to copy/paste the URL or title
     from/to the clipboard and primary selection.

--- a/tests/end2end/features/zoom.feature
+++ b/tests/end2end/features/zoom.feature
@@ -1,3 +1,5 @@
+# vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
+
 Feature: Zooming in and out
 
     Background:


### PR DESCRIPTION
This really tripped me up yesterday, My "Vim default" is to use tabs.

This (where `!···` is a tab) does not work as you'll hope it works:

```
    Scenario: Retrying a failed download when the directory didn't exist (issue 2445)
        When I download http://localhost:(port)/data/downloads/download.bin to <path>
        And I wait for the error "Download error: No such file or directory: *"
        And I make the directory <mkdir>
        And I run :download-retry
!···!···And I wait until the download is finished
        Then the downloaded file <expected> should exist

        Examples:
        | path                 | mkdir   | expected             |
        | asd/zxc/             | asd/zxc | asd/zxc/download.bin |
```

Unfortunately, pytest-bdd uses the "Python 2 behaviour" of "expand all
tabs to 8 spaces", and doesn't give any errors on strange/inconsistent
whitespace. It can cause very confusing errors.
