### PR TITLE
Add caching for tab size hints

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -447,13 +447,14 @@ class TabBar(QTabBar):
         Return:
             A QSize of the smallest tab size we can make.
         """
-        return self.__minimumTabSizeHintHelper(self.tabText(index),
-                                               self.tabIcon(index), ellipsis)
+        return self._minimum_tab_size_hint_helper(self.tabText(index),
+                                                  self.tabIcon(index),
+                                                  ellipsis)
 
     @functools.lru_cache(maxsize=100)
-    def __minimumTabSizeHintHelper(self, tab_text: str,
-                                   icon,
-                                   ellipsis: bool) -> QSize:
+    def _minimum_tab_size_hint_helper(self, tab_text: str,
+                                      icon,
+                                      ellipsis: bool) -> QSize:
         """Helper function to cache tab results."""
         text = '\u2026' if ellipsis else tab_text
         # Don't ever shorten if text is shorter than the ellipsis

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -486,17 +486,15 @@ class TabBar(QTabBar):
                  padding_h + config.val.tabs.width.indicator)
         return QSize(width, height)
 
-    def _tab_total_width_pinned(self):
-        """Get the current total width of pinned tabs.
-
-        This width is calculated assuming no shortening due to ellipsis."""
-        return sum(self.minimumTabSizeHint(idx, ellipsis=False).width()
-            for idx in range(self.count())
-            if self._tab_pinned(idx))
-
-    def _pinnedCount(self) -> int:
-        """Get the number of pinned tabs."""
-        return sum(self._tab_pinned(idx) for idx in range(self.count()))
+    def _pinned_statistics(self) -> (int, int):
+        """Get the number of pinned tabs and the total width of pinned tabs."""
+        pinned_list = [idx
+                       for idx in range(self.count())
+                       if self._tab_pinned(idx)]
+        pinned_count = len(pinned_list)
+        pinned_width = sum(self.minimumTabSizeHint(idx, ellipsis=False).width()
+                           for idx in pinned_list)
+        return (pinned_count, pinned_width)
 
     def _tab_pinned(self, index: int) -> bool:
         """Return True if tab is pinned."""
@@ -535,8 +533,8 @@ class TabBar(QTabBar):
             return QSize()
         else:
             pinned = self._tab_pinned(index)
-            no_pinned_count = self.count() - self._pinnedCount()
-            pinned_width = self._tab_total_width_pinned()
+            pinned_count, pinned_width = self._pinned_statistics()
+            no_pinned_count = self.count() - pinned_count
             no_pinned_width = self.width() - pinned_width
 
             if pinned:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -453,20 +453,25 @@ class TabBar(QTabBar):
         Return:
             A QSize of the smallest tab size we can make.
         """
+        icon = self.tabIcon(index)
+        extent = self.style().pixelMetric(QStyle.PM_TabBarIconSize, None, self)
+        if not icon:
+            icon_width = 0
+        else:
+            icon_width = icon.actualSize(QSize(extent, extent)).width()
         return self._minimum_tab_size_hint_helper(self.tabText(index),
-                                                  self.tabIcon(index),
+                                                  icon_width,
                                                   ellipsis)
 
-    @functools.lru_cache(maxsize=100)
+    @functools.lru_cache(maxsize=2**10)
     def _minimum_tab_size_hint_helper(self, tab_text: str,
-                                      icon,
+                                      icon_width: int,
                                       ellipsis: bool) -> QSize:
         """Helper function to cache tab results.
 
         Acessing config values in here should be added to _on_config_changed to
         ensure cache is flushed when needed.
         """
