### PR TITLE
Add an uptime section to qute:version

### DIFF
--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -29,6 +29,7 @@ import importlib
 import collections
 import enum
 import pkg_resources
+import datetime
 
 import attr
 from PyQt5.QtCore import PYQT_VERSION_STR, QLibraryInfo
@@ -324,6 +325,12 @@ def _backend():
         assert objects.backend == webengine, objects.backend
         return 'QtWebEngine (Chromium {})'.format(_chromium_version())
 
+def _uptime() -> datetime.timedelta:
+    launch_time = QApplication.instance().launch_time
+    time_delta = datetime.datetime.now() - launch_time
+    # Round off microseconds
+    time_delta -= datetime.timedelta(microseconds=time_delta.microseconds)
+    return time_delta
 
 def version():
     """Return a string with various version informations."""
@@ -387,6 +394,11 @@ def version():
     ]
     for name, path in sorted(_path_info().items()):
         lines += ['{}: {}'.format(name, path)]
+
+    lines += [
+        '',
+        'Uptime: {}'.format(str(_uptime()))
+    ]
 
     return '\n'.join(lines)
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -31,6 +31,7 @@ import importlib
 import logging
 import textwrap
 import pkg_resources
+import datetime
 
 import attr
 import pytest
@@ -870,6 +871,7 @@ def test_version_output(params, stubs, monkeypatch):
                          stubs.FakeQApplication(instance=None)),
         'QLibraryInfo.location': (lambda _loc: 'QT PATH'),
         'sql.version': lambda: 'SQLITE VERSION',
+        '_uptime': lambda: datetime.timedelta(hours=1, minutes=23, seconds=45),
     }
 
     substitutions = {
@@ -913,6 +915,8 @@ def test_version_output(params, stubs, monkeypatch):
     else:
         monkeypatch.delattr(sys, 'frozen', raising=False)
 
+    substitutions['uptime'] = "1:23:45"
+
     template = textwrap.dedent("""
         qutebrowser vVERSION{git_commit}
         Backend: {backend}
@@ -934,6 +938,8 @@ def test_version_output(params, stubs, monkeypatch):
         {osinfo}
         Paths:
         PATH DESC: PATH NAME
+
+        Uptime: {uptime}
     """.lstrip('\n'))
 
     expected = template.rstrip('\n').format(**substitutions)


### PR DESCRIPTION
Sorry for taking an easy issue but I really wanted this for memory testing in the future. 

Closes #3265.

![2017-11-13-215819_919x625_scrot](https://user-images.githubusercontent.com/4349709/32760764-c83c149a-c8bd-11e7-975d-c242be1b7855.png)

1. Is that a good location to put the uptime in the version output?
2. Is calling `QApplication.instance()` safe? Can it error out?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3286)
<!-- Reviewable:end -->
