### PR TITLE
Add option to persist current mode on tab change

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1235,6 +1235,11 @@ tabs.padding:
   type: Padding
   desc: Padding (in pixels) around text for tabs.
 
+tabs.persist_mode_on_change:
+  default: false
+  type: Bool
+  desc: When switching tabs, retain the current mode.
+
 tabs.position:
   default: top
   type: Position

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -652,9 +652,10 @@ class TabbedBrowser(tabwidget.TabWidget):
 
         log.modes.debug("Current tab changed, focusing {!r}".format(tab))
         tab.setFocus()
-        for mode in [usertypes.KeyMode.hint, usertypes.KeyMode.insert,
-                     usertypes.KeyMode.caret, usertypes.KeyMode.passthrough]:
-            modeman.leave(self._win_id, mode, 'tab changed', maybe=True)
+        if not config.val.tabs.persist_mode_on_change:
+            for mode in [usertypes.KeyMode.hint, usertypes.KeyMode.insert,
+                         usertypes.KeyMode.caret, usertypes.KeyMode.passthrough]:
+                modeman.leave(self._win_id, mode, 'tab changed', maybe=True)
         if self._now_focused is not None:
             objreg.register('last-focused-tab', self._now_focused, update=True,
                             scope='window', window=self._win_id)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -654,7 +654,8 @@ class TabbedBrowser(tabwidget.TabWidget):
         tab.setFocus()
         if not config.val.tabs.persist_mode_on_change:
             for mode in [usertypes.KeyMode.hint, usertypes.KeyMode.insert,
-                         usertypes.KeyMode.caret, usertypes.KeyMode.passthrough]:
+                         usertypes.KeyMode.caret,
+                         usertypes.KeyMode.passthrough]:
                 modeman.leave(self._win_id, mode, 'tab changed', maybe=True)
         if self._now_focused is not None:
             objreg.register('last-focused-tab', self._now_focused, update=True,


### PR DESCRIPTION
Implements #3065. The current behaviour is retained by default, with a config option added to enable the new behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3323)
<!-- Reviewable:end -->

---

edit by @the-compiler: Closes #3065