### PR TITLE
Fix qute_history benchmark.

### DIFF
--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -154,7 +154,8 @@ class TestHistoryHandler:
             assert items[0]["next"] == now - next_time
 
     def test_qute_history_benchmark(self, fake_web_history, benchmark, now):
-        for t in range(100000):  # one history per second
+        # items must be earliest-first to ensure history is sorted properly
+        for t in range(100000, 0, -1):  # one history per second
             entry = history.Entry(
                 atime=str(now - t),
                 url=QUrl('www.x.com/{}'.format(t)),
@@ -162,4 +163,5 @@ class TestHistoryHandler:
             fake_web_history._add_entry(entry)
 
         url = QUrl("qute://history/data?start_time={}".format(now))
-        _mimetype, _data = benchmark(qutescheme.qute_history, url)
+        _mimetype, data = benchmark(qutescheme.qute_history, url)
+        assert len(json.loads(data)) > 1


### PR DESCRIPTION
I've been going crazy trying to figure out why I couldn't get SQL even close to as fast as the old implementation...

This benchmark was running very quickly due to an improper setup.
The current history implementation expects that a newly inserted entry must
be more recent than any existing entries and sorts according to this
assumption.

The benchmark test inserts increasingly older entries, breaking this invariant.
When run in the benchmark, the qute://history/data implementation would
see an entry older than the oldest time in the time window and would
immediately return with a single "next" entry.

This patch inserts data in an order that mantains history's invariant and adds
a sanity-check at the end of the test. It does not check for the exact length
as not all entries will be within the time window. The length will be some
values <= 100000, the check just ensures that there is at least something more
than a "next" entry.

Before:
```
---------------------------------------------- benchmark: 1 tests ----------------------------------------------
Name (time in us)                  Min      Max    Mean  StdDev  Median     IQR  Outliers(*)  Rounds  Iterations
----------------------------------------------------------------------------------------------------------------
test_qute_history_benchmark     9.3050  21.9250  9.6143  0.2454  9.5880  0.1070      230;360    9930           1
----------------------------------------------------------------------------------------------------------------
```

After:
```
-------------------------------------------------- benchmark: 1 tests -------------------------------------------------
Name (time in ms)                    Min       Max      Mean  StdDev    Median     IQR  Outliers(*)  Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------
test_qute_history_benchmark     220.7040  223.1900  221.7536  1.1070  221.1939  1.8803          1;0       5           1
-----------------------------------------------------------------------------------------------------------------------
```
