### PR TITLE
Lazy sessions

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1070,7 +1070,7 @@ Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-win
 Save a session.
 
 ==== positional arguments
-* +'name'+: The name of the session. If not given, the session configured in session_default_name is saved.
+* +'name'+: The name of the session. If not given, the session configured in session.default_name is saved.
 
 
 ==== optional arguments

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -222,7 +222,7 @@
 |<<qt.highdpi,qt.highdpi>>|Turn on Qt HighDPI scaling.
 |<<scrolling.bar,scrolling.bar>>|Show a scrollbar.
 |<<scrolling.smooth,scrolling.smooth>>|Enable smooth scrolling for web pages.
-|<<session_default_name,session_default_name>>|Name of the session to save by default.
+|<<session.default_name,session.default_name>>|Name of the session to save by default.
 |<<spellcheck.languages,spellcheck.languages>>|Languages to use for spell checking.
 |<<statusbar.hide,statusbar.hide>>|Hide the statusbar unless a message is shown.
 |<<statusbar.padding,statusbar.padding>>|Padding (in pixels) for the statusbar.
@@ -2554,8 +2554,8 @@ Type: <<types,Bool>>
 
 Default: +pass:[false]+
 
-[[session_default_name]]
-=== session_default_name
+[[session.default_name]]
+=== session.default_name
 Name of the session to save by default.
 If this is set to null, the session which was last loaded is saved.
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -29,6 +29,7 @@ import os
 import time
 import textwrap
 import mimetypes
+import urllib
 
 import pkg_resources
 from PyQt5.QtCore import QUrlQuery, QUrl
@@ -431,8 +432,9 @@ def qute_back(url):
 
     Simple page to free ram / lazy load a site, goes back on focusing the tab.
     """
-    html = jinja.render('back.html',
-                        title='Suspended: ' + url.fragment())
+    html = jinja.render(
+            'back.html',
+            title='Suspended: ' + urllib.parse.unquote(url.fragment()))
     return 'text/html', html
 
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -424,6 +424,13 @@ def qute_settings(url):
                         confget=config.instance.get_str)
     return 'text/html', html
 
+@add_handler('back')
+def qute_back(url):
+    """Handler for qute://back. Simple page to free ram / lazy load a site,
+    goes back on focusing the tab."""
+
+    html = jinja.render('back.html', title='Suspended')
+    return 'text/html', html
 
 @add_handler('configdiff')
 def qute_configdiff(url):

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -427,10 +427,12 @@ def qute_settings(url):
 
 @add_handler('back')
 def qute_back(url):
-    """Handler for qute://back. Simple page to free ram / lazy load a site,
-    goes back on focusing the tab."""
+    """Handler for qute://back.
 
-    html = jinja.render('back.html', title='Suspended')
+    Simple page to free ram / lazy load a site, goes back on focusing the tab.
+    """
+    html = jinja.render('back.html',
+                        title='Suspended: ' + url.url().split('#')[-1])
     return 'text/html', html
 
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -424,6 +424,7 @@ def qute_settings(url):
                         confget=config.instance.get_str)
     return 'text/html', html
 
+
 @add_handler('back')
 def qute_back(url):
     """Handler for qute://back. Simple page to free ram / lazy load a site,
@@ -431,6 +432,7 @@ def qute_back(url):
 
     html = jinja.render('back.html', title='Suspended')
     return 'text/html', html
