### PR TITLE
Greasemonkey

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -64,7 +64,7 @@ from qutebrowser.completion.models import miscmodels
 from qutebrowser.commands import cmdutils, runners, cmdexc
 from qutebrowser.config import config, websettings, configfiles, configinit
 from qutebrowser.browser import (urlmarks, adblock, history, browsertab,
-                                 downloads)
+                                 downloads, greasemonkey)
 from qutebrowser.browser.network import proxy
 from qutebrowser.browser.webkit import cookies, cache
 from qutebrowser.browser.webkit.network import networkmanager
@@ -490,6 +490,10 @@ def _init_modules(args, crash_handler):
     log.init.debug("Initializing cache...")
     diskcache = cache.DiskCache(standarddir.cache(), parent=qApp)
     objreg.register('cache', diskcache)
+
+    log.init.debug("Initializing Greasemonkey...")
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    objreg.register('greasemonkey', gm_manager)
 
     log.init.debug("Misc initialization...")
     macros.init()

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -31,7 +31,7 @@ from qutebrowser.keyinput import modeman
 from qutebrowser.config import config
 from qutebrowser.utils import utils, objreg, usertypes, log, qtutils
 from qutebrowser.misc import miscwidgets, objects
-from qutebrowser.browser import mouse, hints
+from qutebrowser.browser import mouse, hints, greasemonkey
 
 
 tab_id_gen = itertools.count(0)
@@ -63,6 +63,10 @@ def init():
     if objects.backend == usertypes.Backend.QtWebEngine:
         from qutebrowser.browser.webengine import webenginetab
         webenginetab.init()
+
+    log.init.debug("Initializing Greasemonkey...")
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    objreg.register('greasemonkey', gm_manager)
 
 
 class WebTabError(Exception):

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -31,7 +31,7 @@ from qutebrowser.keyinput import modeman
 from qutebrowser.config import config
 from qutebrowser.utils import utils, objreg, usertypes, log, qtutils
 from qutebrowser.misc import miscwidgets, objects
-from qutebrowser.browser import mouse, hints, greasemonkey
+from qutebrowser.browser import mouse, hints
 
 
 tab_id_gen = itertools.count(0)
@@ -63,10 +63,6 @@ def init():
     if objects.backend == usertypes.Backend.QtWebEngine:
         from qutebrowser.browser.webengine import webenginetab
         webenginetab.init()
-
-    log.init.debug("Initializing Greasemonkey...")
-    gm_manager = greasemonkey.GreasemonkeyManager()
-    objreg.register('greasemonkey', gm_manager)
 
 
 class WebTabError(Exception):

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -226,6 +226,10 @@ class GreasemonkeyManager(QObject):
     """
 
     scripts_reloaded = pyqtSignal()
+    # https://wiki.greasespot.net/Include_and_exclude_rules#Greaseable_schemes
+    # Limit the schemes scripts can run on due to unreasonable levels of
+    # exploitability
+    greaseable_schemes = ['http', 'https', 'ftp', 'file']
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -273,6 +277,8 @@ class GreasemonkeyManager(QObject):
         returns a tuple of lists of scripts meant to run at (document-start,
         document-end, document-idle)
         """
+        if url.split(':', 1)[0] not in self.greaseable_schemes:
+            return [], [], []
         match = functools.partial(fnmatch.fnmatch, url)
         tester = (lambda script:
                   any([match(pat) for pat in script.includes]) and

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -181,9 +181,10 @@ class GreasemonkeyManager(QObject):
         returns a tuple of lists of scripts meant to run at (document-start,
         document-end, document-idle)
         """
-        if url.split(':', 1)[0] not in self.greaseable_schemes:
+        if url.scheme() not in self.greaseable_schemes:
             return MatchingScripts(url, [], [], [])
-        match = functools.partial(fnmatch.fnmatch, url)
+        match = functools.partial(fnmatch.fnmatch,
+                                  str(url.toEncoded(), 'utf-8'))
         tester = (lambda script:
                   any([match(pat) for pat in script.includes]) and
                   not any([match(pat) for pat in script.excludes]))

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -49,6 +49,9 @@ class GreasemonkeyScript:
         self.name = None
         self.namespace = None
         self.run_at = None
+        self.script_meta = None
+        # Running on subframes is only supported on the qtwebengine backend.
+        self.runs_on_sub_frames = True
         for name, value in properties:
             if name == 'name':
                 self.name = value
@@ -62,6 +65,8 @@ class GreasemonkeyScript:
                 self.excludes.append(value)
             elif name == 'run-at':
                 self.run_at = value
+            elif name == 'noframes':
+                self.runs_on_sub_frames = False
 
     HEADER_REGEX = r'// ==UserScript==|\n+// ==/UserScript==\n'
     PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s+(?P<val>.+)'

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -256,9 +256,12 @@ class GreasemonkeyManager(QObject):
                     self._run_end.append(script)
                 else:
                     log.greasemonkey.warning("Script {} has invalid run-at "
-                                             "defined, ignoring."
+                                             "defined, defaulting to "
+                                             "document-end"
                                              .format(script_path))
-                    continue
+                    # Default as per
+                    # https://wiki.greasespot.net/Metadata_Block#.40run-at
+                    self._run_end.append(script)
                 log.greasemonkey.debug("Loaded script: {}".format(script.name))
         self.scripts_reloaded.emit()
 

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -27,7 +27,7 @@ import functools
 import glob
 
 import attr
-from PyQt5.QtCore import pyqtSignal, QObject
+from PyQt5.QtCore import pyqtSignal, QObject, QUrl
 
 from qutebrowser.utils import log, standarddir, jinja
 from qutebrowser.commands import cmdutils
@@ -47,10 +47,13 @@ class GreasemonkeyScript:
         self.excludes = []
         self.description = None
         self.name = None
+        self.namespace = None
         self.run_at = None
         for name, value in properties:
             if name == 'name':
                 self.name = value
+            elif name == 'namespace':
+                self.namespace = value
             elif name == 'description':
                 self.description = value
             elif name in ['include', 'match']:
@@ -93,7 +96,7 @@ class GreasemonkeyScript:
         """
         return jinja.js_environment.get_template(
             'greasemonkey_wrapper.js').render(
-                scriptName=self.name,
+                scriptName="/".join([self.namespace or '', self.name]),
                 scriptInfo=self._meta_json(),
                 scriptMeta=self.script_meta,
                 scriptSource=self._code)
@@ -184,7 +187,7 @@ class GreasemonkeyManager(QObject):
         if url.scheme() not in self.greaseable_schemes:
             return MatchingScripts(url, [], [], [])
         match = functools.partial(fnmatch.fnmatch,
-                                  str(url.toEncoded(), 'utf-8'))
+                                  url.toString(QUrl.FullyEncoded))
         tester = (lambda script:
                   any([match(pat) for pat in script.includes]) and
                   not any([match(pat) for pat in script.excludes]))

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -68,7 +68,7 @@ class GreasemonkeyScript:
                 self.runs_on_sub_frames = False
 
     HEADER_REGEX = r'// ==UserScript==|\n+// ==/UserScript==\n'
