### PR TITLE
[RDY] Avoid scheduling spurious completion updates

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -186,8 +186,6 @@ class Completer(QObject):
                 # keep offering completions (see issue #1519)
                 self._ignore_change = True
         else:
-            log.completion.debug("Will ignore next completion update.")
-            self._ignore_change = True
             self._change_completed_part(text, before, after)
 
     @pyqtSlot()
@@ -284,7 +282,20 @@ class Completer(QObject):
             # pad with a space if quick-completing the last entry
             text += ' '
         log.completion.debug("setting text = '{}', pos = {}".format(text, pos))
+
+        # generally, we don't want to let self._cmd emit cursorPositionChanged,
+        # because that'll schedule a completion update. That happens when
+        # tabbing through the completions, and we want to change the command
+        # text but we also want to keep the original completion list for the
+        # command the user manually entered. The exception is when we're
+        # immediately completing, in which case we *do* want to update the
+        # completion view so that we can start completing the next part
+        if not immediate:
+            self._cmd.blockSignals(True)
+
         self._cmd.setText(text)
         self._cmd.setCursorPosition(pos)
         self._cmd.setFocus()
+
+        self._cmd.blockSignals(False)
         self._cmd.show_cmd.emit()

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -95,3 +95,9 @@ Feature: Using completion
         Then the following tabs should be open:
             - data/hello2.txt (active)
             - data/hello.txt
+
+    Scenario: Space updates completion model after selecting full command
+        When I run :set-cmd-text :set
+        And I run :completion-item-focus next
+        When I run :set-cmd-text -s :set
+        Then the completion model should be option


### PR DESCRIPTION
This fixes #2974 

Instead of setting `_ignore_change` to `True` before calling
`_change_completed_part` we just stop `_cmd` from emitting
`update_completion`.

This has the nice side-effect that when writing a complete command
`_ignore_change` was set to `True` regardless, and thus hitting space
would not update the completion view.

Now, hitting space will (as always) schedule a completion update that
now will not be incorrectly ignored

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3179)
<!-- Reviewable:end -->
