### PR TITLE
Add TOC to installation instructions

### DIFF
--- a/INSTALL.asciidoc
+++ b/INSTALL.asciidoc
@@ -1,6 +1,8 @@
 Installing qutebrowser
 ======================
 
+toc::[]
+
 On Debian / Ubuntu
 ------------------
 

--- a/scripts/asciidoc2html.py
+++ b/scripts/asciidoc2html.py
@@ -184,7 +184,7 @@ class AsciiDoc:
         with open(modified_src, 'w+', encoding='utf-8') as final_version:
             final_version.write(title + "\n\n" + header + current_lines)
 
-        self.call(modified_src, dst, '--theme=qute')
+        self.call(modified_src, dst, '--theme=qute', '-a toc', '-a toc-placement=manual')
 
     def _build_website(self):
         """Prepare and build the website."""

--- a/scripts/asciidoc2html.py
+++ b/scripts/asciidoc2html.py
@@ -184,7 +184,8 @@ class AsciiDoc:
         with open(modified_src, 'w+', encoding='utf-8') as final_version:
             final_version.write(title + "\n\n" + header + current_lines)
 
-        self.call(modified_src, dst, '--theme=qute', '-a toc', '-a toc-placement=manual')
+        asciidoc_args = ['--theme=qute', '-a toc', '-a toc-placement=manual']
+        self.call(modified_src, dst, *asciidoc_args)
 
     def _build_website(self):
         """Prepare and build the website."""

--- a/www/header.asciidoc
+++ b/www/header.asciidoc
@@ -2,7 +2,7 @@
 <div id="headline">
 	<img class="qutebrowser-logo" src="/icons/qutebrowser.svg" alt="qutebrowser" />
 	<div class="text">
-		<h1>qutebrowser</h1>
+		<span class="heading-text">qutebrowser</span>
 		A keyboard-driven browser.
 	</div>
 </div>

--- a/www/qute.css
+++ b/www/qute.css
@@ -44,9 +44,13 @@ p {
 	text-align: right;
 }
 
-#headline .text h1 {
+#headline .text .heading-text {
 	color: #1e89c6;
+	font-weight: bold;
+	font-size: 2em;
 	border: none;
+	display: block;
+	white-space: pre-line;
 }
 
 #headline .text {

--- a/www/qute.css
+++ b/www/qute.css
@@ -224,6 +224,34 @@ table td {
 	}
 }
 
+#toc {
+  margin-bottom: 2.5em;
+}
+
+#toctitle {
+  color: #0A396E;
+  font-size: 1.1em;
+  font-weight: bold;
+  margin-top: 1.0em;
+  margin-bottom: 0.1em;
+}
+
+div.toclevel0, div.toclevel1, div.toclevel2, div.toclevel3, div.toclevel4 {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+div.toclevel2 {
+  margin-left: 2em;
+  font-size: 0.9em;
+}
+div.toclevel3 {
+  margin-left: 4em;
+  font-size: 0.9em;
+}
+div.toclevel4 {
+  margin-left: 6em;
+  font-size: 0.9em;
+}
 </style>
 <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
 <link href="/media/font.css" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
This adds a table of contents to the installation instructions to
improve the navigation within the document.

I decided to use the command line to configure the TOC because there
were problems with just using an attribute entry in the asciidoc 
document header.
Specifically the insertion of the `header.asciidoc` into the resulting
HTML file prevented the attribute entry approach from working.

The TOC can now be inserted into any doc file at any position using

    toc::[]

One small thing that changed is the `h1` element in the site header.
Asciidoc was putting this into the table of contents as well, so I changed
that element to a `span` and reapplied the same styles as before.

Here is what it looks like: http://i.imgur.com/qb3SPCH.png

More asciidoc TOC options are documented at the bottom of this table:
http://asciidoc.org/userguide.html#X88

#2440 :sparkles: 