### PR TITLE
Resolve crash when editor tab is closed.

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -22,6 +22,7 @@
 import enum
 import itertools
 
+import sip
 import attr
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, QObject, QSizeF, Qt
 from PyQt5.QtGui import QIcon
@@ -864,3 +865,6 @@ class AbstractTab(QWidget):
         except (AttributeError, RuntimeError) as exc:
             url = '<{}>'.format(exc.__class__.__name__)
         return utils.get_repr(self, tab_id=self.tab_id, url=url)
+
+    def is_deleted(self):
+        return sip.isdeleted(self._widget)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1621,6 +1621,9 @@ class CommandDispatcher:
         ed = editor.ExternalEditor(self._tabbed_browser)
         ed.editing_finished.connect(functools.partial(
             self.on_editing_finished, elem))
+        tab = self._current_widget()
+        tab.shutting_down.connect(functools.partial(
+            self.on_editor_orphaned, ed))
         ed.edit(text, caret_position)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
@@ -1646,6 +1649,11 @@ class CommandDispatcher:
             elem.set_value(text)
         except webelem.Error as e:
             raise cmdexc.CommandError(str(e))
+
+    def on_editor_orphaned(self, ed):
+        ed.editing_finished.disconnect()
+        ed.editing_finished.connect(
+            lambda: message.warning('Edited element was closed'))
 
     @cmdutils.register(instance='command-dispatcher', maxsplit=0,
                        scope='window')

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1621,9 +1621,6 @@ class CommandDispatcher:
         ed = editor.ExternalEditor(self._tabbed_browser)
         ed.editing_finished.connect(functools.partial(
             self.on_editing_finished, elem))
-        tab = self._current_widget()
-        tab.shutting_down.connect(functools.partial(
-            self.on_editor_orphaned, ed))
         ed.edit(text, caret_position)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
@@ -1647,13 +1644,10 @@ class CommandDispatcher:
         """
         try:
             elem.set_value(text)
+        except webelem.OrphanedError as e:
+            message.warning('Edited element vanished')
         except webelem.Error as e:
             raise cmdexc.CommandError(str(e))
-
-    def on_editor_orphaned(self, ed):
-        ed.editing_finished.disconnect()
-        ed.editing_finished.connect(
-            lambda: message.warning('Edited element vanished'))
 
     @cmdutils.register(instance='command-dispatcher', maxsplit=0,
                        scope='window')

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1653,7 +1653,7 @@ class CommandDispatcher:
     def on_editor_orphaned(self, ed):
         ed.editing_finished.disconnect()
         ed.editing_finished.connect(
-            lambda: message.warning('Edited element was closed'))
+            lambda: message.warning('Edited element vanished'))
 
     @cmdutils.register(instance='command-dispatcher', maxsplit=0,
                        scope='window')

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -60,6 +60,13 @@ class Error(Exception):
     pass
 
 
+class OrphanedError(Exception):
+
+    """Raised when a webelement's parent has vanished."""
+
+    pass
+
+
 class AbstractWebElement(collections.abc.MutableMapping):
 
     """A wrapper around QtWebKit/QtWebEngine web element.

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -100,6 +100,8 @@ class WebEngineElement(webelem.AbstractWebElement):
 
     def _js_call(self, name, *args, callback=None):
         """Wrapper to run stuff from webelem.js."""
+        if self._tab.is_deleted():
+            raise webelem.OrphanedError("Tab containing element vanished")
         js_code = javascript.assemble('webelem', name, self._id, *args)
         self._tab.run_js_async(js_code, callback=callback)
 

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -118,6 +118,8 @@ class WebKitElement(webelem.AbstractWebElement):
 
     def set_value(self, value):
         self._check_vanished()
+        if self._tab.is_deleted():
+            raise webelem.OrphanedError("Tab containing element vanished")
         if self.is_content_editable():
             log.webelem.debug("Filling {!r} via set_text.".format(self))
             self._elem.setPlainText(value)

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -115,6 +115,16 @@ Feature: Opening external editors
         And I run :click-element id qute-button
         Then the javascript message "text: foobar" should be logged
 
+    Scenario: Spawning an editor and closing the tab
+        When I set up a fake editor returning "foo" after 1s
+        And I open data/editor.html
+        And I run :click-element id qute-textarea
+        And I wait for "Entering mode KeyMode.insert (reason: clicking input)" in the log
+        And I run :open-editor
+        And I set tabs.last_close to blank
+        And I run :tab-close
+        Then the warning "Edited element was closed" should be shown
+
     @qtwebengine_todo: Caret mode is not implemented yet
     Scenario: Spawning an editor in caret mode
         When I set up a fake editor returning "foobar"

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -115,6 +115,8 @@ Feature: Opening external editors
         And I run :click-element id qute-button
         Then the javascript message "text: foobar" should be logged
 
+    # Could not get signals working on Windows
+    @posix
     Scenario: Spawning an editor and closing the tab
         When I set up a fake editor that waits
         And I open data/editor.html

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -116,14 +116,15 @@ Feature: Opening external editors
         Then the javascript message "text: foobar" should be logged
 
     Scenario: Spawning an editor and closing the tab
-        When I set up a fake editor returning "foo" after 1s
+        When I set up a fake editor that waits
         And I open data/editor.html
         And I run :click-element id qute-textarea
         And I wait for "Entering mode KeyMode.insert (reason: clicking input)" in the log
         And I run :open-editor
         And I set tabs.last_close to blank
         And I run :tab-close
-        Then the warning "Edited element was closed" should be shown
+        And I kill the waiting editor
+        Then the warning "Edited element vanished" should be shown
 
     @qtwebengine_todo: Caret mode is not implemented yet
     Scenario: Spawning an editor in caret mode

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -82,12 +82,8 @@ def set_up_editor_wait(quteproc, server, tmpdir):
         with open(r'{pidfile}', 'w') as f:
             f.write(str(os.getpid()))
 
-        signal.signal(signal.SIGINT, lambda s, f: sys.exit(0))
-
-        try:
-            time.sleep(100)
-        except InterruptedError:
-            pass
+        signal.signal(signal.SIGUSR1, lambda s, f: sys.exit(0))
+        time.sleep(100)
     """.format(pidfile=pidfile)))
     editor = json.dumps([sys.executable, str(script), '{}'])
     quteproc.set_setting('editor.command', editor)
