### PR TITLE
Add qutebrowser config directory to python path

### DIFF
--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -289,7 +289,6 @@ def _post_config_load(save_tuple):
     sys.path = save_tuple[0]
     for module in set(sys.modules).difference(save_tuple[1]):
         del sys.modules[module]
-    pass
 
 
 def init():

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -247,7 +247,7 @@ def read_config_py(filename=None):
         raise configexc.ConfigFileErrors(basename, [desc])
     except SyntaxError as e:
         desc = configexc.ConfigErrorDesc("Syntax Error", e,
-                                        traceback=traceback.format_exc())
+                                         traceback=traceback.format_exc())
         raise configexc.ConfigFileErrors(basename, [desc])
 
     try:
@@ -257,13 +257,14 @@ def read_config_py(filename=None):
             # other files in logical places
             config_dir = os.path.dirname(filename)
             if config_dir not in sys.path:
-                sys.path = [config_dir] + sys.path
+                sys.path.insert(0, config_dir)
 
             exec(code, module.__dict__)
     except Exception as e:
         api.errors.append(configexc.ConfigErrorDesc(
             "Unhandled exception",
             exception=e, traceback=traceback.format_exc()))
+
     api.finalize()
     return api
 
@@ -271,13 +272,11 @@ def read_config_py(filename=None):
 @contextlib.contextmanager
 def saved_sys_properties():
     """Save various sys properties such as sys.path and sys.modules."""
-    old_path = sys.path
+    old_path = sys.path.copy()
     old_modules = sys.modules.copy()
 
     try:
         yield
-    except:
-        raise
     finally:
         sys.path = old_path
         for module in set(sys.modules).difference(old_modules):

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -226,8 +226,9 @@ def read_config_py(filename=None):
     # Add config directory to python path, so config.py can import other files
     # in logical places
     old_path = sys.path.copy()
-    if standarddir.config() not in sys.path:
-        sys.path.insert(0, standarddir.config())
+    config_dir = os.path.dirname(filename)
+    if config_dir not in sys.path:
+        sys.path.insert(0, config_dir)
 
     container = config.ConfigContainer(config.instance, configapi=api)
     basename = os.path.basename(filename)

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -21,6 +21,7 @@
 
 import types
 import os.path
+import sys
 import textwrap
 import traceback
 import configparser
@@ -222,6 +223,12 @@ def read_config_py(filename=None):
         if not os.path.exists(filename):
             return api
 
+    # Add config directory to python path, so config.py can import other files
+    # in logical places
+    old_path = sys.path.copy()
+    if standarddir.config() not in sys.path:
+        sys.path.insert(0, standarddir.config())
+
     container = config.ConfigContainer(config.instance, configapi=api)
     basename = os.path.basename(filename)
 
@@ -255,6 +262,9 @@ def read_config_py(filename=None):
         api.errors.append(configexc.ConfigErrorDesc(
             "Unhandled exception",
             exception=e, traceback=traceback.format_exc()))
+
+    # Restore previous path, to protect qutebrowser's imports
+    sys.path = old_path
 
     api.finalize()
     return api

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -209,121 +209,50 @@ class TestYaml:
 
 class TestConfigPyModules:
 
-    """Test for ConfigPy Modules."""
-
     pytestmark = pytest.mark.usefixtures('config_stub', 'key_config_stub')
-    _old_sys_path = sys.path.copy()
-
-    class ConfPy:
-
-        """Helper class to get a confpy fixture."""
-
-        def __init__(self, tmpdir):
-            self._confpy = tmpdir / 'config.py'
-            self.filename = str(self._confpy)
-
-        def write(self, *lines):
-            text = '\n'.join(lines)
-            self._confpy.write_text(text, 'utf-8', ensure=True)
-
-    class QbModulePy:
-
-        """Helper class to get a QbModulePy fixture."""
-
-        def __init__(self, tmpdir):
-            self._qbmodulepy = tmpdir / 'qbmodule.py'
-            self.filename = str(self._qbmodulepy)
-
-        def write(self, *lines):
-            text = '\n'.join(lines)
-            self._qbmodulepy.write_text(text, 'utf-8', ensure=True)
 
     @pytest.fixture
     def confpy(self, tmpdir):
-        return self.ConfPy(tmpdir)
+        return TestConfigPy.ConfPy(tmpdir)
 
     @pytest.fixture
     def qbmodulepy(self, tmpdir):
-        return self.QbModulePy(tmpdir)
+        return TestConfigPy.ConfPy(tmpdir, filename="qbmodule.py")
 