+
 
 @add_handler('configdiff')
 def qute_configdiff(url):

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -432,7 +432,7 @@ def qute_back(url):
     Simple page to free ram / lazy load a site, goes back on focusing the tab.
     """
     html = jinja.render('back.html',
-                        title='Suspended: ' + url.url().split('#')[-1])
+                        title='Suspended: ' + url.fragment())
     return 'text/html', html
 
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -92,9 +92,7 @@ session.default_name:
     If this is set to null, the session which was last loaded is saved.
 
 session.lazy_restore:
-  type:
-    name: Bool
-    none_ok: true
+  type: Bool
   default: false
   desc: Load a restored tab as soon as it takes focus.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -79,6 +79,9 @@ new_instance_open_target_window:
     When `new_instance_open_target` is not set to `window`, this is ignored.
 
 session_default_name:
+  renamed: session.default_name
+
+session.default_name:
   type:
     name: SessionName
     none_ok: true
@@ -88,13 +91,12 @@ session_default_name:
 
     If this is set to null, the session which was last loaded is saved.
 
-session_lazy_restore:
+session.lazy_restore:
   type:
     name: Bool
     none_ok: true
   default: false
-  desc: >-
-    Load a restored tab as soon as it takes focus.
+  desc: Load a restored tab as soon as it takes focus.
 
 backend:
   type:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -88,6 +88,14 @@ session_default_name:
 
     If this is set to null, the session which was last loaded is saved.
 
+session_lazy_restore:
+  type:
+    name: Bool
+    none_ok: true
+  default: false
+  desc: >-
+    Load a restored tab as soon as it takes focus.
+
 backend:
   type:
     name: String

--- a/qutebrowser/html/back.html
+++ b/qutebrowser/html/back.html
@@ -12,5 +12,5 @@ setTimeout(function() {
 {% endblock %}
 
 {% block content %}
-<noscript><p class="noscript-text">Javascript isn't enabled. So you need to manually go back in history to restore this tab.</p></noscript>
+<noscript><p>Javascript isn't enabled. So you need to manually go back in history to restore this tab.</p></noscript>
 {% endblock %}

--- a/qutebrowser/html/back.html
+++ b/qutebrowser/html/back.html
@@ -6,9 +6,17 @@ window.onload = function() {
 	var node = document.getElementsByTagName('h1')[0];
 	node.innerText = document.title = title;
 };
-window.onfocus = function() {
-	window.history.back();
-};
+setTimeout(function() {
+	/* drop first focus event, to avoid problems
+	(allow to go easily to newer history entries) */
+	var triggered = false;
+	window.onfocus = function() {
+		if (! triggered) {
+			triggered = true;
+			window.history.back();
+		}
+	};
+}, 1000);
 {% endblock %}
 
 {% block content %}

--- a/qutebrowser/html/back.html
+++ b/qutebrowser/html/back.html
@@ -1,26 +1,16 @@
 {% extends "base.html" %}
 
 {% block script %}
-window.onload = function() {
-	var title = 'Suspended: ' + document.location.hash.substr(1);
-	var node = document.getElementsByTagName('h1')[0];
-	node.innerText = document.title = title;
-};
 setTimeout(function() {
 	/* drop first focus event, to avoid problems
 	(allow to go easily to newer history entries) */
-	var triggered = false;
 	window.onfocus = function() {
-		if (! triggered) {
-			triggered = true;
-			window.history.back();
-		}
+		window.onfocus = null;
+		window.history.back();
 	};
 }, 1000);
 {% endblock %}
 
 {% block content %}
-<noscript><h1 class="noscript">View Only</h1><p class="noscript-text">Changing settings requires javascript to be enabled!</p></noscript>
-<header><h1>{{ title }}</h1></header>
-
+<noscript><p class="noscript-text">Javascript isn't enabled. So you need to manually go back in history to restore this tab.</p></noscript>
 {% endblock %}

--- a/qutebrowser/html/back.html
+++ b/qutebrowser/html/back.html
@@ -1,0 +1,18 @@
+{% extends "base.html" %}
+
+{% block script %}
+window.onload = function() {
+	var title = 'Suspended: ' + document.location.hash.substr(1);
+	var node = document.getElementsByTagName('h1')[0];
+	node.innerText = document.title = title;
+};
+window.onfocus = function() {
+	window.history.back();
+};
+{% endblock %}
+
+{% block content %}
+<noscript><h1 class="noscript">View Only</h1><p class="noscript-text">Changing settings requires javascript to be enabled!</p></noscript>
+<header><h1>{{ title }}</h1></header>
+
+{% endblock %}

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -22,6 +22,7 @@
 import os
 import os.path
 import itertools
+import urllib
 
 import sip
 from PyQt5.QtCore import QUrl, QObject, QPoint, QTimer
@@ -372,7 +373,9 @@ class SessionManager(QObject):
                 lazy_index = i + 1
                 lazy_load.append({
                     'title': histentry['title'],
-                    'url': 'qute://back#' + histentry['title'],
+                    'url':
+                        'qute://back#' +
+                        urllib.parse.quote(histentry['title']),
                     'active': True
                 })
                 histentry['active'] = False

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -205,7 +205,11 @@ class SessionManager(QObject):
         for idx, item in enumerate(tab.history):
             qtutils.ensure_valid(item)
             item_data = self._save_tab_item(tab, idx, item)
-            data['history'].append(item_data)
+            if item_data['url'].startswith('qute://back'):
+                if 'active' in item_data and data['history']:
+                    data['history'][-1]['active'] = item_data.get('active', False)
+            else:
+                data['history'].append(item_data)
         return data
 
     def _save_all(self, *, only_window=None, with_private=False):

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -207,7 +207,8 @@ class SessionManager(QObject):
             item_data = self._save_tab_item(tab, idx, item)
             if item_data['url'].startswith('qute://back'):
                 if 'active' in item_data and data['history']:
-                    data['history'][-1]['active'] = item_data.get('active', False)
+                    data['history'][-1]['active'] = \
+                        item_data.get('active', False)
             else:
                 data['history'].append(item_data)
         return data

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -330,9 +330,6 @@ class SessionManager(QObject):
         """Load yaml data into a newly opened tab."""
         entries = []
 
-        if config.val.session_lazy_restore and data['history']:
-            last = data['history'][-1]
-
         for i, histentry in enumerate(data['history']):
             user_data = {}
 
@@ -370,7 +367,6 @@ class SessionManager(QObject):
                     })
                 histentry['active'] = False
 
-            print(histentry)
             active = histentry.get('active', False)
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))
             if 'original-url' in histentry:

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -370,10 +370,10 @@ class SessionManager(QObject):
                 # remove "active" mark and insert back page marked as active
                 lazy_index = i + 1
                 lazy_load.append({
-                        'title': histentry['title'],
-                        'url': 'qute://back#' + histentry['title'],
-                        'active': True
-                    })
+                    'title': histentry['title'],
+                    'url': 'qute://back#' + histentry['title'],
+                    'active': True
+                })
                 histentry['active'] = False
 
             active = histentry.get('active', False)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -206,9 +206,8 @@ class SessionManager(QObject):
             qtutils.ensure_valid(item)
             item_data = self._save_tab_item(tab, idx, item)
             if item_data['url'].startswith('qute://back'):
-                if 'active' in item_data and data['history']:
-                    data['history'][-1]['active'] = \
-                        item_data.get('active', False)
+                if item_data.get('active', False) and data['history']:
+                    data['history'][-1]['active'] = True
             else:
                 data['history'].append(item_data)
         return data

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -21,8 +21,7 @@
 
 import os
 import os.path
-
-from itertools import chain, dropwhile, takewhile
+import itertools
 
 import sip
 from PyQt5.QtCore import QUrl, QObject, QPoint, QTimer
@@ -207,7 +206,7 @@ class SessionManager(QObject):
         for idx, item in enumerate(tab.history):
             qtutils.ensure_valid(item)
             item_data = self._save_tab_item(tab, idx, item)
-            if item.url().url().startswith('qute://back'):
+            if item.url().scheme() == 'qute' and item.url().host() == 'back':
                 # don't add qute://back to the session file
                 if item_data.get('active', False) and data['history']:
                     # mark entry before qute://back as active
@@ -335,10 +334,12 @@ class SessionManager(QObject):
         # use len(data['history'])
         # -> dropwhile empty if not session.lazy_session
         lazy_index = len(data['history'])
-        gen = chain(
-            takewhile(lambda _: not lazy_load, enumerate(data['history'])),
-            enumerate(lazy_load),
-            dropwhile(lambda i: i[0] < lazy_index, enumerate(data['history'])))
+        gen = itertools.chain(
+                itertools.takewhile(lambda _: not lazy_load,
+                                    enumerate(data['history'])),
+                enumerate(lazy_load),
+                itertools.dropwhile(lambda i: i[0] < lazy_index,
+                                    enumerate(data['history'])))
 
         for i, histentry in gen:
             user_data = {}

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -348,8 +348,8 @@ class SessionManager(QObject):
                 new_tab.data.pinned = histentry['pinned']
 
             active = (histentry.get('active', False) and
-                     (not config.val.session_lazy_restore or
-                      histentry['url'].startswith('qute://')))
+                        (not config.val.session_lazy_restore or
+                        histentry['url'].startswith('qute://')))
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))
             if 'original-url' in histentry:
                 orig_url = QUrl.fromEncoded(
@@ -370,8 +370,10 @@ class SessionManager(QObject):
             active = last.get('active', False)
 
             if not last['url'].startswith('qute://'):
-                entries.append(TabHistoryItem(url=QUrl.fromEncoded(url.encode('ascii')),
-                                              title=title, active=active, user_data={}))
+                entries.append(TabHistoryItem(
+                    url=QUrl.fromEncoded(url.encode('ascii')),
+                    title=title, active=active, user_data={}))
+
                 if active:
                     new_tab.title_changed.emit(title)
 

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -170,7 +170,7 @@ class TestSaveAll:
 ])
 def test_get_session_name(config_stub, sess_man, arg, config, current,
                           expected):
-    config_stub.val.session_default_name = config
+    config_stub.val.session.default_name = config
     sess_man._current = current
     assert sess_man._get_session_name(arg) == expected
 


### PR DESCRIPTION
Lazily restore sessions:  
  
I added an option "session_lazy_restore"(1) which allows to expand the history on restoring a tab.  
The new history entry is the page qute://back which simply executes window.history.back() as soon as it receives a focus event.  
  
Use cases:  

- reduce load
- reduce (mobile) data usage
- avoid auto play 

(1) I named it like "session_default_name".  
However shouldn't it be named "session.default_name" and "session.lazy_restore", so it would fit to the other entries?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3309)
<!-- Reviewable:end -->
