### PR TITLE
Editor triggers update on every save.

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1622,8 +1622,8 @@ class CommandDispatcher:
         caret_position = elem.caret_position()
 
         ed = editor.ExternalEditor(self._tabbed_browser)
-        ed.editing_finished.connect(functools.partial(
-            self.on_editing_finished, elem))
+        ed.file_updated.connect(functools.partial(
+            self.on_file_updated, elem))
         ed.edit(text, caret_position)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
@@ -1636,7 +1636,7 @@ class CommandDispatcher:
         tab = self._current_widget()
         tab.elements.find_focused(self._open_editor_cb)
 
-    def on_editing_finished(self, elem, text):
+    def on_file_updated(self, elem, text):
         """Write the editor text into the form field and clean up tempfile.
 
         Callback for GUIProcess when the editor was closed.
@@ -2146,7 +2146,7 @@ class CommandDispatcher:
         ed = editor.ExternalEditor(self._tabbed_browser)
 
         # Passthrough for openurl args (e.g. -t, -b, -w)
-        ed.editing_finished.connect(functools.partial(
+        ed.file_updated.connect(functools.partial(
             self._open_if_changed, old_url=old_url, bg=bg, tab=tab,
             window=window, private=private, related=related))
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1621,7 +1621,7 @@ class CommandDispatcher:
 
         caret_position = elem.caret_position()
 
-        ed = editor.ExternalEditor(self._tabbed_browser)
+        ed = editor.ExternalEditor(watch=True, parent=self._tabbed_browser)
         ed.file_updated.connect(functools.partial(
             self.on_file_updated, elem))
         ed.edit(text, caret_position)

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -263,7 +263,7 @@ class ConfigCommands:
             except configexc.ConfigFileErrors as e:
                 message.error(str(e))
 
-        ed = editor.ExternalEditor(self._config)
+        ed = editor.ExternalEditor(watch=True, parent=self._config)
         if not no_source:
             ed.file_updated.connect(on_file_updated)
 

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -253,7 +253,7 @@ class ConfigCommands:
         Args:
             no_source: Don't re-source the config file after editing.
         """
-        def on_editing_finished():
+        def on_file_updated():
             """Source the new config when editing finished.
 
             This can't use cmdexc.CommandError as it's run async.
@@ -265,7 +265,7 @@ class ConfigCommands:
 
         ed = editor.ExternalEditor(self._config)
         if not no_source:
-            ed.editing_finished.connect(on_editing_finished)
+            ed.file_updated.connect(on_file_updated)
 
         filename = os.path.join(standarddir.config(), 'config.py')
         ed.edit_file(filename)

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -193,7 +193,7 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
             if run:
                 self.command_accept()
 
-        ed.editing_finished.connect(callback)
+        ed.file_updated.connect(callback)
         ed.edit(self.text())
 
     @pyqtSlot(usertypes.KeyMode)

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -70,7 +70,7 @@ class ExternalEditor(QObject):
             message.error("Failed to delete tempfile... ({})".format(e))
 
     @pyqtSlot(int, QProcess.ExitStatus)
-    def on_proc_closed(self, exitcode, exitstatus):
+    def on_proc_closed(self, _exitcode, exitstatus):
         """Write the editor text into the form field and clean up tempfile.
 
         Callback for QProcess when the editor was closed.

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -135,7 +135,6 @@ class ExternalEditor(QObject):
             self._content = text
             self.file_updated.emit(text)
 
