### PR TITLE
Configurable behavior of close mouse button on bar

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1135,6 +1135,7 @@ tabs.close_mouse_button_on_bar:
       - new-tab: "Open a new tab."
       - close-current: "Close the current tab."
       - close-last: "Close the last tab."
+      - ignore: "Don't do anything."
   desc: Behavior when the close mouse button is pressed on the tab bar.
 
 tabs.favicons.scale:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1127,6 +1127,16 @@ tabs.close_mouse_button:
       - none: "Don't close tabs using the mouse."
   desc: On which mouse button to close tabs.
 
+tabs.close_mouse_button_on_bar:
+  default: new-tab
+  type:
+    name: String
+    valid_values:
+      - new-tab: "Open a new tab."
+      - close-current: "Close the current tab."
+      - close-last: "Close the last tab."
+  desc: Behavior when the close mouse button is pressed on the tab bar.
+
 tabs.favicons.scale:
   default: 1.0
   type:

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -116,6 +116,7 @@ class TabbedBrowser(tabwidget.TabWidget):
         self._tab_insert_idx_right = -1
         self.shutting_down = False
         self.tabCloseRequested.connect(self.on_tab_close_requested)
+        self.new_tab_requested.connect(self.openurl)
         self.currentChanged.connect(self.on_current_changed)
         self.cur_load_started.connect(self.on_cur_load_started)
         self.cur_fullscreen_requested.connect(self.tabBar().maybe_hide)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -116,7 +116,7 @@ class TabbedBrowser(tabwidget.TabWidget):
         self._tab_insert_idx_right = -1
         self.shutting_down = False
         self.tabCloseRequested.connect(self.on_tab_close_requested)
-        self.new_tab_requested.connect(self.openurl)
+        self.new_tab_requested.connect(self.tabopen)
         self.currentChanged.connect(self.on_current_changed)
         self.cur_load_started.connect(self.on_cur_load_started)
         self.cur_fullscreen_requested.connect(self.tabBar().maybe_hide)
@@ -403,6 +403,7 @@ class TabbedBrowser(tabwidget.TabWidget):
 
     @pyqtSlot('QUrl')
     @pyqtSlot('QUrl', bool)
+    @pyqtSlot('QUrl', bool, bool)
     def tabopen(self, url=None, background=None, related=True, idx=None, *,
                 ignore_tabs_are_windows=False):
         """Open a new tab with a given URL.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -50,7 +50,7 @@ class TabWidget(QTabWidget):
     """
 
     tab_index_changed = pyqtSignal(int, int)
-    new_tab_requested = pyqtSignal('QUrl', bool)
+    new_tab_requested = pyqtSignal('QUrl', bool, bool)
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
@@ -267,7 +267,7 @@ class TabWidget(QTabWidget):
     @pyqtSlot()
     def _on_new_tab_requested(self):
         """Open a new tab."""
-        self.new_tab_requested.emit(config.val.url.default_page, True)
+        self.new_tab_requested.emit(config.val.url.default_page, False, False)
 
     def tab_url(self, idx):
         """Get the URL of the tab at the given index.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -46,9 +46,11 @@ class TabWidget(QTabWidget):
         tab_index_changed: Emitted when the current tab was changed.
                            arg 0: The index of the tab which is now focused.
                            arg 1: The total count of tabs.
+        new_tab_requested: Emitted when a new tab is requested.
     """
 
     tab_index_changed = pyqtSignal(int, int)
+    new_tab_requested = pyqtSignal('QUrl', bool)
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
@@ -59,6 +61,7 @@ class TabWidget(QTabWidget):
         bar.tabMoved.connect(functools.partial(
             QTimer.singleShot, 0, self._update_tab_titles))
         bar.currentChanged.connect(self._on_current_changed)
+        bar.new_tab_requested.connect(self._on_new_tab_requested)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.setDocumentMode(True)
         self.setElideMode(Qt.ElideRight)
@@ -261,6 +264,11 @@ class TabWidget(QTabWidget):
         self.tabBar().on_current_changed()
         self.tab_index_changed.emit(index, self.count())
 
+    @pyqtSlot()
+    def _on_new_tab_requested(self):
+        """Open a new tab."""
+        self.new_tab_requested.emit(config.val.url.default_page, True)
+
     def tab_url(self, idx):
         """Get the URL of the tab at the given index.
 
@@ -290,7 +298,12 @@ class TabBar(QTabBar):
     Attributes:
         vertical: When the tab bar is currently vertical.
         win_id: The window ID this TabBar belongs to.
+
+    Signals:
+        new_tab_requested: Emitted when a new tab is requested.
     """
+
+    new_tab_requested = pyqtSignal()
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
@@ -424,7 +437,14 @@ class TabBar(QTabBar):
             e.accept()
             idx = self.tabAt(e.pos())
             if idx == -1:
-                idx = self.currentIndex()
+                action = config.val.tabs.close_mouse_button_on_bar
+                if action == 'new-tab':
+                    self.new_tab_requested.emit()
+                    return
+                elif action == 'close-current':
+                    idx = self.currentIndex()
+                elif action == 'close-last':
+                    idx = self.count() - 1
             self.tabCloseRequested.emit(idx)
             return
         super().mousePressEvent(e)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -438,7 +438,9 @@ class TabBar(QTabBar):
             idx = self.tabAt(e.pos())
             if idx == -1:
                 action = config.val.tabs.close_mouse_button_on_bar
-                if action == 'new-tab':
+                if action == 'ignore':
+                    return
+                elif action == 'new-tab':
                     self.new_tab_requested.emit()
                     return
                 elif action == 'close-current':


### PR DESCRIPTION
As discussed in IRC, I don't like how middle clicking the tab bar closes the current tab. Chromium's behavior is to ignore it, and Firefox's is to open a new tab. I added these as options, as well as a "close-last" option for people who may misclick while closing tabs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3136)
<!-- Reviewable:end -->
