### PR TITLE
Set explicit=False for :navigate --tab

### DIFF
--- a/CHANGELOG.asciidoc
+++ b/CHANGELOG.asciidoc
@@ -55,8 +55,9 @@ Changed
 - The adblocker now also blocks non-GET requests (e.g. POST)
 - `:follow-selected` now also works with QtWebEngine
 - javascript: links can now be hinted
-- :view-source and :tab-clone now don't open the tab as "explicit" anymore, i.e.
-  (with the default settings) open it next to the active tab.
+- `:view-source`, `:tab-clone` and `:navigate --tab` now don't open the tab as
+  "explicit" anymore, i.e. (with the default settings) open it next to the
+  active tab.
 
 Fixed
 ~~~~~

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -560,7 +560,7 @@ class CommandDispatcher:
                         tab=tab, background=bg, window=window)
             elif where in ['up', 'increment', 'decrement']:
                 new_url = handlers[where](url, count)
-                self._open(new_url, tab, bg, window)
+                self._open(new_url, tab, bg, window, explicit=False)
             else:  # pragma: no cover
                 raise ValueError("Got called with invalid value {} for "
                                 "`where'.".format(where))


### PR DESCRIPTION
It turns out that `:navigate --tab up`, `:navigate --tab increment` and `:navigate --tab decrement` open tabs with `explicit=True`, similarly to the issue raised in #2624 and fixed in 273749c. This PR fixes this.

Note that the current behavior is inconsistent within the `:navigate` command, since tabs opened by `:navigate --tab prev` and `:navigate --tab next` are opened with `explicit=False`, so this really should be addressed.