### PR TITLE
Consistently format urls in history.

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -84,12 +84,12 @@ class WebHistory(sql.SqlTable):
         data = {'url': [], 'title': [], 'last_atime': []}
         # select the latest entry for each url
         q = sql.Query('SELECT url, title, max(atime) AS atime FROM History '
-                      'WHERE NOT redirect GROUP BY url')
+                      'WHERE NOT redirect GROUP BY url ORDER BY atime asc')
         for entry in q.run():
             data['url'].append(self._format_completion_url(QUrl(entry.url)))
             data['title'].append(entry.title)
             data['last_atime'].append(entry.atime)
-        self.completion.insert_batch(data)
+        self.completion.insert_batch(data, replace=True)
         sql.Query('pragma user_version = {}'.format(_USER_VERSION)).run()
 
     def get_recent(self):

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -48,7 +48,7 @@ class WebHistory(sql.SqlTable):
         super().__init__("History", ['url', 'title', 'atime', 'redirect'],
                          parent=parent)
         self.completion = CompletionHistory(parent=self)
-        if len(self.completion) == 0:
+        if not self.completion:
             self._rebuild_completion()
         self.create_index('HistoryIndex', 'url')
         self.create_index('HistoryAtimeIndex', 'atime')

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -48,6 +48,8 @@ class WebHistory(sql.SqlTable):
         super().__init__("History", ['url', 'title', 'atime', 'redirect'],
                          parent=parent)
         self.completion = CompletionHistory(parent=self)
+        if len(self.completion) == 0:
+            self._rebuild_completion()
         self.create_index('HistoryIndex', 'url')
         self.create_index('HistoryAtimeIndex', 'atime')
         self._contains_query = self.contains_query('url')
@@ -70,6 +72,17 @@ class WebHistory(sql.SqlTable):
 
     def __contains__(self, url):
         return self._contains_query.run(val=url).value()
+
+    def _rebuild_completion(self):
+        data = {'url': [], 'title': [], 'last_atime': []}
+        # select the latest entry for each url
+        q = sql.Query('SELECT url, title, max(atime) AS atime FROM History '
+                      'WHERE NOT redirect GROUP BY url')
+        for entry in q.run():
+            data['url'].append(self._format_completion_url(QUrl(entry.url)))
+            data['title'].append(entry.title)
+            data['last_atime'].append(entry.atime)
+        self.completion.insert_batch(data)
 
     def get_recent(self):
         """Get the most recent history entries."""

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -377,3 +377,20 @@ def test_no_rebuild_completion(hist):
 
     hist2 = history.WebHistory()
     assert list(hist2.completion) == [('example.com/1', '', 1)]
+
+
+def test_user_version(hist, monkeypatch):
+    """Ensure that completion is regenerated if user_version is incremented."""
+    hist.add_url(QUrl('example.com/1'), redirect=False, atime=1)
+    hist.add_url(QUrl('example.com/2'), redirect=False, atime=2)
+    hist.completion.delete('url', 'example.com/2')
+
+    hist2 = history.WebHistory()
+    assert list(hist2.completion) == [('example.com/1', '', 1)]
+
+    monkeypatch.setattr(history, '_USER_VERSION', history._USER_VERSION + 1)
+    hist3 = history.WebHistory()
+    assert list(hist3.completion) == [
+        ('example.com/1', '', 1),
+        ('example.com/2', '', 2),
+    ]

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -353,3 +353,17 @@ def test_debug_dump_history_nonexistent(hist, tmpdir):
     histfile = tmpdir / 'nonexistent' / 'history'
     with pytest.raises(cmdexc.CommandError):
         hist.debug_dump_history(str(histfile))
+
+
+def test_rebuild_completion(hist):
+    hist.add_url(QUrl('example.com/1'), redirect=False, atime=1)
+    hist.add_url(QUrl('example.com/1'), redirect=False, atime=2)
+    hist.add_url(QUrl('example.com/2%203'), redirect=False, atime=3)
+    hist.add_url(QUrl('example.com/3'), redirect=True, atime=4)
+    hist.completion.delete_all()
+
+    hist2 = history.WebHistory()
+    assert list(hist2.completion) == [
+        ('example.com/1', '', 2),
+        ('example.com/2 3', '', 3),
+    ]

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -356,16 +356,22 @@ def test_debug_dump_history_nonexistent(hist, tmpdir):
 
 
 def test_rebuild_completion(hist):
