### PR TITLE
Make fonts.monospace a list.

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1827,10 +1827,25 @@ colors.webpage.bg:
 ## fonts
 
 fonts.monospace:
-  default: '"xos4 Terminus", Terminus, Monospace, "DejaVu Sans Mono", Monaco, "Bitstream
-    Vera Sans Mono", "Andale Mono", "Courier New", Courier, "Liberation Mono", monospace,
-    Fixed, Consolas, Terminal'
-  type: Font
+  default:
+    - "xos4 Terminus"
+    - "Terminus"
+    - "Monospace"
+    - "DejaVu Sans Mono"
+    - "Monaco"
+    - "Bitstream Vera Sans Mono"
+    - "Andale Mono"
+    - "Courier New"
+    - "Courier"
+    - "Liberation Mono"
+    - "monospace"
+    - "Fixed"
+    - "Consolas"
+    - "Terminal"
+  type:
+    name: ListOrValue
+    valtype: Font
+    none_ok: True
   desc: >-
     Default monospace fonts.
 

--- a/qutebrowser/config/configinit.py
+++ b/qutebrowser/config/configinit.py
@@ -74,7 +74,8 @@ def early_init(args):
         except configexc.Error as e:
             message.error("set: {} - {}".format(e.__class__.__name__, e))
 
-    configtypes.Font.monospace_fonts = config.val.fonts.monospace
+    configtypes.Font.monospace_fonts = ', '.join(
+        '"{}"'.format(name) for name in config.val.fonts.monospace)
     config.instance.changed.connect(_update_monospace_fonts)
 
     _init_envvars()
@@ -98,7 +99,8 @@ def _init_envvars():
 @config.change_filter('fonts.monospace', function=True)
 def _update_monospace_fonts():
     """Update all fonts if fonts.monospace was set."""
-    configtypes.Font.monospace_fonts = config.val.fonts.monospace
+    configtypes.Font.monospace_fonts = ', '.join(
+        '"{}"'.format(name) for name in config.val.fonts.monospace)
     for name, opt in configdata.DATA.items():
         if name == 'fonts.monospace':
             continue

--- a/tests/unit/config/test_configinit.py
+++ b/tests/unit/config/test_configinit.py
@@ -203,10 +203,10 @@ class TestEarlyInit:
 
     @pytest.mark.parametrize('settings, size, family', [
         # Only fonts.monospace customized
-        ([('fonts.monospace', '"Comic Sans MS"')], 8, 'Comic Sans MS'),
+        ([('fonts.monospace', 'Comic Sans MS')], 8, 'Comic Sans MS'),
         # fonts.monospace and font settings customized
         # https://github.com/qutebrowser/qutebrowser/issues/3096
-        ([('fonts.monospace', '"Comic Sans MS"'),
+        ([('fonts.monospace', 'Comic Sans MS'),
           ('fonts.tabs', '10pt monospace'),
           ('fonts.keyhint', '10pt monospace')], 10, 'Comic Sans MS'),
     ])
@@ -248,7 +248,7 @@ class TestEarlyInit:
         changed_options = []
         config.instance.changed.connect(changed_options.append)
 
-        config.instance.set_obj('fonts.monospace', '"Comic Sans MS"')
+        config.instance.set_obj('fonts.monospace', 'Comic Sans MS')
 
         assert 'fonts.keyhint' in changed_options  # Font
         assert config.instance.get('fonts.keyhint') == '8pt "Comic Sans MS"'


### PR DESCRIPTION
This makes the setting easier to manipulate in config.py.

To prepend your favorite font, instead of writing:

```
c.fonts.monospace = '"Hack", ' + c.fonts.monospace
```

You can write

```
c.fonts.monospace.insert('Hack', 0)
```

Resolves #3107.

I also considered creating a `FontList` configtype that would format to a comma-separated string on the way out, but couldn't figure out which methods to override and wasn't sure if that was a better approach anyways.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3148)
<!-- Reviewable:end -->
