### PR TITLE
Add :tab-{give,take}, closes #1788

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -526,6 +526,32 @@ class CommandDispatcher:
         cur_widget = self._current_widget()
         self._tabbed_browser.close_tab(cur_widget, add_undo=False)
 
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def tab_attach(self, win_id: int = None):
+        """Attach the current tab to a different window.
+
+        Args:
+            win_id: The id of the window to attach to, uses the
+                    first-opened window's id if not given.
+        """
+        window = None
+        if win_id is None:
+            window = objreg.window_by_index(0)
+        else:
+            if win_id not in objreg.window_registry:
+                raise cmdexc.CommandError(
+                    "There's no window with id {}!".format(win_id))
+            window = objreg.window_registry[win_id]
+
+        if window.win_id == self._win_id:
+            raise cmdexc.CommandError(
+                "Tab is already attached to that window!")
+
+        url = self._current_url()
+        cur_widget = self._current_widget()
+        window.tabbed_browser.tabopen(url, explicit=True)
+        self._tabbed_browser.close_tab(cur_widget, add_undo=False)
+
     def _back_forward(self, tab, bg, window, count, forward):
         """Helper function for :back/:forward."""
         history = self._current_widget().history

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -660,6 +660,56 @@ Feature: Tab management
         And I run :tab-detach
         Then the error "Cannot detach one tab." should be shown
 
+    # :tab-attach
+
+    # Needs qutewm to run properly
+    # See https://github.com/qutebrowser/qutebrowser/pull/1844
+    @xfail_norun
+    Scenario: Attach tab to first-opened window
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I run :buffer "2.txt"
+        And I run :tab-attach
+        And I run :buffer "1.txt"
+        And I run :window-only
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+
+    # Needs qutewm to run properly
+    # See https://github.com/qutebrowser/qutebrowser/pull/1844
+    @xfail_norun
+    Scenario: Attach tab to arbitrary window
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I run :buffer "1.txt"
+        And I run :tab-attach 1
+        And I run :buffer "2.txt"
+        And I run :window-only
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+              - history:
+                - url: http://localhost:*/data/numbers/1.txt
+
+    Scenario: Attach tab to same window
+        When I open data/numbers/1.txt
+        And I run :tab-attach
+        Then the error "Tab is already attached to that window!" should be shown
+
+    Scenario: Attach tab to nonexistent window
+        When I open data/numbers/1.txt
+        And I run :tab-attach 9999
+        Then the error "There's no window with id 9999!" should be shown
+
     # :undo
 
     Scenario: Undo without any closed tabs


### PR DESCRIPTION
This is a simple fix for #1788, I just open the tab's URL in the window you want to attach to and close it in the current one, except when the target window either doesn't exist or is the same as the current window.

Sorry if I've missed something, this is my first time contributing to a big project on GitHub :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2783)
<!-- Reviewable:end -->
