### PR TITLE
Hide quickmark/bookmark completion if empty.

### DIFF
--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -56,14 +56,17 @@ def url(*, info):
     """
     model = completionmodel.CompletionModel(column_widths=(40, 50, 10))
 
-    quickmarks = ((url, name) for (name, url)
-                  in objreg.get('quickmark-manager').marks.items())
+    quickmarks = [(url, name) for (name, url)
+                  in objreg.get('quickmark-manager').marks.items()]
     bookmarks = objreg.get('bookmark-manager').marks.items()
 
-    model.add_category(listcategory.ListCategory(
-        'Quickmarks', quickmarks, delete_func=_delete_quickmark, sort=False))
-    model.add_category(listcategory.ListCategory(
-        'Bookmarks', bookmarks, delete_func=_delete_bookmark, sort=False))
+    if quickmarks:
+        model.add_category(listcategory.ListCategory(
+            'Quickmarks', quickmarks, delete_func=_delete_quickmark,
+            sort=False))
+    if bookmarks:
+        model.add_category(listcategory.ListCategory(
+            'Bookmarks', bookmarks, delete_func=_delete_bookmark, sort=False))
 
     if info.config.get('completion.web_history_max_items') != 0:
         hist_cat = histcategory.HistoryCategory(delete_func=_delete_history)

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -354,6 +354,50 @@ def test_url_completion(qtmodeltester, web_history_populated,
     })
 
 
+def test_url_completion_no_quickmarks(qtmodeltester, web_history_populated,
+                                      quickmark_manager_stub, bookmarks, info):
+    """Test that the quickmark category is gone with no quickmarks."""
+    model = urlmodel.url(info=info)
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        "Bookmarks": [
+            ('https://github.com', 'GitHub', None),
+            ('https://python.org', 'Welcome to Python.org', None),
+            ('http://qutebrowser.org', 'qutebrowser | qutebrowser', None),
+        ],
+        "History": [
+            ('https://github.com', 'https://github.com', '2016-05-01'),
+            ('https://python.org', 'Welcome to Python.org', '2016-03-08'),
+            ('http://qutebrowser.org', 'qutebrowser', '2015-09-05'),
+        ],
+    })
+
+
+def test_url_completion_no_bookmarks(qtmodeltester, web_history_populated,
+                                     quickmarks, bookmark_manager_stub, info):
+    """Test that the bookmarks category is gone with no bookmarks."""
+    model = urlmodel.url(info=info)
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        "Quickmarks": [
+            ('https://wiki.archlinux.org', 'aw', None),
+            ('https://wikipedia.org', 'wiki', None),
+            ('https://duckduckgo.com', 'ddg', None),
+        ],
+        "History": [
+            ('https://github.com', 'https://github.com', '2016-05-01'),
+            ('https://python.org', 'Welcome to Python.org', '2016-03-08'),
+            ('http://qutebrowser.org', 'qutebrowser', '2015-09-05'),
+        ],
+    })
+
+
 @pytest.mark.parametrize('url, title, pattern, rowcount', [
     ('example.com', 'Site Title', '', 1),
     ('example.com', 'Site Title', 'ex', 1),
@@ -380,7 +424,7 @@ def test_url_completion_pattern(web_history, quickmark_manager_stub,
     model = urlmodel.url(info=info)
     model.set_pattern(pattern)
     # 2, 0 is History
-    assert model.rowCount(model.index(2, 0)) == rowcount
+    assert model.rowCount(model.index(0, 0)) == rowcount
 
 
 def test_url_completion_delete_bookmark(qtmodeltester, bookmarks,


### PR DESCRIPTION
If there are no quickmarks/bookmarks, hide the entire category in url
completion. Note that this only hides the category if
quickmarks/bookmarks is empty to begin with. An empty category is still
shown if the completion pattern filters out all items in that category.

See #960. I think it makes sense to implement category hiding on a case-by-case basis (just not adding empty categories) rather than implemeting some more complex logic to hide empty categories in the parent completion model.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3279)
<!-- Reviewable:end -->
