### PR TITLE
Prompt for non-existing download directories.

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -27,7 +27,6 @@ import collections
 import functools
 import pathlib
 import tempfile
-import errno
 
 import sip
 from PyQt5.QtCore import (pyqtSlot, pyqtSignal, Qt, QObject, QModelIndex,

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -632,7 +632,6 @@ class AbstractDownloadItem(QObject):
             remember_directory: If True, remember the directory for future
                                 downloads.
         """
-        global last_used_directory
         filename = os.path.expanduser(filename)
         self._ensure_can_set_filename(filename)
 

--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -203,6 +203,17 @@ class DownloadItem(downloads.AbstractDownloadItem):
                               no_action=no_action, cancel_action=no_action,
                               abort_on=[self.cancelled, self.error])
 
+    def _ask_create_parent_question(self, title, msg,
+                                    force_overwrite, remember_directory):
+        no_action = functools.partial(self.cancel, remove_data=False)
+        message.confirm_async(title=title, text=msg,
+                              yes_action=(lambda:
+                                          self._after_create_parent_question(
+                                              force_overwrite,
+                                              remember_directory)),
+                              no_action=no_action, cancel_action=no_action,
+                              abort_on=[self.cancelled, self.error])
+
     def _set_fileobj(self, fileobj, *, autoclose=True):
         """"Set the file object to write the download to.
 

--- a/qutebrowser/browser/webengine/webenginedownloads.py
+++ b/qutebrowser/browser/webengine/webenginedownloads.py
@@ -120,6 +120,19 @@ class DownloadItem(downloads.AbstractDownloadItem):
                              "state {} (not in requested state)!".format(
                                  filename, self, state_name))
 
+    def _ask_confirm_question(self, title, msg):
+        no_action = functools.partial(self.cancel, remove_data=False)
+        question = usertypes.Question()
+        question.title = title
+        question.text = msg
+        question.mode = usertypes.PromptMode.yesno
+        question.answered_yes.connect(self._after_set_filename)
+        question.answered_no.connect(no_action)
+        question.cancelled.connect(no_action)
+        self.cancelled.connect(question.abort)
+        self.error.connect(question.abort)
+        message.global_bridge.ask(question, blocking=True)
+
     def _ask_create_parent_question(self, title, msg,
                                     force_overwrite, remember_directory):
         no_action = functools.partial(self.cancel, remove_data=False)
@@ -130,19 +143,6 @@ class DownloadItem(downloads.AbstractDownloadItem):
         question.answered_yes.connect(lambda:
                                       self._after_create_parent_question(
                                           force_overwrite, remember_directory))
-        question.answered_no.connect(no_action)
-        question.cancelled.connect(no_action)
-        self.cancelled.connect(question.abort)
-        self.error.connect(question.abort)
-        message.global_bridge.ask(question, blocking=True)
-
-    def _ask_confirm_question(self, title, msg):
-        no_action = functools.partial(self.cancel, remove_data=False)
-        question = usertypes.Question()
-        question.title = title
-        question.text = msg
-        question.mode = usertypes.PromptMode.yesno
-        question.answered_yes.connect(self._after_set_filename)
         question.answered_no.connect(no_action)
         question.cancelled.connect(no_action)
         self.cancelled.connect(question.abort)

--- a/qutebrowser/browser/webengine/webenginedownloads.py
+++ b/qutebrowser/browser/webengine/webenginedownloads.py
@@ -120,6 +120,22 @@ class DownloadItem(downloads.AbstractDownloadItem):
                              "state {} (not in requested state)!".format(
                                  filename, self, state_name))
 
+    def _ask_create_parent_question(self, title, msg,
+                                    force_overwrite, remember_directory):
+        no_action = functools.partial(self.cancel, remove_data=False)
+        question = usertypes.Question()
+        question.title = title
+        question.text = msg
+        question.mode = usertypes.PromptMode.yesno
+        question.answered_yes.connect(lambda:
+                                      self._after_create_parent_question(
+                                          force_overwrite, remember_directory))
+        question.answered_no.connect(no_action)
+        question.cancelled.connect(no_action)
+        self.cancelled.connect(question.abort)
+        self.error.connect(question.abort)
+        message.global_bridge.ask(question, blocking=True)
+
     def _ask_confirm_question(self, title, msg):
         no_action = functools.partial(self.cancel, remove_data=False)
         question = usertypes.Question()

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -256,14 +256,14 @@ Feature: Downloading things from a website.
         Then the error "Can only download the current page as mhtml." should be shown
 
     Scenario: :download with a filename and directory which doesn't exist
