### PR TITLE
Add --output flag for :spawn.

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1148,7 +1148,7 @@ Set a mark at the current scroll position in the current tab.
 
 [[spawn]]
 === spawn
-Syntax: +:spawn [*--userscript*] [*--verbose*] [*--detach*] 'cmdline'+
+Syntax: +:spawn [*--userscript*] [*--verbose*] [*--output-to-tab*] [*--detach*] 'cmdline'+
 
 Spawn a command in a shell.
 
@@ -1163,6 +1163,7 @@ Spawn a command in a shell.
  - `/usr/share/qutebrowser/userscripts`
 
 * +*-v*+, +*--verbose*+: Show notifications when the command started/exited.
+* +*-v*+, +*--output-to-tab*+: Show stderr, stdout, and exit status in a new tab.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
 
 ==== note

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1148,7 +1148,7 @@ Set a mark at the current scroll position in the current tab.
 
 [[spawn]]
 === spawn
-Syntax: +:spawn [*--userscript*] [*--verbose*] [*--output-to-tab*] [*--detach*] 'cmdline'+
+Syntax: +:spawn [*--userscript*] [*--verbose*] [*--output*] [*--detach*] 'cmdline'+
 
 Spawn a command in a shell.
 
@@ -1163,7 +1163,7 @@ Spawn a command in a shell.
  - `/usr/share/qutebrowser/userscripts`
 
 * +*-v*+, +*--verbose*+: Show notifications when the command started/exited.
-* +*-v*+, +*--output-to-tab*+: Show stderr, stdout, and exit status in a new tab.
+* +*-o*+, +*--output*+: Whether the output should be shown in a new tab.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
 
 ==== note

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1178,7 +1178,7 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_replace_variables=True)
     def spawn(self, cmdline, userscript=False, verbose=False,
-            output=False, detach=False):
+              output=False, detach=False):
         """Spawn a command in a shell.
 
         Args:
@@ -1218,7 +1218,7 @@ class CommandDispatcher:
 
         if output:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                    window='last-focused')
+                                        window='last-focused')
             tabbed_browser.openurl(QUrl('qute://spawn-output'), newtab=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1177,7 +1177,8 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_replace_variables=True)
-    def spawn(self, cmdline, userscript=False, verbose=False, detach=False):
+    def spawn(self, cmdline, userscript=False, verbose=False,
+            output_to_tab=False, detach=False):
         """Spawn a command in a shell.
 
         Args:
@@ -1208,7 +1209,8 @@ class CommandDispatcher:
         else:
             cmd = os.path.expanduser(cmd)
             proc = guiprocess.GUIProcess(what='command', verbose=verbose,
-                                         parent=self._tabbed_browser)
+                                         parent=self._tabbed_browser,
+                                         output_to_tab=output_to_tab)
             if detach:
                 proc.start_detached(cmd, args)
             else:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1178,7 +1178,7 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_replace_variables=True)
     def spawn(self, cmdline, userscript=False, verbose=False,
-            output_to_tab=False, detach=False):
+            output=False, detach=False):
         """Spawn a command in a shell.
 
         Args:
@@ -1189,6 +1189,7 @@ class CommandDispatcher:
                               (or `$XDG_DATA_DIR`)
                             - `/usr/share/qutebrowser/userscripts`
             verbose: Show notifications when the command started/exited.
+            output: Whether the output should be shown in a new tab.
             detach: Whether the command should be detached from qutebrowser.
             cmdline: The commandline to execute.
         """
@@ -1210,7 +1211,7 @@ class CommandDispatcher:
             cmd = os.path.expanduser(cmd)
             proc = guiprocess.GUIProcess(what='command', verbose=verbose,
                                          parent=self._tabbed_browser,
-                                         output_to_tab=output_to_tab)
+                                         output=output)
             if detach:
                 proc.start_detached(cmd, args)
             else:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1210,12 +1210,16 @@ class CommandDispatcher:
         else:
             cmd = os.path.expanduser(cmd)
             proc = guiprocess.GUIProcess(what='command', verbose=verbose,
-                                         parent=self._tabbed_browser,
-                                         output=output)
+                                         parent=self._tabbed_browser)
             if detach:
                 proc.start_detached(cmd, args)
             else:
                 proc.start(cmd, args)
