### PR TITLE
Added functions to check OS/Platform

### DIFF
--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -858,16 +858,10 @@ def expand_windows_drive(path):
         return path
 
 def is_mac():
-    if sys.platform.startswith('darwin'):
-        return True
-    return False
+    return sys.platform.startswith('darwin')
 
 def is_linux():
-    if sys.platform.startswith('linux'):
-        return True
-    return False
+    return sys.platform.startswith('linux')
 
 def is_windows():
-    if sys.platform.startswith('win'):
-        return True
-    return False
+    return sys.platform.startswith('win')

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -858,12 +858,12 @@ def expand_windows_drive(path):
         return path
 
 def is_mac():
-    if sys.platform == 'darwin':
+    if sys.platform.startswith('darwin'):
         return True
     return False
 
 def is_linux():
-    if sys.platform == 'linux' or sys.platform == 'linux2':
+    if sys.platform.startswith('linux'):
         return True
     return False
 

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -856,3 +856,18 @@ def expand_windows_drive(path):
         return path + "\\"
     else:
         return path
+
+def is_mac():
+    if sys.platform == 'darwin':
+        return True
+    return False
+
+def is_linux():
+    if sys.platform == 'linux' or sys.platform == 'linux2':
+        return True
+    return False
+
+def is_windows():
+    if sys.platform.startswith('win'):
+        return True
+    return False


### PR DESCRIPTION
#### Solution for #2961 (Introduce utils functions for OS/platform checks)

Added 3 functions in ```qutebrowser/qutebrowser/utils/utils.py``` that return ```True``` or ```False``` depending on the OS/Platform.

Functions being : 
- ```is_mac()```
- ```is_linux()``` 
- ```is_windows()```

##### Tested successfully on MacOS and Ubuntu.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2972)
<!-- Reviewable:end -->
