### PR TITLE
Remove default config-cycle bindings.

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2241,9 +2241,6 @@ bindings.default:
       Sb: open qute://bookmarks#bookmarks
       Sq: open qute://bookmarks
       Sh: open qute://history
-      xx: config-cycle statusbar.hide ;; config-cycle tabs.show always switching
-      xt: config-cycle tabs.show always switching
-      xb: config-cycle statusbar.hide
       <Return>: follow-selected
       <Ctrl-Return>: follow-selected -t
       .: repeat-command


### PR DESCRIPTION
Many people accidentally hit 'x{x,t,b}', hiding their statusbar by mistake

Discussion on IRC:

```
<radiantgum> Hello guys, my top panel with tabs in qutebrowser is gone and i
			 can't find a way to bring it back, please give me a clue. Thank
			 you [03:51 PM]
<jgkamat> radiantgum: :set tabs.show always [03:52 PM]
<radiantgum> thanks a lot
<jgkamat> I think there's a keybind that toggles that setting, dont remember
		  what it was [03:53 PM]
<pkill9> jgkamat: xx [03:57 PM]
<pkill9> and xt
<jgkamat> ah yes [03:58 PM]
<jgkamat> imho that shouldn't be a default :P  [03:59 PM]
<The-Compiler> I think I agree after seeing so many people accidentally
			   trigger it, even though dwb has it :P [04:06 PM]
<The-Compiler> Open a PR so I don't forget again? :D [04:07 PM]

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3271)
<!-- Reviewable:end -->
