### PR TITLE
Add table headers and widen input fields in qute://settings, Remove extra backslashes in configdata.yml

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -562,7 +562,7 @@ content.xss_auditing:
   desc: >-
     Whether load requests should be monitored for cross-site scripting attempts.
 
-    Suspicious scripts will be blocked and reported in the inspector\'s
+    Suspicious scripts will be blocked and reported in the inspector's
     JavaScript console. Enabling this feature might have an impact on
     performance.
 
@@ -917,7 +917,7 @@ keyhint.blacklist:
       name: String
   default: []
   desc: >-
-    Keychains that shouldn\'t be shown in the keyhint dialog.
+    Keychains that shouldn't be shown in the keyhint dialog.
 
     Globs are supported, so `;*` will blacklist all keychains starting with `;`.
     Use `*` to disable keyhints.
@@ -1734,7 +1734,7 @@ fonts.monospace:
   desc: >-
     Default monospace fonts.
 
-    Whenever "monospace" is used in a font setting, it\'s replaced with the
+    Whenever "monospace" is used in a font setting, it's replaced with the
     fonts listed here.
 
 fonts.completion.entry:

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -17,6 +17,9 @@ pre { margin: 2px; }
 th, td { border: 1px solid grey; padding: 0px 5px; }
 th { background: lightgrey; }
 th pre { color: grey; text-align: left; }
+input { width: 98%; }
+.setting { width: 75%; }
+.value { width: 25%; text-align: center; }
 .noscript, .noscript-text { color:red; }
 .noscript-text { margin-bottom: 5cm; }
 .option_description { margin: .5ex 0; color: grey; font-size: 80%; font-style: italic; white-space: pre-line; }
@@ -26,15 +29,19 @@ th pre { color: grey; text-align: left; }
 <noscript><h1 class="noscript">View Only</h1><p class="noscript-text">Changing settings requires javascript to be enabled!</p></noscript>
 <header><h1>{{ title }}</h1></header>
 <table>
+    <tr>
+        <th>Setting</th>
+        <th>Value</th>
+    </tr>
   {% for option in configdata.DATA.values() %}
     <tr>
       <!-- FIXME: convert to string properly -->
-      <td>{{ option.name }} (Current: {{ confget(option.name) | string |truncate(100) }})
+      <td class="setting">{{ option.name }} (Current: {{ confget(option.name) | string |truncate(100) }})
         {% if option.description %}
           <p class="option_description">{{ option.description|e }}</p>
         {% endif %}
       </td>
-      <td>
+      <td class="value">
         <input type="text"
           id="input-{{ option.name }}"
           onblur="cset('{{ option.name }}', this.value)"


### PR DESCRIPTION
Makes editing long values easier and removes extra backslashes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3029)
<!-- Reviewable:end -->
