### PR TITLE
Issue3111: Separate color config for "pass-through mode"

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -524,7 +524,6 @@ content.netrc_file:
 content.notifications:
   default: ask
   type: BoolAsk
-  backend: QtWebKit
   desc: Allow websites to show notifications.
 
 content.pdfjs:
@@ -1503,6 +1502,16 @@ colors.completion.match.fg:
   default: '#ff4444'
   type: QssColor
   desc: Foreground color of the matched text in the completion.
+
+colors.statusbar.passthrough.fg:
+  default: white
+  type: QssColor
+  desc: Foreground color of the statusbar in passthrough mode.
+
+colors.statusbar.passthrough.bg:
+  default: darkblue
+  type: QssColor
+  desc: Background color of the statusbar in passthrough mode.
 
 colors.completion.scrollbar.fg:
   default: white

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -524,6 +524,7 @@ content.netrc_file:
 content.notifications:
   default: ask
   type: BoolAsk
+  backend: QtWebKit
   desc: Allow websites to show notifications.
 
 content.pdfjs:

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -249,6 +249,9 @@ class StatusBar(QWidget):
         if mode == usertypes.KeyMode.insert:
             log.statusbar.debug("Setting insert flag to {}".format(val))
             self._color_flags.insert = val
+        if mode == usertypes.KeyMode.passthrough:
+            log.statusbar.debug("Setting passthrough flag to {}".format(val))
+            self._color_flags.passthrough = val
         if mode == usertypes.KeyMode.command:
             log.statusbar.debug("Setting command flag to {}".format(val))
             self._color_flags.command = val
@@ -312,7 +315,8 @@ class StatusBar(QWidget):
                     usertypes.KeyMode.command,
                     usertypes.KeyMode.caret,
                     usertypes.KeyMode.prompt,
-                    usertypes.KeyMode.yesno]:
+                    usertypes.KeyMode.yesno,
+                    usertypes.KeyMode.passthrough]:
             self.set_mode_active(mode, True)
 
     @pyqtSlot(usertypes.KeyMode, usertypes.KeyMode)
@@ -329,7 +333,8 @@ class StatusBar(QWidget):
                         usertypes.KeyMode.command,
                         usertypes.KeyMode.caret,
                         usertypes.KeyMode.prompt,
-                        usertypes.KeyMode.yesno]:
+                        usertypes.KeyMode.yesno,
+                        usertypes.KeyMode.passthrough]:
             self.set_mode_active(old_mode, False)
 
     @pyqtSlot(browsertab.AbstractTab)

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -43,6 +43,7 @@ class ColorFlags:
         command: If we're currently in command mode.
         mode: The current caret mode (CaretMode.off/.on/.selection).
         private: Whether this window is in private browsing mode.
+        passthrough: If we're currently in passthrough-mode
     """
 
     CaretMode = usertypes.enum('CaretMode', ['off', 'on', 'selection'])
@@ -51,6 +52,7 @@ class ColorFlags:
     command = attr.ib(False)
     caret = attr.ib(CaretMode.off)
     private = attr.ib(False)
+    passthrough = attr.ib(False)
 
     def to_stringlist(self):
         """Get a string list of set flags used in the stylesheet.
@@ -66,6 +68,8 @@ class ColorFlags:
             strings.append('command')
         if self.private:
             strings.append('private')
+        if self.passthrough:
+            strings.append('passthrough')
 
         if self.private and self.command:
             strings.append('private-command')
@@ -88,6 +92,7 @@ def _generate_stylesheet():
         ('prompt', 'prompts'),
         ('insert', 'statusbar.insert'),
         ('command', 'statusbar.command'),
+        ('passthrough', 'statusbar.passthrough'),
         ('private-command', 'statusbar.command.private'),
     ]
     stylesheet = """


### PR DESCRIPTION
Addressing issue #3111 
Triggering passthrough mode colors the statusbar at the bottom dark-blue.

This is my first time trying to contribute to a public repository, so just tell me if I did anything wrong

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3119)
<!-- Reviewable:end -->