@@ -98,4 +94,4 @@ def kill_editor_wait(quteproc, server, tmpdir):
     """Kill the waiting editor."""
     pidfile = tmpdir / 'editor_pid'
     pid = int(pidfile.read())
-    os.kill(pid, signal.SIGINT)
+    os.kill(pid, signal.SIGUSR1)

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -79,10 +79,10 @@ def set_up_editor_wait(quteproc, server, tmpdir):
         import time
         import signal
 
-        with open('{pidfile}', 'w') as f:
+        with open(r'{pidfile}', 'w') as f:
             f.write(str(os.getpid()))
 
-        signal.signal(signal.SIGUSR1, lambda s, f: sys.exit(0))
+        signal.signal(signal.SIGTERM, lambda s, f: sys.exit(0))
 
         time.sleep(100)
     """.format(pidfile=pidfile)))
@@ -95,4 +95,4 @@ def kill_editor_wait(quteproc, server, tmpdir):
     """Kill the waiting editor."""
     pidfile = tmpdir / 'editor_pid'
     pid = int(pidfile.read())
-    os.kill(pid, signal.SIGUSR1)
+    os.kill(pid, signal.SIGTERM)

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -64,3 +64,21 @@ def set_up_editor(quteproc, server, tmpdir, text):
 def set_up_editor_empty(quteproc, server, tmpdir):
     """Set up editor.command to a small python script inserting empty text."""
     set_up_editor(quteproc, server, tmpdir, "")
+
+
+@bdd.when(bdd.parsers.parse(
+    'I set up a fake editor returning "{text}" after {t}s'))
+def set_up_editor_delay(quteproc, server, tmpdir, text, t):
+    """Set up editor.command to a small python script inserting a text."""
+    script = tmpdir / 'script.py'
+    script.write(textwrap.dedent("""
+        import sys
+        import time
+
+        time.sleep({t})
+
+        with open(sys.argv[1], 'w', encoding='utf-8') as f:
+            f.write({text!r})
+    """.format(text=text, t=t)))
+    editor = json.dumps([sys.executable, str(script), '{}'])
+    quteproc.set_setting('editor.command', editor)

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -94,4 +94,7 @@ def kill_editor_wait(quteproc, server, tmpdir):
     """Kill the waiting editor."""
     pidfile = tmpdir / 'editor_pid'
     pid = int(pidfile.read())
+    # windows has no SIGUSR1, but we don't run this on windows anyways
+    # for posix, there IS a member so we need to ignore useless-suppression
+    # pylint: disable=no-member,useless-suppression
     os.kill(pid, signal.SIGUSR1)

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -82,9 +82,12 @@ def set_up_editor_wait(quteproc, server, tmpdir):
         with open(r'{pidfile}', 'w') as f:
             f.write(str(os.getpid()))
 
-        signal.signal(signal.SIGTERM, lambda s, f: sys.exit(0))
+        signal.signal(signal.SIGINT, lambda s, f: sys.exit(0))
 
-        time.sleep(100)
+        try:
+            time.sleep(100)
+        except InterruptedError:
+            pass
     """.format(pidfile=pidfile)))
     editor = json.dumps([sys.executable, str(script), '{}'])
     quteproc.set_setting('editor.command', editor)