-
     def edit_file(self, filename):
         """Edit the file with the given filename."""
         self._filename = filename

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -43,7 +43,7 @@ class ExternalEditor(QObject):
         _watcher: A QFileSystemWatcher to watch the edited file for changes.
     """
 
-    editing_finished = pyqtSignal(str)
+    file_updated = pyqtSignal(str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -128,7 +128,7 @@ class ExternalEditor(QObject):
             message.error("Failed to read back edited file: {}".format(e))
             return
         log.procs.debug("Read back: {}".format(text))
-        self.editing_finished.emit(text)
+        self.file_updated.emit(text)
 
     def edit_file(self, filename):
         """Edit the file with the given filename."""

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -23,7 +23,7 @@ import os
 import tempfile
 
 from PyQt5.QtCore import (pyqtSignal, pyqtSlot, QObject, QProcess,
-    QFileSystemWatcher)
+                          QFileSystemWatcher)
 
 from qutebrowser.config import config
 from qutebrowser.utils import message, log

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -55,7 +55,7 @@ class ExternalEditor(QObject):
     def _cleanup(self):
         """Clean up temporary files after the editor closed."""
         assert self._remove_file is not None
-        self._watcher.fileChanged.disconnect()
+        self._watcher.removePaths(self._watcher.files())
         if self._filename is None or not self._remove_file:
             # Could not create initial file.
             return

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -119,7 +119,7 @@ Feature: Opening external editors
     # There's no guarantee that the tab gets deleted...
     @posix @flaky
     Scenario: Spawning an editor and closing the tab
-        When I set up a fake editor that waits
+        When I set up a fake editor that writes "foobar" on save
         And I open data/editor.html
         And I run :click-element id qute-textarea
         And I wait for "Entering mode KeyMode.insert (reason: clicking input)" in the log
@@ -128,6 +128,18 @@ Feature: Opening external editors
         And I run :tab-close
         And I kill the waiting editor
         Then the error "Edited element vanished" should be shown
+
+    # Could not get signals working on Windows
+    @posix
+    Scenario: Spawning an editor and saving
+        When I set up a fake editor that writes "foobar" on save
+        And I open data/editor.html
+        And I run :click-element id qute-textarea
+        And I wait for "Entering mode KeyMode.insert (reason: clicking input)" in the log
+        And I run :open-editor
+        And I save without exiting the editor
+        And I run :click-element id qute-button
+        Then the javascript message "text: foobar" should be logged
 
     Scenario: Spawning an editor in caret mode
         When I set up a fake editor returning "foobar"

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -138,6 +138,7 @@ Feature: Opening external editors
         And I wait for "Entering mode KeyMode.insert (reason: clicking input)" in the log
         And I run :open-editor
         And I save without exiting the editor
+        And I wait for "Read back: foobar" in the log
         And I run :click-element id qute-button
         Then the javascript message "text: foobar" should be logged
 

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -22,6 +22,7 @@ import json
 import textwrap
 import os
 import signal
+import time
 
 import pytest_bdd as bdd
 bdd.scenarios('editor.feature')
@@ -115,6 +116,11 @@ def kill_editor_wait(tmpdir):
 def save_editor_wait(tmpdir):
     """Trigger the waiting editor to write without exiting."""
     pidfile = tmpdir / 'editor_pid'
+    # give the "editor" process time to write its pid
+    for _ in range(10):
+        if pidfile.check():
+            break
+        time.sleep(1)
     pid = int(pidfile.read())
     # windows has no SIGUSR2, but we don't run this on windows anyways
     # for posix, there IS a member so we need to ignore useless-suppression

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -90,11 +90,12 @@ def set_up_editor_wait(quteproc, tmpdir, text):
             if sig == signal.SIGUSR1:
                 sys.exit(0)
 
+        signal.signal(signal.SIGUSR1, handle)
+        signal.signal(signal.SIGUSR2, handle)
+
         with open(r'{pidfile}', 'w') as f:
             f.write(str(os.getpid()))
 
-        signal.signal(signal.SIGUSR1, handle)
-        signal.signal(signal.SIGUSR2, handle)
         time.sleep(100)
     """.format(pidfile=pidfile, text=text)))
     editor = json.dumps([sys.executable, str(script), '{}'])

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -70,8 +70,9 @@ def set_up_editor_empty(quteproc, tmpdir):
     set_up_editor(quteproc, tmpdir, "")
 
 
-@bdd.when(bdd.parsers.parse('I set up a fake editor that waits'))
-def set_up_editor_wait(quteproc, tmpdir):
+@bdd.when(bdd.parsers.parse('I set up a fake editor that writes "{text}" on '
+                            'save'))
+def set_up_editor_wait(quteproc, tmpdir, text):
     """Set up editor.command to a small python script inserting a text."""
     assert not utils.is_windows
     pidfile = tmpdir / 'editor_pid'
@@ -82,12 +83,19 @@ def set_up_editor_wait(quteproc, tmpdir):
         import time
         import signal
 
+        def handle(sig, frame):
+            with open(sys.argv[1], 'w', encoding='utf-8') as f:
+                f.write({text!r})
+            if sig == signal.SIGUSR1:
+                sys.exit(0)
+
         with open(r'{pidfile}', 'w') as f:
             f.write(str(os.getpid()))
 
