### PR TITLE
[RDY] Pass line and column number to external editor

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -1919,8 +1919,8 @@ respective value when executing the command.
 `{file}` gets replaced by the filename of the file to be edited.
 `{line}` gets replaced by the line in which the caret is found in the text.
 `{column}` gets replaced by the column in which the caret is found in the text.
-`{line0}` same as `{line}`, but starting from index 0
-`{column0}` same as `{column}`, but starting from index 0
+`{line0}` same as `{line}`, but starting from index 0.
+`{column0}` same as `{column}`, but starting from index 0.
 
 Type: <<types,ShellCommand>>
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -1913,7 +1913,14 @@ Default: +pass:[-1]+
 [[editor.command]]
 === editor.command
 The editor (and arguments) to use for the `open-editor` command.
-`{}` gets replaced by the filename of the file to be edited.
+Several placeholders are supported. Placeholders are substituted by the
+respective value when executing the command.
+
+`{file}` gets replaced by the filename of the file to be edited.
+`{line}` gets replaced by the line in which the caret is found in the text.
+`{column}` gets replaced by the column in which the caret is found in the text.
+`{line0}` same as `{line}`, but starting from index 0
+`{column0}` same as `{column}`, but starting from index 0
 
 Type: <<types,ShellCommand>>
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1594,10 +1594,12 @@ class CommandDispatcher:
             return
         assert isinstance(text, str), text
 
+        caret_position = elem.caret_position()
+
         ed = editor.ExternalEditor(self._tabbed_browser)
         ed.editing_finished.connect(functools.partial(
             self.on_editing_finished, elem))
-        ed.edit(text)
+        ed.edit(text, caret_position)
 
     @cmdutils.register(instance='command-dispatcher', hide=True,
                        scope='window')

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -134,6 +134,7 @@ class WebEngineElement(webelem.AbstractWebElement):
         self._js_call('set_value', value)
 
     def caret_position(self):
+        """Get the text caret position for the current element"""
         return self._js_dict.get('caret_position', 0)
 
     def insert_text(self, text):

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -134,7 +134,7 @@ class WebEngineElement(webelem.AbstractWebElement):
         self._js_call('set_value', value)
 
     def caret_position(self):
-        """Get the text caret position for the current element"""
+        """Get the text caret position for the current element."""
         return self._js_dict.get('caret_position', 0)
 
     def insert_text(self, text):

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -47,6 +47,7 @@ class WebEngineElement(webelem.AbstractWebElement):
             'class_name': str,
             'rects': list,
             'attributes': dict,
+            'caret_position': int,
         }
         assert set(js_dict.keys()).issubset(js_dict_types.keys())
         for name, typ in js_dict_types.items():
@@ -131,6 +132,9 @@ class WebEngineElement(webelem.AbstractWebElement):
 
     def set_value(self, value):
         self._js_call('set_value', value)
+
+    def caret_position(self):
+        return self._js_dict.get('caret_position', 0)
 
     def insert_text(self, text):
         if not self.is_editable(strict=True):

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -127,6 +127,7 @@ class WebKitElement(webelem.AbstractWebElement):
             self._elem.evaluateJavaScript("this.value='{}'".format(value))
 
     def caret_position(self):
+        """Get the text caret position for the current element"""
         self._check_vanished()
         pos = self._elem.evaluateJavaScript('this.selectionStart')
         assert isinstance(pos, (int, float, type(None)))

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -130,7 +130,6 @@ class WebKitElement(webelem.AbstractWebElement):
         """Get the text caret position for the current element."""
         self._check_vanished()
         pos = self._elem.evaluateJavaScript('this.selectionStart')
-        assert isinstance(pos, (int, float, type(None)))
         if pos is None:
             return 0
         return int(pos)

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -127,7 +127,7 @@ class WebKitElement(webelem.AbstractWebElement):
             self._elem.evaluateJavaScript("this.value='{}'".format(value))
 
     def caret_position(self):
