### PR TITLE
Ensure HistoryCategory works in isolation.

### DIFF
--- a/qutebrowser/completion/models/completionmodel.py
+++ b/qutebrowser/completion/models/completionmodel.py
@@ -60,8 +60,6 @@ class CompletionModel(QAbstractItemModel):
     def add_category(self, cat):
         """Add a completion category to the model."""
         self._categories.append(cat)
-        cat.layoutAboutToBeChanged.connect(self.layoutAboutToBeChanged)
-        cat.layoutChanged.connect(self.layoutChanged)
 
     def data(self, index, role=Qt.DisplayRole):
         """Return the item data for index.
@@ -179,8 +177,10 @@ class CompletionModel(QAbstractItemModel):
             pattern: The filter pattern to set.
         """
         log.completion.debug("Setting completion pattern '{}'".format(pattern))
+        self.layoutAboutToBeChanged.emit()
         for cat in self._categories:
             cat.set_pattern(pattern)
+        self.layoutChanged.emit()
 
     def first_item(self):
         """Return the index of the first child (non-category) in the model."""

--- a/tests/unit/completion/test_completionmodel.py
+++ b/tests/unit/completion/test_completionmodel.py
@@ -68,17 +68,18 @@ def test_count(counts):
     assert model.count() == sum(counts)
 
 
-@hypothesis.given(strategies.text())
-def test_set_pattern(pat):
+@hypothesis.given(pat=strategies.text())
+def test_set_pattern(pat, qtbot):
     """Validate the filtering and sorting results of set_pattern."""
     model = completionmodel.CompletionModel()
-    cats = [mock.Mock(spec=['set_pattern', 'layoutChanged',
-                            'layoutAboutToBeChanged'])
+    cats = [mock.Mock(spec=['set_pattern', 'layoutAboutToBeChanged'])
             for _ in range(3)]
     for c in cats:
         c.set_pattern = mock.Mock(spec=[])
         model.add_category(c)
-    model.set_pattern(pat)
+    with qtbot.waitSignals([model.layoutAboutToBeChanged, model.layoutChanged],
+                           order='strict'):
+        model.set_pattern(pat)
     for c in cats:
         c.set_pattern.assert_called_with(pat)
 


### PR DESCRIPTION
While QSortFilterProxyModel emits layoutChanged when changing the
pattern, QSqlQueryModel emits modelReset. As only layoutChanged was
connected, a HistoryCategory would only work in a model that also had at
least one ListCategory.

The simplest solution is to have the parent model emit the signal
directly. This also emits a single signal on a pattern change rather
that one for each child model.

Resolves #3016.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3033)
<!-- Reviewable:end -->
