### PR TITLE
Add support for follow_selected in qtwebengine

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -196,6 +196,10 @@ class AbstractSearch(QObject):
         """
         raise NotImplementedError
 
+    def searching(self):
+        """Return True if we are currently searching or not."""
+        raise NotImplementedError
+
 
 class AbstractZoom(QObject):
 

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -163,6 +163,8 @@ class AbstractSearch(QObject):
         super().__init__(parent)
         self._widget = None
         self.text = None
+        # Implementing classes will set this.
+        self.search_displayed = False
 
     def search(self, text, *, ignore_case=False, reverse=False,
                result_cb=None):
@@ -194,10 +196,6 @@ class AbstractSearch(QObject):
         Args:
             result_cb: Called with a bool indicating whether a match was found.
         """
-        raise NotImplementedError
-
-    def searching(self):
-        """Return True if we are currently searching or not."""
         raise NotImplementedError
 
 

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -306,6 +306,11 @@ class AbstractWebElement(collections.abc.MutableMapping):
         qtutils.ensure_valid(url)
         return url
 
+    def is_link(self):
+        """Return True if this AbstractWebElement is a link."""
+        href_tags = ['a', 'area', 'link']
+        return self.tag_name() in href_tags
+
     def _mouse_pos(self):
         """Get the position to click/hover."""
         # Click the center of the largest square fitting into the top/left
@@ -403,9 +408,8 @@ class AbstractWebElement(collections.abc.MutableMapping):
             self._click_fake_event(click_target)
             return
 
-        href_tags = ['a', 'area', 'link']
         if click_target == usertypes.ClickTarget.normal:
-            if self.tag_name() in href_tags:
+            if self.is_link():
                 log.webelem.debug("Clicking via JS click()")
                 self._click_js(click_target)
             elif self.is_editable(strict=True):
@@ -418,7 +422,7 @@ class AbstractWebElement(collections.abc.MutableMapping):
         elif click_target in [usertypes.ClickTarget.tab,
                               usertypes.ClickTarget.tab_bg,
                               usertypes.ClickTarget.window]:
-            if self.tag_name() in href_tags:
+            if self.is_link():
                 self._click_href(click_target)
             else:
                 self._click_fake_event(click_target)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -311,6 +311,10 @@ class WebEngineScroller(browsertab.AbstractScroller):
         page = widget.page()
         page.scrollPositionChanged.connect(self._update_pos)
 
+    def _repeated_key_press(self, key, count=1, modifier=Qt.NoModifier):
+        for _ in range(min(count, 5000)):
+            self._tab.key_press(key, modifier)
+
     @pyqtSlot()
     def _update_pos(self):
         """Update the scroll position attributes when it changed."""
@@ -366,16 +370,16 @@ class WebEngineScroller(browsertab.AbstractScroller):
         self._tab.run_js_async(js_code)
 
     def up(self, count=1):
-        self._tab.key_press(Qt.Key_Up, count)
+        self._repeated_key_press(Qt.Key_Up, count)
 
     def down(self, count=1):
-        self._tab.key_press(Qt.Key_Down, count)
+        self._repeated_key_press(Qt.Key_Down, count)
 
     def left(self, count=1):
-        self._tab.key_press(Qt.Key_Left, count)
+        self._repeated_key_press(Qt.Key_Left, count)
 
     def right(self, count=1):
-        self._tab.key_press(Qt.Key_Right, count)
+        self._repeated_key_press(Qt.Key_Right, count)
 
     def top(self):
         self._tab.key_press(Qt.Key_Home)
@@ -384,10 +388,10 @@ class WebEngineScroller(browsertab.AbstractScroller):
         self._tab.key_press(Qt.Key_End)
 
     def page_up(self, count=1):
-        self._tab.key_press(Qt.Key_PageUp, count)
+        self._repeated_key_press(Qt.Key_PageUp, count)
 
     def page_down(self, count=1):
-        self._tab.key_press(Qt.Key_PageDown, count)
+        self._repeated_key_press(Qt.Key_PageDown, count)
 
     def at_top(self):
         return self.pos_px().y() == 0
@@ -647,13 +651,12 @@ class WebEngineTab(browsertab.AbstractTab):
     def clear_ssl_errors(self):
         raise browsertab.UnsupportedOperationError
 
