### PR TITLE
Limit fullscreen to window only

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -259,11 +259,11 @@ content.default_encoding:
     The encoding must be a string describing an encoding such as _utf-8_,
     _iso-8859-1_, etc.
 
-content.desktop_fullscreen:
+content.windowed_fullscreen:
   type: Bool
-  default: true
+  default: false
   desc: >-
-    Allow fullscreen to cover the entire desktop.
+    Limit fullscreen to the browser window (does not expand to fill the screen).
 
 content.developer_extras:
   type: Bool

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -259,6 +259,12 @@ content.default_encoding:
     The encoding must be a string describing an encoding such as _utf-8_,
     _iso-8859-1_, etc.
 
+content.desktop_fullscreen:
+  type: Bool
+  default: true
+  desc: >-
+    Allow fullscreen to cover the entire desktop.
+
 content.developer_extras:
   type: Bool
   default: false

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -493,7 +493,8 @@ class MainWindow(QWidget):
     def _on_fullscreen_requested(self, on):
         if on:
             self.state_before_fullscreen = self.windowState()
-            self.showFullScreen()
+            if config.val.content.desktop_fullscreen:
+                self.showFullScreen()
         elif self.isFullScreen():
             self.setWindowState(self.state_before_fullscreen)
         log.misc.debug('on: {}, state before fullscreen: {}'.format(

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -491,14 +491,12 @@ class MainWindow(QWidget):
 
     @pyqtSlot(bool)
     def _on_fullscreen_requested(self, on):
-        if on:
-            self.window_state_before_fullscreen = self.windowState()
-            self.config_state_before_fullscreen = config.val.content.desktop_fullscreen
-            if config.val.content.desktop_fullscreen:
+        if not config.val.content.windowed_fullscreen:
+            if on:
+                self.state_before_fullscreen = self.windowState()
                 self.showFullScreen()
-        elif self.isFullScreen():
-            if config.val.content.desktop_fullscreen or self.config_state_before_fullscreen:
-                self.setWindowState(self.window_state_before_fullscreen)
+            elif self.isFullScreen():
+                self.setWindowState(self.state_before_fullscreen)
         log.misc.debug('on: {}, state before fullscreen: {}'.format(
             on, debug.qflags_key(Qt, self.state_before_fullscreen)))
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -492,11 +492,13 @@ class MainWindow(QWidget):
     @pyqtSlot(bool)
     def _on_fullscreen_requested(self, on):
         if on:
-            self.state_before_fullscreen = self.windowState()
+            self.window_state_before_fullscreen = self.windowState()
+            self.config_state_before_fullscreen = config.val.content.desktop_fullscreen
             if config.val.content.desktop_fullscreen:
                 self.showFullScreen()
         elif self.isFullScreen():
-            self.setWindowState(self.state_before_fullscreen)
+            if config.val.content.desktop_fullscreen or self.config_state_before_fullscreen:
+                self.setWindowState(self.window_state_before_fullscreen)
         log.misc.debug('on: {}, state before fullscreen: {}'.format(
             on, debug.qflags_key(Qt, self.state_before_fullscreen)))
 

--- a/qutebrowser/misc/miscwidgets.py
+++ b/qutebrowser/misc/miscwidgets.py
@@ -300,10 +300,10 @@ class FullscreenNotification(QLabel):
             self.setText("Page is now fullscreen.")
 
         self.resize(self.sizeHint())
-        if config.val.content.desktop_fullscreen:
-            geom = QApplication.desktop().screenGeometry(self)
-        else:
+        if config.val.content.windowed_fullscreen:
             geom = self.parentWidget().geometry()
+        else:
+            geom = QApplication.desktop().screenGeometry(self)
         self.move((geom.width() - self.sizeHint().width()) / 2, 30)
 
     def set_timeout(self, timeout):

--- a/qutebrowser/misc/miscwidgets.py
+++ b/qutebrowser/misc/miscwidgets.py
@@ -300,7 +300,10 @@ class FullscreenNotification(QLabel):
             self.setText("Page is now fullscreen.")
 
         self.resize(self.sizeHint())
-        geom = QApplication.desktop().screenGeometry(self)
+        if config.val.content.desktop_fullscreen:
+            geom = QApplication.desktop().screenGeometry(self)
+        else:
+            geom = self.parentWidget().geometry()
         self.move((geom.width() - self.sizeHint().width()) / 2, 30)
 
     def set_timeout(self, timeout):


### PR DESCRIPTION
#3213 Adds `content.desktop_fullscreen` config option to enable/disable fullscreen covering the entire desktop.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3285)
<!-- Reviewable:end -->
