### PR TITLE
Enforce a minimum size for non-pinned tabs

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -517,7 +517,9 @@ class TabBar(QTabBar):
 
             no_pinned_count = self.count() - self.pinned_count
             pinned_width = tab_width_pinned_conf * self.pinned_count
-            no_pinned_width = self.width() - pinned_width
+            # Prevent any tabs from being smaller than the min size
+            no_pinned_width = max(self.width() - pinned_width,
+                                  minimum_size.width() * no_pinned_count)
 
             if pinned:
                 width = tab_width_pinned_conf

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -503,10 +503,6 @@ class TabBar(QTabBar):
             # We return it directly rather than setting `size' because we don't
             # want to ensure it's valid in this special case.
             return QSize()
-        elif self.count() * minimum_size.width() > self.width():
-            # If we don't have enough space, we return the minimum size so we
-            # get scroll buttons as soon as needed.
-            size = minimum_size
         else:
             tab_width_pinned_conf = config.get('tabs', 'pinned-width')
 
@@ -517,21 +513,19 @@ class TabBar(QTabBar):
 
             no_pinned_count = self.count() - self.pinned_count
             pinned_width = tab_width_pinned_conf * self.pinned_count
-            # Prevent any tabs from being smaller than the min size
-            no_pinned_width = max(self.width() - pinned_width,
-                                  minimum_size.width() * no_pinned_count)
+            no_pinned_width = self.width() - pinned_width
 
             if pinned:
                 width = tab_width_pinned_conf
             else:
 
-                # If we *do* have enough space, tabs should occupy the whole
-                # window width. If there are pinned tabs their size will be
-                # subtracted from the total window width.
-                # During shutdown the self.count goes down,
-                # but the self.pinned_count not - this generates some odd
+                # Tabs should attempt to occupy the whole window width. If
+                # there are pinned tabs their size will be subtracted from the
+                # total window width.  During shutdown the self.count goes
+                # down, but the self.pinned_count not - this generates some odd
                 # behavior. To avoid this we compare self.count against
-                # self.pinned_count.
+                # self.pinned_count. If we end up having too little space, we
+                # set the minimum size below.
                 if self.pinned_count > 0 and no_pinned_count > 0:
                     width = no_pinned_width / no_pinned_count
                 else:
@@ -542,6 +536,10 @@ class TabBar(QTabBar):
             if (no_pinned_count > 0 and
                     index < no_pinned_width % no_pinned_count):
                 width += 1
+
+            # If we don't have enough space, we return the minimum size so we
+            # get scroll buttons as soon as needed.
+            width = max(width, minimum_size.width())
 
             size = QSize(width, height)
         qtutils.ensure_valid(size)


### PR DESCRIPTION
Closes #2826 

Let's see if the tests pass....

Also, does this logic seem right? Essentially enforcing a minimum size allocated for non-pinned tabs, even if the window is small.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2827)
<!-- Reviewable:end -->
