### PR TITLE
Enable proxy server authentication

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -22,6 +22,7 @@
 import os
 import math
 import functools
+import html
 
 import sip
 from PyQt5.QtCore import pyqtSlot, Qt, QEvent, QPoint, QUrl, QTimer
@@ -37,7 +38,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            webenginesettings)
 from qutebrowser.misc import miscwidgets
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
-                               objreg, jinja, debug, version)
+                               message, objreg, jinja, debug, version)
 
 
 _qute_scheme_handler = None
@@ -682,6 +683,20 @@ class WebEngineTab(browsertab.AbstractTab):
 
         self.add_history_item.emit(url, requested_url, title)
 
+    @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
+    def _on_proxy_authentication_required(self, _url, authenticator,
+                                          proxy_host):
+        """Called when a proxy needs authentication."""
+        msg = "<b>{}</b> requires a username and password.".format(
+            html.escape(proxy_host))
+        answer = message.ask(
+            title="Proxy authentication required", text=msg,
+            mode=usertypes.PromptMode.user_pwd,
+            abort_on=[self.shutting_down, self.load_started])
+        if answer is not None:
+            authenticator.setUser(answer.user)
+            authenticator.setPassword(answer.password)
+
     @pyqtSlot(QUrl, 'QAuthenticator*')
     def _on_authentication_required(self, url, authenticator):
         # FIXME:qtwebengine support .netrc
@@ -759,6 +774,8 @@ class WebEngineTab(browsertab.AbstractTab):
         page.loadFinished.connect(self._on_load_finished)
         page.certificate_error.connect(self._on_ssl_errors)
         page.authenticationRequired.connect(self._on_authentication_required)
+        page.proxyAuthenticationRequired.connect(
+            self._on_proxy_authentication_required)
         page.fullScreenRequested.connect(self._on_fullscreen_requested)
         page.contentsSizeChanged.connect(self.contents_size_changed)
 

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -148,7 +148,7 @@ class WebEnginePage(QWebEnginePage):
         self.setBackgroundColor(col)
 
     @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
-    def _on_proxy_authentication_required(self, url, authenticator,
+    def _on_proxy_authentication_required(self, _url, authenticator,
                                           proxy_host):
         """Called when a proxy needs authentication."""
         msg = "<b>{}</b> requires a username and password.".format(

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -24,6 +24,7 @@ import functools
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, PYQT_VERSION
 from PyQt5.QtGui import QPalette
 from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
+from PyQt5.QtNetwork import QAuthenticator
 
 from qutebrowser.browser import shared
 from qutebrowser.browser.webengine import certificateerror, webenginesettings
@@ -133,6 +134,8 @@ class WebEnginePage(QWebEnginePage):
         self._is_shutting_down = False
         self.featurePermissionRequested.connect(
             self._on_feature_permission_requested)
+        self.proxyAuthenticationRequired.connect(
+            self._on_proxy_authentication_required)
         self._theme_color = theme_color
         self._set_bg_color()
         objreg.get('config').changed.connect(self._set_bg_color)
@@ -143,6 +146,11 @@ class WebEnginePage(QWebEnginePage):
         if col is None:
             col = self._theme_color
         self.setBackgroundColor(col)
+
+    @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
+    def _on_proxy_authentication_required(self, url, authenticator, proxyHost):
+        log.webview.debug("Proxy authentication required for URL: %s"%url.toString())
+        shared.authentication_required(url, authenticator, [self.shutting_down, self.loadStarted])
 
     @pyqtSlot(QUrl, 'QWebEnginePage::Feature')
     def _on_feature_permission_requested(self, url, feature):

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -24,7 +24,6 @@ import functools
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, PYQT_VERSION
 from PyQt5.QtGui import QPalette
 from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
-from PyQt5.QtNetwork import QAuthenticator
 
 from qutebrowser.browser import shared
 from qutebrowser.browser.webengine import certificateerror, webenginesettings
@@ -149,7 +148,6 @@ class WebEnginePage(QWebEnginePage):
 
     @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
     def _on_proxy_authentication_required(self, url, authenticator, proxyHost):
-        log.webview.debug("Proxy authentication required for URL: %s"%url.toString())
         shared.authentication_required(url, authenticator, [self.shutting_down, self.loadStarted])
 
     @pyqtSlot(QUrl, 'QWebEnginePage::Feature')

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -20,7 +20,6 @@
 """The main browser widget for QtWebEngine."""
 
 import functools
-import html
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, PYQT_VERSION
 from PyQt5.QtGui import QPalette
@@ -134,8 +133,6 @@ class WebEnginePage(QWebEnginePage):
         self._is_shutting_down = False
         self.featurePermissionRequested.connect(
             self._on_feature_permission_requested)
-        self.proxyAuthenticationRequired.connect(
-            self._on_proxy_authentication_required)
         self._theme_color = theme_color
         self._set_bg_color()
         objreg.get('config').changed.connect(self._set_bg_color)
@@ -146,20 +143,6 @@ class WebEnginePage(QWebEnginePage):
         if col is None:
             col = self._theme_color
         self.setBackgroundColor(col)
-
-    @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
-    def _on_proxy_authentication_required(self, _url, authenticator,
-                                          proxy_host):
-        """Called when a proxy needs authentication."""
-        msg = "<b>{}</b> requires a username and password.".format(
-            html.escape(proxy_host))
-        answer = message.ask(
-            title="Proxy authentication required", text=msg,
-            mode=usertypes.PromptMode.user_pwd,
-            abort_on=[self.loadStarted, self.shutting_down])
-        if answer is not None:
-            authenticator.setUser(answer.user)
-            authenticator.setPassword(answer.password)
 
     @pyqtSlot(QUrl, 'QWebEnginePage::Feature')
     def _on_feature_permission_requested(self, url, feature):

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -148,7 +148,15 @@ class WebEnginePage(QWebEnginePage):
 
     @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
     def _on_proxy_authentication_required(self, url, authenticator, proxyHost):
-        shared.authentication_required(url, authenticator, [self.shutting_down, self.loadStarted])
+        answer = shared.authentication_required(url, authenticator, [self.shutting_down, self.loadStarted])
+        if answer is None:
+            authenticator.setUser(None)
+            authenticator.setPassword(None)
+            url_string = url.toDisplayString()
+            error_page = jinja.render(
+                'error.html', title="Error loading page: {}".format(url_string),
+                url=url_string, error="Proxy authentication required.", icon='')
+            self.setHtml(error_page)
 
     @pyqtSlot(QUrl, 'QWebEnginePage::Feature')
     def _on_feature_permission_requested(self, url, feature):


### PR DESCRIPTION
Adds the [`proxyAuthenticationRequired()`](http://doc.qt.io/qt-5/qwebenginepage.html#proxyAuthenticationRequired) signal handler to the WebEnginePage to allow users to login to a proxy server.

Aborting the username/password dialog displays an error page.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/2984)
<!-- Reviewable:end -->
