### PR TITLE
[RDY] Avoid crash with `LC_ALL=C` and unicode filename

### DIFF
--- a/qutebrowser/browser/webkit/network/filescheme.py
+++ b/qutebrowser/browser/webkit/network/filescheme.py
@@ -127,7 +127,10 @@ class FileSchemeHandler(schemehandler.SchemeHandler):
             A QNetworkReply for directories, None for files.
         """
         path = request.url().toLocalFile()
-        if os.path.isdir(path):
-            data = dirbrowser_html(path)
-            return networkreply.FixedDataNetworkReply(
-                request, data, 'text/html', self.parent())
+        try:
+            if os.path.isdir(path):
+                data = dirbrowser_html(path)
+                return networkreply.FixedDataNetworkReply(
+                    request, data, 'text/html', self.parent())
+        except UnicodeEncodeError:
+            return None


### PR DESCRIPTION
Fixes #1450 

This fixes the crash, instead displaying an error.

It's not the best option, but it's better than a crash

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3175)
<!-- Reviewable:end -->