-        """Get the text caret position for the current element"""
+        """Get the text caret position for the current element."""
         self._check_vanished()
         pos = self._elem.evaluateJavaScript('this.selectionStart')
         assert isinstance(pos, (int, float, type(None)))

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -126,6 +126,14 @@ class WebKitElement(webelem.AbstractWebElement):
             value = javascript.string_escape(value)
             self._elem.evaluateJavaScript("this.value='{}'".format(value))
 
+    def caret_position(self):
+        self._check_vanished()
+        pos = self._elem.evaluateJavaScript('this.selectionStart')
+        assert isinstance(pos, (int, float, type(None)))
+        if pos is None:
+            return 0
+        return int(pos)
+
     def insert_text(self, text):
         self._check_vanished()
         if not self.is_editable(strict=True):

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -746,11 +746,11 @@ editor.command:
   type:
     name: ShellCommand
     placeholder: true
-  default: ["gvim", "-f", "{}"]
+  default: ["gvim", "-f", "{file}", "-c", "normal {line}G{column0}l"]
   desc: >-
     The editor (and arguments) to use for the `open-editor` command.
 
-    `{}` gets replaced by the filename of the file to be edited.
+    `{file}` gets replaced by the filename of the file to be edited.
 
 editor.encoding:
   type: Encoding

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1341,9 +1341,12 @@ class ShellCommand(List):
         if not value:
             return value
 