-    hist.add_url(QUrl('example.com/1'), redirect=False, atime=1)
-    hist.add_url(QUrl('example.com/1'), redirect=False, atime=2)
-    hist.add_url(QUrl('example.com/2%203'), redirect=False, atime=3)
-    hist.add_url(QUrl('example.com/3'), redirect=True, atime=4)
+    hist.insert({'url': 'example.com/1', 'title': 'example1',
+                 'redirect': False, 'atime': 1})
+    hist.insert({'url': 'example.com/1', 'title': 'example1',
+                 'redirect': False, 'atime': 2})
+    hist.insert({'url': 'example.com/2%203', 'title': 'example2',
+                 'redirect': False, 'atime': 3})
+    hist.insert({'url': 'example.com/3', 'title': 'example3',
+                 'redirect': True, 'atime': 4})
+    hist.insert({'url': 'example.com/2 3', 'title': 'example2',
+                 'redirect': False, 'atime': 5})
     hist.completion.delete_all()
 
     hist2 = history.WebHistory()
     assert list(hist2.completion) == [
-        ('example.com/1', '', 2),
-        ('example.com/2 3', '', 3),
+        ('example.com/1', 'example1', 2),
+        ('example.com/2 3', 'example2', 5),
     ]
 
 

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -367,3 +367,13 @@ def test_rebuild_completion(hist):
         ('example.com/1', '', 2),
         ('example.com/2 3', '', 3),
     ]
+
+
+def test_no_rebuild_completion(hist):
+    """Ensure that completion is not regenerated unless completely empty."""
+    hist.add_url(QUrl('example.com/1'), redirect=False, atime=1)
+    hist.add_url(QUrl('example.com/2'), redirect=False, atime=2)
+    hist.completion.delete('url', 'example.com/2')
+
+    hist2 = history.WebHistory()
+    assert list(hist2.completion) == [('example.com/1', '', 1)]

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -143,23 +143,27 @@ def test_delete_url(hist):
     assert completion_diff == {('http://example.com/1', '', 0)}
 
 
-@pytest.mark.parametrize('url, atime, title, redirect, expected_url', [
-    ('http://www.example.com', 12346, 'the title', False,
-        'http://www.example.com'),
-    ('http://www.example.com', 12346, 'the title', True,
-        'http://www.example.com'),
-    ('http://www.example.com/spa ce', 12346, 'the title', False,
-        'http://www.example.com/spa%20ce'),
-    ('https://user:pass@example.com', 12346, 'the title', False,
-        'https://user@example.com'),
-])
-def test_add_url(qtbot, hist, url, atime, title, redirect, expected_url):
+@pytest.mark.parametrize(
+    'url, atime, title, redirect, history_url, completion_url', [
+
+        ('http://www.example.com', 12346, 'the title', False,
+            'http://www.example.com', 'http://www.example.com'),
+        ('http://www.example.com', 12346, 'the title', True,
+            'http://www.example.com', None),
+        ('http://www.example.com/sp ce', 12346, 'the title', False,
+            'http://www.example.com/sp%20ce', 'http://www.example.com/sp ce'),
+        ('https://user:pass@example.com', 12346, 'the title', False,
+            'https://user@example.com', 'https://user@example.com'),
+    ]
+)
+def test_add_url(qtbot, hist, url, atime, title, redirect, history_url,
+                 completion_url):
     hist.add_url(QUrl(url), atime=atime, title=title, redirect=redirect)
-    assert list(hist) == [(expected_url, title, atime, redirect)]
-    if redirect:
+    assert list(hist) == [(history_url, title, atime, redirect)]
+    if completion_url is None:
         assert not len(hist.completion)
     else:
-        assert list(hist.completion) == [(expected_url, title, atime)]
+        assert list(hist.completion) == [(completion_url, title, atime)]
 
 
 def test_add_url_invalid(qtbot, hist, caplog):


### PR DESCRIPTION
Encode urls that are inserted into the history, but do not encode urls
for completion (other than removing passwords).
Also ensure that urls read from the history text file are formatted
consistenly with those added while browsing.

Fixes #2903.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2905)
<!-- Reviewable:end -->