-    PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s+(?P<val>.+)'
+    PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s*(?P<val>.*)'
 
     @classmethod
     def parse(cls, source):

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -1,0 +1,262 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2017 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Load, parse and make avalaible greasemonkey scripts."""
+
+import re
+import os
+import json
+import fnmatch
+import functools
+import glob
+
+from PyQt5.QtCore import pyqtSignal, QObject
+
+from qutebrowser.utils import log, standarddir
+
+# TODO: GM_ bootstrap
+
+
+def _scripts_dir():
+    """Get the directory of the scripts."""
+    return os.path.join(standarddir.data(), 'greasemonkey')
+
+
+class GreasemonkeyScript:
+    """Container class for userscripts, parses metadata blocks."""
+
+    GM_BOOTSTRAP_TEMPLATE = r"""var _qute_script_id = "__gm_{scriptName}";
+
+function GM_log(text) {{
+    console.log(text);
+}}
+
+GM_info = (function() {{
+    return {{
+        'script': {scriptInfo},
+        'scriptMetaStr': {scriptMeta},
+        'scriptWillUpdate': false,
+        'version': '0.0.1',
+        'scriptHandler': 'Tampermonkey' //so scripts don't expect exportFunction
+    }};
+}}());
+
+function GM_setValue(key, value) {{
+    if (localStorage !== null &&
+        typeof key === "string" &&
+        (typeof value === "string" ||
+            typeof value === "number" ||
+            typeof value == "boolean")) {{
+        localStorage.setItem(_qute_script_id + key, value);
+    }}
+}}
+
+function GM_getValue(key, default_) {{
+    if (localStorage !== null && typeof key === "string") {{
+        return localStorage.getItem(_qute_script_id + key) || default_;
+    }}
+}}
+
+function GM_deleteValue(key) {{
+    if (localStorage !== null && typeof key === "string") {{
+        localStorage.removeItem(_qute_script_id + key);
+    }}
+}}
+
+function GM_listValues() {{
+    var i;
+    var keys = [];
+    for (i = 0; i < localStorage.length; ++i) {{
+        if (localStorage.key(i).startsWith(_qute_script_id)) {{
+            keys.push(localStorage.key(i));
+        }}
+    }}
+    return keys;
+}}
+
+function GM_openInTab(url) {{
+    window.open(url);
+}}
+
+
+// Almost verbatim copy from Eric
+function GM_xmlhttpRequest(/* object */ details) {{
+    details.method = details.method.toUpperCase() || "GET";
+
+    if(!details.url) {{
+        throw("GM_xmlhttpRequest requires an URL.");
+    }}
+
+    // build XMLHttpRequest object
+    var oXhr = new XMLHttpRequest;
+    // run it
+    if("onreadystatechange" in details)
+        oXhr.onreadystatechange = function() {{
+            details.onreadystatechange(oXhr)
+        }};
+    if("onload" in details)
+        oXhr.onload = function() {{ details.onload(oXhr) }};
+    if("onerror" in details)
+        oXhr.onerror = function() {{ details.onerror(oXhr) }};
+
+    oXhr.open(details.method, details.url, true);
+
+    if("headers" in details)
+        for(var header in details.headers)
+            oXhr.setRequestHeader(header, details.headers[header]);
+
+    if("data" in details)
+        oXhr.send(details.data);
+    else
+        oXhr.send();
+}}
+
+function GM_addStyle(/* String */ styles) {{
+    var head = document.getElementsByTagName("head")[0];
+    if (head === undefined) {{
+        document.onreadystatechange = function() {{
+            if (document.readyState == "interactive") {{
+                var oStyle = document.createElement("style");
+                oStyle.setAttribute("type", "text/css");
+                oStyle.appendChild(document.createTextNode(styles));
+                document.getElementsByTagName("head")[0].appendChild(oStyle);
+            }}
+        }}
+    }}
+    else {{
+        var oStyle = document.createElement("style");
+        oStyle.setAttribute("type", "text/css");
+        oStyle.appendChild(document.createTextNode(styles));
+        head.appendChild(oStyle);
+    }}
+}}
+
+unsafeWindow = window;
+"""
+
+    def __init__(self, properties, code):
+        self._code = code
+        self.includes = []
+        self.excludes = []
+        self.description = None
+        self.name = None
+        self.run_at = None
+        for name, value in properties:
+            if name == 'name':
+                self.name = value
+            elif name == 'description':
+                self.description = value
+            elif name in ['include', 'match']:
+                self.includes.append(value)
+            elif name in ['exclude', 'exclude_match']:
+                self.excludes.append(value)
+            elif name == 'run-at':
+                self.run_at = value
+
+    HEADER_REGEX = r'// ==UserScript==.|\n+// ==/UserScript==\n'
+    PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s+(?P<val>.+)'
+
+    @classmethod
+    def parse(cls, source):
+        """GreaseMonkeyScript factory.
+
+        Takes a userscript source and returns a GreaseMonkeyScript.
+        Parses the greasemonkey metadata block, if present, to fill out
+        attributes.
+        """
+        matches = re.split(cls.HEADER_REGEX, source, maxsplit=1)
+        try:
+            props, _code = matches
+        except ValueError:
+            props = ""
+        script = cls(re.findall(cls.PROPS_REGEX, props), code)
+        script.script_meta = '"{}"'.format("\\n".join(props.split('\n')[2:]))
+        return script
+
+    def code(self):
+        """Return the processed javascript code of this script.
+
+        Adorns the source code with GM_* methods for greasemonkey
+        compatibility and wraps it in an IFFE to hide it within a
+        lexical scope. Note that this means line numbers in your
+        browser's debugger/inspector will not match up to the line
+        numbers in the source script directly.
+        """
+        gm_bootstrap = self.GM_BOOTSTRAP_TEMPLATE.format(
+            scriptName=self.name,
+            scriptInfo=self._meta_json(),
+            scriptMeta=self.script_meta)
+        return '\n'.join([gm_bootstrap, self._code])
+
+    def _meta_json(self):
+        return json.dumps({
+            'name': self.name,
+            'description': self.description,
+            'matches': self.includes,
+            'includes': self.includes,
+            'excludes': self.excludes,
+            'run-at': self.run_at,
+        })
+
+
+class GreasemonkeyManager:
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self._run_start = []
+        self._run_end = []
+
+        scripts_dir = os.path.abspath(_scripts_dir())
+        log.greasemonkey.debug("Reading scripts from: {}".format(scripts_dir))
+        for script_filename in glob.glob(os.path.join(scripts_dir, '*.js')):
+            if not os.path.isfile(script_filename):
+                continue
+            script_path = os.path.join(scripts_dir, script_filename)
+            with open(script_path, encoding='utf-8') as script_file:
+                script = GreasemonkeyScript.parse(script_file.read())
+                if not script.name:
+                    script.name = script_filename
+
+                if script.run_at == 'document-start':
+                    self._run_start.append(script)
+                elif script.run_at == 'document-end':
+                    self._run_end.append(script)
+                else:
+                    log.greasemonkey.warning("Script {} has invalid run-at "
+                                             "defined, ignoring."
+                                             .format(script_path))
+                    continue
+                log.greasemonkey.debug("Loaded script: {}".format(script.name))
+
+    def scripts_for(self, url):
+        """Fetch scripts that are registered to run for url.
+
+        returns a tuple of lists of scripts meant to run at (document-start,
+        document-end)
+        """
+        match = functools.partial(fnmatch.fnmatch, url)
+        tester = (lambda script:
+                  any(map(match, script.includes())) and not
+                  any(map(match, script.excludes())))
+        return (list(filter(tester, self._run_start)),
+                list(filter(tester, self._run_end)))
+
+    def all_scripts(self):
+        """Return all scripts found in the configured script directory."""
+        return self._run_start + self._run_end

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -193,8 +193,8 @@ class GreasemonkeyManager(QObject):
         match = functools.partial(fnmatch.fnmatch,
                                   url.toString(QUrl.FullyEncoded))
         tester = (lambda script:
-                  any([match(pat) for pat in script.includes]) and
-                  not any([match(pat) for pat in script.excludes]))
+                  any(match(pat) for pat in script.includes) and
+                  not any(match(pat) for pat in script.excludes))
         return MatchingScripts(
             url,
             [script for script in self._run_start if tester(script)],

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -50,7 +50,6 @@ class GreasemonkeyScript:
         self.namespace = None
         self.run_at = None
         self.script_meta = None
-        # Running on subframes is only supported on the qtwebengine backend.
         self.runs_on_sub_frames = True
         for name, value in properties:
             if name == 'name':

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -60,7 +60,7 @@ class GreasemonkeyScript:
             elif name == 'run-at':
                 self.run_at = value
 
-    HEADER_REGEX = r'// ==UserScript==.|\n+// ==/UserScript==\n'
+    HEADER_REGEX = r'// ==UserScript==|\n+// ==/UserScript==\n'
     PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s+(?P<val>.+)'
 
     @classmethod
@@ -71,13 +71,13 @@ class GreasemonkeyScript:
         Parses the greasemonkey metadata block, if present, to fill out
         attributes.
         """