-    def key_press(self, key, count=1, modifier=Qt.NoModifier):
-        for _ in range(min(count, 5000)):
-            press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
-            release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
-                                    0, 0, 0)
-            self.send_event(press_evt)
-            self.send_event(release_evt)
+    def key_press(self, key, modifier=Qt.NoModifier):
+        press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
+        release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
+                                0, 0, 0)
+        self.send_event(press_evt)
+        self.send_event(release_evt)
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -17,9 +17,6 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-# FIXME:qtwebengine remove this once the stubs are gone
-# pylint: disable=unused-argument
-
 """Wrapper over a QWebEngineView."""
 
 import functools
@@ -281,10 +278,10 @@ class WebEngineCaret(browsertab.AbstractCaret):
 
             log.webview.debug("Clicking a searched link via fake key press.")
             # send a fake enter, clicking the orange selection box
-            if not tab:
-                self._tab.key_press(Qt.Key_Enter)
-            else:
+            if tab:
                 self._tab.key_press(Qt.Key_Enter, modifier=Qt.ControlModifier)
+            else:
+                self._tab.key_press(Qt.Key_Enter)
 
         else:
             # click an existing blue selection

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -285,9 +285,9 @@ class WebEngineCaret(browsertab.AbstractCaret):
             log.webview.debug("Clicking a searched link via fake key press.")
             # send a fake enter, clicking the orange selection box
             if not tab:
-                self._tab.scroller._key_press(Qt.Key_Enter)
+                self._tab.key_press(Qt.Key_Enter)
             else:
-                self._tab.scroller._key_press(Qt.Key_Enter, modifier=Qt.ControlModifier)
+                self._tab.key_press(Qt.Key_Enter, modifier=Qt.ControlModifier)
 
         else:
             # click an existing blue selection
@@ -310,14 +310,6 @@ class WebEngineScroller(browsertab.AbstractScroller):
         super()._init_widget(widget)
         page = widget.page()
         page.scrollPositionChanged.connect(self._update_pos)
-
-    def _key_press(self, key, count=1, modifier=Qt.NoModifier):
-        for _ in range(min(count, 5000)):
-            press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
-            release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
-                                    0, 0, 0)
-            self._tab.send_event(press_evt)
-            self._tab.send_event(release_evt)
 
     @pyqtSlot()
     def _update_pos(self):
@@ -374,28 +366,28 @@ class WebEngineScroller(browsertab.AbstractScroller):
         self._tab.run_js_async(js_code)
 
     def up(self, count=1):
-        self._key_press(Qt.Key_Up, count)
+        self._tab.key_press(Qt.Key_Up, count)
 
     def down(self, count=1):
-        self._key_press(Qt.Key_Down, count)
+        self._tab.key_press(Qt.Key_Down, count)
 
     def left(self, count=1):
-        self._key_press(Qt.Key_Left, count)
+        self._tab.key_press(Qt.Key_Left, count)
 
     def right(self, count=1):
-        self._key_press(Qt.Key_Right, count)
+        self._tab.key_press(Qt.Key_Right, count)
 
     def top(self):
-        self._key_press(Qt.Key_Home)
+        self._tab.key_press(Qt.Key_Home)
 
     def bottom(self):
-        self._key_press(Qt.Key_End)
+        self._tab.key_press(Qt.Key_End)
 
     def page_up(self, count=1):
-        self._key_press(Qt.Key_PageUp, count)
+        self._tab.key_press(Qt.Key_PageUp, count)
 
     def page_down(self, count=1):
-        self._key_press(Qt.Key_PageDown, count)
+        self._tab.key_press(Qt.Key_PageDown, count)
 
     def at_top(self):
         return self.pos_px().y() == 0
@@ -654,6 +646,14 @@ class WebEngineTab(browsertab.AbstractTab):
 
     def clear_ssl_errors(self):
         raise browsertab.UnsupportedOperationError
+
+    def key_press(self, key, count=1, modifier=Qt.NoModifier):
+        for _ in range(min(count, 5000)):
+            press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
+            release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
+                                    0, 0, 0)
+            self.send_event(press_evt)
+            self.send_event(release_evt)
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -312,6 +312,7 @@ class WebEngineScroller(browsertab.AbstractScroller):
         page.scrollPositionChanged.connect(self._update_pos)
 
     def _repeated_key_press(self, key, count=1, modifier=Qt.NoModifier):
