### PR TITLE
Preserve fullscreen when exiting video fullscreen

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -615,6 +615,7 @@ class WebEngineTab(browsertab.AbstractTab):
 
     def shutdown(self):
         self.shutting_down.emit()
+        self.action.exit_fullscreen()
         if qtutils.version_check('5.8', exact=True):
             # WORKAROUND for
             # https://bugreports.qt.io/browse/QTBUG-58563

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -128,6 +128,8 @@ class MainWindow(QWidget):
         _commandrunner: The main CommandRunner instance.
         _overlays: Widgets shown as overlay for the current webpage.
         _private: Whether the window is in private browsing mode.
+        _restore_fullscreen: Whether to restore the fullscreen after leaving
+            a video fullscreen.
     """
 
     def __init__(self, *, private, geometry=None, parent=None):
@@ -216,6 +218,8 @@ class MainWindow(QWidget):
         objreg.get('config').changed.connect(self.on_config_changed)
 
         objreg.get("app").new_window.emit(self)
+
+        self._restore_fullscreen = False
 
     def _init_geometry(self, geometry):
         """Initialize the window geometry or load it from disk."""
@@ -483,9 +487,14 @@ class MainWindow(QWidget):
     @pyqtSlot(bool)
     def _on_fullscreen_requested(self, on):
         if on:
+            self._restore_fullscreen = self.isFullScreen()
             self.showFullScreen()
-        else:
+        elif not self._restore_fullscreen:
             self.showNormal()
+        else:
+            self._restore_fullscreen = self.isFullScreen()
+        log.misc.debug('on: {}, restore fullscreen: {}'
+                       .format(on, self._restore_fullscreen))
 
     @cmdutils.register(instance='main-window', scope='window')
     @pyqtSlot()


### PR DESCRIPTION
Fixes #2778

Assuming that the `_on_fullscreen_requested` slot is used only by the video elements, it should work as expected...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2781)
<!-- Reviewable:end -->