@@ -95,4 +98,4 @@ def kill_editor_wait(quteproc, server, tmpdir):
     """Kill the waiting editor."""
     pidfile = tmpdir / 'editor_pid'
     pid = int(pidfile.read())
-    os.kill(pid, signal.SIGTERM)
+    os.kill(pid, signal.SIGINT)

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -20,6 +20,8 @@
 import sys
 import json
 import textwrap
+import os
+import signal
 
 import pytest_bdd as bdd
 bdd.scenarios('editor.feature')
@@ -66,19 +68,31 @@ def set_up_editor_empty(quteproc, server, tmpdir):
     set_up_editor(quteproc, server, tmpdir, "")
 
 
-@bdd.when(bdd.parsers.parse(
-    'I set up a fake editor returning "{text}" after {t}s'))
-def set_up_editor_delay(quteproc, server, tmpdir, text, t):
+@bdd.when(bdd.parsers.parse('I set up a fake editor that waits'))
+def set_up_editor_wait(quteproc, server, tmpdir):
     """Set up editor.command to a small python script inserting a text."""
+    pidfile = tmpdir / 'editor_pid'
     script = tmpdir / 'script.py'
     script.write(textwrap.dedent("""
+        import os
         import sys
         import time
+        import signal
 
-        time.sleep({t})
+        with open('{pidfile}', 'w') as f:
+            f.write(str(os.getpid()))
 
-        with open(sys.argv[1], 'w', encoding='utf-8') as f:
-            f.write({text!r})
-    """.format(text=text, t=t)))
+        signal.signal(signal.SIGUSR1, lambda s, f: sys.exit(0))
+
+        time.sleep(100)
+    """.format(pidfile=pidfile)))
     editor = json.dumps([sys.executable, str(script), '{}'])
     quteproc.set_setting('editor.command', editor)
+
+
+@bdd.when(bdd.parsers.parse('I kill the waiting editor'))
+def kill_editor_wait(quteproc, server, tmpdir):
+    """Kill the waiting editor."""
+    pidfile = tmpdir / 'editor_pid'
+    pid = int(pidfile.read())
+    os.kill(pid, signal.SIGUSR1)

--- a/tests/unit/browser/webkit/test_webkitelem.py
+++ b/tests/unit/browser/webkit/test_webkitelem.py
@@ -29,7 +29,7 @@ import pytest
 from PyQt5.QtCore import QRect, QPoint, QUrl
 QWebElement = pytest.importorskip('PyQt5.QtWebKit').QWebElement
 
-from qutebrowser.browser import webelem
+from qutebrowser.browser import webelem, browsertab
 from qutebrowser.browser.webkit import webkitelem
 from qutebrowser.misc import objects
 from qutebrowser.utils import usertypes
@@ -127,7 +127,9 @@ def get_webelem(geometry=None, frame=None, *, null=False, style=None,
         return style_dict[name]
 
     elem.styleProperty.side_effect = _style_property
-    wrapped = webkitelem.WebKitElement(elem, tab=None)
+    tab = mock.Mock(autospec=browsertab.AbstractTab)
+    tab.is_deleted.return_value = False
+    wrapped = webkitelem.WebKitElement(elem, tab=tab)
     return wrapped
 
 


### PR DESCRIPTION
If an editor is open on a form in a tab and that tab is closed, rewire
the callback to print a warning. Previously, the callback would access a
deleted C++ object and cause a crash.
Resolves #2758.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3333)
<!-- Reviewable:end -->
