### PR TITLE
Make :undo re-open all tabs closed by :tab-only

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -93,7 +93,7 @@ It is possible to run or bind multiple commands by separating them with `;;`.
 |<<tab-prev,tab-prev>>|Switch to the previous tab, or switch [count] tabs back.
 |<<tab-take,tab-take>>|Take a tab from another window.
 |<<unbind,unbind>>|Unbind a keychain.
-|<<undo,undo>>|Re-open a closed tab.
+|<<undo,undo>>|Re-open the last closed tab or tabs.
 |<<version,version>>|Show version information.
 |<<view-source,view-source>>|Show the source of the current page in a new tab.
 |<<window-only,window-only>>|Close all windows except for the current one.
@@ -1065,7 +1065,7 @@ Unbind a keychain.
 
 [[undo]]
 === undo
-Re-open a closed tab.
+Re-open the last closed tab or tabs.
 
 [[version]]
 === version

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -968,13 +968,15 @@ class CommandDispatcher:
                             prev=prev, next_=next_, force=True))
                     return
 
+        first_tab = True
         for i, tab in enumerate(self._tabbed_browser.widgets()):
             if _to_close(i):
-                self._tabbed_browser.close_tab(tab)
+                self._tabbed_browser.close_tab(tab, new_undo=first_tab)
+                first_tab = False
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def undo(self):
-        """Re-open a closed tab."""
+        """Re-open the last closed tab or tabs."""
         try:
             self._tabbed_browser.undo()
         except IndexError:

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -772,6 +772,18 @@ Feature: Tab management
             - data/numbers/2.txt
             - data/numbers/3.txt
 
+    Scenario: Undo the closing of tabs using :tab-only
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-focus 2
+        And I run :tab-only
+        And I run :undo
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+            - data/numbers/2.txt
+            - data/numbers/3.txt
+
     # tabs.last_close
 
     # FIXME:qtwebengine


### PR DESCRIPTION
This changes the undo stack from a list of `UndoEntry` objects to a list of lists of `UndoEntry` objects, so groups of tabs can be added. Only `:tab-only` does that, but it's exposed by `TabbedBrowser.close_tab` as a keyword argument.

I've pressed `co` by mistake a few times. This should make it less destructive.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3253)
<!-- Reviewable:end -->
