### PR TITLE
Add support for breadability module in readability userscript

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -12,15 +12,22 @@
 #
 from __future__ import absolute_import
 import codecs, os
-from readability.readability import Document
 
 tmpfile=os.path.expanduser('~/.local/share/qutebrowser/userscripts/readability.html')
 if not os.path.exists(os.path.dirname(tmpfile)):
     os.makedirs(os.path.dirname(tmpfile))
 
 with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
-    doc = Document(source.read())
-    content = doc.summary().replace('<html>', '<html><head><title>%s</title></head>' % doc.title())
+    data = source.read()
+
+    try:
+        from breadability.readable import Article as reader
+        doc = reader(data)
+        content = doc.readable
+    except ImportError:
+        from readability import Document
+        doc = Document(data)
+        content = doc.summary().replace('<html>', '<html><head><title>%s</title></head>' % doc.title())
 
     with codecs.open(tmpfile, 'w', 'utf-8') as target:
         target.write('<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />')


### PR DESCRIPTION
Turns out the latest version of `python-readability` breaks the userscript, apparently some UTF-8 error...

So in addition to my documentation update in #2831, I have patched the script to prefer the `breadability` fork if available. If not available the script will try to use the old module as before.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2834)
<!-- Reviewable:end -->
