### PR TITLE
Expand ~ to user's home on Linux

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2048,8 +2048,9 @@ class CommandDispatcher:
                     message.info(out)
 
         if file:
+            path = os.path.expanduser(js_code)
             try:
-                with open(js_code, 'r', encoding='utf-8') as f:
+                with open(path, 'r', encoding='utf-8') as f:
                     js_code = f.read()
             except OSError as e:
                 raise cmdexc.CommandError(str(e))


### PR DESCRIPTION
This allows for relative paths instead of having to specify the absolute path to the file. Useful for example when executing a javascript file through a binding using `jseval`, in a similar fashion to userscripts.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2899)
<!-- Reviewable:end -->
