### PR TITLE
[RDY] Make completer less stateful

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -183,7 +183,8 @@ class Completer(QObject):
             if maxsplit is not None and maxsplit < len(before):
                 self._change_completed_part(text, before, after)
             else:
-                self._change_completed_part(text, before, after, immediate=True)
+                self._change_completed_part(text, before, after,
+                                            immediate=True)
         else:
             self._change_completed_part(text, before, after)
 

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -274,7 +274,11 @@ def test_on_selection_changed(before, newtxt, after, completer_obj,
     check(True, 2, after_txt, after_pos)
 
     # quick-completing a single item should move the cursor ahead by 1 and add
-    # a trailing space if at the end of the cmd string
+    # a trailing space if at the end of the cmd string, unless the command has
+    # maxsplit < len(before) (such as :open in these tests)
+    if after_txt.startswith(':open'):
+        return
+
     after_pos += 1
     if after_pos > len(after_txt):
         after_txt += ' '

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -299,6 +299,12 @@ def test_quickcomplete_flicker(status_command_stub, completer_obj,
     config_stub.val.completion.quick = True
 
     _set_cmd_prompt(status_command_stub, ':open |')
-    completer_obj.on_selection_changed('http://example.com')
-    completer_obj.schedule_completion_update()
-    assert not completion_widget_stub.set_model.called
+
+    url = 'http://example.com'
+    completer_obj._change_completed_part = unittest.mock.Mock()
+    completer_obj.on_selection_changed(url)
+
+    # no immediate (default is false)
+    completer_obj._change_completed_part.assert_called_with(url,      # text
+                                                            ['open'], # before
+                                                            [])       # after

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -303,12 +303,11 @@ def test_quickcomplete_flicker(status_command_stub, completer_obj,
     config_stub.val.completion.quick = True
 
     _set_cmd_prompt(status_command_stub, ':open |')
+    completer_obj.schedule_completion_update()
+    assert completion_widget_stub.set_model.called
+    completion_widget_stub.set_model.reset_mock()
 
-    url = 'http://example.com'
-    completer_obj._change_completed_part = unittest.mock.Mock()
-    completer_obj.on_selection_changed(url)
-
-    # no immediate (default is false)
-    completer_obj._change_completed_part.assert_called_with(url,      # text
-                                                            ['open'], # before
-                                                            [])       # after
+    # selecting a completion should not re-set the model
+    completer_obj.on_selection_changed('http://example.com')
+    completer_obj.schedule_completion_update()
+    assert not completion_widget_stub.set_model.called


### PR DESCRIPTION
As requested in https://github.com/qutebrowser/qutebrowser/pull/3179#issuecomment-339581332, we can remove the `_ignore_change` attribute from the `Completer` class.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3208)
<!-- Reviewable:end -->
