### PR TITLE
Exit command mode after :edit-command --run.

### DIFF
--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -178,7 +178,7 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         def callback(text):
             self.set_cmd_text(text)
             if run:
-                self.got_cmd[str].emit(text)
+                self.command_accept()
 
         ed.editing_finished.connect(callback)
         ed.edit(self.text())

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -149,3 +149,4 @@ Feature: Opening external editors
         And I set up a fake editor replacing "foo" by "bar"
         And I run :edit-command --run
         Then the message "bar" should be shown
+        And "Leaving mode KeyMode.command (reason: cmd accept)" should be logged


### PR DESCRIPTION
Resolves #3317, where the command prompt was left open and populated
with text after running the command.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3318)
<!-- Reviewable:end -->
