### PR TITLE
password_fill: Stop filling username to invisible input fields

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -327,6 +327,17 @@ open_entry "$file"
 
 js() {
 cat <<EOF
+    function isVisible(elem) {
+        var style = elem.ownerDocument.defaultView.getComputedStyle(elem, null);
+
+        if (style.getPropertyValue("visibility") !== "visible" ||
+            style.getPropertyValue("display") === "none" ||
+            style.getPropertyValue("opacity") === "0") {
+            return false;
+        }
+
+        return elem.offsetWidth > 0 && elem.offsetHeight > 0;
+    };
     function hasPasswordField(form) {
         var inputs = form.getElementsByTagName("input");
         for (var j = 0; j < inputs.length; j++) {
@@ -341,7 +352,7 @@ cat <<EOF
         var inputs = form.getElementsByTagName("input");
         for (var j = 0; j < inputs.length; j++) {
             var input = inputs[j];
-            if (input.type == "text" || input.type == "email") {
+            if (isVisible(input) && (input.type == "text" || input.type == "email")) {
                 input.focus();
                 input.value = "$(javascript_escape "${username}")";
                 input.blur();


### PR DESCRIPTION
> There is no reason to fill usernames into invisible input fields. We are
> probably not leaking anything but it can break some apps (like TTRSS).

I just found out that Tiny Tiny RSS is not working with `password_fill` because it has multiple hiddent text fields in login page (not sure why). And all of them get populated with found username which breaks whole app.

IMHO there isn't any use case where filling hidden input field is wanted anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2942)
<!-- Reviewable:end -->
