### PR TITLE
Track number of searches to ignore old search callbacks

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -126,13 +126,19 @@ class WebEngineSearch(browsertab.AbstractSearch):
     def __init__(self, parent=None):
         super().__init__(parent)
         self._flags = QWebEnginePage.FindFlags(0)
+        self.num_of_searches = 0
 
     def _find(self, text, flags, callback, caller):
         """Call findText on the widget."""
         self.search_displayed = True
+        self.num_of_searches += 1
 
         def wrapped_callback(found):
             """Wrap the callback to do debug logging."""
+            self.num_of_searches -= 1
+            if self.num_of_searches > 0:
+                return
+
             found_text = 'found' if found else "didn't find"
             if flags:
                 flag_text = 'with flags {}'.format(debug.qflags_key(


### PR DESCRIPTION
Should fix #2442. Keeping a count may be overkill, as it seems like there are never more than 2 searches going at once.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3299)
<!-- Reviewable:end -->