-        matches = re.split(cls.HEADER_REGEX, source, maxsplit=1)
+        matches = re.split(cls.HEADER_REGEX, source, maxsplit=2)
         try:
-            props, _code = matches
+            _, props, _code = matches
         except ValueError:
             props = ""
         script = cls(re.findall(cls.PROPS_REGEX, props), source)
-        script.script_meta = '"{}"'.format("\\n".join(props.split('\n')[2:]))
+        script.script_meta = props
         if not props:
             script.includes = ['*']
         return script

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -29,7 +29,7 @@ import glob
 import attr
 from PyQt5.QtCore import pyqtSignal, QObject
 
-from qutebrowser.utils import log, standarddir
+from qutebrowser.utils import log, standarddir, jinja
 from qutebrowser.commands import cmdutils
 
 
@@ -40,115 +40,6 @@ def _scripts_dir():
 
 class GreasemonkeyScript:
     """Container class for userscripts, parses metadata blocks."""
-
-    GM_BOOTSTRAP_TEMPLATE = r"""var _qute_script_id = "__gm_{scriptName}";
-
-function GM_log(text) {{
-    console.log(text);
-}}
-
-GM_info = (function() {{
-    return {{
-        'script': {scriptInfo},
-        'scriptMetaStr': {scriptMeta},
-        'scriptWillUpdate': false,
-        'version': '0.0.1',
-        'scriptHandler': 'Tampermonkey' //so scripts don't expect exportFunction
-    }};
-}}());
-
-function GM_setValue(key, value) {{
-    if (localStorage !== null &&
-        typeof key === "string" &&
-        (typeof value === "string" ||
-            typeof value === "number" ||
-            typeof value == "boolean")) {{
-        localStorage.setItem(_qute_script_id + key, value);
-    }}
-}}
-
-function GM_getValue(key, default_) {{
-    if (localStorage !== null && typeof key === "string") {{
-        return localStorage.getItem(_qute_script_id + key) || default_;
-    }}
-}}
-
-function GM_deleteValue(key) {{
-    if (localStorage !== null && typeof key === "string") {{
-        localStorage.removeItem(_qute_script_id + key);
-    }}
-}}
-
-function GM_listValues() {{
-    var i;
-    var keys = [];
-    for (i = 0; i < localStorage.length; ++i) {{
-        if (localStorage.key(i).startsWith(_qute_script_id)) {{
-            keys.push(localStorage.key(i));
-        }}
-    }}
-    return keys;
-}}
-
-function GM_openInTab(url) {{
-    window.open(url);
-}}
-
-
-// Almost verbatim copy from Eric
-function GM_xmlhttpRequest(/* object */ details) {{
-    details.method = details.method.toUpperCase() || "GET";
-
-    if(!details.url) {{
-        throw("GM_xmlhttpRequest requires an URL.");
-    }}
-
-    // build XMLHttpRequest object
-    var oXhr = new XMLHttpRequest;
-    // run it
-    if("onreadystatechange" in details)
-        oXhr.onreadystatechange = function() {{
-            details.onreadystatechange(oXhr)
-        }};
-    if("onload" in details)
-        oXhr.onload = function() {{ details.onload(oXhr) }};
-    if("onerror" in details)
-        oXhr.onerror = function() {{ details.onerror(oXhr) }};
-
-    oXhr.open(details.method, details.url, true);
-
-    if("headers" in details)
-        for(var header in details.headers)
-            oXhr.setRequestHeader(header, details.headers[header]);
-
-    if("data" in details)
-        oXhr.send(details.data);
-    else
-        oXhr.send();
-}}
-
-function GM_addStyle(/* String */ styles) {{
-    var head = document.getElementsByTagName("head")[0];
-    if (head === undefined) {{
-        document.onreadystatechange = function() {{
-            if (document.readyState == "interactive") {{
-                var oStyle = document.createElement("style");
-                oStyle.setAttribute("type", "text/css");
-                oStyle.appendChild(document.createTextNode(styles));
-                document.getElementsByTagName("head")[0].appendChild(oStyle);
-            }}
-        }}
-    }}
-    else {{
-        var oStyle = document.createElement("style");
-        oStyle.setAttribute("type", "text/css");
-        oStyle.appendChild(document.createTextNode(styles));
-        head.appendChild(oStyle);
-    }}
-}}
-
-unsafeWindow = window;
-"""
 
     def __init__(self, properties, code):
         self._code = code
