### PR TITLE
Add keyhint radius configuration option

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -978,6 +978,13 @@ keyhint.blacklist:
     Globs are supported, so `;*` will blacklist all keychains starting with `;`.
     Use `*` to disable keyhints.
 
+keyhint.radius:
+  type:
+    name: Int
+    minval: 0
+  default: 6
+  desc: The rounding radius for the edges of the keyhint dialog.
+
 # emacs: '
 
 keyhint.delay:

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -54,9 +54,9 @@ class KeyHintView(QLabel):
             background-color: {{ conf.colors.keyhint.bg }};
             padding: 6px;
             {% if conf.statusbar.position == 'top' %}
-                border-bottom-right-radius: 6px;
+                border-bottom-right-radius: {{ conf.keyhint.radius }}px;
             {% else %}
-                border-top-right-radius: 6px;
+                border-top-right-radius: {{ conf.keyhint.radius }}px;
             {% endif %}
         }
     """


### PR DESCRIPTION
The radius for the keyhint dialog box should be configurable vi via
c.keyhint.radius. The default was set to 6px, which is the previous
hardcoded value.

Test:
Works fine, default was applied as expected. Changes are applied
successfully.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3165)
<!-- Reviewable:end -->
