### PR TITLE
[WIP] browser/commands.py: Added a command for searhing on duckduckgo.com

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1012,6 +1012,18 @@ class CommandDispatcher:
         else:
             raise cmdexc.CommandError("Last tab")
 
+        self._open(url, tab, bg, window)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    @cmdutils.argument('term')
+    def duckduckgo(self, term, tab=False, bg=False, window=False):
+        """Peform a web search using duckduckgo
+        Args:
+            term: The search term to use
+        """
+        url = urlutils.fuzzy_url("https://duckduckgo.com?q={}".format(term))
+        self._open(url, tab, bg, window)
+
     def _resolve_buffer_index(self, index):
         """Resolve a buffer index to the tabbedbrowser and tab.
 


### PR DESCRIPTION
This pr is very much WIP, and designed to be the start (or end) of a discussion.
This implements a new command "duckduckgo" which performs a search for the given term on duckduckgo.com:
```
:duckduckgo qutebrowser
:duckduckgo "qutebrowser wikipedia"
```
I'd be interested to know if this feature would be interesting to others, if so I'd be happy to get the pr up to a landable state

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3152)
<!-- Reviewable:end -->
