### PR TITLE
Fix handling of caret position with Qt 5.10

### DIFF
--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -47,7 +47,7 @@ class WebEngineElement(webelem.AbstractWebElement):
             'class_name': str,
             'rects': list,
             'attributes': dict,
-            'caret_position': int,
+            'caret_position': (int, type(None)),
         }
         assert set(js_dict.keys()).issubset(js_dict_types.keys())
         for name, typ in js_dict_types.items():
@@ -134,8 +134,11 @@ class WebEngineElement(webelem.AbstractWebElement):
         self._js_call('set_value', value)
 
     def caret_position(self):
-        """Get the text caret position for the current element."""
-        return self._js_dict.get('caret_position', 0)
+        """Get the text caret position for the current element.
+
+        If the element is not a text element, None is returned.
+        """
+        return self._js_dict.get('caret_position', None)
 
     def insert_text(self, text):
         if not self.is_editable(strict=True):

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -48,14 +48,16 @@ window._qutebrowser.webelem = (function() {
         const id = elements.length;
         elements[id] = elem;
 
-        // InvalidStateError will be thrown if elem doesn't have selectionStart
-        let caret_position = 0;
+        // With older Chromium versions (and QtWebKit), InvalidStateError will
+        // be thrown if elem doesn't have selectionStart.
+        // With newer Chromium versions (>= Qt 5.10), we get null.
+        let caret_position = null;
         try {
             caret_position = elem.selectionStart;
         } catch (err) {
             if (err instanceof DOMException &&
                     err.name === "InvalidStateError") {
-                // nothing to do, caret_position is already 0
+                // nothing to do, caret_position is already null
             } else {
                 // not the droid we're looking for
                 throw err;

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -96,7 +96,7 @@ class ExternalEditor(QObject):
     def on_proc_error(self, _err):
         self._cleanup()
 
-    def edit(self, text, caret_position=0):
+    def edit(self, text, caret_position=None):
         """Edit a given text.
 
         Args:
@@ -174,11 +174,13 @@ class ExternalEditor(QObject):
 
         Args:
             text: the text for which the numbers must be calculated
-            caret_position: the position of the caret in the text
+            caret_position: the position of the caret in the text, or None
 
         Return:
             A (line, column) tuple of (int, int)
         """
+        if caret_position is None:
+            return 1, 1
         line = text[:caret_position].count('\n') + 1
         column = caret_position - text[:caret_position].rfind('\n')
         return line, column

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -188,6 +188,7 @@ def test_modify(qtbot, editor, initial_text, edited_text):
     ('a\nbb\nccc', 4, (2, 3)),
     ('a\nbb\nccc', 5, (3, 1)),
     ('a\nbb\nccc', 8, (3, 4)),
+    ('', None, (1, 1)),
 ])
 def test_calculation(editor, text, caret_position, result):
     """Test calculation for line and column given text and caret_position."""


### PR DESCRIPTION
With Chromium 61 in Qt 5.10, we get null when getting .selectionStart on a
non-text element, like described in the WhatWG HTML standard:
https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#dom-textarea/input-selectionstart

Older QtWebEngines and QtWebKit raise InvalidStateError instead.

This also changes the surrounding code and API so None is used to say "there's
no caret position available", which seems like a nicer API.

@7lb, can you please take a quick look at this?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3258)
<!-- Reviewable:end -->
