### PR TITLE
Use CommandParser for configmodel.bind.

### DIFF
--- a/qutebrowser/completion/models/configmodel.py
+++ b/qutebrowser/completion/models/configmodel.py
@@ -21,7 +21,7 @@
 
 from qutebrowser.config import configdata, configexc
 from qutebrowser.completion.models import completionmodel, listcategory, util
-from qutebrowser.commands import cmdutils
+from qutebrowser.commands import runners
 
 
 def option(*, info):
@@ -71,8 +71,8 @@ def bind(key, *, info):
     cmd_text = info.keyconf.get_command(key, 'normal')
 
     if cmd_text:
-        cmd_name = cmd_text.split(' ')[0]
-        cmd = cmdutils.cmd_dict.get(cmd_name)
+        parser = runners.CommandParser()
+        cmd = parser.parse(cmd_text).cmd
         data = [(cmd_text, cmd.desc, key)]
         model.add_category(listcategory.ListCategory("Current", data))
 

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -573,6 +573,24 @@ def test_bind_completion(qtmodeltester, cmdutils_stub, config_stub,
     })
 
 
+def test_bind_completion_no_current(qtmodeltester, cmdutils_stub, config_stub,
+                                    key_config_stub, configdata_stub, info):
+    """Test keybinding completion with no current binding. """
+    model = configmodel.bind('x', info=info)
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        "Commands": [
+            ('open', 'open a url', ''),
+            ('q', "Alias for 'quit'", ''),
+            ('quit', 'quit qutebrowser', 'ZQ, <ctrl+q>'),
+            ('scroll', 'Scroll the current tab in the given direction.', '')
+        ],
+    })
+
+
 def test_url_completion_benchmark(benchmark, info,
                                   quickmark_manager_stub,
                                   bookmark_manager_stub,


### PR DESCRIPTION
The parsing bind() did manually is now available through CommandParser.
Resolves #2952.

This also adds a unit test for the case when there is no current
binding, as I broke that while working on this and there was no test to
catch it :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2953)
<!-- Reviewable:end -->
