### PR TITLE
Don't error out on unicode errors when reading the edit file

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -40,7 +40,7 @@ Changed
 - The HTTP cache is disabled with QtWebKit on Qt 5.8 now as it leads to frequent
   crashes due to a Qt bug.
 - Don't remove temporary `/tmp/qutebrowser-editor-*` files when there was a
-  problem reading back this text. This allows users to recover test from those
+  problem reading back this text. This allows users to recover text from those
   files.
 
 Fixed

--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -39,6 +39,9 @@ Changed
   options instead of being before sections.
 - The HTTP cache is disabled with QtWebKit on Qt 5.8 now as it leads to frequent
   crashes due to a Qt bug.
+- Don't remove temporary `/tmp/qutebrowser-editor-*` files when there was a
+  problem reading back this text. This allows users to recover test from those
+  files.
 
 Fixed
 ~~~~~

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -68,29 +68,26 @@ class ExternalEditor(QObject):
         Callback for QProcess when the editor was closed.
         """
         log.procs.debug("Editor closed")
-        if exitstatus != QProcess.NormalExit:
-            # No error/cleanup here, since we already handle this in
-            # on_proc_error.
+        if exitstatus != QProcess.NormalExit or exitcode != 0:
+            message.error("Editor processed failed to exit cleanly."
+                          "The file is still available at {}".format(
+                              self._file.name))
             return
-        try:
-            if exitcode != 0:
-                return
-            encoding = config.get('general', 'editor-encoding')
-            try:
-                with open(self._file.name, 'r', encoding=encoding) as f:
-                    text = f.read()
-            except OSError as e:
-                # NOTE: Do not replace this with "raise CommandError" as it's
-                # executed async.
-                message.error("Failed to read back edited file: {}".format(e))
-                return
-            log.procs.debug("Read back: {}".format(text))
-            self.editing_finished.emit(text)
-        finally:
-            self._cleanup()
 
-    @pyqtSlot(QProcess.ProcessError)
-    def on_proc_error(self, _err):
+        encoding = config.get('general', 'editor-encoding')
+        try:
+            with open(self._file.name, 'r', encoding=encoding) as f:
+                text = f.read()
+        except (OSError, UnicodeError, UnicodeDecodeError) as e:
+            # NOTE: Do not replace this with "raise CommandError" as it's
+            # executed async.
+            message.error("Failed to read back edited file: {}\n"
+                          "The file is still available at {}".format(
+                              e, self._file.name))
+            return
+        log.procs.debug("Read back: {}".format(text))
+        self.editing_finished.emit(text)
+
         self._cleanup()
 
     def edit(self, text):
@@ -119,7 +116,6 @@ class ExternalEditor(QObject):
             return
         self._proc = guiprocess.GUIProcess(what='editor', parent=self)
         self._proc.finished.connect(self.on_proc_closed)
-        self._proc.error.connect(self.on_proc_error)
         editor = config.get('general', 'editor')
         executable = editor[0]
         args = [arg.replace('{}', self._file.name) for arg in editor[1:]]

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -54,12 +54,11 @@ class ExternalEditor(QObject):
             # Could not create initial file.
             return
         try:
-            if self._proc.exit_status() != QProcess.CrashExit:
-                os.remove(self._file.name)
+            os.remove(self._file.name)
         except OSError as e:
             # NOTE: Do not replace this with "raise CommandError" as it's
             # executed async.
-            message.error("Failed to delete tempfile... ({})".format(e))
+            message.error("Failed to delete tempfile: {}".format(e))
 
     @pyqtSlot(int, QProcess.ExitStatus)
     def on_proc_closed(self, exitcode, exitstatus):
@@ -67,18 +66,20 @@ class ExternalEditor(QObject):
 
         Callback for QProcess when the editor was closed.
         """
-        log.procs.debug("Editor closed")
+        log.procs.debug("Editor closed; exitcode: {}; exitstatus: {}".format(
+            exitcode, exitstatus))
         if exitstatus != QProcess.NormalExit or exitcode != 0:
-            message.error("Editor processed failed to exit cleanly."
-                          "The file is still available at {}".format(
-                              self._file.name))
+            # guiprocess already gives a "Editor exited with status X", so we
+            # don't need to repeat that here.
+            message.error("The file is still available at {}".format(
+                          self._file.name))
             return
 
         encoding = config.get('general', 'editor-encoding')
         try:
             with open(self._file.name, 'r', encoding=encoding) as f:
                 text = f.read()
-        except (OSError, UnicodeError, UnicodeDecodeError) as e:
+        except (OSError, UnicodeError) as e:
             # NOTE: Do not replace this with "raise CommandError" as it's
             # executed async.
             message.error("Failed to read back edited file: {}\n"


### PR DESCRIPTION
Also don't delete the temp file when there is an error reading the file.
IMHO it's a lot better to leave some files in `/tmp/` than delete that
long essay you've been writing for the last 30 minutes.

I renamed the `_cleanup()` method to `_cleanup_file()` to communicate
more clearly what it does; this should also prevent people from adding
more stuff here in the future.

Fixes #2302