-        When I run :download --dest (tmpdir)/downloads/somedir/file http://localhost:(port)/data/downloads/download.bin
+        When I run :download --dest (tmpdir)(dirsep)downloads(dirsep)somedir(dirsep)file http://localhost:(port)/data/downloads/download.bin
         And I wait for "Asking question <qutebrowser.utils.usertypes.Question default=None mode=<PromptMode.yesno: 1> text='<b>*</b> does not exist. Create it?' title='Create directory?'>, *" in the log
         And I run :prompt-accept yes
         And I wait until the download is finished
         Then the downloaded file somedir/file should exist
 
     Scenario: :download with a directory which doesn't exist
-        When I run :download --dest (tmpdir)/downloads/somedir/ http://localhost:(port)/data/downloads/download.bin
+        When I run :download --dest (tmpdir)(dirsep)downloads(dirsep)somedir(dirsep) http://localhost:(port)/data/downloads/download.bin
         And I wait for "Asking question <qutebrowser.utils.usertypes.Question default=None mode=<PromptMode.yesno: 1> text='<b>*</b> does not exist. Create it?' title='Create directory?'>, *" in the log
         And I run :prompt-accept yes
         And I wait until the download is finished

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -256,8 +256,11 @@ Feature: Downloading things from a website.
         Then the error "Can only download the current page as mhtml." should be shown
 
     Scenario: :download with a directory which doesn't exist
-        When I run :download --dest (tmpdir)/downloads/somedir/filename http://localhost:(port)/
-        Then the error "Download error: No such file or directory" should be shown
+        When I run :download --dest (tmpdir)/downloads/somedir/filename http://localhost:(port)/data/downloads/download.bin
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default=None mode=<PromptMode.yesno: 1> text='<b>*</b> does not exist. Create it?' title='Create directory?'>, *" in the log
+        And I run :prompt-accept yes
+        And I wait until the download filename is finished
+        Then the downloaded file filename should not exist
 
     ## mhtml downloads
 

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -255,12 +255,19 @@ Feature: Downloading things from a website.
         When I run :download --mhtml http://foobar/
         Then the error "Can only download the current page as mhtml." should be shown
 
-    Scenario: :download with a directory which doesn't exist
-        When I run :download --dest (tmpdir)/downloads/somedir/filename http://localhost:(port)/data/downloads/download.bin
+    Scenario: :download with a filename and directory which doesn't exist
+        When I run :download --dest (tmpdir)/downloads/somedir/file http://localhost:(port)/data/downloads/download.bin
         And I wait for "Asking question <qutebrowser.utils.usertypes.Question default=None mode=<PromptMode.yesno: 1> text='<b>*</b> does not exist. Create it?' title='Create directory?'>, *" in the log
         And I run :prompt-accept yes
-        And I wait until the download filename is finished
-        Then the downloaded file filename should not exist
+        And I wait until the download is finished
+        Then the downloaded file somedir/file should exist
+
+    Scenario: :download with a directory which doesn't exist
+        When I run :download --dest (tmpdir)/downloads/somedir/ http://localhost:(port)/data/downloads/download.bin
+        And I wait for "Asking question <qutebrowser.utils.usertypes.Question default=None mode=<PromptMode.yesno: 1> text='<b>*</b> does not exist. Create it?' title='Create directory?'>, *" in the log
+        And I run :prompt-accept yes
+        And I wait until the download is finished
+        Then the downloaded file somedir/download.bin should exist
 
     ## mhtml downloads
 


### PR DESCRIPTION
Closes #2120 

Hi!

This is my first real pull request here on github! :)

Nothing really complicated going on, I just split `_set_filename`, so that we can display the prompt. flake8 and pylint seem to pass, and I updated the relevant feature test.

Thanks, best regards, congratulations on writing my favorite browser! :)
Panos

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3097)
<!-- Reviewable:end -->
