### PR TITLE
Fix crashes on qute_pylint module when not running in the root

### DIFF
--- a/scripts/dev/pylint_checkers/qute_pylint/config.py
+++ b/scripts/dev/pylint_checkers/qute_pylint/config.py
@@ -27,9 +27,11 @@ import yaml
 import astroid
 from pylint import interfaces, checkers
 from pylint.checkers import utils
+from pathlib import Path
 
 
 OPTIONS = None
+FAILED_LOAD = False
 
 
 class ConfigChecker(checkers.BaseChecker):
@@ -44,6 +46,7 @@ class ConfigChecker(checkers.BaseChecker):
                   None),
     }
     priority = -1
+    printed_warning = False
 
     @utils.check_messages('bad-config-option')
     def visit_attribute(self, node):
@@ -58,6 +61,13 @@ class ConfigChecker(checkers.BaseChecker):
 
     def _check_config(self, node, name):
         """Check that we're accessing proper config options."""
+        if FAILED_LOAD:
+            if not ConfigChecker.printed_warning:
+                print("[WARN] Could not find configdata.yml. Please run " +
+                      "pylint from qutebrowser root.", file=sys.stderr)
+                print("Skipping some checks...", file=sys.stderr)
+                ConfigChecker.printed_warning = True
+            return
         if name not in OPTIONS:
             self.add_message('bad-config-option', node=node, args=name)
 
@@ -66,6 +76,11 @@ def register(linter):
     """Register this checker."""
     linter.register_checker(ConfigChecker(linter))
     global OPTIONS
-    yaml_file = os.path.join('qutebrowser', 'config', 'configdata.yml')
-    with open(yaml_file, 'r', encoding='utf-8') as f:
+    global FAILED_LOAD
+    yaml_file = Path('qutebrowser') / 'config' / 'configdata.yml'
+    if not yaml_file.exists():
+        OPTIONS = None
+        FAILED_LOAD = True
+        return
+    with yaml_file.open(mode='r', encoding='utf-8') as f:
         OPTIONS = list(yaml.load(f))

--- a/scripts/dev/pylint_checkers/qute_pylint/config.py
+++ b/scripts/dev/pylint_checkers/qute_pylint/config.py
@@ -20,14 +20,11 @@
 """Custom astroid checker for config calls."""
 
 import sys
-import os
-import os.path
-
+import pathlib
 import yaml
 import astroid
 from pylint import interfaces, checkers
 from pylint.checkers import utils
-from pathlib import Path
 
 
 OPTIONS = None
@@ -63,7 +60,7 @@ class ConfigChecker(checkers.BaseChecker):
         """Check that we're accessing proper config options."""
         if FAILED_LOAD:
             if not ConfigChecker.printed_warning:
-                print("[WARN] Could not find configdata.yml. Please run " +
+                print("[WARN] Could not find configdata.yml. Please run "
                       "pylint from qutebrowser root.", file=sys.stderr)
                 print("Skipping some checks...", file=sys.stderr)
                 ConfigChecker.printed_warning = True
@@ -77,7 +74,7 @@ def register(linter):
     linter.register_checker(ConfigChecker(linter))
     global OPTIONS
     global FAILED_LOAD
-    yaml_file = Path('qutebrowser') / 'config' / 'configdata.yml'
+    yaml_file = pathlib.Path('qutebrowser') / 'config' / 'configdata.yml'
     if not yaml_file.exists():
         OPTIONS = None
         FAILED_LOAD = True


### PR DESCRIPTION
Useful for editors that run from non-root directories for integrations, but skips some tests. Shouldn't impact tests run normally. For example, flycheck runs pylint from the directory above the current file, which breaks all tests currenly (since it searches but cannot find `configdata.yml`). 

I also switched this test to use pathlib over os.

Let's see if travis prints the warning.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3149)
<!-- Reviewable:end -->