-        print("running!")
         text = '\u2026' if ellipsis else tab_text
         # Don't ever shorten if text is shorter than the ellipsis
         text_width = min(self.fontMetrics().width(text),
@@ -476,14 +481,8 @@ class TabBar(QTabBar):
         padding_h = padding.left + padding.right
         padding_h += indicator_padding.left + indicator_padding.right
         padding_v = padding.top + padding.bottom
-        if icon.isNull():
-            icon_size = QSize(0, 0)
-        else:
-            extent = self.style().pixelMetric(QStyle.PM_TabBarIconSize, None,
-                                              self)
-            icon_size = icon.actualSize(QSize(extent, extent))
         height = self.fontMetrics().height() + padding_v
-        width = (text_width + icon_size.width() +
+        width = (text_width + icon_width +
                  padding_h + config.val.tabs.width.indicator)
         return QSize(width, height)
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -424,7 +424,7 @@ class TabBar(QTabBar):
             return
         super().mousePressEvent(e)
 
-    def minimumTabSizeHint(self, index, ellipsis: bool = True):
+    def minimumTabSizeHint(self, index, ellipsis: bool = True) -> QSize:
         """Set the minimum tab size to indicator/icon/... text.
 
         Args:
@@ -434,11 +434,18 @@ class TabBar(QTabBar):
         Return:
             A QSize of the smallest tab size we can make.
         """
-        text = '\u2026' if ellipsis else self.tabText(index)
+        return self.__minimumTabSizeHintHelper(self.tabText(index),
+                                               self.tabIcon(index), ellipsis)
+
+    @functools.lru_cache(maxsize=100)
+    def __minimumTabSizeHintHelper(self, tab_text: str,
+                                   icon,
+                                   ellipsis: bool) -> QSize:
+        """Helper function to cache tab results."""
+        text = '\u2026' if ellipsis else tab_text
         # Don't ever shorten if text is shorter than the ellipsis
         text_width = min(self.fontMetrics().width(text),
-                         self.fontMetrics().width(self.tabText(index)))
-        icon = self.tabIcon(index)
+                         self.fontMetrics().width(tab_text))
         padding = config.val.tabs.padding
         indicator_padding = config.val.tabs.indicator_padding
         padding_h = padding.left + padding.right

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -323,7 +323,7 @@ class TabBar(QTabBar):
         return self.parent().currentWidget()
 
     @pyqtSlot(str)
-    def _on_config_changed(self, option):
+    def _on_config_changed(self, option: str):
         if option == 'fonts.tabs':
             self._set_font()
         elif option == 'tabs.favicons.scale':
@@ -337,6 +337,12 @@ class TabBar(QTabBar):
 
         if option.startswith('colors.tabs.'):
             self.update()
+
+        # Clear _minimum_tab_size_hint_helper cache when appropriate
+        if option in ["tabs.indicator_padding",
+                      "tabs.padding",
+                      "tabs.width.indicator"]:
+            self._minimum_tab_size_hint_helper.cache_clear()
 
     def _on_show_switching_delay_changed(self):
         """Set timer interval when tabs.show_switching_delay got changed."""
@@ -455,7 +461,12 @@ class TabBar(QTabBar):
     def _minimum_tab_size_hint_helper(self, tab_text: str,
                                       icon,
                                       ellipsis: bool) -> QSize:
-        """Helper function to cache tab results."""
+        """Helper function to cache tab results.
+
+        Acessing config values in here should be added to _on_config_changed to
+        ensure cache is flushed when needed.
+        """
+        print("running!")
         text = '\u2026' if ellipsis else tab_text
         # Don't ever shorten if text is shorter than the ellipsis
         text_width = min(self.fontMetrics().width(text),

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -488,8 +488,7 @@ class TabBar(QTabBar):
 
     def _pinned_statistics(self) -> (int, int):
         """Get the number of pinned tabs and the total width of pinned tabs."""
-        pinned_list = [idx
-                       for idx in range(self.count())
+        pinned_list = [idx for idx in range(self.count())
                        if self._tab_pinned(idx)]
         pinned_count = len(pinned_list)
         pinned_width = sum(self.minimumTabSizeHint(idx, ellipsis=False).width()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -455,7 +455,7 @@ class TabBar(QTabBar):
         """
         icon = self.tabIcon(index)
         extent = self.style().pixelMetric(QStyle.PM_TabBarIconSize, None, self)
-        if not icon:
+        if icon.isNull():
             icon_width = 0
         else:
             icon_width = icon.actualSize(QSize(extent, extent)).width()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -463,13 +463,13 @@ class TabBar(QTabBar):
                                                   icon_width,
                                                   ellipsis)
 
-    @functools.lru_cache(maxsize=2**10)
+    @functools.lru_cache(maxsize=2**9)
     def _minimum_tab_size_hint_helper(self, tab_text: str,
                                       icon_width: int,
                                       ellipsis: bool) -> QSize:
         """Helper function to cache tab results.
 
-        Acessing config values in here should be added to _on_config_changed to
+        Config values accessed in here should be added to _on_config_changed to
         ensure cache is flushed when needed.
         """
         text = '\u2026' if ellipsis else tab_text

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -185,8 +185,8 @@ def debug_cache_stats():
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window='last-focused')
     # pylint: disable=protected-access
-    tabbed_browser_info = tabbed_browser.tabBar(). \
-        _minimum_tab_size_hint_helper.cache_info()
+    tab_bar = tabbed_browser.tabBar()
+    tabbed_browser_info = tab_bar._minimum_tab_size_hint_helper.cache_info()
     # pylint: enable=protected-access
 
     log.misc.debug('is_valid_prefix: {}'.format(prefix_info))

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -181,9 +181,15 @@ def debug_cache_stats():
     except ImportError:
         pass
 
+    tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                window='last-focused')
+    tabbed_browser_info = tabbed_browser.tabBar(). \
+        _minimum_tab_size_hint_helper.cache_info()
+
     log.misc.debug('is_valid_prefix: {}'.format(prefix_info))
     log.misc.debug('_render_stylesheet: {}'.format(render_stylesheet_info))
     log.misc.debug('history: {}'.format(history_info))
+    log.misc.debug('tab width cache: {}'.format(tabbed_browser_info))
 
 
 @cmdutils.register(debug=True)

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -171,6 +171,7 @@ def debug_cache_stats():
     prefix_info = configdata.is_valid_prefix.cache_info()
     # pylint: disable=protected-access
     render_stylesheet_info = config._render_stylesheet.cache_info()
+    # pylint: enable=protected-access
 
     history_info = None
     try:
@@ -183,8 +184,10 @@ def debug_cache_stats():
 
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window='last-focused')
+    # pylint: disable=protected-access
     tabbed_browser_info = tabbed_browser.tabBar(). \
         _minimum_tab_size_hint_helper.cache_info()
+    # pylint: enable=protected-access
 
     log.misc.debug('is_valid_prefix: {}'.format(prefix_info))
     log.misc.debug('_render_stylesheet: {}'.format(render_stylesheet_info))

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -52,3 +52,21 @@ class TestTabWidget:
 
         with qtbot.waitExposed(widget):
             widget.show()
+
+    def test_update_tab_titles_benchmark(self, benchmark, widget,
+                                         qtbot, fake_web_tab):
+        """Benchmark for update_tab_titles."""
+        widget.addTab(fake_web_tab(), 'foobar')
+        widget.addTab(fake_web_tab(), 'foobar2')
+        widget.addTab(fake_web_tab(), 'foobar3')
+        widget.addTab(fake_web_tab(), 'foobar4')
+
+        with qtbot.waitExposed(widget):
+            widget.show()
+
+        def bench():
+            for _a in range(1000):
+                # pylint: disable=protected-access
+                widget._update_tab_titles()
+                # pylint: enable=protected-access
+        benchmark(bench)

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -64,9 +64,4 @@ class TestTabWidget:
         with qtbot.waitExposed(widget):
             widget.show()
 
-        def bench():
-            for _a in range(1000):
-                # pylint: disable=protected-access
-                widget._update_tab_titles()
-                # pylint: enable=protected-access
-        benchmark(bench)
+        benchmark(widget._update_tab_titles)


### PR DESCRIPTION
I noticed that in newer versions of qb, `:tab-move` has become much slower (it's only noticable if you bind it to a key, I `:bind <alt-h> :tab-move -`.

I took a profile and (as I suspected) there was a regression which was partially introduced in https://github.com/qutebrowser/qutebrowser/pull/2847 (but not all).

I took a profile:

![2017-10-14-175302_1370x792_scrot](https://user-images.githubusercontent.com/4349709/31579653-89d079b6-b108-11e7-9c51-0ead0febf809.png)

So I decided to cache the minimumTabSizeHint function, which resulted in this profile

![2017-10-14-175342_1385x780_scrot](https://user-images.githubusercontent.com/4349709/31579655-a12cec8e-b108-11e7-81d5-93429c0c1ff7.png)

It still seems slower than before though....

This is a super low priority thing, so please handle other PR's first since they are more important :) 

One of the possible problems that I see is this won't have indicator and other padding changes take effect until text or icons change. Maybe I'll add a hook to clear the cache when those settings are reset...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3122)
<!-- Reviewable:end -->