+
+        if output:
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window='last-focused')
+            tabbed_browser.openurl(QUrl('qute://spawn-output'), newtab=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def home(self):

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -269,9 +269,9 @@ def qute_pyeval(_url):
     return 'text/html', html
 
 
-@add_handler('spawn_output')
+@add_handler('spawn-output')
 def qute_spawn_output(_url):
-    """Handler for qute://spawn_output."""
+    """Handler for qute://spawn-output."""
     html = jinja.render('pre.html', title='spawn output', content=spawn_output)
     return 'text/html', html
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -42,6 +42,7 @@ from qutebrowser.misc import objects
 
 
 pyeval_output = ":pyeval was never called"
+spawn_output = ":spawn was never called"
 
 
 _HANDLERS = {}
@@ -265,6 +266,13 @@ def qute_javascript(url):
 def qute_pyeval(_url):
     """Handler for qute://pyeval."""
     html = jinja.render('pre.html', title='pyeval', content=pyeval_output)
+    return 'text/html', html
+
+
+@add_handler('spawn_output')
+def qute_spawn_output(_url):
+    """Handler for qute://spawn_output."""
+    html = jinja.render('pre.html', title='spawn output', content=spawn_output)
     return 'text/html', html
 
 

--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -22,9 +22,11 @@
 import shlex
 
 from PyQt5.QtCore import (pyqtSlot, pyqtSignal, QObject, QProcess,
-                          QProcessEnvironment)
+                          QProcessEnvironment, QUrl)
 
-from qutebrowser.utils import message, log
+from qutebrowser.utils import message, log, objreg
+
+from qutebrowser.browser import qutescheme
 
 # A mapping of QProcess::ErrorCode's to human-readable strings.
 
@@ -62,10 +64,11 @@ class GUIProcess(QObject):
     started = pyqtSignal()
 
     def __init__(self, what, *, verbose=False, additional_env=None,
-                 parent=None):
+                 parent=None, output_to_tab=False):
         super().__init__(parent)
         self._what = what
         self.verbose = verbose
+        self.output_to_tab = output_to_tab
         self._started = False
         self.cmd = None
         self.args = None
@@ -96,6 +99,30 @@ class GUIProcess(QObject):
         self._started = False
         log.procs.debug("Process finished with code {}, status {}.".format(
             code, status))
+
+        stdout = None
+        stderr = None
+
+        if self.output_to_tab:
+            stderr = bytes(self._proc.readAllStandardError()).decode('utf-8')
+            stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8')
+
+            spawn_log = ""
+
+            spawn_log += "Process finished with code {},status {}.".format(
+                code, status)
+
+            if stdout:
+                spawn_log += "\nProcess stdout:\n" + stdout.strip()
+            if stderr:
+                spawn_log += "\nProcess stderr:\n" + stderr.strip()
+
+            qutescheme.spawn_output = spawn_log
+
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window='last-focused')
+            tabbed_browser.openurl(QUrl('qute://spawn_output'), newtab=True)
+
         if status == QProcess.CrashExit:
             message.error("{} crashed!".format(self._what.capitalize()))
         elif status == QProcess.NormalExit and code == 0:

--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -100,21 +100,18 @@ class GUIProcess(QObject):
         log.procs.debug("Process finished with code {}, status {}.".format(
             code, status))
 
+        stderr = bytes(self._proc.readAllStandardError()).decode('utf-8')
+        stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8')
+
+        spawn_log = "Process finished with code {}, status {}.".format(
+            code, status)
+
+        spawn_log += "\nProcess stdout:\n" + (stdout or "(No output)").strip()
+        spawn_log += "\nProcess stderr:\n" + (stderr or "(No output)").strip()
+
+        qutescheme.spawn_output = spawn_log
+
         if self._output:
