### PR TITLE
Greasemonkey-like Userscript Support

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -47,7 +47,7 @@ from qutebrowser.commands import cmdutils, runners, cmdexc
 from qutebrowser.config import style, config, websettings, configexc
 from qutebrowser.config.parsers import keyconf
 from qutebrowser.browser import (urlmarks, adblock, history, browsertab,
-                                 downloads)
+                                 downloads, greasemonkey)
 from qutebrowser.browser.network import proxy
 from qutebrowser.browser.webkit import cookies, cache
 from qutebrowser.browser.webkit.network import networkmanager
@@ -468,6 +468,10 @@ def _init_modules(args, crash_handler):
     log.init.debug("Initializing cache...")
     diskcache = cache.DiskCache(standarddir.cache(), parent=qApp)
     objreg.register('cache', diskcache)
+
+    log.init.debug("Initializing Greasemonkey...")
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    objreg.register('greasemonkey', gm_manager)
 
     log.init.debug("Misc initialization...")
     if config.get('ui', 'hide-wayland-decoration'):

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -10,8 +10,6 @@ from qutebrowser.config import config
 from qutebrowser.utils import log, standarddir
 from qutebrowser.commands import cmdutils
 
-# TODO: GM_ bootstrap
-
 def _scripts_dir():
     """Get the directory of the scripts"""
     directory = config.get('storage', 'greasemonkey-directory')
@@ -161,7 +159,7 @@ unsafeWindow = window
     @classmethod
     def parse(cls, source):
         props, code = re.split(cls.HEADER_REGEX, source)
-        return cls(re.findall(cls.PROPS_REGEX, props), code)
+        return cls(re.findall(cls.PROPS_REGEX, props), source)
 
 
     def includes(self):

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -141,6 +141,8 @@ unsafeWindow = window
         self._includes = []
         self._excludes = []
         self._description = None
+        self._Name = None
+        self._run_at = None
         for name, value in properties:
             if name == 'name':
                 self._name = value
@@ -241,7 +243,9 @@ class GreasemonkeyManager(QObject):
                     log.greasemonkey.warning(
                         "Script {} has invalid run-at defined".format(
                             script_path))
