### PR TITLE
fix password_fill using libsecret

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -283,8 +283,8 @@ secret_backend() {
     query_entries() {
         local domain="$1"
         while read -r line ; do
-            if [[ "$line" == "attribute.username ="* ]] ; then
-                files+=("$domain ${line#${BASH_REMATCH[0]}}")
+            if [[ "$line" == "attribute.username = "* ]] ; then
+                files+=("$domain ${line:21}")
             fi
         done < <( secret-tool search --unlock --all domain "$domain" 2>&1 )
     }


### PR DESCRIPTION
The password_fill broke in 595a53ad3b29570bed35764b0b2cbfdda9af2dfe. More precisely the libsecret backend.

The regex matching the username prefix was replaced with globbing, but you can't use `BASH_REMATCH` then. As this is a constant prefix of constant length, I replaced it with a simple position-based substring.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3392)
<!-- Reviewable:end -->
