### PR TITLE
implemented format_json userscript

### DIFF
--- a/misc/userscripts/format_json
+++ b/misc/userscripts/format_json
@@ -1,0 +1,47 @@
+#!/bin/sh
+#
+# Behavior:
+#   Userscript for qutebrowser which will take the raw JSON text of the current
+#   page, format it using `jq`, will add syntax highlighting using `pygments`,
+#   and open the syntax highlighted pretty printed html in a new tab. If the file
+#   is larger than 10MB then this script will only indent the json and will forego
+#   syntax highlighting using pygments.
+#
+#   In order to use this script, just start it using `spawn --userscript` from
+#   qutebrowser. I recommend using an alias, e.g. put this in the
+#   [alias]-section of qutebrowser.conf:
+#
+#     json = spawn --userscript /path/to/json_format
+#
+#   Note that the color style defaults to monokai, but a different pygments style
+#   can be passed as the first parameter to the script. A full list of the pygments
+#   styles can be found at: https://help.farbox.com/pygments.html
+#
+# Bryan Gilbert, 2017
+
+# default style to monokai if none is provided
+STYLE=${1:-monokai}
+# format json using jq
+FORMATTED_JSON="$(cat "$QUTE_TEXT" | jq '.')"
+
+# if jq command failed or formatted json is empty, assume failure and terminate
+if [ $? -ne 0 ] || [ -z "$FORMATTED_JSON" ]; then
+    echo "Invalid json, aborting..."
+    exit 1
+fi
+
+# calculate the filesize of the json document
+FILE_SIZE=$(ls -s --block-size=1048576 "$QUTE_TEXT" | cut -d' ' -f1)
+
+# use pygments to pretty-up the json (syntax highlight) if file is less than 10MB
+if [ "$FILE_SIZE" -lt "10" ]; then
+    FORMATTED_JSON="$(echo "$FORMATTED_JSON" | pygmentize -l json -f html -O full,style=$STYLE)"
+fi
+
+# create a temp file and write the formatted json to that file
+TEMP_FILE="$(mktemp --suffix '.html')"
+echo "$FORMATTED_JSON" > $TEMP_FILE
+
+
+# send the command to qutebrowser to open the new file containing the formatted json
+echo "open -t file://$TEMP_FILE" >> "$QUTE_FIFO"


### PR DESCRIPTION
Hey, this pull request adds a useful userscript that will will format and syntax highlight a json response. Here's a quick before/after set of screenshots showing it off:

![Before](http://drop.bryan.sh/t5RzkeyGty.png)

![After](http://drop.bryan.sh/gOhGK7RTKr.png)

The script uses `jq` to validate and format the json and `pygments` to provide syntax highlighting. After the json is formatted, it is base64 encoded (to prevent formatting issues) and sent in the form of a `jseval` command to qutebrowser to replace the page's content. It is relatively safe to use as it validates proper json formatting before proceeding to highlighting and attempting to replace the current page's content.

It additionally provides an optional parameter that can be used to set the desired pygments theme used to generate the syntax highlighted html.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2923)
<!-- Reviewable:end -->
