### PR TITLE
Remove obsolete signals.

### DIFF
--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -77,13 +77,9 @@ class UrlMarkManager(QObject):
 
     Signals:
         changed: Emitted when anything changed.
-        added: Emitted when a new quickmark/bookmark was added.
-        removed: Emitted when an existing quickmark/bookmark was removed.
     """
 
     changed = pyqtSignal()
-    added = pyqtSignal(str, str)
-    removed = pyqtSignal(str)
 
     def __init__(self, parent=None):
         """Initialize and read quickmarks."""
@@ -121,7 +117,6 @@ class UrlMarkManager(QObject):
         """
         del self.marks[key]
         self.changed.emit()
-        self.removed.emit(key)
 
 
 class QuickmarkManager(UrlMarkManager):
@@ -133,7 +128,6 @@ class QuickmarkManager(UrlMarkManager):
         - self.marks maps names to URLs.
         - changed gets emitted with the name as first argument and the URL as
           second argument.
-        - removed gets emitted with the name as argument.
     """
 
     def _init_lineparser(self):
@@ -193,7 +187,6 @@ class QuickmarkManager(UrlMarkManager):
             """Really set the quickmark."""
             self.marks[name] = url
             self.changed.emit()
-            self.added.emit(name, url)
             log.misc.debug("Added quickmark {} for {}".format(name, url))
 
         if name in self.marks:
@@ -243,7 +236,6 @@ class BookmarkManager(UrlMarkManager):
         - self.marks maps URLs to titles.
         - changed gets emitted with the URL as first argument and the title as
           second argument.
-        - removed gets emitted with the URL as argument.
     """
 
     def _init_lineparser(self):
@@ -295,5 +287,4 @@ class BookmarkManager(UrlMarkManager):
         else:
             self.marks[urlstr] = title
             self.changed.emit()
-            self.added.emit(title, urlstr)
             return True

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -23,7 +23,7 @@ import os
 import os.path
 
 import sip
-from PyQt5.QtCore import pyqtSignal, QUrl, QObject, QPoint, QTimer
+from PyQt5.QtCore import QUrl, QObject, QPoint, QTimer
 from PyQt5.QtWidgets import QApplication
 import yaml
 try:
@@ -106,13 +106,7 @@ class SessionManager(QObject):
                               closed.
         _current: The name of the currently loaded session, or None.
         did_load: Set when a session was loaded.
-
-    Signals:
-        update_completion: Emitted when the session completion should get
-                           updated.
     """
-
-    update_completion = pyqtSignal()
 
     def __init__(self, base_path, parent=None):
         super().__init__(parent)
@@ -303,8 +297,7 @@ class SessionManager(QObject):
                           encoding='utf-8', allow_unicode=True)
         except (OSError, UnicodeEncodeError, yaml.YAMLError) as e:
             raise SessionError(e)
-        else:
-            self.update_completion.emit()
+
         if load_next_time:
             state_config = objreg.get('state-config')
             state_config['general']['session'] = name
@@ -425,7 +418,6 @@ class SessionManager(QObject):
             os.remove(path)
         except OSError as e:
             raise SessionError(e)
-        self.update_completion.emit()
 
     def list_sessions(self):
         """Get a list of all session names."""

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -215,11 +215,6 @@ class TestSave:
         objreg.delete('main-window', scope='window', window=0)
         objreg.delete('tabbed-browser', scope='window', window=0)
 
-    def test_update_completion_signal(self, sess_man, tmpdir, qtbot):
-        session_path = tmpdir / 'foo.yml'
-        with qtbot.waitSignal(sess_man.update_completion):
-            sess_man.save(str(session_path))
-
     def test_no_state_config(self, sess_man, tmpdir, state_config):
         session_path = tmpdir / 'foo.yml'
         sess_man.save(str(session_path))
@@ -365,14 +360,6 @@ class TestLoadTab:
         loaded_item = fake_webview.loaded_history[0]
         assert loaded_item.url == QUrl(url)
         assert loaded_item.original_url == expected
-
-
-def test_delete_update_completion_signal(sess_man, qtbot, tmpdir):
-    sess = tmpdir / 'foo.yml'
-    sess.ensure()
-
-    with qtbot.waitSignal(sess_man.update_completion):
-        sess_man.delete(str(sess))
 
 
 class TestListSessions:


### PR DESCRIPTION
The added/removed signals for the urlmark managers are no longer used as
the completion models are generated on-the-fly. The changed signal is
still needed so the save-manager knows when to trigger a write to disk.

Also removes session_manager.update_completion, which is no longer
needed for the same reason as above.

keyconf.changed cannot be removed, as it is still wired up to
basekeyparser.

Resolves #2874.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2875)
<!-- Reviewable:end -->
