### PR TITLE
importer: add mozilla places.sqlite support

### DIFF
--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -122,6 +122,7 @@ def whitelist_generator():  # noqa
     yield 'qutebrowser.command.command.ArgInfo._validate_exclusive'
     yield 'scripts.get_coredumpctl_traces.Line.uid'
     yield 'scripts.get_coredumpctl_traces.Line.gid'
+    yield 'scripts.importer.import_moz_places.places.row_factory'
 
 
 def filter_func(item):


### PR DESCRIPTION
This adds supports for the places.sqlite format as used by Firefox, Seamonkey, Pale Moon, and presumably others. 

Search engine support is still limited to keyword-style '%s' functionality, as while the places database is fairly straightforward and backward-compatible (for reads, anyway) across everything in current use, the search engine file [is intentionally unstable in format to stop hijacking](http://blog.queze.net/post/2015/11/02/What-about-search-hijacking).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3229)
<!-- Reviewable:end -->
