### PR TITLE
Fix broken link

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -221,5 +221,5 @@ My issue is not listed.::
     https://github.com/qutebrowser/qutebrowser/issues[the issue tracker] or
     using the `:report` command.
     If you are reporting a segfault, make sure you read the
-    link:doc/stacktrace.asciidoc[guide] on how to report them with all needed
+    link:stacktrace.asciidoc[guide] on how to report them with all needed
     information.


### PR DESCRIPTION
The link to the stacktrace guide is wrong. https://www.qutebrowser.org/doc/faq.html#footer

If this isn't the correct fix just close this and fix it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3422)
<!-- Reviewable:end -->
