### PR TITLE
Disallow horizontal pan on completion view.

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -300,9 +300,7 @@ class CompletionView(QTreeView):
 
         model.setParent(self)
         self._active = True
-        self._maybe_show()
 
-        self._resize_columns()
         for i in range(model.rowCount()):
             self.expand(model.index(i, 0))
 
@@ -381,6 +379,7 @@ class CompletionView(QTreeView):
         scrollbar = self.verticalScrollBar()
         if scrollbar is not None:
             scrollbar.setValue(scrollbar.minimum())
+        self._resize_columns()
         super().showEvent(e)
 
     @cmdutils.register(instance='completion',


### PR DESCRIPTION
Resolves #3359.
I don't think it should be a problem to completely disable horizontal scrolling of the completion view, right?
@Al-Caveman mind giving this a try?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3389)
<!-- Reviewable:end -->
