### PR TITLE
Add hinting for labels with a "for"-attribute

### DIFF
--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -44,7 +44,7 @@ Group = usertypes.enum('Group', ['all', 'links', 'images', 'url', 'prevnext',
 SELECTORS = {
     Group.all: ('a, area, textarea, select, input:not([type=hidden]), button, '
                 'frame, iframe, link, [onclick], [onmousedown], [role=link], '
-                '[role=option], [role=button], img'),
+                '[role=option], [role=button], img, label[for]'),
     Group.links: 'a, area, link, [role=link]',
     Group.images: 'img',
     Group.url: '[src], [href]',
@@ -52,7 +52,7 @@ SELECTORS = {
     Group.inputs: ('input[type=text], input[type=email], input[type=url], '
                    'input[type=tel], input[type=number], '
                    'input[type=password], input[type=search], '
-                   'input:not([type]), textarea'),
+                   'input:not([type]), textarea, label[for]'),
 }
 
 


### PR DESCRIPTION
See [here](https://w3c.github.io/html/sec-forms.html#element-attrdef-label-for). [Here](http://royalroadl.com/fiction/1439) is a real-world example where this is used, but currently not hinted by qutebrowser (the "show more/less"-button of the description).

I also added the new selector to the "inputs"-group, figuring that a label can only be bound to form controls, which are usually inputs -- I hope that was correct.