### PR TITLE
Fix :download-retry for directories that didn't exist

### DIFF
--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -103,7 +103,7 @@ class DownloadItem(downloads.AbstractDownloadItem):
         try:
             fileobj = open(self._filename, 'wb')
         except OSError as e:
-            self._die(e.strerror)
+            self._die('{}: {}'.format(e.strerror, self._filename))
         else:
             self._set_fileobj(fileobj)
 
@@ -172,9 +172,9 @@ class DownloadItem(downloads.AbstractDownloadItem):
         assert not self.successful
         new_reply = self._retry_info.manager.get(self._retry_info.request)
         new_download = self._manager.fetch(new_reply,
+                                           target=self.target,
                                            suggested_filename=self.basename)
         self.adopt_download.emit(new_download)
-        self.cancel()
 
     def _get_open_filename(self):
         filename = self._filename

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -213,6 +213,19 @@ Feature: Downloading things from a website.
         And I run :download-retry
         Then the error "No failed downloads!" should be shown
 
+    Scenario: Retrying a failed download when the directory didn't exist (issue 2445)
+        When I download http://localhost:(port)/data/downloads/download.bin to <path>
+        And I wait for the error "Download error: No such file or directory: *"
+        And I make the directory <mkdir>
+        And I run :download-retry
+        And I wait until the download is finished
+        Then the downloaded file <expected> should exist
+
+        Examples:
+        | path                 | mkdir   | expected             |
+        | asd/zxc/             | asd/zxc | asd/zxc/download.bin |
+        | qwe/rty              | qwe     | qwe/rty              |
+
     ## Wrong invocations
 
     Scenario: :download with deprecated dest-old argument
@@ -230,7 +243,7 @@ Feature: Downloading things from a website.
 
     Scenario: :download with a directory which doesn't exist
         When I run :download --dest (tmpdir)/downloads/somedir/filename http://localhost:(port)/
-        Then the error "Download error: No such file or directory" should be shown
+        Then the error "Download error: No such file or directory: *" should be shown
 
     ## mhtml downloads
 
@@ -573,7 +586,7 @@ Feature: Downloading things from a website.
     Scenario: Downloading to unwritable destination
         When I set storage -> prompt-download-directory to false
         And I run :download http://localhost:(port)/data/downloads/download.bin --dest (tmpdir)/downloads/unwritable
-        Then the error "Download error: Permission denied" should be shown
+        Then the error "Download error: Permission denied: *" should be shown
 
     Scenario: Downloading 20MB file
         When I set storage -> prompt-download-directory to false

--- a/tests/end2end/features/test_downloads_bdd.py
+++ b/tests/end2end/features/test_downloads_bdd.py
@@ -18,8 +18,8 @@
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
-import sys
 import shlex
+import sys
 
 import pytest_bdd as bdd
 bdd.scenarios('downloads.feature')
@@ -86,7 +86,12 @@ def download_should_not_exist(filename, tmpdir):
 
 @bdd.then(bdd.parsers.parse("The downloaded file {filename} should exist"))
 def download_should_exist(filename, tmpdir):
-    path = tmpdir / 'downloads' / filename
+    path = tmpdir / 'downloads'
+    if '/' in filename:
+        for f in filename.split('/'):
+            path /= f
+    else:
+        path = tmpdir / 'downloads' / filename
     assert path.check()
 
 
@@ -149,3 +154,33 @@ def fifo_should_be_fifo(tmpdir):
     download_dir = tmpdir / 'downloads'
     assert download_dir.exists()
     assert not os.path.isfile(str(download_dir / 'fifo'))
+
+
+@bdd.when(bdd.parsers.parse("I download {url} to <path>"))
+def download_dest(quteproc, httpbin, tmpdir, url, path):
+    dest = '{}/downloads/{}'.format(tmpdir, path)
+    assert not os.path.exists(dest)
+
+    url = url.replace('(port)', str(httpbin.port))
+    quteproc.send_cmd(':download --dest {} {}'.format(dest, url))
+
+
+@bdd.when(bdd.parsers.parse("I make the directory <mkdir>"))
+def mkdir_test(tmpdir, mkdir):
+    dest = tmpdir / 'downloads'
+    for p in mkdir.split('/'):
+        dest /= p
+    assert not dest.exists()
+    dest.ensure(dir=True)
+    assert dest.exists()
+
+
+@bdd.then(bdd.parsers.parse("The downloaded file <expected> should exist"))
+def download_should_exist_table(tmpdir, expected):
+    path = tmpdir / 'downloads'
+    if '/' in expected:
+        for f in expected.split('/'):
+            path /= f
+    else:
+        path = tmpdir / 'downloads' / expected
+    assert path.check()


### PR DESCRIPTION
Also:

- Adds the filename when showing errors. Makes for clearer error
  messages.
- Fix downloading files that end with a trailing /.
- The `retry()` method added with `self.cancel()`, but that would remove
  the file after it was downloaded(?!). I don't see any reason that
  should be there, so I think this fixes another bug?

Fixes #2445