-            stderr = bytes(self._proc.readAllStandardError()).decode('utf-8')
-            stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8')
-
-            stderr = stderr or "(No output)"
-            stdout = stdout or "(No output)"
-
-            spawn_log = "Process finished with code {}, status {}.".format(
-                code, status)
-
-            spawn_log += "\nProcess stdout:\n" + stdout.strip()
-            spawn_log += "\nProcess stderr:\n" + stderr.strip()
-
-            qutescheme.spawn_output = spawn_log
-
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window='last-focused')
             tabbed_browser.openurl(QUrl('qute://spawn-output'), newtab=True)
@@ -132,8 +129,6 @@ class GUIProcess(QObject):
             message.error("{} exited with status {}, see :messages for "
                           "details.".format(self._what.capitalize(), code))
 
-            stderr = bytes(self._proc.readAllStandardError()).decode('utf-8')
-            stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8')
             if stdout:
                 log.procs.error("Process stdout:\n" + stdout.strip())
             if stderr:

--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -101,7 +101,7 @@ class GUIProcess(QObject):
         stderr = bytes(self._proc.readAllStandardError()).decode('utf-8')
         stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8')
 
-        qutescheme.spawn_output = self.spawn_format(code, status,
+        qutescheme.spawn_output = self._spawn_format(code, status,
                                                     stdout, stderr)
 
         if status == QProcess.CrashExit:
@@ -122,7 +122,7 @@ class GUIProcess(QObject):
             if stderr:
                 log.procs.error("Process stderr:\n" + stderr.strip())
 
-    def spawn_format(self, code=0, status=0, stdout="", stderr=""):
+    def _spawn_format(self, code=0, status=0, stdout="", stderr=""):
         """Produce a formatted string for spawn output."""
         stdout = (stdout or "(No output)").strip()
         stderr = (stderr or "(No output)").strip()
@@ -130,7 +130,7 @@ class GUIProcess(QObject):
         spawn_string = ("Process finished with code {}, status {}\n"
                         "\nProcess stdout:\n {}"
                         "\nProcess stderr:\n {}").format(code, status,
-                                                       stdout, stderr)
+                                                         stdout, stderr)
         return spawn_string
 
     @pyqtSlot()

--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -82,6 +82,7 @@ def whitelist_generator():  # noqa
     yield 'qutebrowser.utils.jinja.Loader.get_source'
     yield 'qutebrowser.utils.log.QtWarningFilter.filter'
     yield 'qutebrowser.browser.pdfjs.is_available'
+    yield 'qutebrowser.misc.guiprocess.spawn_output'
     yield 'QEvent.posted'
     yield 'log_stack'  # from message.py
     yield 'propagate'  # logging.getLogger('...).propagate = False

--- a/tests/unit/misc/test_guiprocess.py
+++ b/tests/unit/misc/test_guiprocess.py
@@ -60,7 +60,7 @@ def test_start(proc, qtbot, message_mock, py_proc):
         proc.start(*argv)
 
     assert not message_mock.messages
-    assert qutescheme.spawn_output == proc.spawn_format(0, 0, stdout="test")
+    assert qutescheme.spawn_output == proc._spawn_format(stdout="test")
 
 
 def test_start_verbose(proc, qtbot, message_mock, py_proc):
@@ -77,24 +77,7 @@ def test_start_verbose(proc, qtbot, message_mock, py_proc):
     assert msgs[1].level == usertypes.MessageLevel.info
     assert msgs[0].text.startswith("Executing:")
     assert msgs[1].text == "Testprocess exited successfully."
