### PR TITLE
Fix the link to faq.html in help page

### DIFF
--- a/doc/help/index.asciidoc
+++ b/doc/help/index.asciidoc
@@ -7,7 +7,7 @@ Documentation
 The following help pages are currently available:
 
 * link:../quickstart.html[Quick start guide]
-* link:../doc.html[Frequently asked questions]
+* link:../faq.html[Frequently asked questions]
 * link:../changelog.html[Change Log]
 * link:commands.html[Documentation of commands]
 * link:configuring.html[Configuring qutebrowser]


### PR DESCRIPTION
It got broken in 4c616a5733dfa98a0d1b557d679af255ddb9759b

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3032)
<!-- Reviewable:end -->
