### PR TITLE
Add setting to avoid shrinking pinned tabs

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1358,6 +1358,11 @@ tabs.indicator.padding:
 tabs.width.pinned:
   deleted: true
 
+tabs.pinned.shrink:
+  default: true
+  type: Bool
+  desc: Shrink pinned tabs down to their contents.
+
 tabs.wrap:
   default: true
   type: Bool

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -565,8 +565,12 @@ class TabBar(QTabBar):
             # want to ensure it's valid in this special case.
             return QSize()
         else:
-            pinned = self._tab_pinned(index)
-            pinned_count, pinned_width = self._pinned_statistics()
+            if config.val.tabs.pinned.shrink:
+                pinned = self._tab_pinned(index)
+                pinned_count, pinned_width = self._pinned_statistics()
+            else:
+                pinned = False
+                pinned_count, pinned_width = (0, 0)
             no_pinned_count = self.count() - pinned_count
             no_pinned_width = self.width() - pinned_width
 


### PR DESCRIPTION
Closes #3226

I'm not sure if the name/description of this setting is good. Let me know if you think they are off. (also, it's so easy to add new settings! :smile: )

I don't think there's a good way to unit or end2end test tab sizes, is there a way to do that?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3266)
<!-- Reviewable:end -->