-    assert qutescheme.spawn_output == proc.spawn_format(0, 0, stdout="test")
-
-
-def test_start_output(proc, qtbot, message_mock, py_proc):
-    """Test starting a process verbosely."""
-    proc.verbose = True
-
-    with qtbot.waitSignals([proc.started, proc.finished], timeout=10000,
-                           order='strict'):
-        argv = py_proc("import sys; print('test'); sys.exit(0)")
-        proc.start(*argv)
-
-    msgs = message_mock.messages
-    assert msgs[0].level == usertypes.MessageLevel.info
-    assert msgs[1].level == usertypes.MessageLevel.info
-    assert msgs[0].text.startswith("Executing:")
-    assert msgs[1].text == "Testprocess exited successfully."
-    assert qutescheme.spawn_output == proc.spawn_format(0, 0, stdout="test")
+    assert qutescheme.spawn_output == proc._spawn_format(stdout="test")
 
 
 def test_start_env(monkeypatch, qtbot, py_proc):

--- a/tests/unit/misc/test_guiprocess.py
+++ b/tests/unit/misc/test_guiprocess.py
@@ -19,7 +19,6 @@
 
 """Tests for qutebrowser.misc.guiprocess."""
 
-import json
 import logging
 
 import pytest
@@ -27,6 +26,7 @@ from PyQt5.QtCore import QProcess, QIODevice
 
 from qutebrowser.misc import guiprocess
 from qutebrowser.utils import usertypes
+from qutebrowser.browser import qutescheme
 
 
 @pytest.fixture()
@@ -60,7 +60,7 @@ def test_start(proc, qtbot, message_mock, py_proc):
         proc.start(*argv)
 
     assert not message_mock.messages
-    assert bytes(proc._proc.readAll()).rstrip() == b'test'
+    assert qutescheme.spawn_output == proc.spawn_format(0, 0, stdout="test")
 
 
 def test_start_verbose(proc, qtbot, message_mock, py_proc):
@@ -77,7 +77,24 @@ def test_start_verbose(proc, qtbot, message_mock, py_proc):
     assert msgs[1].level == usertypes.MessageLevel.info
     assert msgs[0].text.startswith("Executing:")
     assert msgs[1].text == "Testprocess exited successfully."
-    assert bytes(proc._proc.readAll()).rstrip() == b'test'
+    assert qutescheme.spawn_output == proc.spawn_format(0, 0, stdout="test")
+
+
+def test_start_output(proc, qtbot, message_mock, py_proc):
+    """Test starting a process verbosely."""
+    proc.verbose = True
+
+    with qtbot.waitSignals([proc.started, proc.finished], timeout=10000,
+                           order='strict'):
+        argv = py_proc("import sys; print('test'); sys.exit(0)")
+        proc.start(*argv)
+
+    msgs = message_mock.messages
+    assert msgs[0].level == usertypes.MessageLevel.info
+    assert msgs[1].level == usertypes.MessageLevel.info
+    assert msgs[0].text.startswith("Executing:")
+    assert msgs[1].text == "Testprocess exited successfully."
+    assert qutescheme.spawn_output == proc.spawn_format(0, 0, stdout="test")
 
 
 def test_start_env(monkeypatch, qtbot, py_proc):
@@ -99,10 +116,9 @@ def test_start_env(monkeypatch, qtbot, py_proc):
                            order='strict'):
         proc.start(*argv)
 
-    data = bytes(proc._proc.readAll()).decode('utf-8')
-    ret_env = json.loads(data)
-    assert 'QUTEBROWSER_TEST_1' in ret_env
-    assert 'QUTEBROWSER_TEST_2' in ret_env
+    data = qutescheme.spawn_output
+    assert 'QUTEBROWSER_TEST_1' in data
+    assert 'QUTEBROWSER_TEST_2' in data
 
 
 @pytest.mark.qt_log_ignore('QIODevice::read.*: WriteOnly device')


### PR DESCRIPTION
This puts the exit status, stdout, and stderr in a new tab when spawn is called with the flag.

This modifies guiprocess.py, so in principle the spawn_output variable could be renamed and used for other processes that could use a simple textual output.

This is my first public contribution to any software, please be gentle :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3374)
<!-- Reviewable:end -->
