### PR TITLE
Implement :edit-command.

### DIFF
--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -24,7 +24,7 @@ from PyQt5.QtWidgets import QSizePolicy
 
 from qutebrowser.keyinput import modeman, modeparsers
 from qutebrowser.commands import cmdexc, cmdutils
-from qutebrowser.misc import cmdhistory
+from qutebrowser.misc import cmdhistory, editor
 from qutebrowser.misc import miscwidgets as misc
 from qutebrowser.utils import usertypes, log, objreg
 
@@ -165,6 +165,23 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         self.history.append(text)
         modeman.leave(self._win_id, usertypes.KeyMode.command, 'cmd accept')
         self.got_cmd[str].emit(prefixes[text[0]] + text[1:])
+
+    @cmdutils.register(instance='status-command', scope='window', maxsplit=0)
+    def edit_command(self, run=False):
+        """Open an editor to modify the current command.
+
+        Args:
+            run: Run the command if the editor exits successfully.
+        """
+        ed = editor.ExternalEditor(parent=self)
+
+        def callback(text):
+            self.set_cmd_text(text)
+            if run:
+                self.got_cmd[str].emit(text)
+
+        ed.editing_finished.connect(callback)
+        ed.edit(self.text())
 
     @pyqtSlot(usertypes.KeyMode)
     def on_mode_left(self, mode):

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -166,7 +166,7 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         modeman.leave(self._win_id, usertypes.KeyMode.command, 'cmd accept')
         self.got_cmd[str].emit(prefixes[text[0]] + text[1:])
 
-    @cmdutils.register(instance='status-command', scope='window', maxsplit=0)
+    @cmdutils.register(instance='status-command', scope='window')
     def edit_command(self, run=False):
         """Open an editor to modify the current command.
 

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -141,3 +141,11 @@ Feature: Opening external editors
         And I wait for "Read back: bar" in the log
         And I run :click-element id qute-button
         Then the javascript message "text: bar" should be logged
+
+    ## :edit-command
+
+    Scenario: Edit a command and run it
+        When I run :set-cmd-text :message-info foo
+        And I set up a fake editor replacing "foo" by "bar"
+        And I run :edit-command --run
+        Then the message "bar" should be shown


### PR DESCRIPTION
:edit-command opens the current command line in an editor, and updates
the command line if the editor exits successfully. If --run is passed,
the command is executed when the editor exits sucessfully.

Resolves #2453.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3306)
<!-- Reviewable:end -->
