### PR TITLE
supplement broken webengine load signals

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -843,7 +843,6 @@ class WebEngineTab(browsertab.AbstractTab):
         # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
         if qtutils.version_check('5.10', compiled=False):
             page.loadProgress.connect(self._on_load_progress_workaround)
-            self._load_progress_fake.connect(self._on_load_progress)
             self._load_finished_fake.connect(self._on_history_trigger)
             self._load_finished_fake.connect(self._restore_zoom)
             self._load_finished_fake.connect(self._on_load_finished)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -546,6 +546,7 @@ class WebEngineTab(browsertab.AbstractTab):
         _load_finished_fake:
             Used in place of unreliable loadFinished
     """
+
     # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
     _load_finished_fake = pyqtSignal(bool)
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -840,7 +840,7 @@ class WebEngineTab(browsertab.AbstractTab):
             self._on_render_process_terminated)
         view.iconChanged.connect(self.icon_changed)
         # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
-        if qtutils.version_check('5.10',compiled=False):
+        if qtutils.version_check('5.10', compiled=False):
             page.loadProgress.connect(self._on_load_progress_workaround)
             self._load_progress_fake.connect(self._on_load_progress)
             self._load_finished_fake.connect(self._on_history_trigger)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -852,6 +852,7 @@ class WebEngineTab(browsertab.AbstractTab):
             page.loadProgress.connect(self._on_load_progress)
             page.loadFinished.connect(self._on_history_trigger)
             page.loadFinished.connect(self._restore_zoom)
+            page.loadFinished.connect(self._on_load_finished)
 
     def event_target(self):
         return self._widget.focusProxy()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -24,7 +24,8 @@ import functools
 import html as html_utils
 
 import sip
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QEvent, QPoint, QPointF, QUrl, QTimer
+from PyQt5.QtCore import (pyqtSignal, pyqtSlot, Qt, QEvent, QPoint, QPointF,
+                          QUrl, QTimer)
 from PyQt5.QtGui import QKeyEvent
 from PyQt5.QtNetwork import QAuthenticator
 from PyQt5.QtWidgets import QApplication

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -854,7 +854,6 @@ class WebEngineTab(browsertab.AbstractTab):
         else:
             #for older Qt versions which break with the above
             page.loadProgress.connect(self._on_load_progress)
-            page.loadStarted.connect(self._on_load_started)
             page.loadFinished.connect(self._on_history_trigger)
             page.loadFinished.connect(self._restore_zoom)
             page.loadFinished.connect(self._on_load_finished)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -24,7 +24,7 @@ import functools
 import html as html_utils
 
 import sip
-from PyQt5.QtCore import pyqtSlot, Qt, QEvent, QPoint, QPointF, QUrl, QTimer
+from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QEvent, QPoint, QPointF, QUrl, QTimer
 from PyQt5.QtGui import QKeyEvent
 from PyQt5.QtNetwork import QAuthenticator
 from PyQt5.QtWidgets import QApplication
@@ -539,7 +539,18 @@ class WebEngineElements(browsertab.AbstractElements):
 
 class WebEngineTab(browsertab.AbstractTab):
 
-    """A QtWebEngine tab in the browser."""
+    """A QtWebEngine tab in the browser.
+
+    Signals:
+        loadFinishedFake:
+            Used in place of unreliable loadFinished
+        loadProgressFake:
+            Used in place of loadProgress
+    """
+
+    #WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
+    loadFinishedFake = pyqtSignal(bool)
+    loadProgressFake = pyqtSignal(int)
 
     def __init__(self, *, win_id, mode_manager, private, parent=None):
         super().__init__(win_id=win_id, mode_manager=mode_manager,
@@ -793,17 +804,31 @@ class WebEngineTab(browsertab.AbstractTab):
         }
         self.renderer_process_terminated.emit(status_map[status], exitcode)
 
+    @pyqtSlot(int)
+    def _on_load_progress_fake(self, perc):
+        """Use loadProgress(100) to emit loadFinished(True).
+
+        See https://bugreports.qt.io/browse/QTBUG-65223
+        """
+        self.loadProgressFake.emit(perc)
+        if perc == 100 and self.load_status() != usertypes.LoadStatus.error:
+            self.loadFinishedFake.emit(True)
+
+    @pyqtSlot(bool)
+    def _on_load_finished_fake(self, ok):
+        """Use only loadFinished(False).
+
+        See https://bugreports.qt.io/browse/QTBUG-65223
+        """
+        if not ok:
+            self.loadFinishedFake.emit(False)
+
     def _connect_signals(self):
         view = self._widget
         page = view.page()
 
         page.windowCloseRequested.connect(self.window_close_requested)
         page.linkHovered.connect(self.link_hovered)
-        page.loadProgress.connect(self._on_load_progress)
-        page.loadStarted.connect(self._on_load_started)
-        page.loadFinished.connect(self._on_history_trigger)
-        page.loadFinished.connect(self._restore_zoom)
-        page.loadFinished.connect(self._on_load_finished)
         page.certificate_error.connect(self._on_ssl_errors)
         page.authenticationRequired.connect(self._on_authentication_required)
         page.proxyAuthenticationRequired.connect(
@@ -816,6 +841,14 @@ class WebEngineTab(browsertab.AbstractTab):
         view.renderProcessTerminated.connect(
             self._on_render_process_terminated)
         view.iconChanged.connect(self.icon_changed)
+        #WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
+        page.loadProgress.connect(self._on_load_progress_fake)
+        self.loadProgressFake.connect(self._on_load_progress)
+        page.loadStarted.connect(self._on_load_started)
+        self.loadFinishedFake.connect(self._on_history_trigger)
+        self.loadFinishedFake.connect(self._restore_zoom)
+        self.loadFinishedFake.connect(self._on_load_finished)
+        page.loadFinished.connect(self._on_load_finished_fake)
 
     def event_target(self):
         return self._widget.focusProxy()

--- a/tests/end2end/features/marks.feature
+++ b/tests/end2end/features/marks.feature
@@ -86,7 +86,7 @@ Feature: Setting positional marks
         And I wait until the scroll position changed to 10/10
         Then the page should be scrolled to 10 10
 
-    @qtwebengine_todo: Does not emit loaded signal for fragments?
+    @qtwebengine_skip: Does not emit loaded signal for fragments?
     Scenario: Jumping back after following a link
         When I hint with args "links normal" and follow s
         And I wait until data/marks.html#bottom is loaded


### PR DESCRIPTION
This uses the much more reliable `loadProgress(100)` in place of
`loadFinished(true)` for WebEngine, with `loadProgressFake` and
`loadFinishedFake` used instead of the 'official' variants.

Fixes #3401 and #3110.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3427)
<!-- Reviewable:end -->
