### PR TITLE
Fix Qt Mnemonics affecting min tab width

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -501,8 +501,12 @@ class TabBar(QTabBar):
         """
         text = '\u2026' if ellipsis else tab_text
         # Don't ever shorten if text is shorter than the ellipsis
-        text_width = min(self.fontMetrics().width(text),
-                         self.fontMetrics().width(tab_text))
+
+        def _text_to_width(text):
+            # Calculate text width taking into account qt mnemonics
+            return self.fontMetrics().size(Qt.TextShowMnemonic, text).width()
+        text_width = min(_text_to_width(text),
+                         _text_to_width(tab_text))
         padding = config.val.tabs.padding
         indicator_width = config.val.tabs.width.indicator
         indicator_padding = config.val.tabs.indicator_padding


### PR DESCRIPTION
See #3245 

@helbling, I'm confident this will fix #3245, could you please verify that for me on this branch?

This is still a wip, I haven't verified all the edge cases, but the tab sizing seems right when I add `&`'s to `title_format_pinned`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3254)
<!-- Reviewable:end -->
