### PR TITLE
Implement netrc for webengine

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -23,6 +23,9 @@ import html
 
 import jinja2
 
+import os
+import netrc
+
 from qutebrowser.config import config
 from qutebrowser.utils import usertypes, message, log, objreg
 
@@ -243,3 +246,29 @@ def get_user_stylesheet():
         css += '\nhtml > ::-webkit-scrollbar { width: 0px; height: 0px; }'
 
     return css
+
+
+def netrc_authentication(url, authenticator):
+    if 'HOME' in os.environ:
+        # We'll get an OSError by netrc if 'HOME' isn't available in
+        # os.environ. We don't want to log that, so we prevent it
+        # altogether.
+        user, password = None, None
+        try:
+            net = netrc.netrc(config.get('network', 'netrc-file'))
+            authenticators = net.authenticators(url.host())
+            if authenticators is not None:
+                (user, _account, password) = authenticators
+        except FileNotFoundError:
+            log.misc.debug("No .netrc file found")
+        except OSError:
+            log.misc.exception("Unable to read the netrc file")
+        except netrc.NetrcParseError:
+            log.misc.exception("Error when parsing the netrc file")
+
+        if user is not None:
+            authenticator.setUser(user)
+            authenticator.setPassword(password)
+            return True
+
+    return False

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -631,11 +631,12 @@ class WebEngineTab(browsertab.AbstractTab):
 
     @pyqtSlot(QUrl, 'QAuthenticator*')
     def _on_authentication_required(self, url, authenticator):
-        # FIXME:qtwebengine support .netrc
-        answer = shared.authentication_required(
-            url, authenticator, abort_on=[self.shutting_down,
-                                          self.load_started])
-        if answer is None:
+        netrc = shared.netrc_authentication(url, authenticator)
+        if not netrc:
+            answer = shared.authentication_required(
+                url, authenticator, abort_on=[self.shutting_down,
+                                              self.load_started])
+        if not netrc and answer is None:
             try:
                 # pylint: disable=no-member, useless-suppression
                 sip.assign(authenticator, QAuthenticator())

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -277,28 +277,7 @@ class NetworkManager(QNetworkAccessManager):
     @pyqtSlot('QNetworkReply*', 'QAuthenticator*')
     def on_authentication_required(self, reply, authenticator):
         """Called when a website needs authentication."""
-        user, password = None, None
-        if not hasattr(reply, "netrc_used") and 'HOME' in os.environ:
-            # We'll get an OSError by netrc if 'HOME' isn't available in
-            # os.environ. We don't want to log that, so we prevent it
-            # altogether.
-            reply.netrc_used = True
-            try:
-                net = netrc.netrc(config.get('network', 'netrc-file'))
-                authenticators = net.authenticators(reply.url().host())
-                if authenticators is not None:
-                    (user, _account, password) = authenticators
-            except FileNotFoundError:
-                log.misc.debug("No .netrc file found")
-            except OSError:
-                log.misc.exception("Unable to read the netrc file")
-            except netrc.NetrcParseError:
-                log.misc.exception("Error when parsing the netrc file")
-
-        if user is not None:
-            authenticator.setUser(user)
-            authenticator.setPassword(password)
-        else:
+        if not shared.netrc_authentication(reply.url(), authenticator):
             abort_on = self._get_abort_signals(reply)
             shared.authentication_required(reply.url(), authenticator,
                                            abort_on=abort_on)


### PR DESCRIPTION
netrc authentication was currently only supported with QtWebkit, so I moved the implementation to the shared module, and use it now with QtWebEngine as well.