### PR TITLE
Inject user-stylesheet earlier during page load

### DIFF
--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -131,9 +131,10 @@ class PersistentCookiePolicy(DefaultProfileSetter):
 def _init_stylesheet(profile):
     """Initialize custom stylesheets.
 
-    Mostly inspired by QupZilla:
+    Mostly inspired by QupZilla and Stylus:
     https://github.com/QupZilla/qupzilla/blob/v2.0/src/lib/app/mainapplication.cpp#L1063-L1101
     https://github.com/QupZilla/qupzilla/blob/v2.0/src/lib/tools/scripts.cpp#L119-L132
+    https://github.com/openstyles/stylus/blob/1.1.4/content/apply.js#L240-L249
     """
     old_script = profile.scripts().findScript('_qute_stylesheet')
     if not old_script.isNull():
@@ -142,14 +143,27 @@ def _init_stylesheet(profile):
     css = shared.get_user_stylesheet()
     source = """
         (function setStylesheet() {{
-            if (document.head === null) {{
+            var parent = document instanceof XMLDocument
+                ? document.documentElement
+                : document.head;
+            if (parent === null) {{
                 setTimeout(setStylesheet);
                 return;
             }}
-            var css = document.createElement('style');
+            var css;
+            if (document instanceof XMLDocument) {{
+                css = document.createElementNS(
+                    parent instanceof SVGSVGElement
+                        ? 'http://www.w3.org/2000/svg'
+                        : 'http://www.w3.org/1999/xhtml',
+                    'style'
+                );
+            }} else {{
+                css = document.createElement('style');
+            }}
             css.setAttribute('type', 'text/css');
             css.appendChild(document.createTextNode('{}'));
-            document.head.insertBefore(css, document.head.firstChild);
+            parent.insertBefore(css, parent.firstChild);
         }})()
     """.format(javascript.string_escape(css))
 

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -141,17 +141,21 @@ def _init_stylesheet(profile):
 
     css = shared.get_user_stylesheet()
     source = """
-        (function() {{
+        (function setStylesheet() {{
+            if (document.head === null) {{
+                setTimeout(setStylesheet);
+                return;
+            }}
             var css = document.createElement('style');
             css.setAttribute('type', 'text/css');
             css.appendChild(document.createTextNode('{}'));
-            document.getElementsByTagName('head')[0].appendChild(css);
+            document.head.insertBefore(css, document.head.firstChild);
         }})()
     """.format(javascript.string_escape(css))
 
     script = QWebEngineScript()
     script.setName('_qute_stylesheet')
-    script.setInjectionPoint(QWebEngineScript.DocumentReady)
+    script.setInjectionPoint(QWebEngineScript.DocumentCreation)
     script.setWorldId(QWebEngineScript.ApplicationWorld)
     script.setRunsOnSubFrames(True)
     script.setSourceCode(source)

--- a/tests/end2end/data/downloads/mhtml/simple/simple-webengine.mht
+++ b/tests/end2end/data/downloads/mhtml/simple/simple-webengine.mht
@@ -13,11 +13,11 @@ Content-Transfer-Encoding: quoted-printable
 Content-Location: http://localhost:(port)/data/downloads/mhtml/simple/simple.html
 
 <!DOCTYPE html><html><head><meta http-equiv=3D"Content-Type" content=3D"tex=
-t/html; charset=3DUTF-8">
+t/html; charset=3DUTF-8"><style type=3D"text/css">
+html > ::-webkit-scrollbar { width: 0px; height: 0px; }</style>
        =20
         <title>Simple MHTML test</title>
-    <style type=3D"text/css">
-html > ::-webkit-scrollbar { width: 0px; height: 0px; }</style></head>
+    </head>
     <body>
         <a href=3D"http://localhost:(port)/">normal link to another page</a>
    =20


### PR DESCRIPTION
Fixes #2771 (or at least fixes the flickering)

Since the `<style>` element is now injected before `<head>` has finished loading, using `appendChild()` would lead to inconsistent results. For consistency, it is now inserted as the first child of `<head>`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2935)
<!-- Reviewable:end -->
