### PR TITLE
Fix padding of remaining tabbar space with pinned tabs

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -522,12 +522,12 @@ class TabBar(QTabBar):
                 width = tab_width_pinned_conf
             else:
 
-                # If we *do* have enough space, tabs should occupy the whole 
-                # window # width. If there are pinned tabs their size will be 
+                # If we *do* have enough space, tabs should occupy the whole
+                # window # width. If there are pinned tabs their size will be
                 # subtracted from the total window width.
                 # During shutdown the self.count goes down,
-                # but the self.pinned_count not - this generates some odd 
-                # behavior. To avoid this we compare self.count against 
+                # but the self.pinned_count not - this generates some odd
+                # behavior. To avoid this we compare self.count against
                 # self.pinned_count.
                 if self.pinned_count > 0 and no_pinned_count > 0:
                     width = no_pinned_width / no_pinned_count
@@ -536,8 +536,8 @@ class TabBar(QTabBar):
 
             # If no_pinned_width is not divisible by no_pinned_count, add a
             # pixel to some tabs so # that there is no ugly leftover space.
-            if no_pinned_count > 0 and 
-                    index < no_pinned_width % no_pinned_count:
+            if (no_pinned_count > 0 and
+                    index < no_pinned_width % no_pinned_count):
                 width += 1
 
             size = QSize(width, height)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -523,7 +523,7 @@ class TabBar(QTabBar):
             else:
 
                 # If we *do* have enough space, tabs should occupy the whole
-                # window # width. If there are pinned tabs their size will be
+                # window width. If there are pinned tabs their size will be
                 # subtracted from the total window width.
                 # During shutdown the self.count goes down,
                 # but the self.pinned_count not - this generates some odd

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -522,20 +522,22 @@ class TabBar(QTabBar):
                 width = tab_width_pinned_conf
             else:
 
-                # If we *do* have enough space, tabs should occupy the whole window
-                # width. If there are pinned tabs their size will be subtracted
-                # from the total window width.
+                # If we *do* have enough space, tabs should occupy the whole 
+                # window # width. If there are pinned tabs their size will be 
+                # subtracted from the total window width.
                 # During shutdown the self.count goes down,
-                # but the self.pinned_count not - this generates some odd behavior.
-                # To avoid this we compare self.count against self.pinned_count.
+                # but the self.pinned_count not - this generates some odd 
+                # behavior. To avoid this we compare self.count against 
+                # self.pinned_count.
                 if self.pinned_count > 0 and no_pinned_count > 0:
                     width = no_pinned_width / no_pinned_count
                 else:
                     width = self.width() / self.count()
 
-            # If no_pinned_width is not divisible by no_pinned_count, add a pixel to some tabs so
-            # that there is no ugly leftover space.
-            if no_pinned_count > 0 and index < no_pinned_width % no_pinned_count:
+            # If no_pinned_width is not divisible by no_pinned_count, add a
+            # pixel to some tabs so # that there is no ugly leftover space.
+            if no_pinned_count > 0 and 
+                    index < no_pinned_width % no_pinned_count:
                 width += 1
 
             size = QSize(width, height)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -514,28 +514,30 @@ class TabBar(QTabBar):
             except KeyError:
                 pinned = False
 
+            no_pinned_count = self.count() - self.pinned_count
+            pinned_width = tab_width_pinned_conf * self.pinned_count
+            no_pinned_width = self.width() - pinned_width
+
             if pinned:
-                size = QSize(tab_width_pinned_conf, height)
-                qtutils.ensure_valid(size)
-                return size
-
-            # If we *do* have enough space, tabs should occupy the whole window
-            # width. If there are pinned tabs their size will be subtracted
-            # from the total window width.
-            # During shutdown the self.count goes down,
-            # but the self.pinned_count not - this generates some odd behavior.
-            # To avoid this we compare self.count against self.pinned_count.
-            if self.pinned_count > 0 and self.count() > self.pinned_count:
-                pinned_width = tab_width_pinned_conf * self.pinned_count
-                no_pinned_width = self.width() - pinned_width
-                width = no_pinned_width / (self.count() - self.pinned_count)
+                width = tab_width_pinned_conf
             else:
-                width = self.width() / self.count()
 
-            # If width is not divisible by count, add a pixel to some tabs so
+                # If we *do* have enough space, tabs should occupy the whole window
+                # width. If there are pinned tabs their size will be subtracted
+                # from the total window width.
+                # During shutdown the self.count goes down,
+                # but the self.pinned_count not - this generates some odd behavior.
+                # To avoid this we compare self.count against self.pinned_count.
+                if self.pinned_count > 0 and no_pinned_count > 0:
+                    width = no_pinned_width / no_pinned_count
+                else:
+                    width = self.width() / self.count()
+
+            # If no_pinned_width is not divisible by no_pinned_count, add a pixel to some tabs so
             # that there is no ugly leftover space.
-            if index < self.width() % self.count():
+            if no_pinned_count > 0 and index < no_pinned_width % no_pinned_count:
                 width += 1
+
             size = QSize(width, height)
         qtutils.ensure_valid(size)
         return size


### PR DESCRIPTION
When filling up leftover space in the tabbar, pinned tabs have to be taken care of. Firstly, only the space that is not used by pinned tabs should be considered. Secondly, pinned tabs may also have their width increased by 1px so returning early does not work.

To reproduce: Open three tabs, pin one of them and resize the window a little. There should be gray leftover space at the right and of the bar.