### PR TITLE
Add tabs->favicon-scale setting

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -126,6 +126,7 @@
 |<<tabs-close-mouse-button,close-mouse-button>>|On which mouse button to close tabs.
 |<<tabs-position,position>>|The position of the tab bar.
 |<<tabs-show-favicons,show-favicons>>|Whether to show favicons in the tab bar.
+|<<tabs-favicon-scale,favicon-scale>>|Scale for favicons in the tab bar. The tab size is unchanged, so big favicons also require extra `tabs->padding`.
 |<<tabs-width,width>>|The width of the tab bar if it's vertical, in px or as percentage of the window.
 |<<tabs-indicator-width,indicator-width>>|Width of the progress indicator (0 to disable).
 |<<tabs-tabs-are-windows,tabs-are-windows>>|Whether to open windows instead of tabs.
@@ -1205,6 +1206,12 @@ Valid values:
  * +false+
 
 Default: +pass:[true]+
+
+[[tabs-favicon-scale]]
+=== favicon-scale
+Scale for favicons in the tab bar. The tab size is unchanged, so big favicons also require extra `tabs->padding`.
+
+Default: +pass:[1.0]+
 
 [[tabs-width]]
 === width

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -680,6 +680,11 @@ def data(readonly=False):
              SettingValue(typ.Bool(), 'true'),
              "Whether to show favicons in the tab bar."),
 
+            ('favicon-scale',
+             SettingValue(typ.Float(minval=0.0), '1.0'),
+             "Scale for favicons in the tab bar. The tab size is unchanged, "
+             "so big favicons also require extra `tabs->padding`."),
+
             ('width',
              SettingValue(typ.PercOrInt(minperc=0, maxperc=100, minint=1),
                           '20%'),

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -22,7 +22,8 @@
 import collections
 import functools
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QSize, QRect, QTimer, QUrl
+from PyQt5.QtCore import (pyqtSignal, pyqtSlot, Qt, QSize, QRect, QPoint,
+                          QTimer, QUrl)
 from PyQt5.QtWidgets import (QTabWidget, QTabBar, QSizePolicy, QCommonStyle,
                              QStyle, QStylePainter, QStyleOptionTab)
 from PyQt5.QtGui import QIcon, QPalette, QColor
@@ -273,6 +274,7 @@ class TabBar(QTabBar):
         self.set_font()
         config_obj = objreg.get('config')
         config_obj.changed.connect(self.set_font)
+        config_obj.changed.connect(self.set_icon_size)
         self.vertical = False
         self._page_fullscreen = False
         self._auto_hide_timer = QTimer()
@@ -374,7 +376,13 @@ class TabBar(QTabBar):
     def set_font(self):
         """Set the tab bar font."""
         self.setFont(config.get('fonts', 'tabbar'))
+        self.set_icon_size()
+
+    @config.change_filter('tabs', 'favicon-scale')
+    def set_icon_size(self):
+        """Set the tab bar favicon size."""
         size = self.fontMetrics().height() - 2
+        size *= config.get('tabs', 'favicon-scale')
         self.setIconSize(QSize(size, size))
 
     @config.change_filter('colors', 'tabs.bg.bar')
@@ -775,7 +783,7 @@ class TabBarStyle(QCommonStyle):
             tab_icon_size = QSize(
                 min(actual_size.width(), icon_size.width()),
                 min(actual_size.height(), icon_size.height()))
-        icon_rect = QRect(text_rect.left(), text_rect.top() + 1,
-                          tab_icon_size.width(), tab_icon_size.height())
+        icon_top = text_rect.center().y() + 1 - tab_icon_size.height() / 2
+        icon_rect = QRect(QPoint(text_rect.left(), icon_top), tab_icon_size)
         icon_rect = self._style.visualRect(opt.direction, opt.rect, icon_rect)
         return icon_rect

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -44,6 +44,7 @@ class TestTabWidget:
             'select-on-remove': 1,
             'show': 'always',
             'show-favicons': True,
+            'favicon-scale': 1.0,
             'padding': configtypes.PaddingValues(0, 0, 5, 5),
             'indicator-width': 3,
             'indicator-padding': configtypes.PaddingValues(2, 2, 0, 4),


### PR DESCRIPTION
This allows users to change the size of the favicon independently from
the size of the font/tab, in order to adjust the balance between
favicons and text. The drawing code is also adjusted to re-center the
favicons vertically with the text. The only other change is that the
initialization function also explicitly calls set_font() in order to
force the font/favicon size to be recomputed when the tab settings are
changed.

Works as expected even for values of 0.0 (which is equivalent to hiding
the favicon completely).

Closes #2549.