### PR TITLE
Add Android UA

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1452,7 +1452,11 @@ class UserAgent(BaseType):
 
             ('Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like '
              'Gecko',
-             "IE 11.0 for Desktop Win7 64-bit")
+             "IE 11.0 for Desktop Win7 64-bit"),
+
+            ('Mozilla/5.0 (Linux; U; Android 7.1.2) AppleWebKit/534.30 '
+             '(KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+             "Mobile Generic Android")
         ]
         return out
 

--- a/scripts/dev/ua_fetch.py
+++ b/scripts/dev/ua_fetch.py
@@ -87,7 +87,10 @@ def add_diversity(table):
         ('Wget/1.16.1 (linux-gnu)',
          "wget 1.16.1"),
         ('curl/7.40.0',
-         "curl 7.40.0")
+         "curl 7.40.0"),
+        ('Mozilla/5.0 (Linux; U; Android 7.1.2) AppleWebKit/534.30 '
+         '(KHTML, like Gecko) Version/4.0 Mobile Safari/534.30',
+         "Mobile Generic Android")
     ]
     return table
 


### PR DESCRIPTION
PR for adding Android user-agent.

### Where is that String from?
[android.googlesource.com](https://android.googlesource.com/platform/frameworks/base/+/master/core/res/res/values/strings.xml#2074)

### Sample page that makes use of Android UA 
https://amazon.com/underground
* __no UA:__ Page offers to send link to an email
*  __UA Version <4.1.0:__ Page tells you that it requires at least 4.1
*  __UA Version >=4.1.0:__ Page offers download to APK

## Need your 2 cents

#### Use latest Android UA Version? And why?
#### Should I try to parse / assemble the user-agent in ua_fetch.py?
#### How to name the UA? (currently "Mobile Generic Android")