+        """Send count fake key presses to this scroller's WebEngineTab."""
         for _ in range(min(count, 5000)):
             self._tab.key_press(key, modifier)
 
@@ -652,6 +653,7 @@ class WebEngineTab(browsertab.AbstractTab):
         raise browsertab.UnsupportedOperationError
 
     def key_press(self, key, modifier=Qt.NoModifier):
+        """Send a fake key event to this WebKitTab."""
         press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
         release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
                                 0, 0, 0)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -127,11 +127,11 @@ class WebEngineSearch(browsertab.AbstractSearch):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._flags = QWebEnginePage.FindFlags(0)
-        self._searching = False
+        self.search_displayed = False
 
     def _find(self, text, flags, callback, caller):
         """Call findText on the widget."""
-        self._searching = True
+        self.search_displayed = True
 
         def wrapped_callback(found):
             """Wrap the callback to do debug logging."""
@@ -163,11 +163,8 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._find(text, flags, result_cb, 'search')
 
     def clear(self):
-        self._searching = False
+        self.search_displayed = False
         self._widget.findText('')
-
-    def searching(self):
-        return self._searching
 
     def prev_result(self, *, result_cb=None):
         # The int() here makes sure we get a copy of the flags.
@@ -256,10 +253,10 @@ class WebEngineCaret(browsertab.AbstractCaret):
     def _follow_selected_cb(self, js_elem, tab=False):
         """Callback for javascript which clicks the selected element.
 
-         Args:
-             js_elems: The elements serialized from javascript.
-             tab: Open in a new tab or not.
-         """
+        Args:
+            js_elems: The elements serialized from javascript.
+            tab: Open in a new tab or not.
+        """
         if js_elem is None:
             return
         assert isinstance(js_elem, dict), js_elem
@@ -276,7 +273,7 @@ class WebEngineCaret(browsertab.AbstractCaret):
             elem.click(click_type)
 
     def follow_selected(self, *, tab=False):
-        if self._tab.search.searching():
+        if self._tab.search.search_displayed:
             # We are currently in search mode.
             # let's click the link via a fake-click
             # https://bugreports.qt.io/browse/QTBUG-60673

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -285,8 +285,7 @@ class WebKitElement(webelem.AbstractWebElement):
         for _ in range(5):
             if elem is None:
                 break
-            tag = elem.tag_name()
-            if tag == 'a' or tag == 'area':
+            if elem.is_link():
                 if elem.get('target', None) == '_blank':
                     elem['target'] = '_top'
                 break

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -103,7 +103,7 @@ class WebKitSearch(browsertab.AbstractSearch):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._flags = QWebPage.FindFlags(0)
-        self._searching = True
+        self.search_displayed = True
 
     def _call_cb(self, callback, found, text, flags, caller):
         """Call the given callback if it's non-None.
@@ -133,14 +133,14 @@ class WebKitSearch(browsertab.AbstractSearch):
             QTimer.singleShot(0, functools.partial(callback, found))
 
     def clear(self):
-        self._searching = False
+        self.search_displayed = False
         # We first clear the marked text, then the highlights
         self._widget.findText('')
         self._widget.findText('', QWebPage.HighlightAllOccurrences)
 
     def search(self, text, *, ignore_case=False, reverse=False,
                result_cb=None):
-        self._searching = True
+        self.search_displayed = True
         flags = QWebPage.FindWrapsAroundDocument
         if ignore_case == 'smart':
             if not text.islower():
@@ -158,12 +158,12 @@ class WebKitSearch(browsertab.AbstractSearch):
         self._call_cb(result_cb, found, text, flags, 'search')
 
     def next_result(self, *, result_cb=None):
-        self._searching = True
+        self.search_displayed = True
         found = self._widget.findText(self.text, self._flags)
         self._call_cb(result_cb, found, self.text, self._flags, 'next_result')
 
     def prev_result(self, *, result_cb=None):
-        self._searching = True
+        self.search_displayed = True
         # The int() here makes sure we get a copy of the flags.
         flags = QWebPage.FindFlags(int(self._flags))
         if flags & QWebPage.FindBackward:
@@ -172,9 +172,6 @@ class WebKitSearch(browsertab.AbstractSearch):
             flags |= QWebPage.FindBackward
         found = self._widget.findText(self.text, flags)
         self._call_cb(result_cb, found, self.text, flags, 'prev_result')