-                    continue
+                    # Default as per
+                    # https://wiki.greasespot.net/Metadata_Block#.40run-at
+                    self._run_end.append(script)
                 log.greasemonkey.debug("Loaded script: {}".format(
                     script.name()))
         self.scripts_reloaded.emit()

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -1,0 +1,238 @@
+import re
+import os
+import json
+from fnmatch import fnmatch
+from functools import partial
+
+from PyQt5.QtCore import QDir, QFile
+
+from qutebrowser.config import config
+from qutebrowser.utils import log, standarddir
+
+# TODO: GM_ bootstrap
+
+def _scripts_dir():
+    """Get the directory of the scripts"""
+    directory = config.get('storage', 'greasemonkey-directory')
+    if directory is None:
+        directory = os.path.join(standarddir.data(), 'greasemonkey')
+    return directory
+
+
+class GreasemonkeyScript:
+
+    GM_BOOTSTRAP_TEMPLATE = """
+
+var _qute_script_id = "__gm_{scriptName}";
+
+function GM_log(text) {{
+    console.log(text);
+}}
+
+GM_info = (function() {{
+    return {{
+        'script': {scriptInfo},
+        'scriptMetaStr': {scriptMeta},
+        'scriptWillUpdate': false,
+        'version': '0.0.1',
+        'scriptHandler': 'Tampermonkey' //so scripts don't expect exportFunction
+    }}
+}})();
+
+function GM_setValue(key, value) {{
+    if (localStorage !== null &&
+        typeof key === "string" &&
+        (typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value == "boolean")) {{
+        localStorage.setItem(_qute_script_id + key, value);
+    }}
+}}
+
+function GM_getValue(key, default_) {{
+    if (localStorage !== null && typeof key === "string") {{
+        return localStorage.getItem(_qute_script_id + key) || default_;
+    }}
+}}
+
+function GM_deleteValue(key) {{
+    if (localStorage !== null && typeof key === "string") {{
+        localStorage.removeItem(_qute_script_id + key);
+    }}
+}}
+
+function GM_listValues() {{
+    var i;
+    var keys = [];
+    for (i = 0; i < localStorage.length; ++i) {{
+        if (localStorage.key(i).startsWith(_qute_script_id)) {{
+            keys.push(localStorage.key(i));
+        }}
+    }}
+    return keys;
+}}
+
+function GM_openInTab(url) {{
+    window.open(url);
+}}
+
+
+// Almost verbatim copy from Eric
+function GM_xmlhttpRequest(/* object */ details) {{
+    details.method = details.method.toUpperCase() || "GET";
+
+    if(!details.url) {{
+        throw("GM_xmlhttpRequest requires an URL.");
+    }}
+
+    // build XMLHttpRequest object
+    var oXhr = new XMLHttpRequest;
+    // run it
+    if(oXhr) {{
+        if("onreadystatechange" in details)
+            oXhr.onreadystatechange = function() {{
+                details.onreadystatechange(oXhr)
+            }};
+        if("onload" in details)
+            oXhr.onload = function() {{ details.onload(oXhr) }};
+        if("onerror" in details)
+            oXhr.onerror = function() {{ details.onerror(oXhr) }};
+
+        oXhr.open(details.method, details.url, true);
+
+        if("headers" in details)
+            for(var header in details.headers)
+                oXhr.setRequestHeader(header, details.headers[header]);
+
+        if("data" in details)
+            oXhr.send(details.data);
+        else
+            oXhr.send();
+    }} else
+        throw ("This Browser is not supported, please upgrade.")
+}}
+
+function GM_addStyle(/* String */ styles) {{
+    var head = document.getElementsByTagName("head")[0];
+    if (head === undefined) {{
+        document.onreadystatechange = function() {{
+            if (document.readyState == "interactive") {{
+                var oStyle = document.createElement("style");
+                oStyle.setAttribute("type", "text\/css");
+                oStyle.appendChild(document.createTextNode(styles));
+                document.getElementsByTagName("head")[0].appendChild(oStyle);
+            }}
+        }}
+    }}
+    else {{
+        var oStyle = document.createElement("style");
+        oStyle.setAttribute("type", "text\/css");
+        oStyle.appendChild(document.createTextNode(styles));
+        head.appendChild(oStyle);
+    }}
+}}
+
+unsafeWindow = window
+    """
+
+    def __init__(self, properties, code):
+        self._code = code
+        self._includes = []
+        self._excludes = []
+        self._description = None
+        for name, value in properties:
+            if name == 'name':
+                self._name = value
+            if name == 'description':
+                self._description = value
+            if name in ['include', 'match']:
+                self._includes.append(value)
+            if name in ['exclude', 'exclude_match']:
+                self._excludes.append(value)
+            if name == 'run-at':
+                self._run_at = value
+
+    HEADER_REGEX = '\/\/ ==UserScript==.|\n+\/\/ ==\/UserScript==\n'
+    PROPS_REGEX = '\/\/ @(?P<prop>[^\s]+)\s+(?P<val>.+)'
+
+    @classmethod
+    def parse(cls, source):
+        props, code = re.split(cls.HEADER_REGEX, source)
+        return cls(re.findall(cls.PROPS_REGEX, props), code)
+
+
+    def includes(self):
+        return self._includes
+
+    def excludes(self):
+        return self._excludes
+
+    def name(self):
+        return self._name
+
+    def run_at(self):
+        return self._run_at
+
+    def code(self):
+        gm_bootstrap = self.GM_BOOTSTRAP_TEMPLATE.format(
+            scriptName=self._name,
+            scriptInfo=self.meta_json() or 'null',
+            scriptMeta=self.meta_raw() or 'null')
+        return '\n'.join([gm_bootstrap, self._code])
+
+    def meta_json(self):
+        return json.dumps({
+            'name': self._name,
+            'description': self._description,
+            'matches': self._includes,
+            'includes': self._includes,
+            'excludes': self._excludes,
+            'run-at': self._run_at,
+        })
+
+    def meta_raw(self):
+        pass
+
+
+class GreasemonkeyManager:
+
+    def __init__(self):
+        self._run_start = []
+        self._run_end = []
+
+        scripts_dir = QDir(_scripts_dir())
+        log.greasemonkey.debug("Reading scripts from: {}".format(
+            scripts_dir.absolutePath()))
+        for script_filename in scripts_dir.entryList(['*.js'], QDir.Files):
+            script_path = scripts_dir.absoluteFilePath(script_filename)
+            log.greasemonkey.debug("Trying to load script: {}".format(
+                script_path))
+            with open(script_path) as script_file:
+                try:
+                    script = GreasemonkeyScript.parse(script_file.read())
+                except Exception as e :
+                    log.greasemonkey.warning("Unable to load: {} {}".format(
+                        script_path, e))
+                    # XXX: Catch-all
+                    continue
+                if script.run_at() == 'document-start':
+                    self._run_start.append(script)
+                elif script.run_at() == 'document-end':
+                    self._run_end.append(script)
+                else:
+                    log.greasemonkey.warning(
+                        "Script {} has invalid run-at defined".format(
+                            script_path))
+                    continue
+                log.greasemonkey.debug("Loaded script: {}".format(
+                    script.name()))
+
+    def scripts_for(self, url):
+        match = partial(fnmatch, url)
+        tester = lambda script: any(map(match, script.includes())) \
+                        and not any(map(match, script.excludes()))
+        return list(filter(tester, self._run_start)), \
+               list(filter(tester, self._run_end))
+
+    def all_scripts(self):
+        return self._run_start + self._run_end

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -179,7 +179,7 @@ unsafeWindow = window
             scriptName=self._name,
             scriptInfo=self.meta_json() or 'null',
             scriptMeta=self.meta_raw() or 'null')
