### PR TITLE
Improved zoom level management and enforcement

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -445,9 +445,6 @@ class WebEngineZoom(browsertab.AbstractZoom):
     def _set_factor_internal(self, factor):
         self._widget.setZoomFactor(factor)
 
-    def factor(self):
-        return self._widget.zoomFactor()
-
 
 class WebEngineElements(browsertab.AbstractElements):
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -378,9 +378,6 @@ class WebKitZoom(browsertab.AbstractZoom):
     def _set_factor_internal(self, factor):
         self._widget.setZoomFactor(factor)
 
-    def factor(self):
-        return self._widget.zoomFactor()
-
 
 class WebKitScroller(browsertab.AbstractScroller):
 

--- a/tests/end2end/data/long_load.html
+++ b/tests/end2end/data/long_load.html
@@ -1,0 +1,9 @@
+<script type="text/javascript">
+    var date = new Date();
+    var curDate = new Date();
+    while(curDate-date < 2000) {
+      curDate = new Date();
+    };
+
+    document.write("<html><h1>hello</h1></html>");
+</script>

--- a/tests/end2end/features/test_zoom_bdd.py
+++ b/tests/end2end/features/test_zoom_bdd.py
@@ -24,5 +24,6 @@ bdd.scenarios('zoom.feature')
 @bdd.then(bdd.parsers.parse("the zoom should be {zoom}%"))
 def check_zoom(quteproc, zoom):
     data = quteproc.get_session()
-    value = data['windows'][0]['tabs'][0]['history'][0]['zoom'] * 100
+    histories = data['windows'][0]['tabs'][0]['history']
+    value = next(h for h in histories if 'zoom' in h)['zoom'] * 100
     assert abs(value - float(zoom)) < 0.0001

--- a/tests/end2end/features/zoom.feature
+++ b/tests/end2end/features/zoom.feature
@@ -81,6 +81,17 @@ Feature: Zooming in and out
         Then the message "Zoom level: 60%" should be shown
         And the zoom should be 60%
 
+    # https://github.com/qutebrowser/qutebrowser/issues/2507
+    # Using 127.0.0.1 because separate domain is required to reproduce
+    Scenario: Qutebrowser enforces correct zoom level
+        When I run :zoom 150%
+        And I open data/search.html
+        And I run :open http://127.0.0.1:(port)/data/long_load.html
+        And I wait until http://127.0.0.1:(port)/data/long_load.html is loaded
+        And I run :back
+        And I wait until data/search.html is loaded
+        Then the zoom should be 150%
+
     # Fixed in QtWebEngine branch
     @xfail
     Scenario: Zooming in with cloned tab

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -411,14 +411,17 @@ class QuteProc(testprocess.Process):
         verbatim.
         """
         special_schemes = ['about:', 'qute:', 'chrome:', 'view-source:',
-                           'data:']
+                           'data:', 'http:', 'https:']
+        server = self.request.getfixturevalue('server')
+        server_port = server.port if port is None else port
+
         if any(path.startswith(scheme) for scheme in special_schemes):
+            path = path.replace('(port)', str(server_port))
             return path
         else:
-            server = self.request.getfixturevalue('server')
             return '{}://localhost:{}/{}'.format(
                 'https' if https else 'http',
-                server.port if port is None else port,
+                server_port,
                 path if path != '/' else '')
 
     def wait_for_js(self, message):

--- a/tests/end2end/fixtures/webserver_sub.py
+++ b/tests/end2end/fixtures/webserver_sub.py
@@ -73,7 +73,7 @@ def redirect_later():
     If delay is -1, wait until a request on redirect-later-continue is done.
     """
     global _redirect_later_event
-    delay = int(flask.request.args.get('delay', '1'))
+    delay = float(flask.request.args.get('delay', '1'))
     if delay == -1:
         _redirect_later_event = threading.Event()
         ok = _redirect_later_event.wait(timeout=30 * 1000)


### PR DESCRIPTION
This pull request is intended to fix #2507.

The problem this is solving is that using the WebEngine backend, the zoom will very frequently become stuck at the default 100% zoom level during a normal browsing session. This is caused by the fact that the zoom level needs to be set to the user-defined default zoom value __after__ the page has fully finished loading. Due to this fact a tab frequently becomes stuck at the 100% resolution because Qutebrowser uses the actual widget as the source of the zoom value.

This pull request adds a new private variable to `AbstractZoom` called `_zoom_factor` that is used to track the current zoom factor for a tab. Additionally, the `factor()` function is now implemented by the `AbstractZoom` class (previously this was implemented on the concrete tab classes), that is now used to communicate this newly tracked zoom level to all existing code. The zoom factor can still be retrieved by from the actual widget by using the `_get_factor_internal()` function on the concrete classes. 

With the zoom level being accurately tracked by the zoom class instead of relying on the widget to tell us the zoom level, we don't have to worry about it getting confused and stuck at the wrong resolution. Additionally, after a page is loaded the zoom factor is always forced to match what the zoom class thinks the level should be. This is especially important for the WebEngine backend since it always defaults to it's stock zoom level and needs to be updated everytime a page is finished loading.

Finally, the `_default_zoom_changed` has been made more robust and will now only be set to `True` if the zoom has actually changed to a value that differs from the user defined default.

I've tested this PR against both the WebEngine and Webkit backends and from all my tests it appears to always do the right thing. Most importantly is that I've been unable to trigger an zoom level issues in the WebEngine backend using the scenarios that would frequently result in losing the default zoom level.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2940)
<!-- Reviewable:end -->
