### PR TITLE
Fix garbage collection of StyleSheetObserver objects

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -483,7 +483,8 @@ def set_register_stylesheet(obj, *, stylesheet=None, update=True):
         stylesheet: The stylesheet to use.
         update: Whether to update the stylesheet on config changes.
     """
-    StyleSheetObserver(obj, stylesheet, update)
+    observer = StyleSheetObserver(obj, stylesheet, update)
+    observer.register()
 
 
 @functools.lru_cache()
@@ -506,16 +507,15 @@ class StyleSheetObserver(QObject):
     def __init__(self, obj, stylesheet, update):
         super().__init__()
         self._obj = obj
-        self.update = update
+        self._update = update
 
         # We only need to hang around if we are asked to update.
-        if self.update:
+        if self._update:
             self.setParent(self._obj)
         if stylesheet is None:
             self._stylesheet = obj.STYLESHEET
         else:
             self._stylesheet = stylesheet
-        self._register()
 
     def _get_stylesheet(self):
         """Format a stylesheet based on a template.
@@ -530,7 +530,7 @@ class StyleSheetObserver(QObject):
         """Update the stylesheet for obj."""
         self._obj.setStyleSheet(self._get_stylesheet())
 
-    def _register(self):
+    def register(self):
         """Do a first update and listen for more.
 
         Args:
@@ -540,5 +540,5 @@ class StyleSheetObserver(QObject):
         log.config.vdebug("stylesheet for {}: {}".format(
             self._obj.__class__.__name__, qss))
         self._obj.setStyleSheet(qss)
-        if self.update:
+        if self._update:
             instance.changed.connect(self._update_stylesheet)

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -483,8 +483,7 @@ def set_register_stylesheet(obj, *, stylesheet=None, update=True):
         stylesheet: The stylesheet to use.
         update: Whether to update the stylesheet on config changes.
     """
-    observer = StyleSheetObserver(obj, stylesheet=stylesheet)
-    observer.register(update=update)
+    StyleSheetObserver(obj, stylesheet, update)
 
 
 @functools.lru_cache()
@@ -504,13 +503,19 @@ class StyleSheetObserver(QObject):
         _stylesheet: The stylesheet template to use.
     """
 
-    def __init__(self, obj, stylesheet):
-        super().__init__(parent=obj)
+    def __init__(self, obj, stylesheet, update):
+        super().__init__()
         self._obj = obj
+        self.update = update
+
+        # We only need to hang around if we are asked to update.
+        if self.update:
+            self.setParent(self._obj)
         if stylesheet is None:
             self._stylesheet = obj.STYLESHEET
         else:
             self._stylesheet = stylesheet
+        self._register()
 
     def _get_stylesheet(self):
         """Format a stylesheet based on a template.
@@ -525,7 +530,7 @@ class StyleSheetObserver(QObject):
         """Update the stylesheet for obj."""
         self._obj.setStyleSheet(self._get_stylesheet())
 
-    def register(self, update):
+    def _register(self):
         """Do a first update and listen for more.
 
         Args:
@@ -535,5 +540,5 @@ class StyleSheetObserver(QObject):
         log.config.vdebug("stylesheet for {}: {}".format(
             self._obj.__class__.__name__, qss))
         self._obj.setStyleSheet(qss)
-        if update:
+        if self.update:
             instance.changed.connect(self._update_stylesheet)

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -601,7 +601,7 @@ class StyleObj(QObject):
 def test_get_stylesheet(config_stub):
     config_stub.val.colors.hints.fg = 'magenta'
     observer = config.StyleSheetObserver(
-        StyleObj(), stylesheet="{{ conf.colors.hints.fg }}")
+        StyleObj(), stylesheet="{{ conf.colors.hints.fg }}", update=False)
     assert observer._get_stylesheet() == 'magenta'
 
 


### PR DESCRIPTION
Fixes #3263, may help with #1476.

There is a memory savings here, but I'm still not sure how much. If you want to test it out for yourself you could try:
```
diff --git a/qutebrowser/mainwindow/statusbar/url.py b/qutebrowser/mainwindow/statusbar/url.py
index a91c67550..25493920c 100644
--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -88,6 +88,8 @@ class UrlText(textbase.TextBase):
         self._normal_url = None
         self._normal_url_type = UrlType.normal
 
+        for i in range(10000 * 6 * 5):
+            config.set_register_stylesheet(self, update=False)
     @pyqtProperty(str)
     def urltype(self):
         """Getter for self.urltype, so it can be used as Qt property.
```
or similar, and see how the memory usage on your system changes before/after this patch.

The only difference I can think of is dropping support for the `StyleSheetObserver.register` method, but I think that was only being used in the `set_register_stylesheet` method.

Let met know if you find any issues with this, I haven't looked at this section very much at all, so it's possible I broke something :smile:. I'll be running this as my daily driver for a while and I'll try to remember to see if the leaking is 'as bad as before'... 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3264)
<!-- Reviewable:end -->