-
-    def searching(self):
-        return self._searching
 
 
 class WebKitCaret(browsertab.AbstractCaret):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -103,6 +103,7 @@ class WebKitSearch(browsertab.AbstractSearch):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._flags = QWebPage.FindFlags(0)
+        self._searching = True
 
     def _call_cb(self, callback, found, text, flags, caller):
         """Call the given callback if it's non-None.
@@ -132,12 +133,14 @@ class WebKitSearch(browsertab.AbstractSearch):
             QTimer.singleShot(0, functools.partial(callback, found))
 
     def clear(self):
+        self._searching = False
         # We first clear the marked text, then the highlights
         self._widget.findText('')
         self._widget.findText('', QWebPage.HighlightAllOccurrences)
 
     def search(self, text, *, ignore_case=False, reverse=False,
                result_cb=None):
+        self._searching = True
         flags = QWebPage.FindWrapsAroundDocument
         if ignore_case == 'smart':
             if not text.islower():
@@ -155,10 +158,12 @@ class WebKitSearch(browsertab.AbstractSearch):
         self._call_cb(result_cb, found, text, flags, 'search')
 
     def next_result(self, *, result_cb=None):
+        self._searching = True
         found = self._widget.findText(self.text, self._flags)
         self._call_cb(result_cb, found, self.text, self._flags, 'next_result')
 
     def prev_result(self, *, result_cb=None):
+        self._searching = True
         # The int() here makes sure we get a copy of the flags.
         flags = QWebPage.FindFlags(int(self._flags))
         if flags & QWebPage.FindBackward:
@@ -167,6 +172,9 @@ class WebKitSearch(browsertab.AbstractSearch):
             flags |= QWebPage.FindBackward
         found = self._widget.findText(self.text, flags)
         self._call_cb(result_cb, found, self.text, flags, 'prev_result')
+
+    def searching(self):
+        return self._searching
 
 
 class WebKitCaret(browsertab.AbstractCaret):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -468,15 +468,11 @@ class WebKitScroller(browsertab.AbstractScroller):
         # self._widget.setFocus()
 
         for _ in range(min(count, 5000)):
-            press_evt = QKeyEvent(QEvent.KeyPress, key, Qt.NoModifier, 0, 0, 0)
-            release_evt = QKeyEvent(QEvent.KeyRelease, key, Qt.NoModifier,
-                                    0, 0, 0)
             # Abort scrolling if the minimum/maximum was reached.
             if (getter is not None and
                     frame.scrollBarValue(direction) == getter(direction)):
                 return
-            self._widget.keyPressEvent(press_evt)
-            self._widget.keyReleaseEvent(release_evt)
+            self._tab.key_press(key)
 
     def up(self, count=1):
         self._key_press(Qt.Key_Up, count, 'scrollBarMinimum', Qt.Vertical)
@@ -701,6 +697,13 @@ class WebKitTab(browsertab.AbstractTab):
 
     def clear_ssl_errors(self):
         self.networkaccessmanager().clear_all_ssl_errors()
+
+    def key_press(self, key, modifier=Qt.NoModifier):
+        press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
+        release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
+                                0, 0, 0)
+        self.send_event(press_evt)
+        self.send_event(release_evt)
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -699,6 +699,7 @@ class WebKitTab(browsertab.AbstractTab):
         self.networkaccessmanager().clear_all_ssl_errors()
 
     def key_press(self, key, modifier=Qt.NoModifier):
+        """Send a fake key event to this WebKitTab."""
         press_evt = QKeyEvent(QEvent.KeyPress, key, modifier, 0, 0, 0)
         release_evt = QKeyEvent(QEvent.KeyRelease, key, modifier,
                                 0, 0, 0)

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -169,6 +169,15 @@ window._qutebrowser.webelem = (function() {
         return serialize_elem(elem);
     };
 
+    // Function for returning a selection to python (so we can click it)
+    funcs.find_selected_link = function() {
+        var elem = window.getSelection().anchorNode;
+        if (!elem) {
+            return null;
+        }
+        return serialize_elem(elem.parentNode);
+    };
+
     funcs.set_value = function(id, value) {
         elements[id].value = value;
     };

--- a/tests/end2end/data/search.html
+++ b/tests/end2end/data/search.html
@@ -16,7 +16,7 @@
             BAZ<br/>
             space travel<br/>
             /slash<br/>
-            <a href="hello.txt">follow me!</a><br/>
+            <a class="toselect" href="hello.txt">follow me!</a><br/>
         </p>
     </body>
 </html>

--- a/tests/end2end/data/search.html
+++ b/tests/end2end/data/search.html
@@ -16,6 +16,7 @@
             BAZ<br/>
             space travel<br/>
             /slash<br/>
+            <a href="hello.txt">follow me!</a><br/>
         </p>
     </body>
 </html>

--- a/tests/end2end/data/search_select.js
+++ b/tests/end2end/data/search_select.js
@@ -1,0 +1,13 @@
+/* Select all elements marked with toselect */
+
+
+var toSelect = document.getElementsByClassName("toselect");
+var s = window.getSelection();
+
+if(s.rangeCount > 0) s.removeAllRanges();
+
+for(var i = 0; i < toSelect.length; i++) {
+  var range = document.createRange();
+  range.selectNode(toSelect[i]);
+  s.addRange(range);
+}

--- a/tests/end2end/data/search_select.js
+++ b/tests/end2end/data/search_select.js
@@ -1,13 +1,12 @@
 /* Select all elements marked with toselect */
 
-
 var toSelect = document.getElementsByClassName("toselect");
 var s = window.getSelection();
 
 if(s.rangeCount > 0) s.removeAllRanges();
 
 for(var i = 0; i < toSelect.length; i++) {
-  var range = document.createRange();
-  range.selectNode(toSelect[i]);
-  s.addRange(range);
+    var range = document.createRange();
+    range.selectNode(toSelect[i]);
+    s.addRange(range);
 }

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -224,3 +224,17 @@ Feature: Searching on a page
         And I run :follow-selected -t
         Then the following tabs should be open:
             - data/search.html (active)
+
+    Scenario: Follow a manually selected link
+        When I run :jseval --file (testdata)/search_select.js
+        And I run :follow-selected
+        Then data/hello.txt should be loaded
+
+    Scenario: Follow a manually selected link in a new tab
+        When I run :window-only
+        And I run :jseval --file (testdata)/search_select.js
+        And I run :follow-selected -t
+        And I wait until data/hello.txt is loaded
+        Then the following tabs should be open:
+            - data/search.html
+            - data/hello.txt (active)

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -191,3 +191,36 @@ Feature: Searching on a page
 
     # TODO: wrapping message with scrolling
     # TODO: wrapping message without scrolling
+
+    ## follow searched links
+    Scenario: Follow a searched link
+        When I run :search follow
+        And I wait for "search found follow" in the log
+        And I run :follow-selected
+        Then data/hello.txt should be loaded
+
+    Scenario: Follow a searched link in a new tab
+        When I run :window-only
+        And I run :search follow
+        And I wait for "search found follow" in the log
+        And I run :follow-selected -t
+        And I wait until data/hello.txt is loaded
+        Then the following tabs should be open:
+            - data/search.html
+            - data/hello.txt (active)
+
+    Scenario: Don't follow searched text
+        When I run :window-only
+        And I run :search foo
+        And I wait for "search found foo" in the log
+        And I run :follow-selected
+        Then the following tabs should be open:
+            - data/search.html (active)
+
+    Scenario: Don't follow searched text in a new tab
+        When I run :window-only
+        And I run :search foo
+        And I wait for "search found foo" in the log
+        And I run :follow-selected -t
+        Then the following tabs should be open:
+            - data/search.html (active)


### PR DESCRIPTION
This PR adds support for follow selected in webengine, so users can search via `/`, select a link, and press enter to follow the link.

This works in webengine by first clearing the search (this causes the selected search result to become selected), and then using the javascript click method found here: https://github.com/qutebrowser/qutebrowser/blob/master/qutebrowser/browser/webkit/webkittab.py#L348-L376

This is pretty hacky, but it does work (and I've seen this beahvior in chrome for a long time, so I don't think it would be removed soon).

This PR is very rough and needs a bunch of work though, for example:

- [x] tab = True does not work (we can't use the same system as webkit since that's not supported). If you tell me where to look, I can try and fix this.
- [x] This assumes javascript is on. I don't see any method for checking if javascript is on in WebEngine, is there anything I can do about that?

This is my first time ever writing any javascript, so let me know if I'm doing anything stupid on that front. Let me know what you think!

Thanks again for maintaining such a great web browser! :smile: 