### PR TITLE
Fix bind completion for bindings with arguments.

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -126,11 +126,12 @@ def bind(key):
         key: the key being bound.
     """
     model = completionmodel.CompletionModel(column_widths=(20, 60, 20))
-    cmd_name = objreg.get('key-config').get_bindings_for('normal').get(key)
+    cmd_text = objreg.get('key-config').get_bindings_for('normal').get(key)
 
-    if cmd_name:
+    if cmd_text:
+        cmd_name = cmd_text.split(' ')[0]
         cmd = cmdutils.cmd_dict.get(cmd_name)
-        data = [(cmd_name, cmd.desc, key)]
+        data = [(cmd_text, cmd.desc, key)]
         model.add_category(listcategory.ListCategory("Current", data))
 
     cmdlist = _get_cmd_completions(include_hidden=True, include_aliases=True)

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -583,7 +583,7 @@ def test_bind_completion(qtmodeltester, monkeypatch, stubs, config_stub,
     _patch_cmdutils(monkeypatch, stubs,
                     'qutebrowser.completion.models.miscmodels.cmdutils')
     config_stub.data['aliases'] = {'rock': 'roll'}
-    key_config_stub.set_bindings_for('normal', {'s': 'stop',
+    key_config_stub.set_bindings_for('normal', {'s': 'stop now',
                                                 'rr': 'roll',
                                                 'ro': 'rock'})
     model = miscmodels.bind('s')
@@ -593,14 +593,14 @@ def test_bind_completion(qtmodeltester, monkeypatch, stubs, config_stub,
 
     _check_completions(model, {
         "Current": [
-            ('stop', 'stop qutebrowser', 's'),
+            ('stop now', 'stop qutebrowser', 's'),
         ],
         "Commands": [
             ('drop', 'drop all user data', ''),
             ('hide', '', ''),
             ('rock', "Alias for 'roll'", 'ro'),
             ('roll', 'never gonna give you up', 'rr'),
-            ('stop', 'stop qutebrowser', 's'),
+            ('stop', 'stop qutebrowser', ''),
         ]
     })
 


### PR DESCRIPTION
When a key is bound to a command line that includes one or more
arguments to a command, bind completion should show the whole command
for the "Current" category, and use only the command name to look up the
description.

Fixes #2859, where a crash was caused by looking up the description by
the full command text rather than just the name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2861)
<!-- Reviewable:end -->
