### PR TITLE
Fix icon width calculation for pinned tabs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ __pycache__
 /.cache
 /.testmondata
 /.hypothesis
+/.mypy_cache
 /prof
 /venv
 TODO


### PR DESCRIPTION
In reviewing these methods to try to find a cause for #3245, I found a couple minor bugs in the calculation of the minimum pinned with.

- Clear width cache when changing fonts (as font's can impact the size of tabs)
- Use correct calculation for the size of the icon (previously, we were using the minimum size)
- Fix extra space being added in pinned tabs when indicator is no longer present.

Before, setting the font size or favicon scaling in the tabbar caused the icon to scale (which wouldn't be reflected in the calculations for pinned tabs), making them too small to fit everything. Now, I *think* they scale correctly. 

I also discovered that these methods are essentially duplicating the work found in the [methods which determine where to place items in the tabs](https://github.com/qutebrowser/qutebrowser/blob/master/qutebrowser/mainwindow/tabwidget.py#L804), so I would like to call them directly if possible. However, to call them, we need a `TabBarStyle` object, and a `QStyleOptionTab` object, is it possible to get those objects from this method somehow?

I haven't tested this thoroughly yet, so it might have some bugs...

If someone could test this on a HiDPI screen, that would be nice :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3250)
<!-- Reviewable:end -->
