### PR TITLE
fix example config.py alias creation example

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -113,7 +113,7 @@ accepted values depend on the type of the option. Commonly used are:
 - Dictionaries:
   * `c.headers.custom = {'X-Hello': 'World', 'X-Awesome': 'yes'}` to override
     any other values in the dictionary.
-  * `c.aliases['foo'] = ':message-info foo'` to add a single value.
+  * `c.aliases['foo'] = 'message-info foo'` to add a single value.
 - Lists:
   * `c.url.start_pages = ["https://www.qutebrowser.org/"]` to override any
     previous elements.


### PR DESCRIPTION
This is a minor documentation update that fixes a bad example of creating an alias using config.py. The current example will produce an error when it is used since the leading `:` is interpreted as part of the command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3039)
<!-- Reviewable:end -->
