### PR TITLE
Implement command-accept --rapid.

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2307,6 +2307,7 @@ bindings.default:
       <Ctrl-C>: completion-item-yank
       <Ctrl-Shift-C>: completion-item-yank --sel
       <Return>: command-accept
+      <Ctrl-Return>: command-accept --rapid
       <Ctrl-B>: rl-backward-char
       <Ctrl-F>: rl-forward-char
       <Alt-B>: rl-backward-word

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -156,8 +156,12 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
 
     @cmdutils.register(instance='status-command',
                        modes=[usertypes.KeyMode.command], scope='window')
-    def command_accept(self):
-        """Execute the command currently in the commandline."""
+    def command_accept(self, rapid=False):
+        """Execute the command currently in the commandline.
+
+        Args:
+            rapid: Run the command without closing or clearing the command bar.
+        """
         prefixes = {
             ':': '',
             '/': 'search -- ',
@@ -165,7 +169,9 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         }
         text = self.text()
         self.history.append(text)
-        modeman.leave(self._win_id, usertypes.KeyMode.command, 'cmd accept')
+        if not rapid:
+            modeman.leave(self._win_id, usertypes.KeyMode.command,
+                          'cmd accept')
         self.got_cmd[str].emit(prefixes[text[0]] + text[1:])
 
     @cmdutils.register(instance='status-command', scope='window')

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -9,6 +9,13 @@ Feature: Various utility commands.
         And I run :command-accept
         Then the message "Hello World" should be shown
 
+    Scenario: :set-cmd-text and :command-accept --rapid
+        When I run :set-cmd-text :message-info "Hello World"
+        And I run :command-accept --rapid
+        And I run :command-accept
+        Then the message "Hello World" should be shown
+        And the message "Hello World" should be shown
+
     Scenario: :set-cmd-text with two commands
         When I run :set-cmd-text :message-info test ;; message-error error
         And I run :command-accept


### PR DESCRIPTION
command-accept --rapid will run the command without clearing the prompt,
allowing "rapid fire" commands. For example, one could open completion
for `open -t` and open several tabs in a row.

The default binding is ctrl+enter.

Resolves #588.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3393)
<!-- Reviewable:end -->
