### PR TITLE
configdata.yml: default focused tab to white background

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1799,22 +1799,22 @@ colors.tabs.even.bg:
   desc: Background color of unselected even tabs.
 
 colors.tabs.selected.odd.fg:
-  default: white
+  default: black
   type: QtColor
   desc: Foreground color of selected odd tabs.
 
 colors.tabs.selected.odd.bg:
-  default: black
+  default: white
   type: QtColor
   desc: Background color of selected odd tabs.
 
 colors.tabs.selected.even.fg:
-  default: white
+  default: black
   type: QtColor
   desc: Foreground color of selected even tabs.
 
 colors.tabs.selected.even.bg:
-  default: black
+  default: white
   type: QtColor
   desc: Background color of selected even tabs.
 


### PR DESCRIPTION
This is a better default from usability standpoint for a couple of
reasons. Subjective ones:

α) Thinking of the focused tab, it's natural to call it "highlighted". I
can't even come up with a similar word having "dark" as infix. So one'd
expect the focused tab to be of a lighter color. Having it instead just a
bit darker that the rest tabs, especially given the rest alternate two
shades of dark, is really disorienting.
β) It works the same way in Chromium. It's uncomparable to Firefox
though, because Firefox uses the same color for all tabs — they
emphasize the focused tab with a shape.

Objective:

γ) For working from a laptop, having the screen slightly bent makes
colors at the top to fade away, effectively making tabs indistinguishable.

Signed-off-by: Constantine Kharlamov <Hi-Angel@yandex.ru>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3121)
<!-- Reviewable:end -->
