### PR TITLE
Clarify dependecies for readability userscript

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -2,6 +2,11 @@
 #
 # Executes python-readability on current page and opens the summary as new tab.
 #
+# Depends on the python-readability package, or its fork:
+#
+#   - https://github.com/buriy/python-readability
+#   - https://github.com/bookieio/breadability
+#
 # Usage:
 #   :spawn --userscript readability
 #


### PR DESCRIPTION
Just a small addition to the inline documentation of the `readability` userscript.

It requires the `readability` python module to be present on the system, so I added a note with two choices that fulfill this dependency:
- https://github.com/buriy/python-readability
- https://github.com/bookieio/breadability

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2831)
<!-- Reviewable:end -->
