### PR TITLE
RFC: Use ruaml.yaml instead PyYAML as drop in replacement

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -284,7 +284,7 @@ You can use:
 .config.py:
 [source,python]
 ----
-import yaml
+import ruamel.yaml
 
 with (config.configdir / 'config.yml').open() as f:
     yaml_data = yaml.load(f)
@@ -314,7 +314,7 @@ You can use:
 .config.py:
 [source,python]
 ----
-import yaml
+import ruamel.yaml as yaml
 
 with (config.configdir / 'colors.yml').open() as f:
     yaml_data = yaml.load(f)

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -28,7 +28,7 @@ import traceback
 import configparser
 import contextlib
 
-import yaml
+import ruamel.yaml as yaml
 from PyQt5.QtCore import pyqtSignal, QObject, QSettings
 
 import qutebrowser

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -54,7 +54,7 @@ import operator
 import json
 
 import attr
-import yaml
+import ruamel.yaml as yaml
 from PyQt5.QtCore import QUrl, Qt
 from PyQt5.QtGui import QColor, QFont
 from PyQt5.QtWidgets import QTabWidget, QTabBar

--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -220,7 +220,7 @@ def check_libraries():
         'pypeg2': _missing_str("pypeg2"),
         'jinja2': _missing_str("jinja2"),
         'pygments': _missing_str("pygments"),
-        'yaml': _missing_str("PyYAML"),
+        'ruamel.yaml': _missing_str("ruamel.yaml"),
         'attr': _missing_str("attrs"),
         'PyQt5.QtQml': _missing_str("PyQt5.QtQml"),
         'PyQt5.QtSql': _missing_str("PyQt5.QtSql"),

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -25,7 +25,7 @@ import os.path
 import sip
 from PyQt5.QtCore import QUrl, QObject, QPoint, QTimer
 from PyQt5.QtWidgets import QApplication
-import yaml
+import ruamel.yaml as yaml
 
 from qutebrowser.utils import (standarddir, objreg, qtutils, log, message,
                                utils)

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -39,12 +39,12 @@ from PyQt5.QtCore import Qt, QUrl
 from PyQt5.QtGui import QKeySequence, QColor, QClipboard, QDesktopServices
 from PyQt5.QtWidgets import QApplication
 import pkg_resources
-import yaml
+import ruamel.yaml as yaml
 try:
-    from yaml import CSafeLoader as YamlLoader, CSafeDumper as YamlDumper
+    from ruamel.yaml import CSafeLoader as YamlLoader, CSafeDumper as YamlDumper
     YAML_C_EXT = True
 except ImportError:  # pragma: no cover
-    from yaml import SafeLoader as YamlLoader, SafeDumper as YamlDumper
+    from ruamel.yaml import SafeLoader as YamlLoader, SafeDumper as YamlDumper
     YAML_C_EXT = False
 
 import qutebrowser

--- a/scripts/dev/pylint_checkers/qute_pylint/config.py
+++ b/scripts/dev/pylint_checkers/qute_pylint/config.py
@@ -23,7 +23,7 @@ import sys
 import os
 import os.path
 
-import yaml
+import ruamel.yaml as yaml
 import astroid
 from pylint import interfaces, checkers
 from pylint.checkers import utils

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ try:
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},
         zip_safe=True,
-        install_requires=['pypeg2', 'jinja2', 'pygments', 'PyYAML', 'attrs'],
+        install_requires=['pypeg2', 'jinja2', 'pygments', 'ruamel.yaml', 'attrs'],
         name='qutebrowser',
         version='.'.join(str(e) for e in _get_constant('version_info')),
         description=_get_constant('description'),

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -31,7 +31,7 @@ import contextlib
 import itertools
 import json
 
-import yaml
+import ruamel.yaml as yaml
 import pytest
 from PyQt5.QtCore import pyqtSignal, QUrl
 

--- a/tests/end2end/test_hints_html.py
+++ b/tests/end2end/test_hints_html.py
@@ -24,7 +24,7 @@ import os.path
 import textwrap
 
 import attr
-import yaml
+import ruamel.yaml as yaml
 import pytest
 import bs4
 

--- a/tests/unit/config/test_configdata.py
+++ b/tests/unit/config/test_configdata.py
@@ -20,7 +20,7 @@
 
 import textwrap
 
-import yaml
+import ruamel.yaml as yaml
 import pytest
 
 # To run cmdutils.register decorators

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -22,7 +22,7 @@
 import logging
 
 import pytest
-import yaml
+import ruamel.yaml as yaml
 from PyQt5.QtCore import QUrl, QPoint, QByteArray, QObject
 QWebView = pytest.importorskip('PyQt5.QtWebKitWidgets').QWebView
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -514,7 +514,7 @@ class ImportFake:
             ('pypeg2', True),
             ('jinja2', True),
             ('pygments', True),
-            ('yaml', True),
+            ('ruamel.yaml', True),
             ('cssutils', True),
             ('attr', True),
             ('PyQt5.QtWebEngineWidgets', True),


### PR DESCRIPTION
PyYAML upstream is dead for some years and here is drop in replacement
which supports also YAML 1.2 specifiation and have active upstream

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3098)
<!-- Reviewable:end -->
