### PR TITLE
Default to NOT NULL for table constraints

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -40,7 +40,10 @@ class CompletionHistory(sql.SqlTable):
 
     def __init__(self, parent=None):
         super().__init__("CompletionHistory", ['url', 'title', 'last_atime'],
-                         constraints={'url': 'PRIMARY KEY'}, parent=parent)
+                         constraints={'url': 'PRIMARY KEY',
+                                      'title': 'NOT NULL',
+                                      'last_atime': 'NOT NULL'},
+                         parent=parent)
         self.create_index('CompletionHistoryAtimeIndex', 'last_atime')
 
 
@@ -50,6 +53,10 @@ class WebHistory(sql.SqlTable):
 
     def __init__(self, parent=None):
         super().__init__("History", ['url', 'title', 'atime', 'redirect'],
+                         constraints={'url': 'NOT NULL',
+                                      'title': 'NOT NULL',
+                                      'atime': 'NOT NULL',
+                                      'redirect': 'NOT NULL'},
                          parent=parent)
         self.completion = CompletionHistory(parent=self)
         if sql.Query('pragma user_version').run().value() < _USER_VERSION:

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -161,7 +161,8 @@ class SqlTable(QObject):
         self._name = name
 
         constraints = constraints or {}
-        column_defs = ['{} {}'.format(field, constraints.get(field, ''))
+        default = 'NOT NULL'
+        column_defs = ['{} {}'.format(field, constraints.get(field, default))
                        for field in fields]
         q = Query("CREATE TABLE IF NOT EXISTS {name} ({column_defs})"
                   .format(name=name, column_defs=', '.join(column_defs)))

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -150,7 +150,7 @@ class SqlTable(QObject):
     def __init__(self, name, fields, constraints=None, parent=None):
         """Create a new table in the sql database.
 
-        Raises SqlError if the table already exists.
+        Does nothing if the table already exists.
 
         Args:
             name: Name of the table.

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -161,8 +161,7 @@ class SqlTable(QObject):
         self._name = name
 
         constraints = constraints or {}
-        default = 'NOT NULL'
-        column_defs = ['{} {}'.format(field, constraints.get(field, default))
+        column_defs = ['{} {}'.format(field, constraints.get(field, ''))
                        for field in fields]
         q = Query("CREATE TABLE IF NOT EXISTS {name} ({column_defs})"
                   .format(name=name, column_defs=', '.join(column_defs)))

--- a/tests/unit/completion/test_histcategory.py
+++ b/tests/unit/completion/test_histcategory.py
@@ -140,20 +140,24 @@ def test_sorting(max_items, before, after, model_validator, hist, config_stub):
 
 
 def test_remove_rows(hist, model_validator):
-    hist.insert({'url': 'foo', 'title': 'Foo'})
-    hist.insert({'url': 'bar', 'title': 'Bar'})
+    hist.insert({'url': 'foo', 'title': 'Foo', 'last_atime': 0})
+    hist.insert({'url': 'bar', 'title': 'Bar', 'last_atime': 0})
     cat = histcategory.HistoryCategory()
     model_validator.set_model(cat)
     cat.set_pattern('')
     hist.delete('url', 'foo')
     cat.removeRows(0, 1)
-    model_validator.validate([('bar', 'Bar', '')])
+    model_validator.validate([('bar', 'Bar', '1970-01-01')])
 
 
 def test_remove_rows_fetch(hist):
     """removeRows should fetch enough data to make the current index valid."""
     # we cannot use model_validator as it will fetch everything up front
-    hist.insert_batch({'url': [str(i) for i in range(300)]})
+    hist.insert_batch({
+        'url': [str(i) for i in range(300)],
+        'title': [str(i) for i in range(300)],
+        'last_atime': [0] * 300,
+    })
     cat = histcategory.HistoryCategory()
     cat.set_pattern('')
 


### PR DESCRIPTION
Ideally, we'd update all existing tables to add the new constraints, but sqlite
doesn't offer an easy way to do so: https://www.sqlite.org/lang_altertable.html

Since that migration really isn't worth the effort, we only set the constraint
for new tables...

This came up with #3044 with @josefson - the import script didn't set the `redirect` field at all, so it was `NULL`, and qutebrowser silently treated that as "it's a redirect" when generating `CompletionHistory`.

(Not sure why that was, though, and I should probably fix that up as well... I guess `WHERE not redirect` is false when `redirect` is `NULL` for sql~~ite~~?)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3048)
<!-- Reviewable:end -->
