### PR TITLE
fix link to configuring page in readme

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -50,7 +50,7 @@ image:https://qutebrowser.org/img/cheatsheet-small.png["qutebrowser key binding 
 * link:doc/quickstart.asciidoc[Quick start guide]
 * A https://www.shortcutfoo.com/app/dojos/qutebrowser[free training course] to remember those key bindings.
 * link:doc/faq.asciidoc[Frequently asked questions]
-* link:doc/help/configuring.html[Configuring qutebrowser]
+* link:doc/help/configuring.asciidoc[Configuring qutebrowser]
 * link:doc/contributing.asciidoc[Contributing to qutebrowser]
 * link:doc/install.asciidoc[Installing qutebrowser]
 * link:doc/changelog.asciidoc[Change Log]


### PR DESCRIPTION
Otherwise clicking the link from GitHub gives a 404.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3000)
<!-- Reviewable:end -->
