### PR TITLE
OSX URLs handling

### DIFF
--- a/misc/qutebrowser.spec
+++ b/misc/qutebrowser.spec
@@ -71,9 +71,5 @@ coll = COLLECT(exe,
 app = BUNDLE(coll,
              name='qutebrowser.app',
              icon=icon,
-             info_plist={
-                 'NSHighResolutionCapable': 'True',
-                 'NSSupportsAutomaticGraphicsSwitching': 'True',
-             },
              # https://github.com/pyinstaller/pyinstaller/blob/b78bfe530cdc2904f65ce098bdf2de08c9037abb/PyInstaller/hooks/hook-PyQt5.QtWebEngineWidgets.py#L24
              bundle_identifier='org.qt-project.Qt.QtWebEngineCore')

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -806,6 +806,18 @@ class Application(QApplication):
         self.launch_time = datetime.datetime.now()
         self.focusObjectChanged.connect(self.on_focus_object_changed)
 
+    def event(self, e):
+        if e.type() != QEvent.FileOpen:
+            return super(QApplication, self).event(e)
+
+        url = e.url()
+        log.misc.info("Got FileOpen event: %s" % url)
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window='last-focused')
+        tabbed_browser.tabopen(url, related=False)
+        return True
+
+
     @pyqtSlot(QObject)
     def on_focus_object_changed(self, obj):
         """Log when the focus object changed."""

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -297,23 +297,25 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
                 message.error("Error in startup argument '{}': {}".format(
                     cmd, e))
             else:
-                win_id = open_url(url, target=open_target)
+                win_id = open_url(url, target=open_target, via_ipc=via_ipc)
 
 
-def open_url(url, target=None, no_raise=False):
+def open_url(url, target=None, no_raise=False, via_ipc=True):
     """Open an URL in new window/tab
 
     Args:
         url: An URL to open
         target: same as new_instance_open_target (used as a default)
         no_raise: suppress target window raising
+        via_ipc: Whether the arguments were transmitted over IPC.
 
     Return:
         ID of a window that was used to open URL
     """
     target = target or config.val.new_instance_open_target
     background = target in {'tab-bg', 'tab-bg-silent'}
-    win_id = mainwindow.get_window(True, force_target=target, no_raise=no_raise)
+    win_id = mainwindow.get_window(via_ipc, force_target=target,
+                                   no_raise=no_raise)
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     log.init.debug("About to open URL: {}".format(url.toDisplayString()))

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -51,7 +51,7 @@ import tokenize
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon, QWindow
 from PyQt5.QtCore import (pyqtSlot, qInstallMessageHandler, QTimer, QUrl,
-                          QObject, QEvent, pyqtSignal)
+                          QObject, QEvent, pyqtSignal, Qt)
 try:
     import hunter
 except ImportError:
@@ -805,6 +805,15 @@ class Application(QApplication):
 
         self.launch_time = datetime.datetime.now()
         self.focusObjectChanged.connect(self.on_focus_object_changed)
+        self.applicationStateChanged.connect(self.on_app_state_changed)
+
+    @pyqtSlot(Qt.ApplicationState)
+    def on_app_state_changed(self, state):
+        if state != Qt.ApplicationActive:
+            return
+
+        window = objreg.last_focused_window()
+        mainwindow.raise_window(window)
 
     def event(self, e):
         if e.type() != QEvent.FileOpen:

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -808,10 +808,10 @@ class Application(QApplication):
 
     def event(self, e):
         if e.type() != QEvent.FileOpen:
-            return super(QApplication, self).event(e)
+            return super().event(e)
 
         url = e.url()
-        log.misc.info("Got FileOpen event: %s" % url)
+        log.misc.info("Got FileOpen event: {}".format(url.toDisplayString()))
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window='last-focused')
         tabbed_browser.tabopen(url, related=False)

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -288,22 +288,32 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
             if via_ipc and target_arg and target_arg != 'auto':
                 open_target = target_arg
             else:
