### PR TITLE
Allow pressing ^C when there's an unknown setting

### DIFF
--- a/qutebrowser/misc/crashsignal.py
+++ b/qutebrowser/misc/crashsignal.py
@@ -171,14 +171,14 @@ class CrashHandler(QObject):
         """
         try:
             pages = self._recover_pages(forgiving=True)
-        except Exception:
-            log.destroy.exception("Error while recovering pages")
+        except Exception as e:
+            log.destroy.exception("Error while recovering pages: {}".format(e))
             pages = []
 
         try:
             cmd_history = objreg.get('command-history')[-5:]
-        except Exception:
-            log.destroy.exception("Error while getting history: {}")
+        except Exception as e:
+            log.destroy.exception("Error while getting history: {}".format(e))
             cmd_history = []
 
         try:


### PR DESCRIPTION
All of it is just converting `objreg.get('xxx')` to `objreg.get('xxx',
None)` and adding a `if xxx is not None` check.

Fixes #1170