### PR TITLE
Fix undercounting short hints

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -446,8 +446,17 @@ class HintManager(QObject):
         # Short hints are the number of hints we can possibly show which are
         # (needed - 1) digits in length.
         if needed > min_chars:
-            short_count = math.floor((len(chars) ** needed - len(elems)) /
-                                     len(chars))
+            total_space = len(chars) ** needed
+            # Calculate short_count naively, by finding the avaiable space and
+            # dividing by the number of spots we would loose by adding a
+            # short element
+            short_count = math.floor((total_space - len(elems)) /
+                                     (len(chars)))
+            # Check if we double counted above to warrant another short_count
+            # https://github.com/qutebrowser/qutebrowser/issues/3242
+            if total_space - (short_count * len(chars) +
+                              (len(elems) - short_count)) >= len(chars) - 1:
+                short_count += 1
         else:
             short_count = 0
 

--- a/tests/end2end/test_hints_html.py
+++ b/tests/end2end/test_hints_html.py
@@ -22,11 +22,16 @@
 import os
 import os.path
 import textwrap
+import string
+import functools
+import operator
 
 import attr
 import yaml
 import pytest
 import bs4
+
+import qutebrowser.browser.hints
 
 
 def collect_tests():
@@ -146,3 +151,45 @@ def test_word_hints_issue1393(quteproc, tmpdir):
         quteproc.wait_for(message='hints: *', category='hints')
         quteproc.send_cmd(':follow-hint {}'.format(hint))
         quteproc.wait_for_load_finished('data/{}'.format(target))
+
+
+@pytest.mark.parametrize('min_len', [0, 3])
+@pytest.mark.parametrize('num_chars', [9])
+@pytest.mark.parametrize('num_elements', range(1, 26))
+def test_scattered_hints_count(win_registry, mode_manager, min_len,
+                               num_chars, num_elements):
+    """Test scattered hints function."""
+    # pylint: disable=W0141
+    manager = qutebrowser.browser.hints.HintManager(0, 0)
+    chars = string.ascii_lowercase[:num_chars]
+
+    hints = manager._hint_scattered(min_len, chars,
+                                    list(range(num_elements)))
+
+    # Check if hints are unique
+    assert len(hints) == len(set(hints))
+
+    # Check if any hints are shorter than min_len
+    assert not any([x for x in hints if len(x) < min_len])
+
+    # Check we don't have more than 2 link lengths
+    # Eg: 'a' 'bc' and 'def' cannot be in the same hint string
+    hint_lens = set(map(len, hints))
+    assert len(hint_lens) <= 2
+
+    if len(hint_lens) == 2:
+        # Check if hint_lens are more than 1 apart
+        # Eg: 'abc' and 'd' cannot be in the same hint sequence, but
+        # 'ab' and 'c' can
+        assert abs(functools.reduce(operator.sub, hint_lens)) <= 1
+
+    longest_hints = filter(lambda x: len(x) == max(hint_lens), hints)
+
+    if min_len < max(hint_lens) - 1:
+        # Check if we have any unique prefixes. For example, 'la'
+        # alone, with no other 'l<x>'
+        count_map = {}
+        for x in longest_hints:
+            prefix = x[:-1]
+            count_map[prefix] = count_map.get(prefix, 0) + 1
+        assert not any(filter(lambda x: x == 1, count_map.values()))


### PR DESCRIPTION
Possible fix for https://github.com/qutebrowser/qutebrowser/issues/3242, although I would prefer another solution if someone can come up with one.

I've manually tested the edge cases, but I would like to add unit tests as well. Is it possible for me to contstruct a fake `HintManager` in a way that I can still call the `_hin_scattered` function? When I tried to construct one manually, I got errors for referring to a non-existent window.

Closes #3242

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3329)
<!-- Reviewable:end -->