-    def setup_method(self, method):
-        # If we plan to add tests that modify modules themselves, that should
-        # be saved as well
-        TestConfigPyModules._old_sys_path = sys.path.copy()
+    @pytest.fixture(autouse=True)
+    def restore_sys_path(self):
+        old_path = sys.path.copy()
+        yield
+        sys.path = old_path
 
-    def teardown_method(self, method):
-        # Restore path to save the rest of the tests
-        sys.path = TestConfigPyModules._old_sys_path
-
-    def test_bind_in_module(self, confpy, qbmodulepy):
-        qbmodulepy.write("""def run(config):
-    config.bind(",a", "message-info foo", mode="normal")""")
-        confpy.write("""import qbmodule
-qbmodule.run(config)""")
-        api = configfiles.read_config_py(confpy.filename)
+    def test_bind_in_module(self, confpy, qbmodulepy, tmpdir):
+        qbmodulepy.write('def run(config):',
+        '    config.bind(",a", "message-info foo", mode="normal")')
+        confpy.write_qbmodule()
+        confpy.read()
         expected = {'normal': {',a': 'message-info foo'}}
-        assert len(api.errors) == 0
         assert config.instance._values['bindings.commands'] == expected
-
-    def test_clear_path(self, confpy, qbmodulepy, tmpdir):
-        qbmodulepy.write("""def run(config):
-    config.bind(",a", "message-info foo", mode="normal")""")
-        confpy.write("""import qbmodule
-qbmodule.run(config)""")
-        api = configfiles.read_config_py(confpy.filename)
-        assert len(api.errors) == 0
+        assert "qbmodule" not in sys.modules.keys()
         assert tmpdir not in sys.path
 
-    def test_clear_modules(self, confpy, qbmodulepy):
-        qbmodulepy.write("""def run(config):
-    config.bind(",a", "message-info foo", mode="normal")""")
-        confpy.write("""import qbmodule
-qbmodule.run(config)""")
-        api = configfiles.read_config_py(confpy.filename)
-        assert len(api.errors) == 0
-        assert "qbmodule" not in sys.modules.keys()
-
-    def test_clear_modules_on_err(self, confpy, qbmodulepy):
-        qbmodulepy.write("""def run(config):
-    1/0""")
-        confpy.write("""import qbmodule
-qbmodule.run(config)""")
+    def test_restore_sys_on_err(self, confpy, qbmodulepy, tmpdir):
+        confpy.write_qbmodule()
+        qbmodulepy.write('def run(config):',
+                         '    1/0')
         api = configfiles.read_config_py(confpy.filename)
 
         assert len(api.errors) == 1
         error = api.errors[0]
         assert error.text == "Unhandled exception"
         assert isinstance(error.exception, ZeroDivisionError)
-
-        tblines = error.traceback.strip().splitlines()
-        assert tblines[0] == "Traceback (most recent call last):"
-        assert tblines[-1] == "ZeroDivisionError: division by zero"
-        assert "    1/0" in tblines
         assert "qbmodule" not in sys.modules.keys()
-
-    def test_clear_path_on_err(self, confpy, qbmodulepy, tmpdir):
-        qbmodulepy.write("""def run(config):
-    1/0""")
-        confpy.write("""import qbmodule
-qbmodule.run(config)""")
-        api = configfiles.read_config_py(confpy.filename)
-
-        assert len(api.errors) == 1
-        error = api.errors[0]
-        assert error.text == "Unhandled exception"
-        assert isinstance(error.exception, ZeroDivisionError)
-
-        tblines = error.traceback.strip().splitlines()
-        assert tblines[0] == "Traceback (most recent call last):"
-        assert tblines[-1] == "ZeroDivisionError: division by zero"
-        assert "    1/0" in tblines
         assert tmpdir not in sys.path
 
     def test_fail_on_nonexistent_module(self, confpy, qbmodulepy, tmpdir):
-        qbmodulepy.write("""def run(config):
-    pass""")
-        confpy.write("""import foobar
-foobar.run(config)""")
+        qbmodulepy.write('def run(config):',
+                         '    pass')
+        confpy.write('import foobar',
+                     'foobar.run(config)')
         api = configfiles.read_config_py(confpy.filename)
 
         assert len(api.errors) == 1