@@ -200,12 +91,12 @@ unsafeWindow = window;
         browser's debugger/inspector will not match up to the line
         numbers in the source script directly.
         """
-        gm_bootstrap = self.GM_BOOTSTRAP_TEMPLATE.format(
-            scriptName=self.name,
-            scriptInfo=self._meta_json(),
-            scriptMeta=self.script_meta)
-        return '\n'.join(
-            ["(function(){", gm_bootstrap, self._code, "})();"])
+        return jinja.js_environment.get_template(
+            'greasemonkey_wrapper.js').render(
+                scriptName=self.name,
+                scriptInfo=self._meta_json(),
+                scriptMeta=self.script_meta,
+                scriptSource=self._code)
 
     def _meta_json(self):
         return json.dumps({

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -31,8 +31,6 @@ from PyQt5.QtCore import pyqtSignal, QObject
 from qutebrowser.utils import log, standarddir
 from qutebrowser.commands import cmdutils
 
-# TODO: GM_ bootstrap
-
 
 def _scripts_dir():
     """Get the directory of the scripts."""
@@ -186,7 +184,7 @@ unsafeWindow = window;
             props, _code = matches
         except ValueError:
             props = ""
-        script = cls(re.findall(cls.PROPS_REGEX, props), code)
+        script = cls(re.findall(cls.PROPS_REGEX, props), source)
         script.script_meta = '"{}"'.format("\\n".join(props.split('\n')[2:]))
         return script
 

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -201,7 +201,8 @@ unsafeWindow = window;
             scriptName=self.name,
             scriptInfo=self._meta_json(),
             scriptMeta=self.script_meta)
-        return '\n'.join([gm_bootstrap, self._code])
+        return '\n'.join(
+            ["(function(){", gm_bootstrap, self._code, "})();"])
 
     def _meta_json(self):
         return json.dumps({

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -276,7 +276,9 @@ def inject_userscripts():
             new_script.setWorldId(QWebEngineScript.MainWorld)
             new_script.setSourceCode(script.code())
             new_script.setName("GM-{}".format(script.name))
-            log.greasemonkey.debug('adding script: %s', new_script.name())
+            new_script.setRunsOnSubFrames(script.runs_on_sub_frames)
+            log.greasemonkey.debug('adding script: {}'
+                                   .format(new_script.name()))
             scripts.insert(new_script)
 
 

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -263,7 +263,9 @@ def inject_userscripts():
     for profile in [default_profile, private_profile]:
         scripts = profile.scripts()
         for script in scripts.toList():
-            if script.worldId() == QWebEngineScript.MainWorld:
+            if script.name().startswith("GM-"):
+                log.greasemonkey.debug('removing script: {}'
+                                       .format(script.name()))
                 scripts.remove(script)
 
     for profile in [default_profile, private_profile]:
@@ -273,6 +275,7 @@ def inject_userscripts():
             new_script = QWebEngineScript()
             new_script.setWorldId(QWebEngineScript.MainWorld)
             new_script.setSourceCode(script.code())
+            new_script.setName("GM-{}".format(script.name))
             log.greasemonkey.debug('adding script: %s', new_script.name())
             scripts.insert(new_script)
 

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -244,6 +244,39 @@ def _init_profiles():
         private_profile.setSpellCheckEnabled(True)
 
 
+def inject_userscripts():
+    """Register user javascript files with the global profiles."""
+    # The greasemonkey metadata block support in qtwebengine only starts at 5.8
+    # Otherwise have to handle injecting the scripts into the page at very
+    # early load, probs same place in view as the enableJS check.
+    if not qtutils.version_check('5.8'):
+        return
+
+    # Since we are inserting scripts into profile.scripts they won't
+    # just get replaced by new gm scripts like if we were injecting them
+    # ourselves so we need to remove all gm scripts, while not removing
+    # any other stuff that might have been added. Like the one for
+    # stylsheets.
+    # Could either use a different world for gm scripts, check for gm metadata
+    # values (would mean no non-gm userscripts), or check the code for
+    # _qute_script_id
+    for profile in [default_profile, private_profile]:
+        scripts = profile.scripts()
+        for script in scripts.toList():
+            if script.worldId() == QWebEngineScript.MainWorld:
+                scripts.remove(script)
+
+    for profile in [default_profile, private_profile]:
+        scripts = profile.scripts()
+        greasemonkey = objreg.get('greasemonkey')
+        for script in greasemonkey.all_scripts():
+            new_script = QWebEngineScript()
+            new_script.setWorldId(QWebEngineScript.MainWorld)
+            new_script.setSourceCode(script.code())
+            log.greasemonkey.debug('adding script: %s', new_script.name())
+            scripts.insert(new_script)
+
+
 def init(args):
     """Initialize the global QWebSettings."""
     if args.enable_webengine_inspector:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -69,6 +69,10 @@ def init():
     download_manager.install(webenginesettings.private_profile)
     objreg.register('webengine-download-manager', download_manager)
 
+    greasemonkey = objreg.get('greasemonkey')
+    greasemonkey.scripts_reloaded.connect(inject_userscripts)
+    inject_userscripts()
+
 
 # Mapping worlds from usertypes.JsWorld to QWebEngineScript world IDs.
 _JS_WORLD_MAP = {
@@ -77,6 +81,42 @@ _JS_WORLD_MAP = {
     usertypes.JsWorld.user: QWebEngineScript.UserWorld,
     usertypes.JsWorld.jseval: QWebEngineScript.UserWorld + 1,
 }
+
+
+def inject_userscripts():
+    """Register user javascript files with the global profiles."""
+    # The greasemonkey metadata block support in qtwebengine only starts at 5.8
+    # Otherwise have to handle injecting the scripts into the page at very
+    # early load, probs same place in view as the enableJS check.
+    if not qtutils.version_check('5.8'):
+        return
+
+    # Since we are inserting scripts into profile.scripts they won't
+    # just get replaced by new gm scripts like if we were injecting them
+    # ourselves so we need to remove all gm scripts, while not removing
+    # any other stuff that might have been added. Like the one for
+    # stylsheets.
+    # Could either use a different world for gm scripts, check for gm metadata
+    # values (would mean no non-gm userscripts), or check the code for
+    # _qute_script_id
+    for profile in [webenginesettings.default_profile,
+                    webenginesettings.private_profile]:
+        scripts = profile.scripts()
+        for script in scripts.toList():
+            if script.worldId() == QWebEngineScript.MainWorld:
+                scripts.remove(script)
+
+    # Should we be adding to private profile too?
+    for profile in [webenginesettings.default_profile,
+                    webenginesettings.private_profile]:
+        scripts = profile.scripts()
+        greasemonkey = objreg.get('greasemonkey')
+        for script in greasemonkey.all_scripts():
+            new_script = QWebEngineScript()
+            new_script.setWorldId(QWebEngineScript.MainWorld)
+            new_script.setSourceCode(script.code())
+            log.greasemonkey.debug('adding script: %s', new_script.name)
+            scripts.insert(new_script)
 
 
 class WebEngineAction(browsertab.AbstractAction):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -70,8 +70,8 @@ def init():
     objreg.register('webengine-download-manager', download_manager)
 
     greasemonkey = objreg.get('greasemonkey')
-    greasemonkey.scripts_reloaded.connect(inject_userscripts)
-    inject_userscripts()
+    greasemonkey.scripts_reloaded.connect(webenginesettings.inject_userscripts)
+    webenginesettings.inject_userscripts()
 
 
 # Mapping worlds from usertypes.JsWorld to QWebEngineScript world IDs.
@@ -81,42 +81,6 @@ _JS_WORLD_MAP = {
     usertypes.JsWorld.user: QWebEngineScript.UserWorld,
     usertypes.JsWorld.jseval: QWebEngineScript.UserWorld + 1,
 }
-
-
-def inject_userscripts():
-    """Register user javascript files with the global profiles."""
-    # The greasemonkey metadata block support in qtwebengine only starts at 5.8
-    # Otherwise have to handle injecting the scripts into the page at very
-    # early load, probs same place in view as the enableJS check.
-    if not qtutils.version_check('5.8'):
-        return
-
-    # Since we are inserting scripts into profile.scripts they won't
-    # just get replaced by new gm scripts like if we were injecting them
-    # ourselves so we need to remove all gm scripts, while not removing
-    # any other stuff that might have been added. Like the one for
-    # stylsheets.
-    # Could either use a different world for gm scripts, check for gm metadata
-    # values (would mean no non-gm userscripts), or check the code for
-    # _qute_script_id
-    for profile in [webenginesettings.default_profile,
-                    webenginesettings.private_profile]:
-        scripts = profile.scripts()
-        for script in scripts.toList():
-            if script.worldId() == QWebEngineScript.MainWorld:
-                scripts.remove(script)
-
-    # Should we be adding to private profile too?
-    for profile in [webenginesettings.default_profile,
-                    webenginesettings.private_profile]:
-        scripts = profile.scripts()
-        greasemonkey = objreg.get('greasemonkey')
-        for script in greasemonkey.all_scripts():
-            new_script = QWebEngineScript()
-            new_script.setWorldId(QWebEngineScript.MainWorld)
-            new_script.setSourceCode(script.code())
-            log.greasemonkey.debug('adding script: %s', new_script.name)
-            scripts.insert(new_script)
 
 
 class WebEngineAction(browsertab.AbstractAction):

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -329,6 +329,7 @@ class WebEnginePage(QWebEnginePage):
             new_script.setWorldId(QWebEngineScript.MainWorld)
             new_script.setSourceCode(script.code())
             new_script.setName("GM-{}".format(script.name))
+            new_script.setRunsOnSubFrames(script.runs_on_sub_frames)
             log.greasemonkey.debug("Adding script: {}"
                                    .format(new_script.name()))
             scripts.insert(new_script)

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -23,12 +23,14 @@ import functools
 
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, PYQT_VERSION
 from PyQt5.QtGui import QPalette
-from PyQt5.QtWebEngineWidgets import QWebEngineView, QWebEnginePage
+from PyQt5.QtWebEngineWidgets import (QWebEngineView, QWebEnginePage,
+                                      QWebEngineScript)
 
 from qutebrowser.browser import shared
 from qutebrowser.browser.webengine import certificateerror, webenginesettings
 from qutebrowser.config import config
-from qutebrowser.utils import log, debug, usertypes, jinja, urlutils, message
+from qutebrowser.utils import (log, debug, usertypes, jinja, urlutils, message,
+                               objreg, qtutils)
 
 
 class WebEngineView(QWebEngineView):
@@ -135,6 +137,7 @@ class WebEnginePage(QWebEnginePage):
         self._theme_color = theme_color
         self._set_bg_color()
         config.instance.changed.connect(self._set_bg_color)
+        self.urlChanged.connect(self._inject_userjs)
 
     @config.change_filter('colors.webpage.bg')
     def _set_bg_color(self):
@@ -300,3 +303,41 @@ class WebEnginePage(QWebEnginePage):
             message.error(msg)
             return False
         return True
+
+    @pyqtSlot('QUrl')
+    def _inject_userjs(self, url):
+        """Inject userscripts registered for `url` into the current page."""
+        if qtutils.version_check('5.8'):
+            # Handled in webenginetab with the builtin greasemonkey
+            # support.
+            return
+
+        # Using QWebEnginePage.scripts() to hold the user scripts means
+        # we don't have to worry ourselves about where to inject the
+        # page but also means scripts hang around for the tab lifecycle.
+        # So clear them here.
+        scripts = self.scripts()
+        for script in scripts.toList():
+            if script.name().startswith("GM-"):
+                really_removed = scripts.remove(script)
+                log.greasemonkey.debug("Removing ({}) script: {}"
+                                       .format(really_removed, script.name()))
+
+        def _add_script(script, injection_point):
+            new_script = QWebEngineScript()
+            new_script.setInjectionPoint(injection_point)
+            new_script.setWorldId(QWebEngineScript.MainWorld)
+            new_script.setSourceCode(script.code())
+            new_script.setName("GM-{}".format(script.name))
+            log.greasemonkey.debug("Adding script: {}"
+                                   .format(new_script.name()))
+            scripts.insert(new_script)
+
+        greasemonkey = objreg.get('greasemonkey')
+        matching_scripts = greasemonkey.scripts_for(url)
+        for script in matching_scripts.start:
+            _add_script(script, QWebEngineScript.DocumentCreation)
+        for script in matching_scripts.end:
+            _add_script(script, QWebEngineScript.DocumentReady)
+        for script in matching_scripts.idle:
+            _add_script(script, QWebEngineScript.Deferred)

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -96,6 +96,8 @@ class BrowserPage(QWebPage):
         Connect the signals used as triggers for injecting user
         javascripts into the passed QWebFrame.
         """
