### PR TITLE
Modify usage of re.match to fit re.fullmatch or re.search.

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -180,7 +180,7 @@ def transform_path(path):
     path = utils.expand_windows_drive(path)
     # Drive dependent working directories are not supported, e.g.
     # E:filename is invalid
-    if re.match(r'[A-Z]:[^\\]', path, re.IGNORECASE):
+    if re.fullmatch(r'[A-Z]:[^\\]', path, re.IGNORECASE):
         return None
     # Paths like COM1, ...
     # See https://github.com/qutebrowser/qutebrowser/issues/82

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -180,7 +180,7 @@ def transform_path(path):
     path = utils.expand_windows_drive(path)
     # Drive dependent working directories are not supported, e.g.
     # E:filename is invalid
-    if re.fullmatch(r'[A-Z]:[^\\]', path, re.IGNORECASE):
+    if re.search(r'^[A-Z]:[^\\]', path, re.IGNORECASE):
         return None
     # Paths like COM1, ...
     # See https://github.com/qutebrowser/qutebrowser/issues/82

--- a/qutebrowser/browser/webengine/spell.py
+++ b/qutebrowser/browser/webengine/spell.py
@@ -30,7 +30,7 @@ from qutebrowser.utils import log
 def version(filename):
     """Extract the version number from the dictionary file name."""
     version_re = re.compile(r".+-(?P<version>[0-9]+-[0-9]+?)\.bdic")
-    match = version_re.match(filename)
+    match = version_re.fullmatch(filename)
     if match is None:
         raise ValueError('the given dictionary file name is malformed: {}'
                          .format(filename))

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -963,7 +963,7 @@ class Font(BaseType):
     # Gets set when the config is initialized.
     monospace_fonts = None
     font_regex = re.compile(r"""
-        ^(
+        (
             (
                 # style
                 (?P<style>normal|italic|oblique) |
@@ -976,14 +976,14 @@ class Font(BaseType):
                 (?P<size>[0-9]+((\.[0-9]+)?[pP][tT]|[pP][xX]))
             )\           # size/weight/style are space-separated
         )*               # 0-inf size/weight/style tags
-        (?P<family>.+)$  # mandatory font family""", re.VERBOSE)
+        (?P<family>.+)  # mandatory font family""", re.VERBOSE)
 
     def to_py(self, value):
         self._basic_py_validation(value, str)
         if not value:
             return None
 
-        if not self.font_regex.match(value):  # pragma: no cover
+        if not self.font_regex.fullmatch(value):  # pragma: no cover
             # This should never happen, as the regex always matches everything
             # as family.
             raise configexc.ValidationError(value, "must be a valid font")
@@ -1002,7 +1002,7 @@ class FontFamily(Font):
         if not value:
             return None
 
-        match = self.font_regex.match(value)
+        match = self.font_regex.fullmatch(value)
         if not match:  # pragma: no cover
             # This should never happen, as the regex always matches everything
             # as family.
@@ -1039,7 +1039,7 @@ class QtFont(Font):
         font.setStyle(QFont.StyleNormal)
         font.setWeight(QFont.Normal)
 
-        match = self.font_regex.match(value)
+        match = self.font_regex.fullmatch(value)
         if not match:  # pragma: no cover
             # This should never happen, as the regex always matches everything
             # as family.

--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -150,7 +150,8 @@ class BaseKeyParser(QObject):
             A (count, command) tuple.
         """
         if self._supports_count:
-            (countstr, cmd_input) = re.match(r'^(\d*)(.*)', keystring).groups()
+            (countstr, cmd_input) = re.fullmatch(r'(\d*)(.*)',
+                                                 keystring).groups()
             count = int(countstr) if countstr else None
             if count == 0 and not cmd_input:
                 cmd_input = keystring

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -62,7 +62,7 @@ def parse_fatal_stacktrace(text):
         r'(Current )?[Tt]hread [^ ]* \(most recent call first\): *',
         r'  File ".*", line \d+ in (?P<func>.*)',
     ]
-    m = re.match('\n'.join(lines), text)
+    m = re.search('\n'.join(lines), text)
     if m is None:
         # We got some invalid text.
         return ('', '')

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -87,7 +87,7 @@ class KeyHintView(QLabel):
         Args:
             prefix: The current partial keystring.
         """
-        countstr, prefix = re.match(r'^(\d*)(.*)', prefix).groups()
+        countstr, prefix = re.fullmatch(r'(\d*)(.*)', prefix).groups()
         if not prefix:
             self._show_timer.stop()
             self.hide()

