### PR TITLE
Add config options for setting category visibility for completing URLs

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -92,6 +92,9 @@
 |<<completion-shrink,shrink>>|Whether to shrink the completion to be smaller than the configured size if there are no scrollbars.
 |<<completion-scrollbar-width,scrollbar-width>>|Width of the scrollbar in the completion window (in px).
 |<<completion-scrollbar-padding,scrollbar-padding>>|Padding of scrollbar handle in completion window (in px).
+|<<completion-url-complete-bookmarks,url-complete-bookmarks>>|Whether to complete from bookmarks when completing URLs.
+|<<completion-url-complete-history,url-complete-history>>|Whether to complete from history when completing URLs.
+|<<completion-url-complete-quickmarks,url-complete-quickmarks>>|Whether to complete from quickmarks when completing URLs.
 |==============
 
 .Quick reference for section ``input''
@@ -956,6 +959,39 @@ Default: +pass:[12]+
 Padding of scrollbar handle in completion window (in px).
 
 Default: +pass:[2]+
+
+[[completion-url-complete-bookmarks]]
+=== url-complete-bookmarks
+Whether to complete from bookmarks when completing URLs.
+
+Valid values:
+
+ * +true+
+ * +false+
+
+Default: +pass:[true]+
+
+[[completion-url-complete-history]]
+=== url-complete-history
+Whether to complete from history when completing URLs.
+
+Valid values:
+
+ * +true+
+ * +false+
+
+Default: +pass:[true]+
+
+[[completion-url-complete-quickmarks]]
+=== url-complete-quickmarks
+Whether to complete from quickmarks when completing URLs.
+
+Valid values:
+
+ * +true+
+ * +false+
+
+Default: +pass:[true]+
 
 == input
 Options related to input modes.

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -51,6 +51,13 @@ class UrlCompletionModel(base.BaseCompletionModel):
         self._bookmark_cat = self.new_category("Bookmarks")
         self._history_cat = self.new_category("History")
 
+        self._quickmark_row = None
+        self._bookmark_row = None
+        self._history_row = None
+
+        self.update_categories()
+        objreg.get('config').changed.connect(self.update_categories)
+
         quickmark_manager = objreg.get('quickmark-manager')
         quickmarks = quickmark_manager.marks.items()
         for qm_name, qm_url in quickmarks:
@@ -115,6 +122,23 @@ class UrlCompletionModel(base.BaseCompletionModel):
             atime_item = self._history_cat.child(i, self.TIME_COLUMN)
             atime = url_item.data(base.Role.sort)
             atime_item.setText(self._fmt_atime(atime))
+
+    @config.change_filter('completion')
+    def update_categories(self):
+        """Update the visible categories by removing unnecessary ones."""
+        if self._quickmark_cat.row() != -1:
+            self._quickmark_row = self.takeRow(self._quickmark_cat.row())
+        if self._bookmark_cat.row() != -1:
+            self._bookmark_row = self.takeRow(self._bookmark_cat.row())
+        if self._history_cat.row() != -1:
+            self._history_row = self.takeRow(self._history_cat.row())
+
+        if config.get('completion', 'url-complete-quickmarks'):
+            self.appendRow(self._quickmark_row)
+        if config.get('completion', 'url-complete-bookmarks'):
+            self.appendRow(self._bookmark_row)
+        if config.get('completion', 'url-complete-history'):
+            self.appendRow(self._history_row)
 
     @pyqtSlot(object)
     def on_history_item_added(self, entry):

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -539,6 +539,18 @@ def data(readonly=False):
              SettingValue(typ.Int(minval=0), '2'),
              "Padding of scrollbar handle in completion window (in px)."),
 
+            ('url-complete-bookmarks',
+             SettingValue(typ.Bool(), 'true'),
+             "Whether to complete from bookmarks when completing URLs."),
+
+            ('url-complete-history',
+             SettingValue(typ.Bool(), 'true'),
+             "Whether to complete from history when completing URLs."),
+
+            ('url-complete-quickmarks',
+             SettingValue(typ.Bool(), 'true'),
+             "Whether to complete from quickmarks when completing URLs."),
+
             readonly=readonly
         )),
 


### PR DESCRIPTION
New set of config options `url-complete-{category}` will allow the user to toggle the visibility of different categories for the URL completion section.