+        log.greasemonkey.debug("Connecting to frame {} ({})"
+                               .format(frame, frame.url().toDisplayString()))
         frame.loadFinished.connect(
             functools.partial(self.inject_userjs, frame))
 
@@ -305,6 +307,9 @@ class BrowserPage(QWebPage):
         url = frame.url()
         if url.isEmpty():
             url = frame.requestedUrl()
+
+        log.greasemonkey.debug("inject_userjs called for {} ({})"
+                               .format(frame, url.toDisplayString()))
 
         greasemonkey = objreg.get('greasemonkey')
         scripts = greasemonkey.scripts_for(url)

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -300,14 +300,14 @@ class BrowserPage(QWebPage):
         """
         greasemonkey = objreg.get('greasemonkey')
         url = self.currentFrame().url()
-        start_scripts, end_scripts, idle_scripts = \
-            greasemonkey.scripts_for(url.toDisplayString())
+        scripts = greasemonkey.scripts_for(url.toDisplayString())
+
         if load == "start":
-            toload = start_scripts
+            toload = scripts.start
         elif load == "end":
-            toload = end_scripts
+            toload = scripts.end
         elif load == "idle":
-            toload = idle_scripts
+            toload = scripts.idle
 
         for script in toload:
             log.webview.debug('Running GM script: {}'.format(script.name))

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -87,11 +87,11 @@ class BrowserPage(QWebPage):
         self.restoreFrameStateRequested.connect(
             self.on_restore_frame_state_requested)
         self.loadFinished.connect(
-            functools.partial(self.inject_userjs, self.mainFrame()))
-        self.frameCreated.connect(self.connect_userjs_signals)
+            functools.partial(self._inject_userjs, self.mainFrame()))
+        self.frameCreated.connect(self._connect_userjs_signals)
 
     @pyqtSlot('QWebFrame*')
-    def connect_userjs_signals(self, frame):
+    def _connect_userjs_signals(self, frame):
         """Connect userjs related signals to `frame`.
 
         Connect the signals used as triggers for injecting user
@@ -100,7 +100,7 @@ class BrowserPage(QWebPage):
         log.greasemonkey.debug("Connecting to frame {} ({})"
                                .format(frame, frame.url().toDisplayString()))
         frame.loadFinished.connect(
-            functools.partial(self.inject_userjs, frame))
+            functools.partial(self._inject_userjs, frame))
 
     def javaScriptPrompt(self, frame, js_msg, default):
         """Override javaScriptPrompt to use qutebrowser prompts."""
@@ -298,8 +298,7 @@ class BrowserPage(QWebPage):
         else:
             self.error_occurred = False
 
-    @pyqtSlot()
-    def inject_userjs(self, frame):
+    def _inject_userjs(self, frame):
         """Inject user javascripts into the page.
 
         Args:
@@ -309,7 +308,7 @@ class BrowserPage(QWebPage):
         if url.isEmpty():
             url = frame.requestedUrl()
 
-        log.greasemonkey.debug("inject_userjs called for {} ({})"
+        log.greasemonkey.debug("_inject_userjs called for {} ({})"
                                .format(frame, url.toDisplayString()))
 
         greasemonkey = objreg.get('greasemonkey')

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -86,7 +86,8 @@ class BrowserPage(QWebPage):
             self.on_save_frame_state_requested)
         self.restoreFrameStateRequested.connect(
             self.on_restore_frame_state_requested)
-        self.connect_userjs_signals(self.mainFrame())
+        self.loadFinished.connect(
+            functools.partial(self.inject_userjs, self.mainFrame()))
         self.frameCreated.connect(self.connect_userjs_signals)
 
     @pyqtSlot('QWebFrame*')

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -300,7 +300,7 @@ class BrowserPage(QWebPage):
         """
         greasemonkey = objreg.get('greasemonkey')
         url = self.currentFrame().url()
-        scripts = greasemonkey.scripts_for(url.toDisplayString())
+        scripts = greasemonkey.scripts_for(url)
 
         if load == "start":
             toload = scripts.start

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -323,6 +323,8 @@ class BrowserPage(QWebPage):
             # also indicate a bug.
             log.greasemonkey.debug("Not running scripts for frame with no "
                                    "url: {}".format(frame))
+            assert not toload, toload
+
         for script in toload:
             if frame is self.mainFrame() or script.runs_on_sub_frames:
                 log.webview.debug('Running GM script: {}'.format(script.name))

--- a/qutebrowser/javascript/.eslintignore
+++ b/qutebrowser/javascript/.eslintignore
@@ -1,2 +1,4 @@
 # Upstream Mozilla's code
 pac_utils.js
