### PR TITLE
normalize url path and strip trailing slashes when doing gu/gU

### DIFF
--- a/qutebrowser/browser/navigate.py
+++ b/qutebrowser/browser/navigate.py
@@ -64,6 +64,7 @@ def path_up(url, count):
         raise Error("Can't go up!")
     for _i in range(0, min(count, path.count('/'))):
         path = posixpath.join(path, posixpath.pardir)
+    path = posixpath.normpath(path)
     url.setPath(path)
     return url
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -135,6 +135,11 @@ def data_for_url(url):
     Return:
         A (mimetype, data) tuple.
     """
+    # normalize path and strip redundant trailing slashes
+    norm_url = url.adjusted(QUrl.NormalizePathSegments | QUrl.StripTrailingSlash)
+    if norm_url != url:
+       raise Redirect(norm_url)
+
     path = url.path()
     host = url.host()
     query = urlutils.query_string(url)
@@ -331,9 +336,13 @@ def qute_help(url):
 
     path = 'html/doc/{}'.format(urlpath)
     if not urlpath.endswith('.html'):
+        try:
+            bdata = utils.read_file(path, binary=True)
+        except OSError as e:
+            raise QuteSchemeOSError(e)
         mimetype, _encoding = mimetypes.guess_type(urlpath)
         assert mimetype is not None, url
-        return mimetype, utils.read_file(path, binary=True)
+        return mimetype, bdata
 
     try:
         data = utils.read_file(path)

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -135,10 +135,10 @@ def data_for_url(url):
     Return:
         A (mimetype, data) tuple.
     """
-    # normalize path and strip redundant trailing slashes
-    norm_url = url.adjusted(QUrl.NormalizePathSegments | QUrl.StripTrailingSlash)
+    norm_url = url.adjusted(QUrl.NormalizePathSegments |
+            QUrl.StripTrailingSlash)
     if norm_url != url:
-       raise Redirect(norm_url)
+        raise Redirect(norm_url)
 
     path = url.path()
     host = url.host()

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -18,6 +18,22 @@ Feature: Using :navigate
         And I run :navigate up with count 2
         Then data/navigate should be loaded
 
+    Scenario: Navigating up in qute://help/
+        When I open qute://help/commands.html
+        And I run :navigate up
+        Then qute://help/ should be loaded
+
+    Scenario: Navigating up by count in qute://help/
+        When I open qute://help/img/cheatsheet-big.png
+        And I run :navigate up with count 2
+        Then qute://help/ should be loaded
+
+    Scenario: Navigating up in qute://help/img/cheatsheet-big.png
+        When I open qute://help/img/cheatsheet-big.png
+        And I run :navigate up
+        Then "OSError while handling qute://* URL" should be logged
+        And "* url='qute://help/img'* LoadStatus.error" should be logged
+
     # prev/next
 
     Scenario: Navigating to previous page

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -23,17 +23,6 @@ Feature: Using :navigate
         And I run :navigate up
         Then qute://help/ should be loaded
 
-    Scenario: Navigating up by count in qute://help/
-        When I open qute://help/img/cheatsheet-big.png
-        And I run :navigate up with count 2
-        Then qute://help/ should be loaded
-
-    Scenario: Navigating up in qute://help/img/cheatsheet-big.png
-        When I open qute://help/img/cheatsheet-big.png
-        And I run :navigate up
-        Then "OSError while handling qute://* URL" should be logged
-        And "* url='qute://help/img'* LoadStatus.error" should be logged
-
     # prev/next
 
     Scenario: Navigating to previous page

--- a/tests/end2end/features/qutescheme.feature
+++ b/tests/end2end/features/qutescheme.feature
@@ -63,6 +63,19 @@ Feature: Special qute:// pages
         And I hint with args "links normal" and follow a
         Then qute://help/quickstart.html should be loaded
 
+    Scenario: Opening a link with qute://help/index.html/..
+        When I open qute://help/index.html/.. without waiting
+        Then qute://help/ should be loaded
+
+    Scenario: Opening a link with qute://help/index.html/../
+        When I open qute://help/index.html/../ without waiting
+        Then qute://help/ should be loaded
+
+    Scenario: Opening a link with qute://help/img/cheatsheet-big.png/..
+        When I open qute://help/img/cheatsheet-big.png/.. without waiting
+        Then "OSError while handling qute://* URL" should be logged
+        And "* url='qute://help/img'* LoadStatus.error" should be logged
+
     # :history
 
     Scenario: :history without arguments

--- a/tests/end2end/features/qutescheme.feature
+++ b/tests/end2end/features/qutescheme.feature
@@ -64,15 +64,18 @@ Feature: Special qute:// pages
         Then qute://help/quickstart.html should be loaded
 
     Scenario: Opening a link with qute://help/index.html/..
-        When I open qute://help/index.html/.. without waiting
+        When the documentation is up to date
+        And I open qute://help/index.html/.. without waiting
         Then qute://help/ should be loaded
 
     Scenario: Opening a link with qute://help/index.html/../
-        When I open qute://help/index.html/../ without waiting
+        When the documentation is up to date
+        And I open qute://help/index.html/../ without waiting
         Then qute://help/ should be loaded
 
-    Scenario: Opening a link with qute://help/img/cheatsheet-big.png/..
-        When I open qute://help/img/cheatsheet-big.png/.. without waiting
+    Scenario: Opening a link with qute://help/img/
+        When the documentation is up to date
+        And I open qute://help/img/ without waiting
         Then "OSError while handling qute://* URL" should be logged
         And "* url='qute://help/img'* LoadStatus.error" should be logged
 


### PR DESCRIPTION
fixes #3221, Also prevents AssertionError in qute://help pages when url resolves to a directory path by raising an OSError beforehand

@The-Compiler I hope I've added test scenarios appropriately.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3291)
<!-- Reviewable:end -->
