### PR TITLE
ipc: change level fro "Opening in existing instance"

### DIFF
--- a/qutebrowser/misc/ipc.py
+++ b/qutebrowser/misc/ipc.py
@@ -437,7 +437,7 @@ def send_to_running_instance(socketname, command, target_arg, *, socket=None):
 
     connected = socket.waitForConnected(CONNECT_TIMEOUT)
     if connected:
-        log.ipc.info("Opening in existing instance")
+        log.ipc.debug("Opening in existing instance")
         json_data = {'args': command, 'target_arg': target_arg,
                      'version': qutebrowser.__version__,
                      'protocol_version': PROTOCOL_VERSION}


### PR DESCRIPTION
This is quite a common/normal message, and therefore is rather noisy
by default.

Had this in a local stash (and used `-l warning` in my wrapper script, likely because of this mostly).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3358)
<!-- Reviewable:end -->
