### PR TITLE
Add --private flag to edit_url.

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -40,7 +40,8 @@ disable=no-self-use,
         # https://github.com/PyCQA/pylint/issues/1698
         unsupported-membership-test,
         unsupported-assignment-operation,
-        unsubscriptable-object
+        unsubscriptable-object,
+        too-many-boolean-expressions
 
 [BASIC]
 function-rgx=[a-z_][a-z0-9_]{2,50}$

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2113,7 +2113,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def edit_url(self, url=None, bg=False, tab=False, window=False,
-                 private=False):
+                 private=False, related=False):
         """Navigate to a url formed in an external editor.
 
         The editor which should be launched can be configured via the
@@ -2125,6 +2125,8 @@ class CommandDispatcher:
             tab: Open in a new tab.
             window: Open in a new window.
             private: Open a new window in private browsing mode.
+            related: If opening a new tab, position the tab as related to the
+                     current one (like clicking on a link).
         """
         cmdutils.check_exclusive((tab, bg, window), 'tbw')
 
@@ -2135,7 +2137,7 @@ class CommandDispatcher:
         # Passthrough for openurl args (e.g. -t, -b, -w)
         ed.editing_finished.connect(functools.partial(
             self._open_if_changed, old_url=old_url, bg=bg, tab=tab,
-            window=window, private=private))
+            window=window, private=private, related=related))
 
         ed.edit(url or old_url)
 
@@ -2160,7 +2162,7 @@ class CommandDispatcher:
         self._tabbed_browser.jump_mark(key)
 
     def _open_if_changed(self, url=None, old_url=None, bg=False, tab=False,
-                         window=False, private=False):
+                         window=False, private=False, related=False):
         """Open a URL unless it's already open in the tab.
 
         Args:
@@ -2170,10 +2172,12 @@ class CommandDispatcher:
             tab: Open in a new tab.
             window: Open in a new window.
             private: Open a new window in private browsing mode.
+            related: If opening a new tab, position the tab as related to the
+                     current one (like clicking on a link).
         """
-        if bg or tab or window or private or url != old_url:
+        if bg or tab or window or private or related or url != old_url:
             self.openurl(url=url, bg=bg, tab=tab, window=window,
-                         private=private)
+                         private=private, related=related)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def fullscreen(self, leave=False):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2112,7 +2112,8 @@ class CommandDispatcher:
         self._current_widget().clear_ssl_errors()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def edit_url(self, url=None, bg=False, tab=False, window=False):
+    def edit_url(self, url=None, bg=False, tab=False, window=False,
+                 private=False):
         """Navigate to a url formed in an external editor.
 
         The editor which should be launched can be configured via the
@@ -2123,6 +2124,7 @@ class CommandDispatcher:
             bg: Open in a new background tab.
             tab: Open in a new tab.
             window: Open in a new window.
+            private: Open a new window in private browsing mode.
         """
         cmdutils.check_exclusive((tab, bg, window), 'tbw')
 
@@ -2133,7 +2135,7 @@ class CommandDispatcher:
         # Passthrough for openurl args (e.g. -t, -b, -w)
         ed.editing_finished.connect(functools.partial(
             self._open_if_changed, old_url=old_url, bg=bg, tab=tab,
-            window=window))
+            window=window, private=private))
 
         ed.edit(url or old_url)
 
@@ -2158,7 +2160,7 @@ class CommandDispatcher:
         self._tabbed_browser.jump_mark(key)
 
     def _open_if_changed(self, url=None, old_url=None, bg=False, tab=False,
-                         window=False):
+                         window=False, private=False):
         """Open a URL unless it's already open in the tab.
 
         Args:
@@ -2167,9 +2169,11 @@ class CommandDispatcher:
             bg: Open in a new background tab.
             tab: Open in a new tab.
             window: Open in a new window.
+            private: Open a new window in private browsing mode.
         """
-        if bg or tab or window or url != old_url:
-            self.openurl(url=url, bg=bg, tab=tab, window=window)
+        if bg or tab or window or private or url != old_url:
+            self.openurl(url=url, bg=bg, tab=tab, window=window,
+                         private=private)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def fullscreen(self, leave=False):

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -23,6 +23,16 @@ Feature: Opening external editors
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
 
+    Scenario: Editing a URL with -rt
+        When I set tabs.new_position.related to prev
+        And I open data/numbers/1.txt
+        And I set up a fake editor replacing "1.txt" by "2.txt"
+        And I run :edit-url -rt
+        Then data/numbers/2.txt should be loaded
+        And the following tabs should be open:
+            - data/numbers/2.txt (active)
+            - data/numbers/1.txt
+
     Scenario: Editing a URL with -b
         When I run :tab-only
         And I open data/numbers/1.txt

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -2,6 +2,9 @@
 
 Feature: Opening external editors
 
+    Background:
+        Given I have a fresh instance
+
     ## :edit-url
 
     Scenario: Editing a URL
@@ -48,6 +51,26 @@ Feature: Opening external editors
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
+
+    Scenario: Editing a URL with -p
+        When I open data/numbers/1.txt in a new tab
+        And I run :tab-only
+        And I set up a fake editor replacing "1.txt" by "2.txt"
+        And I run :edit-url -p
+        Then data/numbers/2.txt should be loaded
+        And the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/numbers/1.txt
+            - tabs:
+              - active: true
+                history:
+                - active: true
+                  url: http://localhost:*/data/numbers/2.txt
+              private: true
 
     Scenario: Editing a URL with -t and -b
         When I run :edit-url -t -b


### PR DESCRIPTION
The command :edit-url --private (or :edit-url -p) will spawn a new
private window with the url input from the editor.

I had to add 'Given I have a fresh instance' to the feature file to
ensure tests were not interfering.

Resolves #3185.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3200)
<!-- Reviewable:end -->
