### PR TITLE
Completion yank

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -381,10 +381,10 @@ class CompletionView(QTreeView):
     @cmdutils.register(instance='completion', hide=True,
                        modes=[usertypes.KeyMode.command], scope='window')
     def completion_item_yank(self, sel=False):
-        """Yank the current completion item onto the clipboard.
+        """Yank the current completion item into the clipboard.
 
         Args:
-            sel: True to use the primary selection instead of the clipboard.
+            sel: Use the primary selection instead of the clipboard.
         """
         index = self.currentIndex()
         if not index.isValid():

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -377,3 +377,17 @@ class CompletionView(QTreeView):
         if not index.isValid():
             raise cmdexc.CommandError("No item selected!")
         self.model().delete_cur_item(index)
+
+    @cmdutils.register(instance='completion', hide=True,
+                       modes=[usertypes.KeyMode.command], scope='window')
+    def completion_item_yank(self, sel=False):
+        """Yank the current completion item onto the clipboard.
+
+        Args:
+            sel: True to use the primary selection instead of the clipboard.
+        """
+        index = self.currentIndex()
+        if not index.isValid():
+            raise cmdexc.CommandError("No item selected!")
+        data = self.model().data(index)
+        utils.set_clipboard(data, selection=sel)

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2245,6 +2245,8 @@ bindings.default:
       <Ctrl-Shift-Tab>: completion-item-focus prev-category
       <Ctrl-D>: completion-item-del
       <Shift-Delete>: completion-item-del
+      <Ctrl-C>: completion-item-yank
+      <Ctrl-Shift-C>: completion-item-yank --sel
       <Return>: command-accept
       <Ctrl-B>: rl-backward-char
       <Ctrl-F>: rl-forward-char

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -245,6 +245,23 @@ def test_completion_item_del_no_selection(completionview):
     func.assert_not_called()
 
 
+@pytest.mark.parametrize('sel', [True, False])
+def test_completion_item_yank(completionview, mocker, sel):
+    """Test that completion_item_yank invokes delete_cur_item in the model."""
+    m = mocker.patch(
+        'qutebrowser.completion.completionwidget.utils',
+        autospec=True)
+    model = completionmodel.CompletionModel()
+    cat = listcategory.ListCategory('', [('foo', 'bar')])
+    model.add_category(cat)
+
+    completionview.set_model(model)
+    completionview.completion_item_focus('next')
+    completionview.completion_item_yank(sel)
+
+    m.set_clipboard.assert_called_once_with('foo', sel)
+
+
 def test_resize_no_model(completionview, qtbot):
     """Ensure no crash if resizeEvent is triggered with no model (#2854)."""
     completionview.resizeEvent(None)


### PR DESCRIPTION
Adds:

- `completion-item-yank` bound to `<ctrl+c>`
- `completion-item-yank --sel` bound to `<ctrl+shift+c>`

I often find myself in this situation:

1. "Hey, what's the url for X?"
2. "I have it bookmarked, let me get that for you"
3. `:open`
4. Find the item
5. Press Enter
6. Wait for the page to load (as yank won't work before the page loads)
7. `yy`

Now you can press <ctrl+c> after step 4.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3249)
<!-- Reviewable:end -->