--- a/qutebrowser/utils/debug.py
+++ b/qutebrowser/utils/debug.py
@@ -184,7 +184,7 @@ def signal_name(sig):
     Return:
         The cleaned up signal name.
     """
-    m = re.match(r'[0-9]+(.*)\(.*\)', sig.signal)
+    m = re.fullmatch(r'[0-9]+(.*)\(.*\)', sig.signal)
     return m.group(1)
 
 

--- a/qutebrowser/utils/docutils.py
+++ b/qutebrowser/utils/docutils.py
@@ -156,7 +156,7 @@ class DocstringParser:
     def _parse_arg_inside(self, line):
         """Parse subsequent argument lines."""
         argname = self._cur_arg_name
-        if re.match(r'^[A-Z][a-z]+:$', line):
+        if re.fullmatch(r'[A-Z][a-z]+:', line):
             if not self.arg_descs[argname][-1].strip():
                 self.arg_descs[argname] = self.arg_descs[argname][:-1]
                 return True

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -306,7 +306,7 @@ def qurl_from_user_input(urlstr):
     """
     # First we try very liberally to separate something like an IPv6 from the
     # rest (e.g. path info or parameters)
-    match = re.match(r'\[?([0-9a-fA-F:.]+)\]?(.*)', urlstr.strip())
+    match = re.fullmatch(r'\[?([0-9a-fA-F:.]+)\]?(.*)', urlstr.strip())
     if match:
         ipstr, rest = match.groups()
     else:
@@ -571,7 +571,7 @@ def incdec_number(url, incdec, count=1, segments=None):
             continue
 
         # Get the last number in a string
-        match = re.match(r'(.*\D|^)(0*)(\d+)(.*)', getter())
+        match = re.fullmatch(r'(.*\D|^)(0*)(\d+)(.*)', getter())
         if not match:
             continue
 

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -869,7 +869,7 @@ def expand_windows_drive(path):
     # E:\. The correct way to specifify drive E: is "E:\", but most users
     # probably don't use the "multiple working directories" feature and expect
     # "E:" and "E:\" to be equal.
-    if re.match(r'[A-Z]:$', path, re.IGNORECASE):
+    if re.fullmatch(r'[A-Z]:', path, re.IGNORECASE):
         return path + "\\"
     else:
         return path

--- a/scripts/asciidoc2html.py
+++ b/scripts/asciidoc2html.py
@@ -154,17 +154,17 @@ class AsciiDoc:
                     hidden = False
                 elif line == "The Compiler <mail@qutebrowser.org>\n":
                     continue
-                elif re.match(r'^:\w+:.*', line):
+                elif re.fullmatch(r':\w+:.*', line):
                     # asciidoc field
                     continue
 
                 if not found_title:
-                    if re.match(r'^=+$', line):
+                    if re.fullmatch(r'=+', line):
                         line = line.replace('=', '-')
                         found_title = True
                         title = last_line.rstrip('\n') + " | qutebrowser\n"
                         title += "=" * (len(title) - 1)
-                    elif re.match(r'^= .+', line):
+                    elif re.fullmatch(r'= .+', line):
                         line = '==' + line[1:]
                         found_title = True
                         title = last_line.rstrip('\n') + " | qutebrowser\n"

--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -132,7 +132,7 @@ def filter_func(item):
         True if the missing function should be filtered/ignored, False
         otherwise.
     """
-    return bool(re.match(r'[a-z]+[A-Z][a-zA-Z]+', item.name))
+    return bool(re.fullmatch(r'[a-z]+[A-Z][a-zA-Z]+', item.name))
 
 
 def report(items):

--- a/scripts/dictcli.py
+++ b/scripts/dictcli.py
@@ -142,7 +142,7 @@ def parse_entry(entry):
     dict_re = re.compile(r"""
         (?P<filename>(?P<code>[a-z]{2}(-[A-Z]{2})?).*)\.bdic
     """, re.VERBOSE)
-    match = dict_re.match(entry['name'])
+    match = dict_re.fullmatch(entry['name'])
     if match is not None:
         return match.group('code'), match.group('filename')
     else:

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -74,7 +74,7 @@ def _get_version_tag(tag):
         (?P<version>\d+\.\d+(\.\d+)?)
     """, re.VERBOSE)
 
-    match = version_re.match(tag)
+    match = version_re.fullmatch(tag)
     if not match:
         return None
 
