### PR TITLE
Mention that qutebrowser@ also gets the mails from qutebrowser-announce@

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -71,7 +71,8 @@ https://lists.schokokeks.org/mailman/listinfo.cgi/qutebrowser[mailinglist] at
 mailto:qutebrowser@lists.qutebrowser.org[].
 
 There's also a https://lists.schokokeks.org/mailman/listinfo.cgi/qutebrowser-announce[announce-only mailinglist]
-at mailto:qutebrowser-announce@lists.qutebrowser.org[].
+at mailto:qutebrowser-announce@lists.qutebrowser.org[] (the announcements also
+get sent to the general qutebrowser@ list).
 
 Contributions / Bugs
 --------------------


### PR DESCRIPTION
Mini-PR, since I subscribed to both twice not realizing I would get double emails.