### PR TITLE
Register qutebrowser as a handler for qute:// links

### DIFF
--- a/misc/qutebrowser.desktop
+++ b/misc/qutebrowser.desktop
@@ -7,5 +7,5 @@ Categories=Network;WebBrowser;
 Exec=qutebrowser %u
 Terminal=false
 StartupNotify=false
-MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;
+MimeType=text/html;text/xml;application/xhtml+xml;application/xml;application/rdf+xml;image/gif;image/jpeg;image/png;x-scheme-handler/http;x-scheme-handler/https;x-scheme-handler/qute;
 Keywords=Browser


### PR DESCRIPTION
These links mostly occur within qutebrowser's documentation.  But the
are also written to the auto generated config file.  Clicking them in
any application that consults the desktop database (or uses xdg-open)
will thus open them in qutebrowser correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3330)
<!-- Reviewable:end -->
