### PR TITLE
Replace malformed utf-8 characters in spawn output.

### DIFF
--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -98,8 +98,10 @@ class GUIProcess(QObject):
         log.procs.debug("Process finished with code {}, status {}.".format(
             code, status))
 
-        stderr = bytes(self._proc.readAllStandardError()).decode('utf-8')
-        stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8')
+        stderr = bytes(self._proc.readAllStandardError()).decode('utf-8',
+                                                                 'replace')
+        stdout = bytes(self._proc.readAllStandardOutput()).decode('utf-8',
+                                                                  'replace')
 
         qutescheme.spawn_output = self._spawn_format(code, status,
                                                      stdout, stderr)


### PR DESCRIPTION
Previously this simply crashed if there was ever malformed utf-8 in the
stderr or stdout streams, perhaps as a result of an incorrectly spawned
command. See e.g. #3222 

There are other instances where things are decoded which have potential errors unchecked, or left with the default 'strict' behaviour. These could perhaps be revisited at a later time.