+# Actually a jinja template so eslint chokes on the {{}} syntax.
+greasemonkey_wrapper.js

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -1,5 +1,5 @@
 (function () {
-    var _qute_script_id = "__gm_{{ scriptName }}";
+    var _qute_script_id = "__gm_"+{{ scriptName | tojson }};
 
     function GM_log(text) {
         console.log(text);
@@ -7,8 +7,8 @@
 
     var GM_info = (function () {
         return {
-            'script': {{ scriptInfo }},
-            'scriptMetaStr': {{ scriptMeta }},
+            'script': {{ scriptInfo | tojson }},
+            'scriptMetaStr': {{ scriptMeta | tojson }},
             'scriptWillUpdate': false,
             'version': '0.0.1',
             'scriptHandler': 'Tampermonkey' // so scripts don't expect exportFunction

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -5,15 +5,19 @@
         console.log(text);
     }
 
-    var GM_info = (function () {
-        return {
-            'script': {{ scriptInfo | tojson }},
-            'scriptMetaStr': {{ scriptMeta | tojson }},
-            'scriptWillUpdate': false,
-            'version': '0.0.1',
-            'scriptHandler': 'Tampermonkey' // so scripts don't expect exportFunction
-        };
-    }());
+    var GM_info = {
+        'script': {{ scriptInfo }},
+        'scriptMetaStr': {{ scriptMeta | tojson }},
+        'scriptWillUpdate': false,
+        'version': "0.0.1",
+        'scriptHandler': 'Tampermonkey' // so scripts don't expect exportFunction
+    };
+
+    function checkKey(key, funcName) {
+        if (typeof key !== "string") {
+          throw new Error(funcName+" requires the first parameter to be of type string, not '"+typeof key+"'");
+        }
+    }
 
     function GM_setValue(key, value) {
         if (typeof key !== "string") {

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -1,0 +1,118 @@
+(function () {
+    var _qute_script_id = "__gm_{{ scriptName }}";
+
+    function GM_log(text) {
+        console.log(text);
+    }
+
+    var GM_info = (function () {
+        return {
+            'script': {{ scriptInfo }},
+            'scriptMetaStr': {{ scriptMeta }},
+            'scriptWillUpdate': false,
+            'version': '0.0.1',
+            'scriptHandler': 'Tampermonkey' // so scripts don't expect exportFunction
+        };
+    }());
+
+    function GM_setValue(key, value) {
+        if (localStorage !== null &&
+                typeof key === "string" &&
+                (typeof value === "string" ||
+                 typeof value === "number" ||
+                 typeof value === "boolean")) {
+            localStorage.setItem(_qute_script_id + key, value);
+        }
+    }
+
+    function GM_getValue(key, default_) {
+        if (localStorage !== null && typeof key === "string") {
+            return localStorage.getItem(_qute_script_id + key) || default_;
+        }
+    }
+
+    function GM_deleteValue(key) {
+        if (localStorage !== null && typeof key === "string") {
+            localStorage.removeItem(_qute_script_id + key);
+        }
+    }
+
+    function GM_listValues() {
+        var i, keys = [];
+        for (i = 0; i < localStorage.length; i = i + 1) {
+            if (localStorage.key(i).startsWith(_qute_script_id)) {
+                keys.push(localStorage.key(i));
+            }
+        }
+        return keys;
+    }
+
+    function GM_openInTab(url) {
+        window.open(url);
+    }
+
+
+    // Almost verbatim copy from Eric
+    function GM_xmlhttpRequest(/* object */ details) {
+        details.method = details.method.toUpperCase() || "GET";
+
+        if (!details.url) {
+            throw ("GM_xmlhttpRequest requires an URL.");
+        }
+
+        // build XMLHttpRequest object
+        var oXhr = new XMLHttpRequest();
+        // run it
+        if ("onreadystatechange" in details) {
+            oXhr.onreadystatechange = function () {
+                details.onreadystatechange(oXhr);
+            };
+        }
+        if ("onload" in details) {
+            oXhr.onload = function () { details.onload(oXhr) };
+        }
+        if ("onerror" in details) {
+            oXhr.onerror = function () { details.onerror(oXhr) };
+        }
+
+        oXhr.open(details.method, details.url, true);
+
+        if ("headers" in details) {
+            for (var header in details.headers) {
+                oXhr.setRequestHeader(header, details.headers[header]);
+            }
+        }
+
+        if ("data" in details) {
+            oXhr.send(details.data);
+        } else {
+            oXhr.send();
+        }
+    }
+
+    function GM_addStyle(/* String */ styles) {
+        var head = document.getElementsByTagName("head")[0];
+        if (head === undefined) {
+            document.onreadystatechange = function () {
+                if (document.readyState == "interactive") {
+                    var oStyle = document.createElement("style");
+                    oStyle.setAttribute("type", "text/css");
+                    oStyle.appendChild(document.createTextNode(styles));
+                    document.getElementsByTagName("head")[0].appendChild(oStyle);
+                }
+            }
+        }
+        else {
+            var oStyle = document.createElement("style");
+            oStyle.setAttribute("type", "text/css");
+            oStyle.appendChild(document.createTextNode(styles));
+            head.appendChild(oStyle);
+        }
+    }
+
+    unsafeWindow = window;
+
+    //====== The actual user script source ======//
+{{ scriptSource }}
+    //====== End User Script ======//
+})();

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -16,25 +16,29 @@
     }());
 
     function GM_setValue(key, value) {
-        if (localStorage !== null &&
-                typeof key === "string" &&
-                (typeof value === "string" ||
-                 typeof value === "number" ||
-                 typeof value === "boolean")) {
-            localStorage.setItem(_qute_script_id + key, value);
+        if (typeof key !== "string") {
+          throw new Error("GM_setValue requires the first parameter to be of type string, not '"+typeof key+"'");
         }
+        if (typeof value !== "string" ||
+            typeof value !== "number" ||
+            typeof value !== "boolean") {
+          throw new Error("GM_setValue requires the second parameter to be of type string, number or boolean, not '"+typeof value+"'");
+        }
+        localStorage.setItem(_qute_script_id + key, value);
     }
 
     function GM_getValue(key, default_) {
-        if (localStorage !== null && typeof key === "string") {
-            return localStorage.getItem(_qute_script_id + key) || default_;
+        if (typeof key !== "string") {
+          throw new Error("GM_getValue requires the first parameter to be of type string, not '"+typeof key+"'");
         }
+        return localStorage.getItem(_qute_script_id + key) || default_;
     }
 
     function GM_deleteValue(key) {
-        if (localStorage !== null && typeof key === "string") {
-            localStorage.removeItem(_qute_script_id + key);
+        if (typeof key !== "string") {
+          throw new Error("GM_deleteValue requires the first parameter to be of type string, not '"+typeof key+"'");
         }
+        localStorage.removeItem(_qute_script_id + key);
     }
 
     function GM_listValues() {

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -1,11 +1,11 @@
 (function () {
-    var _qute_script_id = "__gm_"+{{ scriptName | tojson }};
+    const _qute_script_id = "__gm_"+{{ scriptName | tojson }};
 
     function GM_log(text) {
         console.log(text);
     }
 
-    var GM_info = {
+    const GM_info = {
         'script': {{ scriptInfo }},
         'scriptMetaStr': {{ scriptMeta | tojson }},
         'scriptWillUpdate': false,
@@ -15,7 +15,7 @@
 
     function checkKey(key, funcName) {
         if (typeof key !== "string") {
-          throw new Error(funcName+" requires the first parameter to be of type string, not '"+typeof key+"'");
+          throw new Error(`${funcName} requires the first parameter to be of type string, not '${typeof key}'`);
         }
     }
 
@@ -24,7 +24,7 @@
         if (typeof value !== "string" &&
             typeof value !== "number" &&
             typeof value !== "boolean") {
-          throw new Error("GM_setValue requires the second parameter to be of type string, number or boolean, not '"+typeof value+"'");
+          throw new Error(`GM_setValue requires the second parameter to be of type string, number or boolean, not '${typeof value}'`);
         }
         localStorage.setItem(_qute_script_id + key, value);
     }
@@ -40,8 +40,8 @@
     }
 
     function GM_listValues() {
-        var keys = [];
-        for (var i = 0; i < localStorage.length; i++) {
+        let keys = [];
+        for (let i = 0; i < localStorage.length; i++) {
             if (localStorage.key(i).startsWith(_qute_script_id)) {
                 keys.push(localStorage.key(i).slice(_qute_script_id.length));
             }
@@ -63,7 +63,7 @@
         }
 
         // build XMLHttpRequest object
-        var oXhr = new XMLHttpRequest();
+        let oXhr = new XMLHttpRequest();
         // run it
         if ("onreadystatechange" in details) {
             oXhr.onreadystatechange = function () {
@@ -80,7 +80,7 @@
         oXhr.open(details.method, details.url, true);
 
         if ("headers" in details) {
-            for (var header in details.headers) {
+            for (let header in details.headers) {
                 oXhr.setRequestHeader(header, details.headers[header]);
             }
         }
@@ -93,11 +93,11 @@
     }
 
     function GM_addStyle(/* String */ styles) {
-        var oStyle = document.createElement("style");
+        let oStyle = document.createElement("style");
         oStyle.setAttribute("type", "text/css");
         oStyle.appendChild(document.createTextNode(styles));
 
-        var head = document.getElementsByTagName("head")[0];
+        let head = document.getElementsByTagName("head")[0];
         if (head === undefined) {
             document.onreadystatechange = function () {
                 if (document.readyState == "interactive") {
@@ -110,7 +110,7 @@
         }
     }
 
-    var unsafeWindow = window;
+    const unsafeWindow = window;
 
     //====== The actual user script source ======//
 {{ scriptSource }}

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -20,11 +20,9 @@
     }
 
     function GM_setValue(key, value) {
-        if (typeof key !== "string") {
-          throw new Error("GM_setValue requires the first parameter to be of type string, not '"+typeof key+"'");
-        }
-        if (typeof value !== "string" ||
-            typeof value !== "number" ||
+        checkKey(key, "GM_setValue");
+        if (typeof value !== "string" &&
+            typeof value !== "number" &&
             typeof value !== "boolean") {
           throw new Error("GM_setValue requires the second parameter to be of type string, number or boolean, not '"+typeof value+"'");
         }
@@ -32,24 +30,20 @@
     }
 
     function GM_getValue(key, default_) {
-        if (typeof key !== "string") {
-          throw new Error("GM_getValue requires the first parameter to be of type string, not '"+typeof key+"'");
-        }
+        checkKey(key, "GM_getValue");
         return localStorage.getItem(_qute_script_id + key) || default_;
     }
 
     function GM_deleteValue(key) {
-        if (typeof key !== "string") {
-          throw new Error("GM_deleteValue requires the first parameter to be of type string, not '"+typeof key+"'");
-        }
+        checkKey(key, "GM_deleteValue");
         localStorage.removeItem(_qute_script_id + key);
     }
 
     function GM_listValues() {
-        var i, keys = [];
-        for (i = 0; i < localStorage.length; i = i + 1) {
+        var keys = [];
+        for (var i = 0; i < localStorage.length; i++) {
             if (localStorage.key(i).startsWith(_qute_script_id)) {
-                keys.push(localStorage.key(i));
+                keys.push(localStorage.key(i).slice(_qute_script_id.length));
             }
         }
         return keys;
@@ -62,7 +56,7 @@
 
     // Almost verbatim copy from Eric
     function GM_xmlhttpRequest(/* object */ details) {
-        details.method = details.method.toUpperCase() || "GET";
+        details.method = details.method ? details.method.toUpperCase() : "GET";
 
         if (!details.url) {
             throw ("GM_xmlhttpRequest requires an URL.");
@@ -99,26 +93,24 @@
     }
 
     function GM_addStyle(/* String */ styles) {
+        var oStyle = document.createElement("style");
+        oStyle.setAttribute("type", "text/css");
+        oStyle.appendChild(document.createTextNode(styles));
+
         var head = document.getElementsByTagName("head")[0];
         if (head === undefined) {
             document.onreadystatechange = function () {
                 if (document.readyState == "interactive") {
-                    var oStyle = document.createElement("style");
-                    oStyle.setAttribute("type", "text/css");
-                    oStyle.appendChild(document.createTextNode(styles));
                     document.getElementsByTagName("head")[0].appendChild(oStyle);
                 }
             }
         }
         else {
-            var oStyle = document.createElement("style");
-            oStyle.setAttribute("type", "text/css");
-            oStyle.appendChild(document.createTextNode(styles));
             head.appendChild(oStyle);
         }
     }
 
-    unsafeWindow = window;
+    var unsafeWindow = window;
 
     //====== The actual user script source ======//
 {{ scriptSource }}

--- a/qutebrowser/utils/jinja.py
+++ b/qutebrowser/utils/jinja.py
@@ -136,3 +136,4 @@ def render(template, **kwargs):
 
 
 environment = Environment()
+js_environment = jinja2.Environment(loader=Loader('javascript'))

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -95,7 +95,8 @@ LOGGER_NAMES = [
     'commands', 'signals', 'downloads',
     'js', 'qt', 'rfc6266', 'ipc', 'shlexer',
     'save', 'message', 'config', 'sessions',
-    'webelem', 'prompt', 'network', 'sql'
+    'webelem', 'prompt', 'network', 'sql',
+    'greasemonkey'
 ]
 
 
@@ -144,6 +145,7 @@ webelem = logging.getLogger('webelem')
 prompt = logging.getLogger('prompt')
 network = logging.getLogger('network')
 sql = logging.getLogger('sql')
+greasemonkey = logging.getLogger('greasemonkey')
 
 
 ram_handler = None

--- a/tests/end2end/features/javascript.feature
+++ b/tests/end2end/features/javascript.feature
@@ -124,11 +124,23 @@ Feature: Javascript stuff
         And I run :tab-next
         Then the window sizes should be the same
 
-    Scenario: Have a greasemonkey script run on a page
-        When I have a greasemonkey file saved
+    Scenario: Have a greasemonkey script run at page start
+        When I have a greasemonkey file saved for document-start with noframes unset
         And I run :greasemonkey-reload
-        And I open data/title.html
+        And I open data/hints/iframe.html
         # This second reload is required in webengine < 5.8 for scripts
         # registered to run at document-start, some sort of timing issue.
         And I run :reload
-        Then the javascript message "Script is running." should be logged
+        Then the javascript message "Script is running on /data/hints/iframe.html" should be logged
+
+    Scenario: Have a greasemonkey script running on frames
+        When I have a greasemonkey file saved for document-end with noframes unset
+        And I run :greasemonkey-reload
+        And I open data/hints/iframe.html
+        Then the javascript message "Script is running on /data/hints/html/wrapped.html" should be logged
+
+    Scenario: Have a greasemonkey script running on noframes
+        When I have a greasemonkey file saved for document-end with noframes set
+        And I run :greasemonkey-reload
+        And I open data/hints/iframe.html
+        Then the javascript message "Script is running on /data/hints/html/wrapped.html" should not be logged

--- a/tests/end2end/features/javascript.feature
+++ b/tests/end2end/features/javascript.feature
@@ -139,6 +139,7 @@ Feature: Javascript stuff
         And I open data/hints/iframe.html
         Then the javascript message "Script is running on /data/hints/html/wrapped.html" should be logged
 
+    @flaky
     Scenario: Have a greasemonkey script running on noframes
         When I have a greasemonkey file saved for document-end with noframes set
         And I run :greasemonkey-reload

--- a/tests/end2end/features/javascript.feature
+++ b/tests/end2end/features/javascript.feature
@@ -123,3 +123,12 @@ Feature: Javascript stuff
         And I wait for "[*/data/javascript/windowsize.html:*] loaded" in the log
         And I run :tab-next
         Then the window sizes should be the same
+
+    Scenario: Have a greasemonkey script run on a page
+        When I have a greasemonkey file saved
+        And I run :greasemonkey-reload
+        And I open data/title.html
+        # This second reload is required in webengine < 5.8 for scripts
+        # registered to run at document-start, some sort of timing issue.
+        And I run :reload
+        Then the javascript message "Script is running." should be logged

--- a/tests/end2end/features/test_javascript_bdd.py
+++ b/tests/end2end/features/test_javascript_bdd.py
@@ -17,6 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
+import os.path
+
 import pytest_bdd as bdd
 bdd.scenarios('javascript.feature')
 
@@ -29,3 +31,23 @@ def check_window_sizes(quteproc):
     hidden_size = hidden.message.split()[-1]
     visible_size = visible.message.split()[-1]
     assert hidden_size == visible_size
+
+test_gm_script="""
+// ==UserScript==
+// @name Qutebrowser test userscript
+// @namespace invalid.org
+// @include http://localhost:*/data/title.html
+// @exclude ???
+// @run-at document-start
+// ==/UserScript==
+console.log("Script is running on " + window.location.pathname);
+"""
+
+@bdd.when("I have a greasemonkey file saved")
+def create_greasemonkey_file(quteproc):
+    script_path = os.path.join(quteproc.basedir, 'data', 'greasemonkey')
+    os.mkdir(script_path)
+    file_path = os.path.join(script_path, 'test.user.js')
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write(test_gm_script)
+

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -527,6 +527,7 @@ class QuteProc(testprocess.Process):
         super().before_test()
         self.send_cmd(':config-clear')
         self._init_settings()
+        self.clear_data()
 
     def _init_settings(self):
         """Adjust some qutebrowser settings after starting."""

--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -1,0 +1,108 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+# Copyright 2017 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for qutebrowser.browser.greasemonkey."""
+
+import os
+import logging
+
+import pytest
+from PyQt5.QtCore import QUrl
+
+from qutebrowser.browser import greasemonkey
+
+test_gm_script = """
+// ==UserScript==
+// @name Qutebrowser test userscript
+// @namespace invalid.org
+// @include http://localhost:*/data/title.html
+// @match http://trolol*
+// @exclude https://badhost.xxx/*
+// @run-at document-start
+// ==/UserScript==
+console.log("Script is running.");
+"""
+
+pytestmark = pytest.mark.usefixtures('data_tmpdir')
+
+
+def save_script(script_text, filename):
+    script_path = greasemonkey._scripts_dir()
+    try:
+        os.mkdir(script_path)
+    except FileExistsError:
+        pass
+    file_path = os.path.join(script_path, filename)
+    with open(file_path, 'w', encoding='utf-8') as f:
+        f.write(script_text)
+
+
+def test_all():
+    """Test that a script gets read from file, parsed and returned."""
+    save_script(test_gm_script, 'test.user.js')
+
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    assert (gm_manager.all_scripts()[0].name ==
+            "Qutebrowser test userscript")
+
+
+@pytest.mark.parametrize("url, expected_matches", [
+    # included
+    ('http://trololololololo.com/', 1),
+    # neither included nor excluded
+    ('http://aaaaaaaaaa.com/', 0),
+    # excluded
+    ('https://badhost.xxx/', 0),
+])
+def test_get_scripts_by_url(url, expected_matches):
+    """Check greasemonkey include/exclude rules work."""
+    save_script(test_gm_script, 'test.user.js')
+    gm_manager = greasemonkey.GreasemonkeyManager()
+
+    scripts = gm_manager.scripts_for(QUrl(url))
+    assert (len(scripts.start + scripts.end + scripts.idle) ==
+            expected_matches)
+
+
+def test_no_metadata(caplog):
+    """Run on all sites at document-end is the default."""
+    save_script("var nothing = true;\n", 'nothing.user.js')
+
+    with caplog.at_level(logging.WARNING):
+        gm_manager = greasemonkey.GreasemonkeyManager()
+
+    scripts = gm_manager.scripts_for(QUrl('http://notamatch.invalid/'))
+    assert len(scripts.start + scripts.end + scripts.idle) == 1
+    assert len(scripts.end) == 1
+
+
+def test_bad_scheme(caplog):
+    """qute:// isn't in the list of allowed schemes."""
+    save_script("var nothing = true;\n", 'nothing.user.js')
+
+    with caplog.at_level(logging.WARNING):
+        gm_manager = greasemonkey.GreasemonkeyManager()
+
+    scripts = gm_manager.scripts_for(QUrl('qute://settings'))
+    assert len(scripts.start + scripts.end + scripts.idle) == 0
+
+
+def test_load_emits_signal(qtbot):
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    with qtbot.wait_signal(gm_manager.scripts_reloaded):
+        gm_manager.load_scripts()


### PR DESCRIPTION
Adds support for reading in userscripts from `<datafolder>/greasemonkey` -(configurable)- and injecting them into pages based on the greasemonkey compatible metadata block.

Tested on (old)webkit and qtwebengine 5.9. qtwebengine 5.7 and below not supported allthough I can add that finicky stuff back in if people actually want it.

Most of the work comes from andor44's fork from a couple of years ago. The impact on the existing codebase is very small. On webkit we manually pick scripts to inject in event handlers on webengine deciding when to inject and on what pages is handled for us.

greasemonkey.py wraps the userscripts in a simple lexical scope along with a bunch of GM_ functions that are used by various userscripts floating about, certainly not all of the ones listed on the docs page. (There is a simillar wrapper in the chromium source.) All the ones we implement should work fine though. Except that GM_xmlhttpRequest is stated in the docs to handle cross-origin requests and due to that being disabled globally on both supported backends we can't. I am going to look into getting that working though. If you want you can pass the `--qt-flag disable-web-security` to enable cross-origin requests globally, which will open that session up to cookie hijacking attacks from random pop-up ads etc.

The scripts currently run in the main javascript "world", meaning they can see all the same stuff you can see when you look at the web inspector console. This is good if you want your scripts to be able to change more about how web pages behave but bad if you are in the habit of running untrusted userscripts.

Adds a new config item `content.javascript.userjs_directory` which defaults to `os.path.join(standarddir.data(), 'greasemonkey')`.

On webengine the scripts are loaded into the global profile(s) so to support realoading greasemonkey scripts live we need to remove them before re-adding them. Currently I am just removeing all of the scripts in the main world, which is not ideal but there is nothing else using it at the moment.

https://github.com/andor44/qutebrowser/commit/a19321714a33b6787ac18ba06800c8571fc376ed
https://wiki.greasespot.net/Greasemonkey_Manual:API
https://doc.qt.io/qt-5/qwebenginescript.html

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3040)
<!-- Reviewable:end -->
