### PR TITLE
Refactor set_tab_pinned to take a tab widget.

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -277,16 +277,9 @@ class CommandDispatcher:
         """
         tab = self._cntwidget(count)
         if tab is None:
-            return
+            raise cmdexc.CommandError("Tab {} does not exist!".format(count))
 
         to_pin = not tab.data.pinned
-        tab_index = self._current_index() if count is None else count - 1
-        cmdutils.check_overflow(tab_index + 1, 'int')
-        tab = self._cntwidget(count)
-
-        if tab is None:
-            raise cmdexc.CommandError("Unable to find tab '{}'.".format(count))
-
         self._tabbed_browser.set_tab_pinned(tab, to_pin)
 
     @cmdutils.register(instance='command-dispatcher', name='open',

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -277,7 +277,7 @@ class CommandDispatcher:
         """
         tab = self._cntwidget(count)
         if tab is None:
-            raise cmdexc.CommandError("Tab {} does not exist!".format(count))
+            return
 
         to_pin = not tab.data.pinned
         self._tabbed_browser.set_tab_pinned(tab, to_pin)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -282,7 +282,12 @@ class CommandDispatcher:
         to_pin = not tab.data.pinned
         tab_index = self._current_index() if count is None else count - 1
         cmdutils.check_overflow(tab_index + 1, 'int')
-        self._tabbed_browser.set_tab_pinned(tab_index, to_pin)
+        tab = self._cntwidget(count)
+
+        if tab is None:
+            raise cmdexc.CommandError("Unable to find tab '{}'.".format(count))
+
+        self._tabbed_browser.set_tab_pinned(tab, to_pin)
 
     @cmdutils.register(instance='command-dispatcher', name='open',
                        maxsplit=0, scope='window')
@@ -515,7 +520,7 @@ class CommandDispatcher:
         newtab.data.keep_icon = True
         newtab.history.deserialize(history)
         newtab.zoom.set_factor(curtab.zoom.factor())
-        new_tabbed_browser.set_tab_pinned(idx, curtab.data.pinned)
+        new_tabbed_browser.set_tab_pinned(newtab, curtab.data.pinned)
         return newtab
 
     @cmdutils.register(instance='command-dispatcher', scope='window')

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -342,7 +342,7 @@ class TabbedBrowser(tabwidget.TabWidget):
             newtab = self.tabopen(url, background=False, idx=idx)
 
         newtab.history.deserialize(history_data)
-        self.set_tab_pinned(idx, pinned)
+        self.set_tab_pinned(newtab, pinned)
 
     @pyqtSlot('QUrl', bool)
     def openurl(self, url, newtab):

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -26,7 +26,7 @@ from PyQt5.QtCore import (pyqtSignal, pyqtSlot, Qt, QSize, QRect, QPoint,
                           QTimer, QUrl)
 from PyQt5.QtWidgets import (QTabWidget, QTabBar, QSizePolicy, QCommonStyle,
                              QStyle, QStylePainter, QStyleOptionTab,
-                             QStyleFactory)
+                             QStyleFactory, QWidget)
 from PyQt5.QtGui import QIcon, QPalette, QColor
 
 from qutebrowser.utils import qtutils, objreg, utils, usertypes, log
@@ -94,17 +94,18 @@ class TabWidget(QTabWidget):
         bar.set_tab_data(idx, 'indicator-color', color)
         bar.update(bar.tabRect(idx))
 
-    def set_tab_pinned(self, idx, pinned, *, loading=False):
+    def set_tab_pinned(self, tab: QWidget,
+                       pinned: bool, *, loading: bool = False) -> None:
         """Set the tab status as pinned.
 
         Args:
-            idx: The tab index.
+            tab: The tab to pin
             pinned: Pinned tab state to set.
             loading: Whether to ignore current data state when
                      counting pinned_count.
         """
         bar = self.tabBar()
-        tab = self.widget(idx)
+        idx = self.indexOf(tab)
 
         # Only modify pinned_count if we had a change
         # always modify pinned_count if we are loading

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -406,7 +406,7 @@ class SessionManager(QObject):
                     tab_to_focus = i
                 if new_tab.data.pinned:
                     tabbed_browser.set_tab_pinned(
-                        i, new_tab.data.pinned, loading=True)
+                        new_tab, new_tab.data.pinned, loading=True)
             if tab_to_focus is not None:
                 tabbed_browser.setCurrentIndex(tab_to_focus)
             if win.get('active', False):

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1078,8 +1078,7 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new tab
         And I open data/numbers/3.txt in a new tab
         And I run :tab-pin with count 23
-        Then the error "Tab 23 does not exist!" should be shown
-        And the following tabs should be open:
+        Then the following tabs should be open:
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1073,6 +1073,17 @@ Feature: Tab management
             - data/numbers/2.txt (pinned)
             - data/numbers/3.txt (active)
 
+    Scenario: :tab-pin with an invalid count
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-pin with count 23
+        Then the error "Tab 23 does not exist!" should be shown
+        And the following tabs should be open:
+            - data/numbers/1.txt
+            - data/numbers/2.txt
+            - data/numbers/3.txt (active)
+
     Scenario: Pinned :tab-close prompt yes
         When I open data/numbers/1.txt
         And I run :tab-pin


### PR DESCRIPTION
An attempt to fix (possibly) #2759. Conflicts with (slightly) #2762, which I'll deal with. This is probably more important...

I think that this change makes it impossible for the `tab` object to be `None`, as long as a tab creation does not result in `None`, (but I can't confirm the issue is fixed because I can't repro). 

Let me know what you think :smile:.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2765)
<!-- Reviewable:end -->
