### PR TITLE
Fix crash of :debug-log-filter when --filter wasn't given

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -24,6 +24,8 @@ Added
 - New `ui -> keyhint-delay` setting to configure the delay until
   the keyhint overlay pops up.
 - New `-s` option for `:open` to force a HTTPS scheme.
+- `:debug-log-filter` now accepts `none` as an argument to clear any log
+  filters.
 
 Changed
 ~~~~~~~

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -52,6 +52,7 @@ Fixed
 - Crash when pressing ctrl-c while a config error is shown
 - Crash when the key config isn't writable
 - Crash when unbinding an unbound key in the key config
+- Crash when using `:debug-log-filter` when `--filter` wasn't given on startup.
 - Various rare crashes
 
 v0.10.1

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -293,16 +293,22 @@ def debug_log_filter(filters: str):
     """Change the log filter for console logging.
 
     Args:
-        filters: A comma separated list of logger names.
+        filters: A comma separated list of logger names. Can also be "none" to
+                 clear any existing filters.
     """
+    if log.console_filter is None:
+        raise cmdexc.CommandError("No log.console_filter. Not attached "
+                                  "to a console?")
+
+    if filters.strip().lower() == 'none':
+        log.console_filter.names = None
+        return
+
     if not set(filters.split(',')).issubset(log.LOGGER_NAMES):
         raise cmdexc.CommandError("filters: Invalid value {} - expected one "
                                   "of: {}".format(filters,
                                                   ', '.join(log.LOGGER_NAMES)))
 
-    if log.console_filter is None:
-        raise cmdexc.CommandError("No log.console_filter. Not attached "
-                                  "to a console?")
     log.console_filter.names = filters.split(',')
 
 

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -295,12 +295,15 @@ def debug_log_filter(filters: str):
     Args:
         filters: A comma separated list of logger names.
     """
-    if set(filters.split(',')).issubset(log.LOGGER_NAMES):
-        log.console_filter.names = filters.split(',')
-    else:
+    if not set(filters.split(',')).issubset(log.LOGGER_NAMES):
         raise cmdexc.CommandError("filters: Invalid value {} - expected one "
                                   "of: {}".format(filters,
                                                   ', '.join(log.LOGGER_NAMES)))
+
+    if log.console_filter is None:
+        raise cmdexc.CommandError("No log.console_filter. Not attached "
+                                  "to a console?")
+    log.console_filter.names = filters.split(',')
 
 
 @cmdutils.register()

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -182,9 +182,10 @@ def init_log(args):
     root = logging.getLogger()
     global console_filter
     if console is not None:
+        console_filter = LogFilter(None)
         if args.logfilter is not None:
-            console_filter = LogFilter(args.logfilter.split(','))
-            console.addFilter(console_filter)
+            console_filter.names = args.logfilter.split(',')
+        console.addFilter(console_filter)
         root.addHandler(console)
     if ram is not None:
         root.addHandler(ram)

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -166,5 +166,8 @@ Feature: Miscellaneous utility commands exposed to the user.
         Then the error "filters: Invalid value blah - expected one of: statusbar, *" should be shown
 
     Scenario: Using debug-log-filter
-        When I run :debug-log-filter webview
-        Then no crash should happen
+        When I run :debug-log-filter commands,ipc,webview
+        And I run :enter-mode insert
+        And I run :debug-log-filter none
+        And I run :leave-mode
+        Then "Entering mode KeyMode.insert *" should not be logged

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -164,3 +164,7 @@ Feature: Miscellaneous utility commands exposed to the user.
     Scenario: Using debug-log-filter with invalid filter
         When I run :debug-log-filter blah
         Then the error "filters: Invalid value blah - expected one of: statusbar, *" should be shown
+
+    Scenario: Using debug-log-filter
+        When I run :debug-log-filter webview
+        Then no crash should happen


### PR DESCRIPTION
There was no `LogFilter`. The fix is to always initialize a
`LogFilter()` with `None`. as the "filter".

Fixes #2303.