### PR TITLE
handle <EOL> of `:config-write-py` generated file

### DIFF
--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -354,15 +354,16 @@ class ConfigPyWriter:
         normal_bindings = self._bindings.pop('normal', {})
         if normal_bindings:
             yield self._line('# Bindings for normal mode')
-        for key, command in sorted(normal_bindings.items()):
-            yield self._line('config.bind({!r}, {!r})'.format(key, command))
+            for key, command in sorted(normal_bindings.items()):
+                yield self._line('config.bind({!r}, {!r})'.format(key, command))
+            yield ''
 
         for mode, mode_bindings in sorted(self._bindings.items()):
-            yield ''
             yield self._line('# Bindings for {} mode'.format(mode))
             for key, command in sorted(mode_bindings.items()):
                 yield self._line('config.bind({!r}, {!r}, mode={!r})'.format(
                     key, command, mode))
+            yield ''
 
 
 def read_config_py(filename, raising=False):

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -355,7 +355,8 @@ class ConfigPyWriter:
         if normal_bindings:
             yield self._line('# Bindings for normal mode')
             for key, command in sorted(normal_bindings.items()):
-                yield self._line('config.bind({!r}, {!r})'.format(key, command))
+                yield self._line('config.bind({!r}, {!r})'.format(
+                    key, command))
             yield ''
 
         for mode, mode_bindings in sorted(self._bindings.items()):

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -667,7 +667,7 @@ class TestConfigPyWriter:
 
             # Bindings for caret mode
             config.bind(',y', 'message-info caret', mode='caret')
-        """).strip()
+        """).lstrip()
 
     def test_binding_options_hidden(self):
         opt1 = configdata.DATA['bindings.default']


### PR DESCRIPTION
#3195 Sorry for not totally obey contents described in [contributing doc](https://github.com/qutebrowser/qutebrowser/blob/master/doc/contributing.asciidoc), but I think this pull request contains very, very few modification to code base.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3196)
<!-- Reviewable:end -->