-                open_target = config.val.new_instance_open_target
-            win_id = mainwindow.get_window(via_ipc, force_target=open_target)
-            tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                        window=win_id)
-            log.init.debug("Startup URL {}".format(cmd))
+                open_target = None
             if not cwd:  # could also be an empty string due to the PyQt signal
                 cwd = None
             try:
                 url = urlutils.fuzzy_url(cmd, cwd, relative=True)
+                win_id = open_url(url, target=open_target)
             except urlutils.InvalidUrlError as e:
                 message.error("Error in startup argument '{}': {}".format(
                     cmd, e))
-            else:
-                background = open_target in ['tab-bg', 'tab-bg-silent']
-                tabbed_browser.tabopen(url, background=background,
-                                       related=False)
+
+
+def open_url(url, target=None):
+    """Open an URLs in new window/tab
+
+    Args:
+        url: An URL to open
+        target: same as new_instance_open_target (used as a default)
+    """
+    target = target or config.val.new_instance_open_target
+    background = target in ['tab-bg', 'tab-bg-silent']
+    win_id = mainwindow.get_window(True, force_target=target)
+    tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                window=win_id)
+    log.init.debug("About to open URL {}".format(url))
+    tabbed_browser.tabopen(url, background=background, related=False)
+    return win_id
 
 
 def _open_startpage(win_id=None):

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -299,7 +299,7 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
                     cmd, e))
 
 
-def open_url(url, target=None):
+def open_url(url, target=None, force_raise=None):
     """Open an URLs in new window/tab
 
     Args:
@@ -308,7 +308,8 @@ def open_url(url, target=None):
     """
     target = target or config.val.new_instance_open_target
     background = target in ['tab-bg', 'tab-bg-silent']
-    win_id = mainwindow.get_window(True, force_target=target)
+    win_id = mainwindow.get_window(True, force_target=target,
+                                   force_raise=force_raise)
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     log.init.debug("About to open URL {}".format(url))

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -293,10 +293,11 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
                 cwd = None
             try:
                 url = urlutils.fuzzy_url(cmd, cwd, relative=True)
-                win_id = open_url(url, target=open_target)
             except urlutils.InvalidUrlError as e:
                 message.error("Error in startup argument '{}': {}".format(
                     cmd, e))
+            else:
+                win_id = open_url(url, target=open_target)
 
 
 def open_url(url, target=None, force_raise=None):
@@ -305,6 +306,13 @@ def open_url(url, target=None, force_raise=None):
     Args:
         url: An URL to open
         target: same as new_instance_open_target (used as a default)
+        force_raise: control target window raising:
+                     * None - obey new_instance_open_target
+                     * True - always raise
+                     * False - never raise
+
+    Return:
+        ID of a window that was used to open URL
     """
     target = target or config.val.new_instance_open_target
     background = target in {'tab-bg', 'tab-bg-silent'}
@@ -312,7 +320,7 @@ def open_url(url, target=None, force_raise=None):
                                    force_raise=force_raise)
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
-    log.init.debug("About to open URL {}".format(url))
+    log.init.debug("About to open URL: {}".format(url.toDisplayString()))
     tabbed_browser.tabopen(url, background=background, related=False)
     return win_id
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -51,7 +51,7 @@ import tokenize
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon, QWindow
 from PyQt5.QtCore import (pyqtSlot, qInstallMessageHandler, QTimer, QUrl,
-                          QObject, QEvent, pyqtSignal, Qt)
+                          QObject, QEvent, pyqtSignal)
 try:
     import hunter
 except ImportError:
@@ -820,7 +820,6 @@ class Application(QApplication):
 
         self.launch_time = datetime.datetime.now()
         self.focusObjectChanged.connect(self.on_focus_object_changed)
-        self.applicationStateChanged.connect(self.on_app_state_changed)
 
     @pyqtSlot(QObject)
     def on_focus_object_changed(self, obj):
@@ -829,14 +828,6 @@ class Application(QApplication):
         if self._last_focus_object != output:
             log.misc.debug("Focus object changed: {}".format(output))
         self._last_focus_object = output
-
-    @pyqtSlot(Qt.ApplicationState)
-    def on_app_state_changed(self, state):
-        if state != Qt.ApplicationActive:
-            return
-
-        window = objreg.last_focused_window()
-        mainwindow.raise_window(window)
 
     def event(self, e):
         if e.type() == QEvent.FileOpen:

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -832,9 +832,7 @@ class Application(QApplication):
 
         url = e.url()
         log.misc.info("Got FileOpen event: {}".format(url.toDisplayString()))
-        tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                    window='last-focused')
-        tabbed_browser.tabopen(url, related=False)
+        open_url(url, force_raise=False)
         return True
 
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -300,14 +300,14 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
 
 
 def open_url(url, target=None, force_raise=None):
-    """Open an URLs in new window/tab
+    """Open an URL in new window/tab
 
     Args:
         url: An URL to open
         target: same as new_instance_open_target (used as a default)
     """
     target = target or config.val.new_instance_open_target