@@ -125,7 +125,7 @@ def _get_dictionary_tag(tag):
         (?P<event>must_have_dict|cannot_have_dict)=(?P<dict>[a-z]{2}-[A-Z]{2})
     """, re.VERBOSE)
 
-    match = dict_re.match(tag)
+    match = dict_re.fullmatch(tag)
     if not match:
         return None
 

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -48,7 +48,7 @@ def is_ignored_qt_message(message):
     """Check if the message is listed in qt_log_ignore."""
     regexes = pytest.config.getini('qt_log_ignore')
     for regex in regexes:
-        if re.match(regex, message):
+        if re.search(regex, message):
             return True
     return False
 

--- a/tests/end2end/fixtures/testprocess.py
+++ b/tests/end2end/fixtures/testprocess.py
@@ -335,7 +335,7 @@ class Process(QObject):
         if expected is None:
             return True
         elif isinstance(expected, regex_type):
-            return expected.match(value)
+            return expected.fullmatch(value)
         elif isinstance(value, (bytes, str)):
             return utils.pattern_match(pattern=expected, value=value)
         else:

--- a/tests/end2end/fixtures/testprocess.py
+++ b/tests/end2end/fixtures/testprocess.py
@@ -335,7 +335,7 @@ class Process(QObject):
         if expected is None:
             return True
         elif isinstance(expected, regex_type):
-            return expected.fullmatch(value)
+            return expected.search(value)
         elif isinstance(value, (bytes, str)):
             return utils.pattern_match(pattern=expected, value=value)
         else:

--- a/tests/unit/misc/test_checkpyver.py
+++ b/tests/unit/misc/test_checkpyver.py
@@ -44,7 +44,7 @@ def test_python2():
         pytest.skip("python2 not found")
     assert not proc.stdout
     stderr = proc.stderr.decode('utf-8')
-    assert re.match(TEXT, stderr), stderr
+    assert re.fullmatch(TEXT, stderr), stderr
     assert proc.returncode == 1
 
 
@@ -64,7 +64,7 @@ def test_patched_no_errwindow(capfd, monkeypatch):
     checkpyver.check_python_version()
     stdout, stderr = capfd.readouterr()
     assert not stdout
-    assert re.match(TEXT, stderr), stderr
+    assert re.fullmatch(TEXT, stderr), stderr
 
 
 def test_patched_errwindow(capfd, mocker, monkeypatch):

--- a/tests/unit/utils/test_debug.py
+++ b/tests/unit/utils/test_debug.py
@@ -90,8 +90,8 @@ class TestLogTime:
 
             assert len(caplog.records) == 1
 
-            pattern = re.compile(r'^Foobar took ([\d.]*) seconds\.$')
-            match = pattern.match(caplog.records[0].msg)
+            pattern = re.compile(r'Foobar took ([\d.]*) seconds\.')
+            match = pattern.fullmatch(caplog.records[0].msg)
             assert match
 
             duration = float(match.group(1))

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -863,7 +863,7 @@ class TestOpenFile:
         cmdline = '{} -c pass'.format(executable)
         utils.open_file('/foo/bar', cmdline)
         result = caplog.records[0].message
-        assert re.match(
+        assert re.fullmatch(
             r'Opening /foo/bar with \[.*python.*/foo/bar.*\]', result)
 
     @pytest.mark.not_frozen
@@ -872,7 +872,7 @@ class TestOpenFile:
         cmdline = '{} -c pass {{}} raboof'.format(executable)
         utils.open_file('/foo/bar', cmdline)
         result = caplog.records[0].message
-        assert re.match(
+        assert re.fullmatch(
             r"Opening /foo/bar with \[.*python.*/foo/bar.*'raboof'\]", result)
 
     @pytest.mark.not_frozen
@@ -882,7 +882,7 @@ class TestOpenFile:
         config_stub.val.downloads.open_dispatcher = cmdline
         utils.open_file('/foo/bar')
         result = caplog.records[1].message
-        assert re.match(
+        assert re.fullmatch(
             r"Opening /foo/bar with \[.*python.*/foo/bar.*\]", result)
 
     def test_system_default_application(self, caplog, config_stub, mocker):
@@ -890,7 +890,7 @@ class TestOpenFile:
                          new_callable=mocker.Mock)
         utils.open_file('/foo/bar')
         result = caplog.records[0].message
-        assert re.match(
+        assert re.fullmatch(
             r"Opening /foo/bar with the system application", result)
         m.assert_called_with(QUrl('file:///foo/bar'))
 


### PR DESCRIPTION
`re.match` features an implicit left anchor, which can be surprising!

in contrast:
`re.fullmatch` features implicit anchors on both sides, but is aptly named
and therefore unsurprising.
`re.search` has no such implicit anchors, which ought to be the default
even if a single anchor is needed.

By modifying the existing instances, we can in future encourage all contributors to use one or the other of the alternatives and ensure that the regex used is the regex that is intended to be used.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3382)
<!-- Reviewable:end -->