-        if self.placeholder and '{}' not in ' '.join(value):
+        if (self.placeholder and
+                '{}' not in ' '.join(value) and
+                '{file}' not in ' '.join(value)):
             raise configexc.ValidationError(value, "needs to contain a "
-                                            "{}-placeholder.")
+                                            "{}-placeholder or a "
+                                            "{file}-placeholder.")
         return value
 
 

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -48,12 +48,20 @@ window._qutebrowser.webelem = (function() {
         var id = elements.length;
         elements[id] = elem;
 
+        // InvalidStateError will be thrown if elem doesn't have selectionStart
+        var caret_position = 0;
+        try {
+            caret_position = elem.selectionStart;
+        } catch (e) {
+            // nothing to do, caret_position is already 0
+        }
+
         var out = {
             "id": id,
             "value": elem.value,
             "outer_xml": elem.outerHTML,
             "rects": [],  // Gets filled up later
-            "caret_position": elem.selectionStart,
+            "caret_position": caret_position,
         };
 
         // https://github.com/qutebrowser/qutebrowser/issues/2569

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -55,6 +55,9 @@ window._qutebrowser.webelem = (function() {
         } catch (e) {
             if (e instanceof DOMException && e.name === "InvalidStateError") {
                 // nothing to do, caret_position is already 0
+            } else {
+                // not the droid we're looking for
+                throw e
             }
         }
 

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -53,10 +53,8 @@ window._qutebrowser.webelem = (function() {
         try {
             caret_position = elem.selectionStart;
         } catch (err) {
-            if (
-                err instanceof DOMException &&
-                err.name === "InvalidStateError"
-            ) {
+            if (err instanceof DOMException &&
+                    err.name === "InvalidStateError") {
                 // nothing to do, caret_position is already 0
             } else {
                 // not the droid we're looking for

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -53,7 +53,9 @@ window._qutebrowser.webelem = (function() {
         try {
             caret_position = elem.selectionStart;
         } catch (e) {
-            // nothing to do, caret_position is already 0
+            if (e instanceof DOMException && e.name === "InvalidStateError") {
+                // nothing to do, caret_position is already 0
+            }
         }
 
         var out = {

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -52,12 +52,15 @@ window._qutebrowser.webelem = (function() {
         var caret_position = 0;
         try {
             caret_position = elem.selectionStart;
-        } catch (e) {
-            if (e instanceof DOMException && e.name === "InvalidStateError") {
+        } catch (err) {
+            if (
+                err instanceof DOMException &&
+                err.name === "InvalidStateError"
+            ) {
                 // nothing to do, caret_position is already 0
             } else {
                 // not the droid we're looking for
-                throw e
+                throw err;
             }
         }
 

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -53,6 +53,7 @@ window._qutebrowser.webelem = (function() {
             "value": elem.value,
             "outer_xml": elem.outerHTML,
             "rects": [],  // Gets filled up later
+            "caret_position": elem.selectionStart,
         };
 
         // https://github.com/qutebrowser/qutebrowser/issues/2569

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -181,7 +181,7 @@ class ExternalEditor(QObject):
         """
         line = text[:caret_position].count('\n') + 1
         column = caret_position - text[:caret_position].rfind('\n')
-        return (line, column)
+        return line, column
 
     def _sub_placeholder(self, arg, line, column):
         """Substitute a single placeholder.

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -150,7 +150,7 @@ class ExternalEditor(QObject):
         self._proc.start(executable, args)
 
     def _calc_line_and_column(self, text, caret_position):
-        """Calculate line and column numbers given a text and caret position
+        r"""Calculate line and column numbers given a text and caret position.
 
         Both line and column are 1-based indexes, because that's what most
         editors use as line and column starting index.  By "most" we mean at

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -152,6 +152,26 @@ class ExternalEditor(QObject):
     def _calc_line_and_column(self, text, caret_position):
         """Calculate line and column numbers given a text and caret position
 
+        Both line and column are 1-based indexes, because that's what most
+        editors use as line and column starting index.  By "most" we mean at
+        least vim, nvim, gvim, emacs, atom, sublimetext, notepad++, brackets,
+        visual studio, QtCreator and so on.
+
+        To find the line we just count how many newlines there are before the
+        caret and add 1.
+
+        To find the column we calculate the difference between the caret and
+        the last newline before the caret.
+
+        For example in the text `aaa\nbb|bbb` (| represents the caret):
+        caret_position = 6
+        text[:caret_position] = `aaa\nbb`
+        text[:caret_position].count('\n') = 1
+        caret_position - text[:caret_position].rfind('\n') = 3
+
+        Thus line, column = 2, 3, and the caret is indeed in the second
+        line, third column
+
         Args:
             text: the text for which the numbers must be calculated
             caret_position: the position of the caret in the text
@@ -159,25 +179,6 @@ class ExternalEditor(QObject):
         Return:
             A (line, column) tuple of (int, int)
         """
-        # Both line and column are 1-based indexes, because that's what most
-        # editors use as line and column starting index.  By "most" we mean at
-        # least vim, nvim, gvim, emacs, atom, sublimetext, notepad++, brackets,
-        # visual studio, QtCreator and so on.
-        #
-        # To find the line we just count how many newlines there are before the
-        # caret and add 1.
-        #
-        # To find the column we calculate the difference between the caret and
-        # the last newline before the caret.
-        #
-        # For example in the text `aaa\nbb|bbb` (| represents the caret):
-        # caret_position = 6
-        # text[:caret_position] = `aaa\nbb`
-        # text[:caret_psotion].count('\n') = 1
-        # caret_position - text[:caret_position].rfind('\n') = 3
-        #
-        # Thus line, column = 2, 3, and the caret is indeed in the second
-        # line, third column
         line = text[:caret_position].count('\n') + 1
         column = caret_position - text[:caret_position].rfind('\n')
         return (line, column)

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -192,11 +192,11 @@ class ExternalEditor(QObject):
 
         Args:
             possible_placeholder: an argument of editor.command.
-            line: the previously-calculated line number for the text caret
-            column: the previously-calculated column number for the text caret
+            line: the previously-calculated line number for the text caret.
+            column: the previously-calculated column number for the text caret.
 
         Return:
-            The substituted placeholder or the original argument
+            The substituted placeholder or the original argument.
         """
         replacements = {
             '{}': self._filename,

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -183,15 +183,15 @@ class ExternalEditor(QObject):
         column = caret_position - text[:caret_position].rfind('\n')
         return (line, column)
 
-    def _sub_placeholder(self, possible_placeholder, line, column):
+    def _sub_placeholder(self, arg, line, column):
         """Substitute a single placeholder.
 
-        If the `possible_placeholder` input to this function is valid it will
+        If the `arg` input to this function is a valid placeholder it will
         be substituted with the appropriate value, otherwise it will be left
         unchanged.
 
         Args:
-            possible_placeholder: an argument of editor.command.
+            arg: an argument of editor.command.
             line: the previously-calculated line number for the text caret.
             column: the previously-calculated column number for the text caret.
 
@@ -207,9 +207,7 @@ class ExternalEditor(QObject):
             '{column0}': str(column-1)
         }
 
-        # The for loop would create a copy anyway, this should be more legible
-        ph = possible_placeholder
         for old, new in replacements.items():
-            ph = ph.replace(old, new)
+            arg = arg.replace(old, new)
 
-        return ph
+        return arg

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -174,20 +174,30 @@ class ExternalEditor(QObject):
     def _sub_placeholder(self, possible_placeholder, line, column):
         """Substitute a single placeholder.
 
-        The input to this function is not guaranteed to be a valid or known
-        placeholder. In this case the return value is the unchanged input.
+        If the `possible_placeholder` input to this function is valid it will
+        be substituted with the appropriate value, otherwise it will be left
+        unchanged.
 
         Args:
             possible_placeholder: an argument of editor.command.
+            line: the previously-calculated line number for the text caret
+            column: the previously-calculated column number for the text caret
 
         Return:
             The substituted placeholder or the original argument
         """
-        sub = possible_placeholder\
-            .replace('{}', self._filename)\
-            .replace('{file}', self._filename)\
-            .replace('{line}', str(line))\
-            .replace('{line0}', str(line-1))\
-            .replace('{column}', str(column))\
-            .replace('{column0}', str(column-1))
-        return sub
+        replacements = {
+            '{}': self._filename,
+            '{file}': self._filename,
+            '{line}': str(line),
+            '{line0}': str(line-1),
+            '{column}': str(column),
+            '{column0}': str(column-1)
+        }
+
+        # The for loop would create a copy anyway, this should be more legible
+        ph = possible_placeholder
+        for old, new in replacements.items():
+            ph = ph.replace(old, new)
+
+        return ph

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -159,7 +159,8 @@ class ExternalEditor(QObject):
         """Start the editor with the file opened as self._filename.
 
         Args:
-            caret_position: The position of the caret in the text.
+            line: the line number to pass to the editor
+            column: the column number to pass to the editor
         """
         self._proc = guiprocess.GUIProcess(what='editor', parent=self)
         self._proc.finished.connect(self.on_proc_closed)

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -96,7 +96,7 @@ class ExternalEditor(QObject):
     def on_proc_error(self, _err):
         self._cleanup()
 
-    def edit(self, text, caret_position):
+    def edit(self, text, caret_position=0):
         """Edit a given text.
 
         Args:

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -60,8 +60,9 @@ class TestSet:
     @pytest.mark.parametrize('option, old_value, inp, new_value', [
         ('url.auto_search', 'naive', 'dns', 'dns'),
         # https://github.com/qutebrowser/qutebrowser/issues/2962
-        ('editor.command', ['gvim', '-f', '{}'], '[emacs, "{}"]',
-         ['emacs', '{}']),
+        ('editor.command',
+         ['gvim', '-f', '{file}', '-c', 'normal {line}G{column0}l'],
+         '[emacs, "{}"]', ['emacs', '{}']),
     ])
     def test_set_simple(self, monkeypatch, commands, config_stub,
                         temp, option, old_value, inp, new_value):

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1832,6 +1832,11 @@ class TestShellCommand:
         ({'placeholder': True}, '[foo, "{", "}", bar'),
         ({'placeholder': True}, '[foo, bar]'),
         ({'placeholder': True}, '[foo, "{fi", "le}", bar'),
+
+        # Like valid ones but with wrong placeholder
+        ({'placeholder': True}, '[f, "{wrong}", b]'),
+        ({'placeholder': True}, '["f{wrong}b"]'),
+        ({'placeholder': True}, '[f, "b {wrong}"]'),
     ])
     def test_from_str_invalid(self, klass, kwargs, val):
         with pytest.raises(configexc.ValidationError):

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1815,12 +1815,12 @@ class TestShellCommand:
 
     @pytest.mark.parametrize('kwargs, val, expected', [
         ({}, '[foobar]', ['foobar']),
-        ({'placeholder': '{}'}, '[foo, "{}", bar]', ['foo', '{}', 'bar']),
-        ({'placeholder': '{}'}, '["foo{}bar"]', ['foo{}bar']),
-        ({'placeholder': '{}'}, '[foo, "bar {}"]', ['foo', 'bar {}']),
-        ({'placeholder': '{file}'}, '[f, "{file}", b]', ['f', '{file}', 'b']),
-        ({'placeholder': '{file}'}, '["f{file}b"]', ['f{file}b']),
-        ({'placeholder': '{file}'}, '[f, "b {file}"]', ['f', 'b {file}']),
+        ({'placeholder': True}, '[foo, "{}", bar]', ['foo', '{}', 'bar']),
+        ({'placeholder': True}, '["foo{}bar"]', ['foo{}bar']),
+        ({'placeholder': True}, '[foo, "bar {}"]', ['foo', 'bar {}']),
+        ({'placeholder': True}, '[f, "{file}", b]', ['f', '{file}', 'b']),
+        ({'placeholder': True}, '["f{file}b"]', ['f{file}b']),
+        ({'placeholder': True}, '[f, "b {file}"]', ['f', 'b {file}']),
     ])
     def test_valid(self, klass, kwargs, val, expected):
         cmd = klass(**kwargs)
@@ -1828,10 +1828,10 @@ class TestShellCommand:
         assert cmd.to_py(expected) == expected
 
     @pytest.mark.parametrize('kwargs, val', [
-        ({'placeholder': '{}'}, '[foo, bar]'),
-        ({'placeholder': '{}'}, '[foo, "{", "}", bar'),
-        ({'placeholder': '{file}'}, '[foo, bar]'),
-        ({'placeholder': '{file}'}, '[foo, "{fi", "le}", bar'),
+        ({'placeholder': True}, '[foo, bar]'),
+        ({'placeholder': True}, '[foo, "{", "}", bar'),
+        ({'placeholder': True}, '[foo, bar]'),
+        ({'placeholder': True}, '[foo, "{fi", "le}", bar'),
     ])
     def test_from_str_invalid(self, klass, kwargs, val):
         with pytest.raises(configexc.ValidationError):

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1818,6 +1818,9 @@ class TestShellCommand:
         ({'placeholder': '{}'}, '[foo, "{}", bar]', ['foo', '{}', 'bar']),
         ({'placeholder': '{}'}, '["foo{}bar"]', ['foo{}bar']),
         ({'placeholder': '{}'}, '[foo, "bar {}"]', ['foo', 'bar {}']),
+        ({'placeholder': '{file}'}, '[f, "{file}", b]', ['f', '{file}', 'b']),
+        ({'placeholder': '{file}'}, '["f{file}b"]', ['f{file}b']),
+        ({'placeholder': '{file}'}, '[f, "b {file}"]', ['f', 'b {file}']),
     ])
     def test_valid(self, klass, kwargs, val, expected):
         cmd = klass(**kwargs)
@@ -1827,6 +1830,8 @@ class TestShellCommand:
     @pytest.mark.parametrize('kwargs, val', [
         ({'placeholder': '{}'}, '[foo, bar]'),
         ({'placeholder': '{}'}, '[foo, "{", "}", bar'),
+        ({'placeholder': '{file}'}, '[foo, bar]'),
+        ({'placeholder': '{file}'}, '[foo, "{fi", "le}", bar'),
     ])
     def test_from_str_invalid(self, klass, kwargs, val):
         with pytest.raises(configexc.ValidationError):

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -190,5 +190,5 @@ def test_modify(qtbot, editor, initial_text, edited_text):
     ('a\nbb\nccc', 8, (3, 4)),
 ])
 def test_calculation(editor, text, caret_position, result):
-    """Test calculation for line and column given text and caret_position"""
+    """Test calculation for line and column given text and caret_position."""
     assert editor._calc_line_and_column(text, caret_position) == result

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -157,24 +157,6 @@ class TestFileHandling:
             editor.edit("")
 
 
-class TestLineColumnCalculation:
-
-    """Test calculation for line and column given text and caret_position"""
-
-    @pytest.mark.parametrize('text, caret_position, result', [
-        ('', 0, (1, 1)),
-        ('a', 0, (1, 1)),
-        ('a\nb', 1, (1, 2)),
-        ('a\nb', 2, (2, 1)),
-        ('a\nb', 3, (2, 2)),
-        ('a\nbb\nccc', 4, (2, 3)),
-        ('a\nbb\nccc', 5, (3, 1)),
-        ('a\nbb\nccc', 8, (3, 4)),
-    ])
-    def test_calculation(self, editor, text, caret_position, result):
-        assert editor._calc_line_and_column(text, caret_position) == result
-
-
 @pytest.mark.parametrize('initial_text, edited_text', [
     ('', 'Hello'),
     ('Hello', 'World'),
@@ -195,3 +177,18 @@ def test_modify(qtbot, editor, initial_text, edited_text):
         editor._proc.finished.emit(0, QProcess.NormalExit)
 
     assert blocker.args == [edited_text]
+
+
+@pytest.mark.parametrize('text, caret_position, result', [
+    ('', 0, (1, 1)),
+    ('a', 0, (1, 1)),
+    ('a\nb', 1, (1, 2)),
+    ('a\nb', 2, (2, 1)),
+    ('a\nb', 3, (2, 2)),
+    ('a\nbb\nccc', 4, (2, 3)),
+    ('a\nbb\nccc', 5, (3, 1)),
+    ('a\nbb\nccc', 8, (3, 4)),
+])
+def test_calculation(editor, text, caret_position, result):
+    """Test calculation for line and column given text and caret_position"""
+    assert editor._calc_line_and_column(text, caret_position) == result

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -157,6 +157,24 @@ class TestFileHandling:
             editor.edit("")
 
 
+class TestLineColumnCalculation:
+
+    """Test calculation for line and column given text and caret_position"""
+
+    @pytest.mark.parametrize('text, caret_position, result', [
+        ('', 0, (1, 1)),
+        ('a', 0, (1, 1)),
+        ('a\nb', 1, (1, 2)),
+        ('a\nb', 2, (2, 1)),
+        ('a\nb', 3, (2, 2)),
+        ('a\nbb\nccc', 4, (2, 3)),
+        ('a\nbb\nccc', 5, (3, 1)),
+        ('a\nbb\nccc', 8, (3, 4)),
+    ])
+    def test_calculation(self, editor, text, caret_position, result):
+        assert editor._calc_line_and_column(text, caret_position) == result
+
+
 @pytest.mark.parametrize('initial_text, edited_text', [
     ('', 'Hello'),
     ('Hello', 'World'),


### PR DESCRIPTION
Fixes #2725.

Added several possible placeholder to `editor.command` in order to be able to pass line and column numbers to the external editor in order to be able to place the cursor in the correct place in the buffer.

Added placegolders:

* `{file}` has the same function as `{}`
* `{line}` is the 1-based index of the target line in the buffer
* `{column}` is the 1-based index of the target column in the buffer
* `{line0}` is like `{line}` but 0-based
* `{column0}` is like `{column}` but 0-based

Also the placeholder check for shell commands accepts both `{}` or `{file}` placeholders

The reason `{line}` and `{column}` are 1-based by default is because most editors count lines and columns starting from 1. In fact I did not find any editor that starts counting lines or columns from 0.

Currently missing tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3100)
<!-- Reviewable:end -->
