### PR TITLE
Return focus to qutebrowser when external editor finishes.

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1639,11 +1639,12 @@ class CommandDispatcher:
         """
         try:
             elem.set_value(text)
-            mainwindow.raise_window(objreg.last_focused_window())
         except webelem.OrphanedError as e:
             message.error('Edited element vanished')
         except webelem.Error as e:
             raise cmdexc.CommandError(str(e))
+
+        mainwindow.raise_window(objreg.last_focused_window(), alert=False)
 
     @cmdutils.register(instance='command-dispatcher', maxsplit=0,
                        scope='window')

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1639,6 +1639,7 @@ class CommandDispatcher:
         """
         try:
             elem.set_value(text)
+            mainwindow.raise_window(objreg.last_focused_window())
         except webelem.OrphanedError as e:
             message.error('Edited element vanished')
         except webelem.Error as e:

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -94,13 +94,15 @@ def get_window(via_ipc, force_window=False, force_tab=False,
     return window.win_id
 
 
-def raise_window(window):
+def raise_window(window, alert=False):
     """Raise the given MainWindow object."""
     window.setWindowState(window.windowState() & ~Qt.WindowMinimized)
     window.setWindowState(window.windowState() | Qt.WindowActive)
     window.raise_()
     window.activateWindow()
-    QApplication.instance().alert(window)
+
+    if alert:
+        QApplication.instance().alert(window)
 
 
 # WORKAROUND for https://github.com/PyCQA/pylint/issues/1770

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -94,7 +94,7 @@ def get_window(via_ipc, force_window=False, force_tab=False,
     return window.win_id
 
 
-def raise_window(window, alert=False):
+def raise_window(window, alert=True):
     """Raise the given MainWindow object."""
     window.setWindowState(window.windowState() & ~Qt.WindowMinimized)
     window.setWindowState(window.windowState() | Qt.WindowActive)


### PR DESCRIPTION
On OSX, currently if you open the external editor and finish editing, the edited content will get copied into the the appropriate input field but the editor will remain the "active app", that is qutebrowser will not have focus and will not receive further keystrokes until you click or cmd-tab back into it. I don't know if this is also the behavior on other platforms but if focus is being redirected there it shouldn't hurt to set it again.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3432)
<!-- Reviewable:end -->
