### PR TITLE
Abort resizeEvent if model is None.

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -148,6 +148,8 @@ class CompletionView(QTreeView):
 
     def _resize_columns(self):
         """Resize the completion columns based on column_widths."""
+        if self.model() is None:
+            return
         width = self.size().width()
         column_widths = self.model().column_widths
         pixel_widths = [(width * perc // 100) for perc in column_widths]

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -240,3 +240,8 @@ def test_completion_item_del_no_selection(completionview):
     with pytest.raises(cmdexc.CommandError, match='No item selected!'):
         completionview.completion_item_del()
     assert not func.called
+
+
+def test_resize_no_model(completionview, qtbot):
+    """Ensure no crash if resizeEvent is triggered with no model (#2854)."""
+    completionview.resizeEvent(None)


### PR DESCRIPTION
Some reports came in that a resizeEvent was causing a crash due to the
model being none in the CompletionView.

Fixes #2854.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2856)
<!-- Reviewable:end -->