-    background = target in ['tab-bg', 'tab-bg-silent']
+    background = target in {'tab-bg', 'tab-bg-silent'}
     win_id = mainwindow.get_window(True, force_target=target,
                                    force_raise=force_raise)
     tabbed_browser = objreg.get('tabbed-browser', scope='window',

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -818,6 +818,14 @@ class Application(QApplication):
         self.focusObjectChanged.connect(self.on_focus_object_changed)
         self.applicationStateChanged.connect(self.on_app_state_changed)
 
+    @pyqtSlot(QObject)
+    def on_focus_object_changed(self, obj):
+        """Log when the focus object changed."""
+        output = repr(obj)
+        if self._last_focus_object != output:
+            log.misc.debug("Focus object changed: {}".format(output))
+        self._last_focus_object = output
+
     @pyqtSlot(Qt.ApplicationState)
     def on_app_state_changed(self, state):
         if state != Qt.ApplicationActive:
@@ -827,22 +835,12 @@ class Application(QApplication):
         mainwindow.raise_window(window)
 
     def event(self, e):
-        if e.type() != QEvent.FileOpen:
+        if e.type() == QEvent.FileOpen:
+            open_url(e.url(), force_raise=False)
+        else:
             return super().event(e)
 
-        url = e.url()
-        log.misc.info("Got FileOpen event: {}".format(url.toDisplayString()))
-        open_url(url, force_raise=False)
         return True
-
-
-    @pyqtSlot(QObject)
-    def on_focus_object_changed(self, obj):
-        """Log when the focus object changed."""
-        output = repr(obj)
-        if self._last_focus_object != output:
-            log.misc.debug("Focus object changed: {}".format(output))
-        self._last_focus_object = output
 
     def __repr__(self):
         return utils.get_repr(self)

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -300,24 +300,20 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
                 win_id = open_url(url, target=open_target)
 
 
-def open_url(url, target=None, force_raise=None):
+def open_url(url, target=None, no_raise=False):
     """Open an URL in new window/tab
 
     Args:
         url: An URL to open
         target: same as new_instance_open_target (used as a default)
-        force_raise: control target window raising:
-                     * None - obey new_instance_open_target
-                     * True - always raise
-                     * False - never raise
+        no_raise: suppress target window raising
 
     Return:
         ID of a window that was used to open URL
     """
     target = target or config.val.new_instance_open_target
     background = target in {'tab-bg', 'tab-bg-silent'}
-    win_id = mainwindow.get_window(True, force_target=target,
-                                   force_raise=force_raise)
+    win_id = mainwindow.get_window(True, force_target=target, no_raise=no_raise)
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     log.init.debug("About to open URL: {}".format(url.toDisplayString()))
@@ -844,7 +840,7 @@ class Application(QApplication):
 
     def event(self, e):
         if e.type() == QEvent.FileOpen:
-            open_url(e.url(), force_raise=False)
+            open_url(e.url(), no_raise=True)
         else:
             return super().event(e)
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -43,7 +43,7 @@ win_id_gen = itertools.count(0)
 
 
 def get_window(via_ipc, force_window=False, force_tab=False,
-               force_target=None, force_raise=None):
+               force_target=None, no_raise=False):
     """Helper function for app.py to get a window id.
 
     Args:
@@ -51,10 +51,7 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         force_window: Whether to force opening in a window.
         force_tab: Whether to force opening in a tab.
         force_target: Override the new_instance_open_target config
-        force_raise: control target window raising:
-                     * None - obey new_instance_open_target
-                     * True - always raise
-                     * False - never raise
+        no_raise: suppress target window raising
 
     Return:
         ID of a window that was used to open URL
@@ -91,7 +88,7 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         window.show()
         should_raise = True
 
-    if (force_raise is True) or (force_raise is None and should_raise):
+    if should_raise and not no_raise:
         raise_window(window)
 
     return window.win_id

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -43,7 +43,7 @@ win_id_gen = itertools.count(0)
 
 
 def get_window(via_ipc, force_window=False, force_tab=False,
-               force_target=None):
+               force_target=None, force_raise=None):
     """Helper function for app.py to get a window id.
 
     Args:
@@ -84,7 +84,7 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         window.show()
         should_raise = True
 
-    if should_raise:
+    if (force_raise is True) or (force_raise is None and should_raise):
         raise_window(window)
 
     return window.win_id

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -71,27 +71,31 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         open_target = 'tab-silent'
 
     window = None
-    raise_window = False
+    should_raise = False
 
     # Try to find the existing tab target if opening in a tab
     if open_target != 'window':
         window = get_target_window()
-        raise_window = open_target not in ['tab-silent', 'tab-bg-silent']
+        should_raise = open_target not in ['tab-silent', 'tab-bg-silent']
 
     # Otherwise, or if no window was found, create a new one
     if window is None:
         window = MainWindow(private=None)
         window.show()
-        raise_window = True
+        should_raise = True
 
-    if raise_window:
-        window.setWindowState(window.windowState() & ~Qt.WindowMinimized)
-        window.setWindowState(window.windowState() | Qt.WindowActive)
-        window.raise_()
-        window.activateWindow()
-        QApplication.instance().alert(window)
+    if should_raise:
+        raise_window(window)
 
     return window.win_id
+
+
+def raise_window(window):
+    window.setWindowState(window.windowState() & ~Qt.WindowMinimized)
+    window.setWindowState(window.windowState() | Qt.WindowActive)
+    window.raise_()
+    window.activateWindow()
+    QApplication.instance().alert(window)
 
 
 def get_target_window():

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -51,6 +51,13 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         force_window: Whether to force opening in a window.
         force_tab: Whether to force opening in a tab.
         force_target: Override the new_instance_open_target config