@@ -337,11 +266,10 @@ foobar.run(config)""")
 
     def test_no_double_if_path_exists(self, confpy, qbmodulepy, tmpdir):
         sys.path.insert(0, tmpdir)
-        confpy.write("""import sys
-if sys.path[1:].count(sys.path[0]) != 0:
-    raise Exception('Path not expected')""")
-        api = configfiles.read_config_py(confpy.filename)
-        assert len(api.errors) == 0
+        confpy.write('import sys',
+                     'if sys.path[0] in sys.path[1:]:',
+                     '    raise Exception("Path not expected")')
+        confpy.read()
         assert sys.path.count(tmpdir) == 1
 
 
@@ -355,8 +283,8 @@ class TestConfigPy:
 
         """Helper class to get a confpy fixture."""
 
-        def __init__(self, tmpdir):
-            self._confpy = tmpdir / 'config.py'
+        def __init__(self, tmpdir, filename: str = "config.py"):
+            self._confpy = tmpdir / filename
             self.filename = str(self._confpy)
 
         def write(self, *lines):
@@ -367,6 +295,10 @@ class TestConfigPy:
             """Read the config.py via configfiles and check for errors."""
             api = configfiles.read_config_py(self.filename)
             assert not api.errors
+
+        def write_qbmodule(self):
+            self.write('import qbmodule',
+                       'qbmodule.run(config)')
 
     @pytest.fixture
     def confpy(self, tmpdir):

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -19,6 +19,7 @@
 """Tests for qutebrowser.config.configfiles."""
 
 import os
+import sys
 
 import pytest
 
@@ -207,17 +208,39 @@ class TestYaml:
         assert error.traceback is None
 
 
+class ConfPy:
+
+    """Helper class to get a confpy fixture."""
+
+    def __init__(self, tmpdir, filename: str = "config.py"):
+        self._file = tmpdir / filename
+        self.filename = str(self._file)
+
+    def write(self, *lines):
+        text = '\n'.join(lines)
+        self._file.write_text(text, 'utf-8', ensure=True)
+
+    def read(self):
+        """Read the config.py via configfiles and check for errors."""
+        api = configfiles.read_config_py(self.filename)
+        assert not api.errors
+
+    def write_qbmodule(self):
+        self.write('import qbmodule',
+                   'qbmodule.run(config)')
+
+
 class TestConfigPyModules:
 
     pytestmark = pytest.mark.usefixtures('config_stub', 'key_config_stub')
 
     @pytest.fixture
     def confpy(self, tmpdir):
-        return TestConfigPy.ConfPy(tmpdir)
+        return ConfPy(tmpdir)
 
     @pytest.fixture
     def qbmodulepy(self, tmpdir):
-        return TestConfigPy.ConfPy(tmpdir, filename="qbmodule.py")
+        return ConfPy(tmpdir, filename="qbmodule.py")
 
     @pytest.fixture(autouse=True)
     def restore_sys_path(self):
@@ -279,30 +302,9 @@ class TestConfigPy:
 
     pytestmark = pytest.mark.usefixtures('config_stub', 'key_config_stub')
 
-    class ConfPy:
-
-        """Helper class to get a confpy fixture."""
-
-        def __init__(self, tmpdir, filename: str = "config.py"):
-            self._confpy = tmpdir / filename
-            self.filename = str(self._confpy)
-
-        def write(self, *lines):
-            text = '\n'.join(lines)
-            self._confpy.write_text(text, 'utf-8', ensure=True)
-
-        def read(self):
-            """Read the config.py via configfiles and check for errors."""
-            api = configfiles.read_config_py(self.filename)
-            assert not api.errors
-
-        def write_qbmodule(self):
-            self.write('import qbmodule',
-                       'qbmodule.run(config)')
-
     @pytest.fixture
     def confpy(self, tmpdir):
-        return self.ConfPy(tmpdir)
+        return ConfPy(tmpdir)
 
     @pytest.mark.parametrize('line', [
         'c.colors.hints.bg = "red"',

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -207,6 +207,144 @@ class TestYaml:
         assert error.traceback is None
 
 
+class TestConfigPyModules:
+
+    """Test for ConfigPy Modules."""
+
+    pytestmark = pytest.mark.usefixtures('config_stub', 'key_config_stub')
+    _old_sys_path = sys.path.copy()
+
+    class ConfPy:
+
+        """Helper class to get a confpy fixture."""
+
+        def __init__(self, tmpdir):
+            self._confpy = tmpdir / 'config.py'
+            self.filename = str(self._confpy)
+
+        def write(self, *lines):
+            text = '\n'.join(lines)
+            self._confpy.write_text(text, 'utf-8', ensure=True)
+
+    class QbModulePy:
+
+        """Helper class to get a QbModulePy fixture."""
+
+        def __init__(self, tmpdir):
+            self._qbmodulepy = tmpdir / 'qbmodule.py'
+            self.filename = str(self._qbmodulepy)
+
+        def write(self, *lines):
+            text = '\n'.join(lines)
+            self._qbmodulepy.write_text(text, 'utf-8', ensure=True)
+
+    @pytest.fixture
+    def confpy(self, tmpdir):
+        return self.ConfPy(tmpdir)
+
+    @pytest.fixture
+    def qbmodulepy(self, tmpdir):
+        return self.QbModulePy(tmpdir)
+
+    def setup_method(self, method):
+        # If we plan to add tests that modify modules themselves, that should
+        # be saved as well
+        TestConfigPyModules._old_sys_path = sys.path.copy()
+
+    def teardown_method(self, method):
+        # Restore path to save the rest of the tests
+        sys.path = TestConfigPyModules._old_sys_path
+
+    def test_bind_in_module(self, confpy, qbmodulepy):
+        qbmodulepy.write("""def run(config):
+    config.bind(",a", "message-info foo", mode="normal")""")
+        confpy.write("""import qbmodule
+qbmodule.run(config)""")
+        api = configfiles.read_config_py(confpy.filename)
+        expected = {'normal': {',a': 'message-info foo'}}
+        assert len(api.errors) == 0
+        assert config.instance._values['bindings.commands'] == expected
+
+    def test_clear_path(self, confpy, qbmodulepy, tmpdir):
+        qbmodulepy.write("""def run(config):
+    config.bind(",a", "message-info foo", mode="normal")""")
+        confpy.write("""import qbmodule
+qbmodule.run(config)""")
+        api = configfiles.read_config_py(confpy.filename)
+        assert len(api.errors) == 0
+        assert tmpdir not in sys.path
+
+    def test_clear_modules(self, confpy, qbmodulepy):
+        qbmodulepy.write("""def run(config):
+    config.bind(",a", "message-info foo", mode="normal")""")
+        confpy.write("""import qbmodule
+qbmodule.run(config)""")
+        api = configfiles.read_config_py(confpy.filename)
+        assert len(api.errors) == 0
+        assert "qbmodule" not in sys.modules.keys()
+
+    def test_clear_modules_on_err(self, confpy, qbmodulepy):
+        qbmodulepy.write("""def run(config):
+    1/0""")
+        confpy.write("""import qbmodule
+qbmodule.run(config)""")
+        api = configfiles.read_config_py(confpy.filename)
+
+        assert len(api.errors) == 1
+        error = api.errors[0]
+        assert error.text == "Unhandled exception"
+        assert isinstance(error.exception, ZeroDivisionError)
+
+        tblines = error.traceback.strip().splitlines()
+        assert tblines[0] == "Traceback (most recent call last):"
+        assert tblines[-1] == "ZeroDivisionError: division by zero"
+        assert "    1/0" in tblines
+        assert "qbmodule" not in sys.modules.keys()
+
+    def test_clear_path_on_err(self, confpy, qbmodulepy, tmpdir):
+        qbmodulepy.write("""def run(config):
+    1/0""")
+        confpy.write("""import qbmodule
+qbmodule.run(config)""")
+        api = configfiles.read_config_py(confpy.filename)
+
+        assert len(api.errors) == 1
+        error = api.errors[0]
+        assert error.text == "Unhandled exception"
+        assert isinstance(error.exception, ZeroDivisionError)
+
+        tblines = error.traceback.strip().splitlines()
+        assert tblines[0] == "Traceback (most recent call last):"
+        assert tblines[-1] == "ZeroDivisionError: division by zero"
+        assert "    1/0" in tblines
+        assert tmpdir not in sys.path
+
+    def test_fail_on_nonexistent_module(self, confpy, qbmodulepy, tmpdir):
+        qbmodulepy.write("""def run(config):
+    pass""")
+        confpy.write("""import foobar
+foobar.run(config)""")
+        api = configfiles.read_config_py(confpy.filename)
+
+        assert len(api.errors) == 1
+        error = api.errors[0]
+        assert error.text == "Unhandled exception"
+        assert isinstance(error.exception, ImportError)
+
+        tblines = error.traceback.strip().splitlines()
+        assert tblines[0] == "Traceback (most recent call last):"
+        assert tblines[-1].endswith("Error: No module named 'foobar'")
+
+    def test_no_double_if_path_exists(self, confpy, qbmodulepy, tmpdir):
+        sys.path.insert(0, tmpdir)
+        confpy.write("""import sys
+if sys.path[1:].count(sys.path[0]) != 0:
+    raise Exception('Path not expected')""")
+        api = configfiles.read_config_py(confpy.filename)
+        assert len(api.errors) == 0
+        assert sys.path.count(tmpdir) == 1
+
+
 class TestConfigPy:
 
     """Tests for ConfigAPI and read_config_py()."""


### PR DESCRIPTION
This is done so config.py can import other python files in the config directory. For example, config.py can 'import theme' which would load a theme.py.

The previous path is restored at the end of this function, to avoid tainting qutebrowser's path

Feel free to trash this PR if this dosen't seem like a good approach.

See #2969

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2970)
<!-- Reviewable:end -->
