### PR TITLE
Abort :edit-command on invalid input.

### DIFF
--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -26,7 +26,7 @@ from qutebrowser.keyinput import modeman, modeparsers
 from qutebrowser.commands import cmdexc, cmdutils
 from qutebrowser.misc import cmdhistory, editor
 from qutebrowser.misc import miscwidgets as misc
-from qutebrowser.utils import usertypes, log, objreg
+from qutebrowser.utils import usertypes, log, objreg, message
 
 
 class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
@@ -176,6 +176,10 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         ed = editor.ExternalEditor(parent=self)
 
         def callback(text):
+            if not text or text[0] not in modeparsers.STARTCHARS:
+                message.error('command must start with one of {}'
+                              .format(modeparsers.STARTCHARS))
+                return
             self.set_cmd_text(text)
             if run:
                 self.command_accept()

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -150,3 +150,16 @@ Feature: Opening external editors
         And I run :edit-command --run
         Then the message "bar" should be shown
         And "Leaving mode KeyMode.command (reason: cmd accept)" should be logged
+
+    Scenario: Edit a command and omit the start char
+        When I set up a fake editor returning "message-info foo"
+        And I run :edit-command
+        Then the error "command must start with one of :/?" should be shown
+        And "Leaving mode KeyMode.command *" should not be logged
+
+    Scenario: Edit a command to be empty
+        When I run :set-cmd-text :
+        When I set up a fake editor returning empty text
+        And I run :edit-command
+        Then the error "command must start with one of :/?" should be shown
+        And "Leaving mode KeyMode.command *" should not be logged

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -58,3 +58,8 @@ def set_up_editor(quteproc, server, tmpdir, text):
     """.format(text=text)))
     editor = json.dumps([sys.executable, str(script), '{}'])
     quteproc.set_setting('editor.command', editor)
+
+@bdd.when(bdd.parsers.parse('I set up a fake editor returning empty text'))
+def set_up_editor_empty(quteproc, server, tmpdir):
+    """Set up editor.command to a small python script inserting empty text."""
+    set_up_editor(quteproc, server, tmpdir, "")


### PR DESCRIPTION
Show an error message if the user edits the command such that it is
missing a start character (:, /, or ?). Previously, this would cause the
browser to crash.

Resolves #3326.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3328)
<!-- Reviewable:end -->
