### PR TITLE
Abort pinned tab prompt if tab is destroyed

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -259,13 +259,14 @@ class TabbedBrowser(tabwidget.TabWidget):
     def tab_close_prompt_if_pinned(self, tab, force, yes_action):
         """Helper method for tab_close.
 
-        If tab is pinned, prompt. If everything is good, run yes_action.
+        If tab is pinned, prompt. If not, run yes_action.
+        If tab is destroyed, abort question.
         """
         if tab.data.pinned and not force:
             message.confirm_async(
                 title='Pinned Tab',
                 text="Are you sure you want to close a pinned tab?",
-                yes_action=yes_action, default=False)
+                yes_action=yes_action, default=False, abort_on=[tab.destroyed])
         else:
             yes_action()
 


### PR DESCRIPTION
The Qt slot/signal paradigm is a lot nicer than I originally thought!

I don't think this will have any side effects, but I'm not 100% sure. Let's see if travis is happy :)

Is it possible to add a test which closes a qutebrowser window?

Closes #3223

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3228)
<!-- Reviewable:end -->
