### PR TITLE
allow tab indexes to be passed to the `tab-detach` command

### DIFF
--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -856,3 +856,47 @@ def expand_windows_drive(path):
         return path + "\\"
     else:
         return path
+
+
+def parse_number_sets(txtset, minnum, maxnum):
+    """Parse comma delimited numbers and ranges into a set.
+
+    Parse the given numbers set in text format, and return it as a list of
+    numbers, such that the numbers are never smaller than minnum, and never
+    greater than maxnum.
+
+    Args:
+        txtset: Number set specification. E.g. '1,5,first,8-last,2', where
+                'first' and 'last' are keywords denoting the minimum and
+                maximum allowable numbers respectively.
+        minnum: Minimum allowable number.
+        maxnum: Maximum allowable number.
+    """
+    txtset = txtset.lower() \
+                   .replace('last', str(maxnum)) \
+                   .replace('first', str(minnum))
+    numset = set()
+    parts = txtset.split(',')
+    for part in parts:
+        if part:
+            if part.find('-') != -1:
+                [start, end] = part.split('-')
+                start = int(start)
+                end = int(end)
+
+                if start > end:
+                    start, end = end, start
+
+                if start < minnum:
+                    start = minnum
+                if end > maxnum:
+                    end = maxnum
+
+                for i in range(start, end+1):
+                    numset.add(i)
+            else:
+                i = int(part)
+                if i >= minnum and i <= maxnum:
+                    numset.add(i)
+
+    return numset

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -655,10 +655,40 @@ Feature: Tab management
               - history:
                 - url: http://localhost:*/data/numbers/2.txt
 
+    Scenario: Detaching multiple tabs
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I open data/numbers/4.txt in a new tab
+        And I open data/numbers/5.txt in a new tab
+        And I open data/numbers/6.txt in a new tab
+        And I open data/numbers/7.txt in a new tab
+        And I run :tab-detach 4-7
+        And I wait until data/numbers/7.txt is loaded
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+              - history:
+                - url: http://localhost:*/data/numbers/3.txt
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/4.txt
+              - history:
+                - url: http://localhost:*/data/numbers/5.txt
+              - history:
+                - url: http://localhost:*/data/numbers/6.txt
+              - history:
+                - url: http://localhost:*/data/numbers/7.txt
+
     Scenario: Detach tab from window with only one tab
         When I open data/hello.txt
         And I run :tab-detach
-        Then the error "Cannot detach one tab." should be shown
+        Then the error "Cannot detach all tabs." should be shown
 
     # :undo
 

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -905,3 +905,36 @@ class TestOpenFile:
 ])
 def test_expand_windows_drive(path, expected):
     assert utils.expand_windows_drive(path) == expected
+
+
+@pytest.mark.parametrize('txtset, minnum, maxnum, expected', [
+    ('5-0', 1, 10, {1, 2, 3, 4, 5}),
+    ('5-0,1-5', 1, 10, {1, 2, 3, 4, 5}),
+    ('5-0,1-5,last', 1, 10, {1, 2, 3, 4, 5, 10}),
+    ('5-0,1, 1-5,last', 1, 10, {1, 2, 3, 4, 5, 10}),
+    ('last,5-0,1-5,last', 1, 10, {1, 2, 3, 4, 5, 10}),
+    ('0-3,7-100', 1, 10, {1, 2, 3, 7, 8, 9, 10}),
+    ('5-0,,1-5', 1, 10, {1, 2, 3, 4, 5}),
+    ('5-0,1-5,,last', 1, 10, {1, 2, 3, 4, 5, 10}),
+    ('first-last', 1, 10, {1, 2, 3, 4, 5, 6, 7, 8, 9, 10}),
+    ('first-5', 3, 10, {3, 4, 5}),
+    ('1-5', 3, 10, {3, 4, 5}),
+    ('5-0', 0, 10, {0, 1, 2, 3, 4, 5}),
+    ('11', 1, 10, set()),
+    ('2', 3, 10, set()),
+    ('-5-0', 1, 10, ValueError),
+    ('-5-0,1-5', 1, 10, ValueError),
+    ('5-0,-1-5', 1, 10, ValueError),
+    ('5--0,1-5', 1, 10, ValueError),
+    ('5-0,-1-5,last', 1, 10, ValueError),
+    ('5-,0,1-5', 1, 10, ValueError),
+    ('-5', 1, 10, ValueError),
+    ('0--5', 1, 10, ValueError),
+    ('foo-bar', 1, 10, ValueError)
+])
+def test_parse_number_sets(txtset, minnum, maxnum, expected):
+    if expected is ValueError:
+        with pytest.raises(ValueError):
+            utils.parse_number_sets(txtset, minnum, maxnum)
+    else:
+        assert utils.parse_number_sets(txtset, minnum, maxnum) == expected


### PR DESCRIPTION
This pull request implements the feature requested in #2913

It allows individual tab indexes and ranges to be passed to the `tab-detach` command and opens the set of tabs in a new single window. If called with no tab indexes, it only detaches the current tab. Additionally, it verifies that at least one tab will remain open in the current window, and raises an error message otherwise.

This code borrows heavily from #2384/#2895 most notably the `parse_number_sets` function, as recommended in the issue.

The code is relatively straight forward. It parses out a set of tab indexes that are verified to be within the bounds of the existing tab indexes, or just the current tab if no indexes are provided. It makes a first pass through all the indexes to retrieve the tab widget and url for each tab to be detached. This first pass is made prior to removing any tabs so we won't have to worry about the tab indexes changing while we're walking through them. Finally we iterate through each tab/url tuple and open the url in a new window and close the tab widget in the current window.

A few things to note, that I could probably use guidance on:

* The most controversial change in this PR is updating the `_open` function to return a `TabbedBrowser`. I did this because I could find no other way to reference the newly created window to attach the rest of the detached tabs to. The only other way I could think of doing this was to actually reproduce the logic to create the window and new tab inline in the `tab-detach` function. However, this is probably not desirable as it would mean the logic (along with private tab/window handling) would be duplicated and hurt overall maintainability. I'm interested on what your thoughts are on this change.

* The previous implementation of `tab-detach` functioned the same way, but with this implementation it's much more noticeable that the tabs are loaded fresh after they are detached. Detaching five or so tabs results in a very noticeable refresh of all the tabs simultaneously. I was wondering if you think it'd be possible / advisable to implement a 'soft' tab remove function that would allow for tabs to be migrated from one `TabbedBrowser` to another. Looking at the underlying api's it appears to be possible to do, but I thought I'd run it by you first to see if you think it'd be a wise decision to migrate tabs. If this is possible, it'd be nice to implement a followup function that would allow tabs to be moved between qutebrowser windows.

I initially picked this issue up because I wanted to contribute to the project and it was marked as easy, but after implementing it, I'm very suprised at how useful it's turned out to be. I'll also mention that I've written an extremely small amount of Python, so don't be afraid to tear me a new one if I'm doing something bad here :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2937)
<!-- Reviewable:end -->
