### PR TITLE
[RDY] Add option to run best partially-matching command

### DIFF
--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -218,7 +218,9 @@ class CommandParser:
         for valid_command in cmdutils.cmd_dict:
             if valid_command.find(cmdstr) == 0:
                 matches.append(valid_command)
-        if len(matches) >= 1:
+        if len(matches) == 1:
+            cmdstr = matches[0]
+        elif len(matches) > 1 and config.val.completion.use_best_match:
             cmdstr = matches[0]
         return cmdstr
 

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -218,7 +218,7 @@ class CommandParser:
         for valid_command in cmdutils.cmd_dict:
             if valid_command.find(cmdstr) == 0:
                 matches.append(valid_command)
-        if len(matches) == 1:
+        if len(matches) >= 1:
             cmdstr = matches[0]
         return cmdstr
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -656,6 +656,11 @@ completion.web_history_max_items:
 
     0: no history / -1: unlimited
 
+completion.use_best_match:
+  type: Bool
+  default: true
+  desc: Whether to execute the best-matching command on a partial match.
+
 ## downloads
 
 downloads.location.directory:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -658,7 +658,7 @@ completion.web_history_max_items:
 
 completion.use_best_match:
   type: Bool
-  default: true
+  default: false
   desc: Whether to execute the best-matching command on a partial match.
 
 ## downloads

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -74,3 +74,32 @@ class TestCommandParser:
         parser = runners.CommandParser(partial_match=True)
         result = parser.parse('message-i')
         assert result.cmd.name == 'message-info'
+
+
+class TestCompletions:
+
+    """Tests for completions.use_best_match."""
+
+    def test_dont_use_best_match(self, config_stub, monkeypatch):
+        """Test multiple completion options with use_best_match set to false.
+
+        Should raise NoSuchCommandError
+        """
+        config_stub.val.completion.use_best_match = False
+        monkeypatch.setattr('qutebrowser.config', config_stub)
+        parser = runners.CommandParser(partial_match=True)
+
+        with pytest.raises(cmdexc.NoSuchCommandError):
+            result = parser.parse('do')
+
+    def test_use_best_match(self, config_stub, monkeypatch):
+        """Test multiple completion options with use_best_match set to true.
+
+        The resulting command should be the best match
+        """
+        config_stub.val.completion.use_best_match = True
+        monkeypatch.setattr('qutebrowser.config', config_stub)
+        parser = runners.CommandParser(partial_match=True)
+
+        result = parser.parse('do')
+        assert result.cmd.name == 'download'

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -100,4 +100,4 @@ class TestCompletions:
         parser = runners.CommandParser(partial_match=True)
 
         result = parser.parse('do')
-        assert result.cmd.name == 'download'
+        assert result.cmd.name == 'download-cancel'

--- a/tests/unit/commands/test_runners.py
+++ b/tests/unit/commands/test_runners.py
@@ -80,25 +80,23 @@ class TestCompletions:
 
     """Tests for completions.use_best_match."""
 
-    def test_dont_use_best_match(self, config_stub, monkeypatch):
+    def test_dont_use_best_match(self, config_stub):
         """Test multiple completion options with use_best_match set to false.
 
         Should raise NoSuchCommandError
         """
         config_stub.val.completion.use_best_match = False
-        monkeypatch.setattr('qutebrowser.config', config_stub)
         parser = runners.CommandParser(partial_match=True)
 
         with pytest.raises(cmdexc.NoSuchCommandError):
             result = parser.parse('do')
 
-    def test_use_best_match(self, config_stub, monkeypatch):
+    def test_use_best_match(self, config_stub):
         """Test multiple completion options with use_best_match set to true.
 
         The resulting command should be the best match
         """
         config_stub.val.completion.use_best_match = True
-        monkeypatch.setattr('qutebrowser.config', config_stub)
         parser = runners.CommandParser(partial_match=True)
 
         result = parser.parse('do')

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -25,7 +25,7 @@ import pytest
 from PyQt5.QtCore import QUrl, QProcess
 
 from qutebrowser.config import configcommands
-from qutebrowser.commands import cmdexc
+from qutebrowser.commands import cmdexc, runners
 from qutebrowser.utils import usertypes
 from qutebrowser.misc import objects
 
@@ -532,3 +532,32 @@ class TestBind:
         """
         with pytest.raises(cmdexc.CommandError, match=expected):
             commands.unbind(key, mode=mode)
+
+
+class TestCompletions:
+
+    """Tests for completions.use_best_match."""
+
+    def test_dont_use_best_match(self, config_stub, monkeypatch):
+        """Test multiple completion options with use_best_match set to false.
+
+        Should raise NoSuchCommandError
+        """
+        config_stub.val.completion.use_best_match = False
+        monkeypatch.setattr('qutebrowser.config', config_stub)
+        parser = runners.CommandParser(partial_match=True)
+
+        with pytest.raises(cmdexc.NoSuchCommandError):
+            result = parser.parse('do')
+
+    def test_use_best_match(self, config_stub, monkeypatch):
+        """Test multiple completion options with use_best_match set to true.
+
+        The resulting command should be the best match
+        """
+        config_stub.val.completion.use_best_match = True
+        monkeypatch.setattr('qutebrowser.config', config_stub)
+        parser = runners.CommandParser(partial_match=True)
+
+        result = parser.parse('do')
+        assert result.cmd.name == 'download'

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -25,7 +25,7 @@ import pytest
 from PyQt5.QtCore import QUrl, QProcess
 
 from qutebrowser.config import configcommands
-from qutebrowser.commands import cmdexc, runners
+from qutebrowser.commands import cmdexc
 from qutebrowser.utils import usertypes
 from qutebrowser.misc import objects
 
@@ -532,32 +532,3 @@ class TestBind:
         """
         with pytest.raises(cmdexc.CommandError, match=expected):
             commands.unbind(key, mode=mode)
-
-
-class TestCompletions:
-
-    """Tests for completions.use_best_match."""
-
-    def test_dont_use_best_match(self, config_stub, monkeypatch):
-        """Test multiple completion options with use_best_match set to false.
-
-        Should raise NoSuchCommandError
-        """
-        config_stub.val.completion.use_best_match = False
-        monkeypatch.setattr('qutebrowser.config', config_stub)
-        parser = runners.CommandParser(partial_match=True)
-
-        with pytest.raises(cmdexc.NoSuchCommandError):
-            result = parser.parse('do')
-
-    def test_use_best_match(self, config_stub, monkeypatch):
-        """Test multiple completion options with use_best_match set to true.
-
-        The resulting command should be the best match
-        """
-        config_stub.val.completion.use_best_match = True
-        monkeypatch.setattr('qutebrowser.config', config_stub)
-        parser = runners.CommandParser(partial_match=True)
-
-        result = parser.parse('do')
-        assert result.cmd.name == 'download'


### PR DESCRIPTION
This fixes #623

Previously, trying to run a non-existent but partially-matching command would fail with "no such command" error, unless the number of partial matches was exactly one.

This adds the `completions.use_best_match` config (defaults to `false`) which if active uses the first of the completions suggestions even if more than one exists.

To illustrate, with `completions.use_best_match` set to `false` (default behaviour), typing `:do<enter>` would result in `no such command`

With `completions.use_best_match` set to `true` (new behaviour), typing `:do<enter>` results in running the `:download` command, since that's the best match

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3063)
<!-- Reviewable:end -->
