### PR TITLE
Fix web-history-max-items-crash.

### DIFF
--- a/qutebrowser/completion/models/histcategory.py
+++ b/qutebrowser/completion/models/histcategory.py
@@ -72,6 +72,10 @@ class HistoryCategory(QSqlQueryModel):
             'ORDER BY last_atime DESC LIMIT :limit)',
         ])).run(limit=max_items).value()
 
+        if not min_atime:
+            # if there are no history items, min_atime may be '' (issue #2849)
+            return ''
+
         return "AND last_atime >= {}".format(min_atime)
 
     def set_pattern(self, pattern):

--- a/tests/unit/completion/test_histcategory.py
+++ b/tests/unit/completion/test_histcategory.py
@@ -126,7 +126,8 @@ def test_set_pattern(pattern, before, after, model_validator, hist):
     ], [
         ('b', 'b', '2017-06-16'),
         ('c', 'c', '2017-05-16'),
-    ])
+    ]),
+    (1, [], []),  # issue 2849 (crash with empty history)
 ])
 def test_sorting(max_items, before, after, model_validator, hist, config_stub):
     """Validate the filtering and sorting results of set_pattern."""


### PR DESCRIPTION
Fixes #2849, where pressing 'o' immediately after starting with
web-history-max-items set would cause a crash as the query result is
empty.

The query is not returning an error here, so it seems like the best
approach is to simply ignore an empty result.

In this case, there will be no crash, but the completion will be empty
anyways (as the main query is also returning an empty result).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2852)
<!-- Reviewable:end -->
