### PR TITLE
Fix saving a session with --only-active-window

### DIFF
--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -485,7 +485,7 @@ class SessionManager(QObject):
         try:
             if only_active_window:
                 name = self.save(name, only_window=win_id,
-                                 with_private=with_private)
+                                 with_private=True)
             else:
                 name = self.save(name, with_private=with_private)
         except SessionError as e:

--- a/tests/end2end/features/private.feature
+++ b/tests/end2end/features/private.feature
@@ -153,3 +153,26 @@ Feature: Using private browsing
               - history:
                 - url: http://localhost:*/data/numbers/1.txt
                 - url: http://localhost:*/data/numbers/2.txt
+
+
+  Scenario: Saving a private session with only-active-window
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a private window
+        And I open data/numbers/4.txt in a new tab
+        And I open data/numbers/5.txt in a new tab
+        And I run :session-save --only-active-window window_session_name
+        And I run :window-only
+        And I run :tab-only
+        And I run :session-load -c window_session_name
+        And I wait until data/numbers/5.txt is loaded
+        Then the session should look like:
+            windows:
+                - tabs:
+                    - history:
+                        - url: http://localhost:*/data/numbers/3.txt
+                    - history:
+                        - url: http://localhost:*/data/numbers/4.txt
+                    - history:
+                        - active: true
+                          url: http://localhost:*/data/numbers/5.txt


### PR DESCRIPTION
Replaces https://github.com/qutebrowser/qutebrowser/pull/2902

Closes #2900 

I have a tiny bit of work on this to clean it up, but it should be good for the most part.

@cryzed (just fyi)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2909)
<!-- Reviewable:end -->