-        signal.signal(signal.SIGUSR1, lambda s, f: sys.exit(0))
+        signal.signal(signal.SIGUSR1, handle)
+        signal.signal(signal.SIGUSR2, handle)
         time.sleep(100)
-    """.format(pidfile=pidfile)))
+    """.format(pidfile=pidfile, text=text)))
     editor = json.dumps([sys.executable, str(script), '{}'])
     quteproc.set_setting('editor.command', editor)
 
@@ -101,3 +109,14 @@ def kill_editor_wait(tmpdir):
     # for posix, there IS a member so we need to ignore useless-suppression
     # pylint: disable=no-member,useless-suppression
     os.kill(pid, signal.SIGUSR1)
+
+
+@bdd.when(bdd.parsers.parse('I save without exiting the editor'))
+def save_editor_wait(tmpdir):
+    """Trigger the waiting editor to write without exiting."""
+    pidfile = tmpdir / 'editor_pid'
+    pid = int(pidfile.read())
+    # windows has no SIGUSR2, but we don't run this on windows anyways
+    # for posix, there IS a member so we need to ignore useless-suppression
+    # pylint: disable=no-member,useless-suppression
+    os.kill(pid, signal.SIGUSR2)

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -22,7 +22,7 @@ import logging
 import unittest.mock
 
 import pytest
-from PyQt5.QtCore import QUrl, QProcess
+from PyQt5.QtCore import QUrl
 
 from qutebrowser.config import configcommands
 from qutebrowser.commands import cmdexc

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -330,7 +330,7 @@ class TestEdit:
             def _write_file(editor_self):
                 with open(editor_self._filename, 'w', encoding='utf-8') as f:
                     f.write(text)
-                editor_self.on_proc_closed(0, QProcess.NormalExit)
+                editor_self.file_updated.emit(text)
 
             return mocker.patch('qutebrowser.config.configcommands.editor.'
                                 'ExternalEditor._start_editor', autospec=True,

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -184,7 +184,7 @@ def test_modify_watch(qtbot):
     editor = editormod.ExternalEditor(watch=True)
     editor.edit('foo')
 
-    with qtbot.wait_signal(editor.file_updated) as blocker:
+    with qtbot.wait_signal(editor.file_updated, timeout=3000) as blocker:
         with open(editor._filename, 'w', encoding='utf-8') as f:
             f.write('bar')
     assert blocker.args == ['bar']

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -170,18 +170,18 @@ def test_modify(qtbot, editor, initial_text, edited_text):
     with open(editor._filename, 'r', encoding='utf-8') as f:
         assert f.read() == initial_text
 
-    with qtbot.wait_signal(editor.file_updated) as blocker:
-        with open(editor._filename, 'w', encoding='utf-8') as f:
-            f.write(edited_text)
+    with open(editor._filename, 'w', encoding='utf-8') as f:
+        f.write(edited_text)
 
-    with qtbot.assert_not_emitted(editor.file_updated):
+    with qtbot.wait_signal(editor.file_updated) as blocker:
         editor._proc.finished.emit(0, QProcess.NormalExit)
 
     assert blocker.args == [edited_text]
 
 
-def test_modify_multiple(qtbot, editor):
-    """Test that multiple saves all trigger file_updated."""
+def test_modify_watch(qtbot):
+    """Test that saving triggers file_updated when watch=True."""
+    editor = editormod.ExternalEditor(watch=True)
     editor.edit('foo')
 
     with qtbot.wait_signal(editor.file_updated) as blocker:

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -173,7 +173,7 @@ def test_modify(qtbot, editor, initial_text, edited_text):
     with open(editor._filename, 'r', encoding='utf-8') as f:
         assert f.read() == initial_text
 
-    with qtbot.wait_signal(editor.editing_finished) as blocker:
+    with qtbot.wait_signal(editor.file_updated) as blocker:
         with open(editor._filename, 'w', encoding='utf-8') as f:
             f.write(edited_text)
 


### PR DESCRIPTION
For any command that spawns an editor, tirgger an update on save, not
just on exit.

- :open-editor writes the text field on save
- :edit-url navigates on save
- :edit-url -t opens a new tab on each save
- :edit-command updates the statusbar text on save
- :edit-command --run runs a command on each save
- :config-edit reloads the config on save

Resolves #2307.
Helps mitigate #1596 by allowing users to 'save' partial work, and
notice if there was an error without closing the editor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3431)
<!-- Reviewable:end -->
