### PR TITLE
Add trailing slash to qute://help pages

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -141,10 +141,16 @@ def data_for_url(url):
     # A url like "qute:foo" is split as "scheme:path", not "scheme:host".
     log.misc.debug("url: {}, path: {}, host {}".format(
         url.toDisplayString(), path, host))
-    if path and not host:
+    if not path or not host:
         new_url = QUrl()
         new_url.setScheme('qute')
-        new_url.setHost(path)
+        # When path is absent, e.g. qute://help (with no trailing slash)
+        if host:
+            new_url.setHost(host)
+        # When host is absent, e.g. qute:help
+        else:
+            new_url.setHost(path)
+
         new_url.setPath('/')
         if new_url.host():  # path was a valid host
             raise Redirect(new_url)

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -138,6 +138,7 @@ def data_for_url(url):
     """
     path = url.path()
     host = url.host()
+    query = url.query()
     # A url like "qute:foo" is split as "scheme:path", not "scheme:host".
     log.misc.debug("url: {}, path: {}, host {}".format(
         url.toDisplayString(), path, host))
@@ -152,6 +153,8 @@ def data_for_url(url):
             new_url.setHost(path)
 
         new_url.setPath('/')
+        if query:
+            new_url.setQuery(query)
         if new_url.host():  # path was a valid host
             raise Redirect(new_url)
 

--- a/tests/end2end/features/qutescheme.feature
+++ b/tests/end2end/features/qutescheme.feature
@@ -55,6 +55,14 @@ Feature: Special qute:// pages
         And I hint with args "links normal" and follow a
         Then qute://help/quickstart.html should be loaded
 
+    Scenario: Opening a link with qute://help
+        When the documentation is up to date
+        And I run :tab-only
+        And I open qute://help
+        And I wait until qute://help/ is loaded
+        And I hint with args "links normal" and follow a
+        Then qute://help/quickstart.html should be loaded
+
     # :history
 
     Scenario: :history without arguments

--- a/tests/end2end/features/qutescheme.feature
+++ b/tests/end2end/features/qutescheme.feature
@@ -58,7 +58,7 @@ Feature: Special qute:// pages
     Scenario: Opening a link with qute://help
         When the documentation is up to date
         And I run :tab-only
-        And I open qute://help
+        And I open qute://help without waiting
         And I wait until qute://help/ is loaded
         And I hint with args "links normal" and follow a
         Then qute://help/quickstart.html should be loaded
@@ -147,12 +147,12 @@ Feature: Special qute:// pages
 
     Scenario: Running :pyeval
         When I run :debug-pyeval 1+1
-        And I wait until qute://pyeval is loaded
+        And I wait until qute://pyeval/ is loaded
         Then the page should contain the plaintext "2"
 
     Scenario: Causing exception in :pyeval
         When I run :debug-pyeval 1/0
-        And I wait until qute://pyeval is loaded
+        And I wait until qute://pyeval/ is loaded
         Then the page should contain the plaintext "ZeroDivisionError"
 
     Scenario: Running :pyeval with --quiet
@@ -166,7 +166,7 @@ Feature: Special qute:// pages
         And I run :message-warning the-warning-message
         And I run :message-info the-info-message
         And I run :messages
-        Then qute://log?level=info should be loaded
+        Then qute://log/?level=info should be loaded
         And the error "the-error-message" should be shown
         And the warning "the-warning-message" should be shown
         And the page should contain the plaintext "the-error-message"
@@ -178,7 +178,7 @@ Feature: Special qute:// pages
         And I run :message-warning the-warning-message
         And I run :message-info the-info-message
         And I run :messages warning
-        Then qute://log?level=warning should be loaded
+        Then qute://log/?level=warning should be loaded
         And the error "the-error-message" should be shown
         And the warning "the-warning-message" should be shown
         And the page should contain the plaintext "the-error-message"
@@ -190,7 +190,7 @@ Feature: Special qute:// pages
         And I run :message-warning the-warning-message
         And I run :message-info the-info-message
         And I run :messages info
-        Then qute://log?level=info should be loaded
+        Then qute://log/?level=info should be loaded
         And the error "the-error-message" should be shown
         And the warning "the-warning-message" should be shown
         And the page should contain the plaintext "the-error-message"


### PR DESCRIPTION
qute://help (without the trailing slash) opens about:blank page due to path being empty. This fixes the issue by redirecting to the root path when path is empty.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3215)
<!-- Reviewable:end -->


edit by @The-Compiler: Fixes #3161 (I think this needs to be in the body for GitHub to auto-close the issue)