### PR TITLE
Note how to ignore pylint in configuring doc.

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -349,12 +349,13 @@ bind_chained('<Escape>', 'clear-keychain', 'search')
 Avoiding flake8 errors
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you use an editor with flake8 integration which complains about `c` and `config` being undefined, you can use:
+If you use an editor with flake8 and pylint integration which complains about
+`c` and `config` being undefined or invalid, you can use:
 
 [source,python]
 ----
-c = c  # noqa: F821
-config = config  # noqa: F821
+c = c  # noqa: F821 pylint: disable=invalid-name,undefined-variable
+config = config  # noqa: F821 pylint: disable=invalid-name,undefined-variable
 ----
 
 For type annotation support (note that those imports aren't guaranteed to be

--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -349,13 +349,15 @@ bind_chained('<Escape>', 'clear-keychain', 'search')
 Avoiding flake8 errors
 ^^^^^^^^^^^^^^^^^^^^^^
 
-If you use an editor with flake8 and pylint integration which complains about
-`c` and `config` being undefined or invalid, you can use:
+If you use an editor with flake8 and pylint integration, it may have some
+complaints about invalid names, undefined variables, or missing docstrings.
+You can silence those with:
 
 [source,python]
 ----
-c = c  # noqa: F821 pylint: disable=invalid-name,undefined-variable
-config = config  # noqa: F821 pylint: disable=invalid-name,undefined-variable
+# pylint: disable=C0111
+c = c  # noqa: F821 pylint: disable=E0602,C0103
+config = config  # noqa: F821 pylint: disable=E0602,C0103
 ----
 
 For type annotation support (note that those imports aren't guaranteed to be
@@ -363,8 +365,9 @@ stable across qutebrowser versions):
 
 [source,python]
 ----
+# pylint: disable=C0111
 from qutebrowser.config.configfiles import ConfigAPI  # noqa: F401
 from qutebrowser.config.config import ConfigContainer  # noqa: F401
-config = config  # type: ConfigAPI # noqa: F821
-c = c  # type: ConfigContainer # noqa: F821
+config = config  # type: ConfigAPI # noqa: F821 pylint: disable=E0602,C0103
+c = c  # type: ConfigContainer # noqa: F821 pylint: disable=E0602,C0103
 ----


### PR DESCRIPTION
The doc explains how to ignore flake8 errors, but the `c` and `config`
variables may also make pylint unhappy

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3102)
<!-- Reviewable:end -->
