### PR TITLE
Fix display of errors while reading the key config file

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -186,7 +186,8 @@ def _init_key_config(parent):
         key_config = keyconf.KeyConfigParser(standarddir.config(), 'keys.conf',
                                              args.relaxed_config,
                                              parent=parent)
-    except (keyconf.KeyConfigError, UnicodeDecodeError) as e:
+    except (keyconf.KeyConfigError, cmdexc.CommandError,
+            UnicodeDecodeError) as e:
         log.init.exception(e)
         errstr = "Error while reading key config:\n"
         if e.lineno is not None:

--- a/qutebrowser/config/parsers/keyconf.py
+++ b/qutebrowser/config/parsers/keyconf.py
@@ -322,7 +322,7 @@ class KeyConfigParser(QObject):
                         else:
                             line = line.strip()
                             self._read_command(line)
-                    except KeyConfigError as e:
+                    except (KeyConfigError, cmdexc.CommandError) as e:
                         if relaxed:
                             continue
                         else:


### PR DESCRIPTION
Also catch `cmdexc.CommandError` on startup to show these errors in the
alert dialog on startup.

Fixes #1340