-        return '\n'.join([gm_bootstrap, self._code])
+        return '\n'.join(["(function(){", gm_bootstrap, self._code, "}).call();"])
 
     def meta_json(self):
         return json.dumps({

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -219,6 +219,7 @@ class GreasemonkeyManager(QObject):
         """Re-Read greasemonkey scripts from disk"""
         self._run_start = []
         self._run_end = []
+        self._run_idle = []
 
         scripts_dir = QDir(_scripts_dir())
         log.greasemonkey.debug("Reading scripts from: {}".format(
@@ -239,6 +240,8 @@ class GreasemonkeyManager(QObject):
                     self._run_start.append(script)
                 elif script.run_at() == 'document-end':
                     self._run_end.append(script)
+                elif script.run_at() == 'document-idle':
+                    self._run_idle.append(script)
                 else:
                     log.greasemonkey.warning(
                         "Script {} has invalid run-at defined".format(
@@ -255,7 +258,8 @@ class GreasemonkeyManager(QObject):
         tester = lambda script: any(map(match, script.includes())) \
                         and not any(map(match, script.excludes()))
         return list(filter(tester, self._run_start)), \
-               list(filter(tester, self._run_end))
+               list(filter(tester, self._run_end)), \
+               list(filter(tester, self._run_idle))
 
     def all_scripts(self):
-        return self._run_start + self._run_end
+        return self._run_start + self._run_end + self._run_idle

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -4,10 +4,11 @@ import json
 from fnmatch import fnmatch
 from functools import partial
 
-from PyQt5.QtCore import QDir, QFile
+from PyQt5.QtCore import QDir, QFile, pyqtSignal, QObject
 
 from qutebrowser.config import config
 from qutebrowser.utils import log, standarddir
+from qutebrowser.commands import cmdutils
 
 # TODO: GM_ bootstrap
 
@@ -194,9 +195,26 @@ unsafeWindow = window
         pass
 
 
-class GreasemonkeyManager:
+class GreasemonkeyManager(QObject):
+
+    """Manager of userscripts and a greasemonkey compatible environment.
+
+    Signals:
+        scripts_reloaded: Emitted when scripts are reloaded from disk.
+            Any any cached or already-injected scripts should be
+            considered obselete.
+    """
+
+    scripts_reloaded = pyqtSignal()
 
     def __init__(self):
+        super().__init__()
+        self.load_scripts()
+
+    @cmdutils.register(name=['greasemonkey-reload'],
+                       instance='greasemonkey')
+    def load_scripts(self):
+        """Re-Read greasemonkey scripts from disk"""
         self._run_start = []
         self._run_end = []
 
@@ -226,6 +244,7 @@ class GreasemonkeyManager:
                     continue
                 log.greasemonkey.debug("Loaded script: {}".format(
                     script.name()))
+        self.scripts_reloaded.emit()
 
     def scripts_for(self, url):
         match = partial(fnmatch, url)

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -23,13 +23,15 @@ import functools
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, PYQT_VERSION
 from PyQt5.QtGui import QPalette
-from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
+from PyQt5.QtWebEngineWidgets import (QWebEngineView, QWebEnginePage,
+                                      QWebEngineScript)
 
 from qutebrowser.browser import shared
-from qutebrowser.browser.webengine import certificateerror, webenginesettings
+from qutebrowser.browser.webengine import (certificateerror, webenginesettings,
+                                           webenginetab)
 from qutebrowser.config import config
 from qutebrowser.utils import (log, debug, usertypes, jinja, urlutils, message,
-                               objreg)
+                               objreg, qtutils)
 
 
 class WebEngineView(QWebEngineView):
@@ -309,3 +311,4 @@ class WebEnginePage(QWebEnginePage):
             message.error(msg)
             return False
         return True
+

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -32,7 +32,7 @@ from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtPrintSupport import QPrinter
 
-from qutebrowser.browser import browsertab
+from qutebrowser.browser import browsertab, greasemonkey
 from qutebrowser.browser.webkit import webview, tabhistory, webkitelem
 from qutebrowser.browser.webkit.network import webkitqutescheme
 from qutebrowser.utils import qtutils, objreg, usertypes, utils, log, debug
@@ -44,6 +44,10 @@ def init():
     log.init.debug("Initializing js-bridge...")
     js_bridge = webkitqutescheme.JSBridge(qapp)
     objreg.register('js-bridge', js_bridge)
+
+    log.init.debug("Initializing Greasemonkey...")
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    objreg.register('greasemonkey', gm_manager)
 
 
 class WebKitAction(browsertab.AbstractAction):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -32,7 +32,7 @@ from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtPrintSupport import QPrinter
 
-from qutebrowser.browser import browsertab, greasemonkey
+from qutebrowser.browser import browsertab
 from qutebrowser.browser.webkit import webview, tabhistory, webkitelem
 from qutebrowser.browser.webkit.network import webkitqutescheme
 from qutebrowser.utils import qtutils, objreg, usertypes, utils, log, debug
@@ -44,10 +44,6 @@ def init():
     log.init.debug("Initializing js-bridge...")
     js_bridge = webkitqutescheme.JSBridge(qapp)
     objreg.register('js-bridge', js_bridge)
-
-    log.init.debug("Initializing Greasemonkey...")
-    gm_manager = greasemonkey.GreasemonkeyManager()
-    objreg.register('greasemonkey', gm_manager)
 
 
 class WebKitAction(browsertab.AbstractAction):

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -751,6 +751,10 @@ def data(readonly=False):
              SettingValue(typ.Bool(), 'true'),
              "Whether to remember the last used download directory."),
 
+            ('greasemonkey-directory',
+             SettingValue(typ.Directory(none_ok=True), ''),
+             "The directory to look for scripts in"),
+
             # Defaults from QWebSettings::QWebSettings() in
             # qtwebkit/Source/WebKit/qt/Api/qwebsettings.cpp
 

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -142,6 +142,7 @@ webelem = logging.getLogger('webelem')
 prompt = logging.getLogger('prompt')
 network = logging.getLogger('network')
 sql = logging.getLogger('sql')
+greasemonkey = logging.getLogger('greasemonkey')
 
 
 ram_handler = None


### PR DESCRIPTION
Adds support for reading in userscripts from `<datafolder>/greasemonkey` (configurable) and injecting them into pages based on the greasemonkey compatible metadata block.

Tested on (old)webkit and qtwebengine 5.9. qtwebengine 5.7 and below not supported allthough I can add that finicky stuff back in if people actually want it.

Most of the work comes from andor44's fork from a couple of years ago. The impact on the existing codebase is very small. On webkit we manually pick scripts to inject in event handlers on webengine deciding when to inject and on what pages is handled for us.

greasemonkey.py wraps the userscripts in a simple lexical scope along with a bunch of GM_ functions that are useb by various userscripts floating about, certainly not all of the ones listed on the docs page. All the ones we implement should work fine though. Except that GM_xmlhttpRequest is stated in the docs to handle cross-origin requests and due to that being disabled globally on both supported backends we can't. I am going to look into getting that working though. If you want you can pass the `--qt-flag disable-web-security` to enable cross-origin requests globally, which will open that session up to cookie hijacking attacks from random pop-up ads etc.

The scripts currently run in the main javascript "world", meaning they can see all the same stuff you can see when you look at the web inspector console. This is good if you want your scripts to be able to change more about how web pages behave but bad if you are in the habit of running untrusted userscripts. The qtwebengine docs say that other worlds should be able to access the DOM too but my more featureful userscripts all fail to effect the page so I am still looking into whether it is possible to get more isolation without sacrificing features.

https://github.com/andor44/qutebrowser/commit/a19321714a33b6787ac18ba06800c8571fc376ed
https://wiki.greasespot.net/Greasemonkey_Manual:API
https://doc.qt.io/qt-5/qwebenginescript.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2867)
<!-- Reviewable:end -->
