### PR TITLE
Prevent empty commands from being bound

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -56,4 +56,6 @@ qt_log_ignore =
     ^QQuickWidget::invalidateRenderControl could not make context current
     ^libpng warning: iCCP: known incorrect sRGB profile
     ^inotify_add_watch(".*") failed: "No space left on device"
+    ^QSettings::value: Empty key passed
+    ^Icon theme ".*" not found
 xfail_strict = true

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -170,6 +170,11 @@ class KeyConfig:
 
     def bind(self, key, command, *, mode, save_yaml=False):
         """Add a new binding from key to command."""
+        if command is not None and not command.strip():
+            raise configexc.KeybindingError(
+                "Can't add binding '{}' with empty command in {} "
+                'mode'.format(key, mode))
+
         key = self._prepare(key, mode)
         log.keyboard.vdebug("Adding binding {} -> {} in mode {}.".format(
             key, command, mode))

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -285,6 +285,12 @@ class TestKeyConfig:
         key_config_stub.unbind('a')
         assert key_config_stub.get_command('a', mode='normal') is None
 
+    def test_empty_command(self, key_config_stub):
+        """Try binding a key to an empty command."""
+        message = "Can't add binding 'x' with empty command in normal mode"
+        with pytest.raises(configexc.KeybindingError, match=message):
+            key_config_stub.bind('x', ' ', mode='normal')
+
 
 class TestConfig:
 


### PR DESCRIPTION
I ran the test selectively like this: `tox -e py36 -- tests/unit/config/test_config.py` and it seems to work properly. However, even without any of the changes, I get the following for some reason: `FAIL tests/unit/config/test_config.py::TestKeyConfig::()::test_bind[message-info foo-normal]` in the summary. I'm unsure what's going wrong there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3259)
<!-- Reviewable:end -->

edited by @The-Compiler: Fixes #3251