### PR TITLE
Add a dead-simple mooltipass integration for password_fill

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -296,6 +296,25 @@ secret_backend() {
 }
 # =======================================================
 
+# =======================================================
+# backend: mooltipass
+
+mooltipass_backend() {
+    init() {
+        if [ -z "$(which mooltipy)" ] ; then
+            die "mooltipy not installed, pip install mooltipy"
+        fi
+    }
+    query_entries() {}
+    open_entry() {
+        output=($(mooltipy login get -w $simple_url))
+        username=${output[0]}
+        password=${output[1]}
+    }
+}
+
+# =======================================================
+
 # load some sane default backend
 reset_backend
 pass_backend

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -303,7 +303,7 @@ secret_backend() {
 mooltipass_backend() {
     init() {
         if [ -z "$(which mooltipy)" ] ; then
-            die "mooltipy not installed, pip install mooltipy"
+            die "mooltipy not installed"
         fi
     }
     # query_entries does nothing due to how the mooltipass works; you pass a

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -298,6 +298,7 @@ secret_backend() {
 
 # =======================================================
 # backend: mooltipass
+# Mooltipass is a hardware password manager, http://themooltipass.com
 
 mooltipass_backend() {
     init() {
@@ -305,7 +306,13 @@ mooltipass_backend() {
             die "mooltipy not installed, pip install mooltipy"
         fi
     }
-    query_entries() {}
+    # query_entries does nothing due to how the mooltipass works; you pass a
+    # domain to the hardware and it decides whether it has a login context to
+    # return to the user, so we just pass through query_entries and let
+    # open_entry figure it out.
+    query_entries() {
+        files+=(1)
+    }
     open_entry() {
         output=($(mooltipy login get -w $simple_url))
         username=${output[0]}


### PR DESCRIPTION
This relies on behavior added to mooltipy in https://github.com/oSquat/mooltipy/pull/11 so probably
shouldn't be merged until that is merged. Wanted to make it visible at least in the meantime in case there are any Mooltipass users who want it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2802)
<!-- Reviewable:end -->
