### PR TITLE
Support different colors per completion column.

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -138,10 +138,10 @@ class CompletionItemDelegate(QStyledItemDelegate):
 
         self._painter.translate(text_rect.left(), text_rect.top())
         self._get_textdoc(index)
-        self._draw_textdoc(text_rect)
+        self._draw_textdoc(text_rect, index.column())
         self._painter.restore()
 
-    def _draw_textdoc(self, rect):
+    def _draw_textdoc(self, rect, col):
         """Draw the QTextDocument of an item.
 
         Args:
@@ -156,7 +156,9 @@ class CompletionItemDelegate(QStyledItemDelegate):
         elif not self._opt.state & QStyle.State_Enabled:
             color = config.val.colors.completion.category.fg
         else:
-            color = config.val.colors.completion.fg
+            colors = config.val.colors.completion.fg
+            # if multiple colors are set, use different colors per column
+            color = colors[col % len(colors)]
         self._painter.setPen(color)
 
         ctx = QAbstractTextDocumentLayout.PaintContext()

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1540,15 +1540,15 @@ zoom.text_only:
 ## colors
 
 colors.completion.fg:
-  default: white
+  default: ["white", "white", "white"]
   type:
     name: ListOrValue
     valtype: QtColor
   desc: >-
     Text color of the completion widget.
 
-    May be a single value to specify the color for all columns, or a list
-    specifying a different color for each column.
+    May be a single color to use for all columns or a list of three colors,
+    one for each column.
 
 colors.completion.odd.bg:
   default: '#444444'

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1541,8 +1541,14 @@ zoom.text_only:
 
 colors.completion.fg:
   default: white
-  type: QtColor
-  desc: Text color of the completion widget.
+  type:
+    name: ListOrValue
+    valtype: QtColor
+  desc: >-
+    Text color of the completion widget.
+
+    May be a single value to specify the color for all columns, or a list
+    specifying a different color for each column.
 
 colors.completion.odd.bg:
   default: '#444444'

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -400,7 +400,7 @@ class TestConfig:
         assert not conf._mutables
 
     def test_get_obj_simple(self, conf):
-        assert conf.get_obj('colors.completion.fg') == 'white'
+        assert conf.get_obj('colors.completion.category.fg') == 'white'
 
     @pytest.mark.parametrize('option', ['content.headers.custom',
                                         'keyhint.blacklist',

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -385,7 +385,7 @@ class TestConfig:
 
     def test_get(self, conf):
         """Test conf.get() with a QColor (where get/get_obj is different)."""
-        assert conf.get('colors.completion.fg') == QColor('white')
+        assert conf.get('colors.completion.category.fg') == QColor('white')
 
     @pytest.mark.parametrize('value', [{}, {'normal': {'a': 'nop'}}])
     def test_get_bindings(self, config_stub, conf, value):


### PR DESCRIPTION
Now colors.completion.fg may be set to a list to specify a different
color for each completion column. For example:

:set colors.completion.fg [black,blue,white] will use black text for the
first column, blue for the second, and white for the third.

Setting to a single value still works and behaves as before. The default
is unchanged from 'white'.

Resolves #1794.

It looks like this after `set colors.completion.fg '["white","#999999","#777777"]'`:

![1513511279](https://user-images.githubusercontent.com/2496231/34079182-4fb1e876-e2f6-11e7-9ff8-08329527bc98.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3407)
<!-- Reviewable:end -->
