### PR TITLE
Rewrite tab-detach and add tab-give/tab-take

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -79,11 +79,13 @@ It is possible to run or bind multiple commands by separating them with `;;`.
 |<<tab-close,tab-close>>|Close the current/[count]th tab.
 |<<tab-detach,tab-detach>>|Detach the current tab to its own window.
 |<<tab-focus,tab-focus>>|Select the tab given as argument/[count].
+|<<tab-give,tab-give>>|Give the current tab to a new window.
 |<<tab-move,tab-move>>|Move the current tab according to the argument and [count].
 |<<tab-next,tab-next>>|Switch to the next tab, or switch [count] tabs forward.
 |<<tab-only,tab-only>>|Close all tabs except for the current one.
 |<<tab-pin,tab-pin>>|Pin/Unpin the current/[count]th tab.
 |<<tab-prev,tab-prev>>|Switch to the previous tab, or switch [count] tabs back.
+|<<tab-take,tab-take>>|Takes a tab from another window and attaches it to this window.
 |<<unbind,unbind>>|Unbind a keychain.
 |<<undo,undo>>|Re-open a closed tab.
 |<<view-source,view-source>>|Show the source of the current page in a new tab.
@@ -871,6 +873,17 @@ If neither count nor index are given, it behaves like tab-next. If both are give
 ==== count
 The tab index to focus, starting with 1.
 
+[[tab-give]]
+=== tab-give
+Syntax: +:tab-give 'win-id'+
+
+Give the current tab to a new window.
+
+If the current window only has a single tab, this behaves like tab-close.
+
+==== positional arguments
+* +'win-id'+: The window ID, starting with 0, to attach the current tab to.
+
 [[tab-move]]
 === tab-move
 Syntax: +:tab-move ['index']+
@@ -922,6 +935,17 @@ Switch to the previous tab, or switch [count] tabs back.
 
 ==== count
 How many tabs to switch back.
+
+[[tab-take]]
+=== tab-take
+Syntax: +:buffer 'index'+
+
+Takes a tab from another window and attaches it to this window.
+
+Select tab by index or url/title best match. If the window being taken from only has a single tab, this behaves like tab-close.
+
+==== positional arguments
+* +'index'+: The [win_id/]index of the tab to take. Or a substring in which case the closest match will be focused.
 
 [[unbind]]
 === unbind

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -135,6 +135,25 @@ def buffer():
     return model
 
 
+def window():
+    """A model to complete on all open windows."""
+    model = completionmodel.CompletionModel(column_widths=(6, 30, 64))
+
+    windows = []
+
+    for win_id in objreg.window_registry:
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window=win_id)
+        tab_titles = (tab.title() for tab in tabbed_browser.widgets())
+        windows.append(("{}".format(win_id),
+                        objreg.window_registry[win_id].windowTitle(),
+                        ", ".join(tab_titles)))
+
+    model.add_category(listcategory.ListCategory("Windows", windows))
+
+    return model
+
+
 def bind(key):
     """A CompletionModel filled with all bindable commands and descriptions.
 

--- a/tests/end2end/features/invoke.feature
+++ b/tests/end2end/features/invoke.feature
@@ -80,7 +80,6 @@ Feature: Invoking a new process
         And I open data/title.html
         And I open data/search.html in a new tab
         And I run :tab-detach
-        And I wait until data/search.html is loaded
         And I open data/hello.txt as a URL
         Then the session should look like:
             windows:

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1007,6 +1007,56 @@ Feature: Tab management
         And I run :buffer "1/2/3"
         Then the error "No matching tab for: 1/2/3" should be shown
 
+    # :tab-take
+
+    Scenario: Take a tab from another window
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I run :tab-take 0/1
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+
+    Scenario: Take a tab from the same window
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I run :tab-take 0/1
+        Then the error "Can't take a tab from the same window" should be shown
+
+    # :tab-give
+
+    Scenario: Give a tab to another window
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I run :tab-give 0
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+            - tabs:
+              - history:
+                - url: about:blank
+
+    Scenario: Give a tab to the same window
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I run :tab-give 0
+        Then the error "Can't give a tab to the same window" should be shown
+
     # Other
 
     Scenario: Using :tab-next after closing last tab (#1448)

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -644,7 +644,6 @@ Feature: Tab management
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I run :tab-detach
-        And I wait until data/numbers/2.txt is loaded
         Then the session should look like:
             windows:
             - tabs:


### PR DESCRIPTION
Replacement for #2783 which closes #1788 and closes #2636

**TODO**
- [x] Add completion functions for tab-{give,take}
- [x] Rename completion function to `window` instead of `windows` 
- [x] Write tests for tab-{give,take}
- [x] Rewrite tests for tab-detach
- [x] Reset window IDs for each feature
- [x] Fix `protected-access`
- [ ] Fix crash on `Given I clean up open tabs`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2848)
<!-- Reviewable:end -->
