### PR TITLE
Yank selected text with completion-item-yank.

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -28,7 +28,7 @@ from PyQt5.QtCore import pyqtSlot, pyqtSignal, Qt, QItemSelectionModel, QSize
 
 from qutebrowser.config import config
 from qutebrowser.completion import completiondelegate
-from qutebrowser.utils import utils, usertypes, debug, log
+from qutebrowser.utils import utils, usertypes, debug, log, objreg
 from qutebrowser.commands import cmdexc, cmdutils
 
 
@@ -386,8 +386,12 @@ class CompletionView(QTreeView):
         Args:
             sel: Use the primary selection instead of the clipboard.
         """
-        index = self.currentIndex()
-        if not index.isValid():
-            raise cmdexc.CommandError("No item selected!")
-        data = self.model().data(index)
-        utils.set_clipboard(data, selection=sel)
+        status = objreg.get('status-command', scope='window',
+                            window=self._win_id)
+        text = status.selectedText()
+        if not text:
+            index = self.currentIndex()
+            if not index.isValid():
+                raise cmdexc.CommandError("No item selected!")
+            text = self.model().data(index)
+        utils.set_clipboard(text, selection=sel)

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -262,6 +262,26 @@ def test_completion_item_yank(completionview, mocker, sel):
     m.set_clipboard.assert_called_once_with('foo', sel)
 
 
+@pytest.mark.parametrize('sel', [True, False])
+def test_completion_item_yank_selected(completionview, status_command_stub,
+                                       mocker, sel):
+    """Test that completion_item_yank yanks selected text."""
+    m = mocker.patch(
+        'qutebrowser.completion.completionwidget.utils',
+        autospec=True)
+    model = completionmodel.CompletionModel()
+    cat = listcategory.ListCategory('', [('foo', 'bar')])
+    model.add_category(cat)
+
+    completionview.set_model(model)
+    completionview.completion_item_focus('next')
+
+    status_command_stub.selectedText = mock.Mock(return_value='something')
+    completionview.completion_item_yank(sel)
+
+    m.set_clipboard.assert_called_once_with('something', sel)
+
+
 def test_resize_no_model(completionview, qtbot):
     """Ensure no crash if resizeEvent is triggered with no model (#2854)."""
     completionview.resizeEvent(None)


### PR DESCRIPTION
If text is highlighted in the status command bar, completion-item-yank
should yank that rather than the selected completion item.

Resolves #3281.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3290)
<!-- Reviewable:end -->
