### PR TITLE
Change qute:version git commit to display hash

### DIFF
--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -148,13 +148,18 @@ def _git_str_subprocess(gitpath):
     if not os.path.isdir(os.path.join(gitpath, ".git")):
         return None
     try:
-        cid = subprocess.check_output(
-            ['git', 'describe', '--tags', '--dirty', '--always'],
+        commit_hash = subprocess.check_output(
+            ['git',
+             'describe',
+             '--match=NeVeRmAtCh',
+             '--always',
+             '--abbrev=40',
+             '--dirty'],
             cwd=gitpath).decode('UTF-8').strip()
         date = subprocess.check_output(
             ['git', 'show', '-s', '--format=%ci', 'HEAD'],
             cwd=gitpath).decode('UTF-8').strip()
-        return '{} ({})'.format(cid, date)
+        return '{} ({})'.format(commit_hash, date)
     except (subprocess.CalledProcessError, OSError):
         return None
 

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -148,13 +148,9 @@ def _git_str_subprocess(gitpath):
     if not os.path.isdir(os.path.join(gitpath, ".git")):
         return None
     try:
+        # https://stackoverflow.com/questions/21017300/21017394#21017394
         commit_hash = subprocess.check_output(
-            ['git',
-             'describe',
-             '--match=NeVeRmAtCh',
-             '--always',
-             '--abbrev=40',
-             '--dirty'],
+            ['git', 'describe', '--match=NeVeRmAtCh', '--always', '--dirty'],
             cwd=gitpath).decode('UTF-8').strip()
         date = subprocess.check_output(
             ['git', 'show', '-s', '--format=%ci', 'HEAD'],

--- a/scripts/setupcommon.py
+++ b/scripts/setupcommon.py
@@ -50,13 +50,14 @@ def _git_str():
     if not os.path.isdir(os.path.join(BASEDIR, ".git")):
         return None
     try:
-        cid = subprocess.check_output(
-            ['git', 'describe', '--tags', '--dirty', '--always'],
+        # https://stackoverflow.com/questions/21017300/21017394#21017394
+        commit_hash = subprocess.check_output(
+            ['git', 'describe', '--match=NeVeRmAtCh', '--always', '--dirty'],
             cwd=BASEDIR).decode('UTF-8').strip()
         date = subprocess.check_output(
             ['git', 'show', '-s', '--format=%ci', 'HEAD'],
             cwd=BASEDIR).decode('UTF-8').strip()
-        return '{} ({})'.format(cid, date)
+        return '{} ({})'.format(commit_hash, date)
     except (subprocess.CalledProcessError, OSError):
         return None
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -356,9 +356,7 @@ class TestGitStrSubprocess:
     def test_real_git(self, git_repo):
         """Test with a real git repository."""
         ret = version._git_str_subprocess(str(git_repo))
-        assert ret == \
-            '6e4b65a529c0ab78fb370c1527d5809f7436b8f3 ' \
-            + '(1970-01-01 01:00:00 +0100)'
+        assert ret == '6e4b65a (1970-01-01 01:00:00 +0100)'
 
     def test_missing_dir(self, tmpdir):
         """Test with a directory which doesn't exist."""

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -356,7 +356,9 @@ class TestGitStrSubprocess:
     def test_real_git(self, git_repo):
         """Test with a real git repository."""
         ret = version._git_str_subprocess(str(git_repo))
-        assert ret == 'foobar (1970-01-01 01:00:00 +0100)'
+        assert ret == \
+            '6e4b65a529c0ab78fb370c1527d5809f7436b8f3 ' \
+            + '(1970-01-01 01:00:00 +0100)'
 
     def test_missing_dir(self, tmpdir):
         """Test with a directory which doesn't exist."""


### PR DESCRIPTION
Replaces output of git-describe

Closes #3095 

Here's a new output of `qute:version`

```
qutebrowser v1.0.1
Git commit: 07105f4fe34048d062a3ad384d8893ef1430c71f (2017-10-13 21:33:03 -0400)
Backend: QtWebEngine (Chromium 49.0.2623.111)
```

I really dislike `git-describe` and I saw the issue that's why I'm doing this :P 

Let me know if you intended a different format.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3118)
<!-- Reviewable:end -->