+        force_raise: control target window raising:
+                     * None - obey new_instance_open_target
+                     * True - always raise
+                     * False - never raise
+
+    Return:
+        ID of a window that was used to open URL
     """
     if force_window and force_tab:
         raise ValueError("force_window and force_tab are mutually exclusive!")

--- a/scripts/dev/build_release.py
+++ b/scripts/dev/build_release.py
@@ -26,6 +26,7 @@ import sys
 import glob
 import os.path
 import shutil
+import plistlib
 import subprocess
 import argparse
 import tarfile
@@ -123,6 +124,19 @@ def patch_mac_app():
         os.symlink(os.path.join(os.pardir, os.pardir, os.pardir, 'Contents',
                                 'MacOS', lib),
                    os.path.join(dest, lib))
+    # Patch Info.plist to declare URLs support
+    plist_path = os.path.join(app_path, 'Contents', 'Info.plist')
+    with open(plist_path, "rb") as f:
+        plist_data = plistlib.load(f)
+    plist_data['CFBundleURLTypes'] = [{
+        "CFBundleURLName": "http(s) URL",
+        "CFBundleURLSchemes": ["http", "https"]
+    }, {
+        "CFBundleURLName": "local file URL",
+        "CFBundleURLSchemes": ["file"]
+    }]
+    with open(plist_path, "wb") as f:
+        plistlib.dump(plist_data, f)
 
 
 def build_mac():

--- a/scripts/dev/build_release.py
+++ b/scripts/dev/build_release.py
@@ -134,6 +134,8 @@ def patch_mac_app():
 
 
 INFO_PLIST_UPDATES = {
+    'CFBundleVersion': qutebrowser.__version__,
+    'CFBundleShortVersionString': qutebrowser.__version__,
     'NSSupportsAutomaticGraphicsSwitching': True,
     'NSHighResolutionCapable': True,
     'CFBundleURLTypes': [{

--- a/scripts/dev/build_release.py
+++ b/scripts/dev/build_release.py
@@ -124,7 +124,7 @@ def patch_mac_app():
         os.symlink(os.path.join(os.pardir, os.pardir, os.pardir, 'Contents',
                                 'MacOS', lib),
                    os.path.join(dest, lib))
-    # Patch Info.plist to declare URLs support
+    # Patch Info.plist - pyinstaller's options are too limiting
     plist_path = os.path.join(app_path, 'Contents', 'Info.plist')
     with open(plist_path, "rb") as f:
         plist_data = plistlib.load(f)
@@ -134,6 +134,8 @@ def patch_mac_app():
 
 
 INFO_PLIST_UPDATES = {
+    'NSSupportsAutomaticGraphicsSwitching': True,
+    'NSHighResolutionCapable': True,
     'CFBundleURLTypes': [{
         "CFBundleURLName": "http(s) URL",
         "CFBundleURLSchemes": ["http", "https"]

--- a/scripts/dev/build_release.py
+++ b/scripts/dev/build_release.py
@@ -128,15 +128,32 @@ def patch_mac_app():
     plist_path = os.path.join(app_path, 'Contents', 'Info.plist')
     with open(plist_path, "rb") as f:
         plist_data = plistlib.load(f)
-    plist_data['CFBundleURLTypes'] = [{
+    plist_data.update(INFO_PLIST_UPDATES)
+    with open(plist_path, "wb") as f:
+        plistlib.dump(plist_data, f)
+
+
+INFO_PLIST_UPDATES = {
+    'CFBundleURLTypes': [{
         "CFBundleURLName": "http(s) URL",
         "CFBundleURLSchemes": ["http", "https"]
     }, {
         "CFBundleURLName": "local file URL",
         "CFBundleURLSchemes": ["file"]
+    }],
+    'CFBundleDocumentTypes': [{
+        "CFBundleTypeExtensions": ["html", "htm"],
+        "CFBundleTypeMIMETypes": ["text/html"],
+        "CFBundleTypeName": "HTML document",
+        "CFBundleTypeOSTypes": ["HTML"],
+        "CFBundleTypeRole": "Viewer",
+    }, {
+        "CFBundleTypeExtensions": ["xhtml"],
+        "CFBundleTypeMIMETypes": ["text/xhtml"],
+        "CFBundleTypeName": "XHTML document",
+        "CFBundleTypeRole": "Viewer",
     }]
-    with open(plist_path, "wb") as f:
-        plistlib.dump(plist_data, f)
+}
 
 
 def build_mac():


### PR DESCRIPTION
These are some OSX-specific changes, required for being a default browser (see #22):

- [x] 1. Open links from other apps
- [x] 2. Open html files on double-click and drop
- [x] 3. Patch Info.plist to declare support of 1 and 2
- [ ] 4. Open links in background/foreground (cmd-click/left-click)
- [x] 5. Show up in browser selection menu
- [ ] ~~6. Setting itself as default browser~~

I've also done task 6 (as a `:`-command), but that will add some deps on osx (`pyobjc-framework-LaunchServices`, `pyobjc-framework-Cocoa`, `pyobjc-core`). As of 4 and 5 - the only option, that I haven't tried yet, requires going deeper in pyobjc land (see part 3 of the accepted answer [here](https://stackoverflow.com/questions/49510/how-do-you-set-your-cocoa-application-as-the-default-web-browser)).

Also need to make my changes compliant with the contributing guidelines. Haven't started on this, because the main work is not completed.

UPDATE: completed task 5, agreed to drop task 6.
UPDATE: completed task 4.
UPDATE: reverted task 4 due to bugs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3055)
<!-- Reviewable:end -->
