### PR TITLE
Consistently space + center favicons when using vertical tabs

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -652,7 +652,7 @@ class TabBarStyle(QCommonStyle):
         icon_state = (QIcon.On if opt.state & QStyle.State_Selected
                       else QIcon.Off)
         icon = opt.icon.pixmap(opt.iconSize, icon_mode, icon_state)
-        p.drawPixmap(layouts.icon.x(), layouts.icon.y(), icon)
+        p.drawItemPixmap(layouts.icon, Qt.AlignCenter, icon)
 
     def drawControl(self, element, opt, p, widget=None):
         """Override drawControl to draw odd tabs in a different color.
@@ -819,8 +819,7 @@ class TabBarStyle(QCommonStyle):
                       else QIcon.Off)
         # reserve space for favicon when tab bar is vertical (issue #1968)
         position = config.val.tabs.position
-        if (opt.icon.isNull() and
-                position in [QTabWidget.East, QTabWidget.West] and
+        if (position in [QTabWidget.East, QTabWidget.West] and
                 config.val.tabs.favicons.show):
             tab_icon_size = icon_size
         else:
@@ -828,6 +827,7 @@ class TabBarStyle(QCommonStyle):
             tab_icon_size = QSize(
                 min(actual_size.width(), icon_size.width()),
                 min(actual_size.height(), icon_size.height()))
+
         icon_top = text_rect.center().y() + 1 - tab_icon_size.height() / 2
         icon_rect = QRect(QPoint(text_rect.left(), icon_top), tab_icon_size)
         icon_rect = self._style.visualRect(opt.direction, opt.rect, icon_rect)


### PR DESCRIPTION
This pull request tries to add more consistency to favicon spacing in vertical tab labels. Currently, smaller favicons can cause spacing issues resulting in the labels in the tabs list being misaligned. I worked around this by always allocating a consistent amount of space for the icon when the tabs list is vertical and always centering the image within this space. I feel that this results in a much more visually appealing and consistent tab list.

This has been a minor annoyance of mine for a while, but became especially apparent when I recently picked up the tree-style-tabs initial commit to play around with. You can see the specific issue in the following images:

Before:

![before1](http://drop.bryan.sh/ET0g24Xc2u.png)

![before2](http://drop.bryan.sh/Kvc1k8YZuw.png)

After:

![after](http://drop.bryan.sh/A8clktmtOA.png)

This change should not affect horizontal tabs at all.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3099)
<!-- Reviewable:end -->
