### PR TITLE
Support delete from :{quick,book}mark-load.

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -60,17 +60,33 @@ def helptopic():
 
 def quickmark():
     """A CompletionModel filled with all quickmarks."""
+    def delete(data):
+        """Delete a quickmark from the completion menu."""
+        name = data[0]
+        quickmark_manager = objreg.get('quickmark-manager')
+        log.completion.debug('Deleting quickmark {}'.format(name))
+        quickmark_manager.delete(name)
+
     model = completionmodel.CompletionModel(column_widths=(30, 70, 0))
     marks = objreg.get('quickmark-manager').marks.items()
-    model.add_category(listcategory.ListCategory('Quickmarks', marks))
+    model.add_category(listcategory.ListCategory('Quickmarks', marks,
+                                                 delete_func=delete))
     return model
 
 
 def bookmark():
     """A CompletionModel filled with all bookmarks."""
+    def delete(data):
+        """Delete a bookmark from the completion menu."""
+        urlstr = data[0]
+        log.completion.debug('Deleting bookmark {}'.format(urlstr))
+        bookmark_manager = objreg.get('bookmark-manager')
+        bookmark_manager.delete(urlstr)
+
     model = completionmodel.CompletionModel(column_widths=(30, 70, 0))
     marks = objreg.get('bookmark-manager').marks.items()
-    model.add_category(listcategory.ListCategory('Bookmarks', marks))
+    model.add_category(listcategory.ListCategory('Bookmarks', marks,
+                                                 delete_func=delete))
     return model
 
 

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -252,6 +252,27 @@ def test_quickmark_completion(qtmodeltester, quickmarks):
     })
 
 
+@pytest.mark.parametrize('row, removed', [
+    (0, 'aw'),
+    (1, 'ddg'),
+    (2, 'wiki'),
+])
+def test_quickmark_completion_delete(qtmodeltester, quickmarks, row, removed):
+    """Test deleting a quickmark from the quickmark completion model."""
+    model = miscmodels.quickmark()
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    parent = model.index(0, 0)
+    idx = model.index(row, 0, parent)
+
+    before = set(quickmarks.marks.keys())
+    model.delete_cur_item(idx)
+    after = set(quickmarks.marks.keys())
+    assert before.difference(after) == {removed}
+
+
 def test_bookmark_completion(qtmodeltester, bookmarks):
     """Test the results of bookmark completion."""
     model = miscmodels.bookmark()
@@ -266,6 +287,27 @@ def test_bookmark_completion(qtmodeltester, bookmarks):
             ('https://python.org', 'Welcome to Python.org', None),
         ]
     })
+
+
+@pytest.mark.parametrize('row, removed', [
+    (0, 'http://qutebrowser.org'),
+    (1, 'https://github.com'),
+    (2, 'https://python.org'),
+])
+def test_bookmark_completion_delete(qtmodeltester, bookmarks, row, removed):
+    """Test deleting a quickmark from the quickmark completion model."""
+    model = miscmodels.bookmark()
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    parent = model.index(0, 0)
+    idx = model.index(row, 0, parent)
+
+    before = set(bookmarks.marks.keys())
+    model.delete_cur_item(idx)
+    after = set(bookmarks.marks.keys())
+    assert before.difference(after) == {removed}
 
 
 def test_url_completion(qtmodeltester, web_history_populated,


### PR DESCRIPTION
Pressing ctrl-d in the completion menu for
:quickmark-load/:bookmark-load  will now delete the selected
quickmark/bookmark.

Resolves #2840.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2873)
<!-- Reviewable:end -->
