### PR TITLE
Change Raise Window behaviour

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -213,8 +213,9 @@
 |<<keyhint.delay,keyhint.delay>>|Time (in milliseconds) from pressing a key to seeing the keyhint dialog.
 |<<keyhint.radius,keyhint.radius>>|Rounding radius (in pixels) for the edges of the keyhint dialog.
 |<<messages.timeout,messages.timeout>>|Duration (in milliseconds) to show messages in the statusbar for.
-|<<new_instance_open_target,new_instance_open_target>>|How to open links in an existing instance if a new one is launched.
-|<<new_instance_open_target_window,new_instance_open_target_window>>|Which window to choose when opening links as new tabs.
+|<<new_instance_open.behavior,new_instance_open.behavior>>|How to draw attention to the window in which the opened link is shown.
+|<<new_instance_open.target,new_instance_open.target>>|How to open links in an existing instance if a new one is launched.
+|<<new_instance_open.target_window,new_instance_open.target_window>>|Which window to choose when opening links as new tabs.
 |<<prompt.filebrowser,prompt.filebrowser>>|Show a filebrowser in upload/download prompts.
 |<<prompt.radius,prompt.radius>>|Rounding radius (in pixels) for the edges of prompts.
 |<<qt.args,qt.args>>|Additional arguments to pass to Qt, without leading `--`.
@@ -2508,28 +2509,40 @@ Type: <<types,Int>>
 
 Default: +pass:[2000]+
 
-[[new_instance_open_target]]
-=== new_instance_open_target
-How to open links in an existing instance if a new one is launched.
-This happens when e.g. opening a link from a terminal.
-See `new_instance_open_target_window` to customize in which window the link is opened in.
+[[new_instance_open.behavior]]
+=== new_instance_open.behavior
+How to draw attention to the window in which the opened link is shown.
 
 Type: <<types,String>>
 
 Valid values:
 
- * +tab+: Open a new tab in the existing window and activate the window.
- * +tab-bg+: Open a new background tab in the existing window and activate the window.
- * +tab-silent+: Open a new tab in the existing window without activating the window.
- * +tab-bg-silent+: Open a new background tab in the existing window without activating the window.
+ * +activate+: Activate the window in which the link is shown. Note that it depends on the OS and window manager how this is handeled exactly.
+ * +mark+: Mark the window in which the link is shown as urgent.
+ * +silent+: Do not draw any attention to the window.
+
+Default: +pass:[activate]+
+
+[[new_instance_open.target]]
+=== new_instance_open.target
+How to open links in an existing instance if a new one is launched.
+This happens when e.g. opening a link from a terminal.
+See `new_instance_open.target_window` to customize in which window the link is opened in. See `new_instance_open.behavior` to customize how and whether the window draws the attention of the user.
+
+Type: <<types,String>>
+
+Valid values:
+
+ * +tab+: Open a new tab in the existing window.
+ * +tab-bg+: Open a new background tab in the existing window.
  * +window+: Open in a new window.
 
 Default: +pass:[tab]+
 
-[[new_instance_open_target_window]]
-=== new_instance_open_target_window
+[[new_instance_open.target_window]]
+=== new_instance_open.target_window
 Which window to choose when opening links as new tabs.
-When `new_instance_open_target` is not set to `window`, this is ignored.
+When `new_instance_open.target` is not set to `window`, this is ignored.
 
 Type: <<types,String>>
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -306,14 +306,14 @@ def open_url(url, target=None, no_raise=False, via_ipc=True):
 
     Args:
         url: An URL to open.
-        target: same as new_instance_open.target (used as a default).
+        target: same as new_instance.target (used as a default).
         no_raise: suppress target window raising.
         via_ipc: Whether the arguments were transmitted over IPC.
 
     Return:
         ID of a window that was used to open URL
     """
-    target = target or config.val.new_instance_open.target
+    target = target or config.val.new_instance.target
     background = target == 'tab-bg'
     win_id = mainwindow.get_window(via_ipc, force_target=target,
                                    no_raise=no_raise)

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -306,15 +306,15 @@ def open_url(url, target=None, no_raise=False, via_ipc=True):
 
     Args:
         url: An URL to open.
-        target: same as new_instance_open_target (used as a default).
+        target: same as new_instance_open.target (used as a default).
         no_raise: suppress target window raising.
         via_ipc: Whether the arguments were transmitted over IPC.
 
     Return:
         ID of a window that was used to open URL
     """
-    target = target or config.val.new_instance_open_target
-    background = target in {'tab-bg', 'tab-bg-silent'}
+    target = target or config.val.new_instance_open.target
+    background = target == 'tab-bg'
     win_id = mainwindow.get_window(via_ipc, force_target=target,
                                    no_raise=no_raise)
     tabbed_browser = objreg.get('tabbed-browser', scope='window',

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1650,7 +1650,7 @@ class CommandDispatcher:
         ed.file_updated.connect(functools.partial(
             self.on_file_updated, ed, elem))
         ed.editing_finished.connect(lambda: mainwindow.raise_window(
-            objreg.last_focused_window(), alert=False))
+            objreg.last_focused_window()))
         ed.edit(text, caret_position)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -51,17 +51,12 @@ search.incremental:
   default: True
   desc: Find text on a page incrementally, renewing the search for each typed character.
 
-new_instance_open_target:
+new_instance_open.target:
   type:
     name: String
     valid_values:
-      - tab: Open a new tab in the existing window and activate the window.
-      - tab-bg: Open a new background tab in the existing window and activate
-          the window.
-      - tab-silent: Open a new tab in the existing window without activating
-          the window.
-      - tab-bg-silent: Open a new background tab in the existing window without
-          activating the window.
+      - tab: Open a new tab in the existing window.
+      - tab-bg: Open a new background tab in the existing window.
       - window: Open in a new window.
   default: tab
   desc: >-
@@ -69,10 +64,24 @@ new_instance_open_target:
 
     This happens when e.g. opening a link from a terminal.
 
-    See `new_instance_open_target_window` to customize in which window the link
+    See `new_instance_open.target_window` to customize in which window the link
     is opened in.
+    See `new_instance_open.behavior` to customize how and whether the window
+    draws the attention of the user.
 
-new_instance_open_target_window:
+new_instance_open.behavior:
+  type:
+    name: String
+    valid_values:
+      - activate: Activate the window in which the link is shown. Note that it
+          depends on the OS and window manager how this is handeled exactly.
+      - mark: Mark the window in which the link is shown as urgent.
+      - silent: Do not draw any attention to the window.
+  default: activate
+  desc: >-
+    How to draw attention to the window in which the opened link is shown.
+
+new_instance_open.target_window:
   type:
     name: String
     valid_values:
@@ -84,7 +93,7 @@ new_instance_open_target_window:
   desc: >-
     Which window to choose when opening links as new tabs.
 
-    When `new_instance_open_target` is not set to `window`, this is ignored.
+    When `new_instance_open.target` is not set to `window`, this is ignored.
 
 session_default_name:
   renamed: session.default_name

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -51,7 +51,7 @@ search.incremental:
   default: True
   desc: Find text on a page incrementally, renewing the search for each typed character.
 
-new_instance_open.target:
+new_instance.target:
   type:
     name: String
     valid_values:
@@ -69,7 +69,7 @@ new_instance_open.target:
     See `new_instance_open.behavior` to customize how and whether the window
     draws the attention of the user.
 
-new_instance_open.behavior:
+new_instance.behavior:
   type:
     name: String
     valid_values:
@@ -81,7 +81,7 @@ new_instance_open.behavior:
   desc: >-
     How to draw attention to the window in which the opened link is shown.
 
-new_instance_open.target_window:
+new_instance.target_window:
   type:
     name: String
     valid_values:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -74,7 +74,7 @@ new_instance_open.behavior:
     name: String
     valid_values:
       - activate: Activate the window in which the link is shown. Note that it
-          depends on the OS and window manager how this is handeled exactly.
+          depends on the OS and window manager how this is handled exactly.
       - mark: Mark the window in which the link is shown as urgent.
       - silent: Do not draw any attention to the window.
   default: activate

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -95,6 +95,9 @@ new_instance.target_window:
 
     When `new_instance_open.target` is not set to `window`, this is ignored.
 
+new_instance_open_target_window:
+  renamed: new_instance.target_window
+
 session_default_name:
   renamed: session.default_name
 

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -262,6 +262,24 @@ class YamlConfig(QObject):
             del settings[old]
             self._mark_changed()
 
+        # new_instance_open_target got renamed and split into
+        # new_instance.target and new_instance.behavior
+        old = 'new_instance_open_target'
+        new = 'new_instance.target'
+        new_behavior = 'new_instance.behavior'
+        if old in settings:
+            settings[new] = {}
+            for scope, val in settings[old].items():
+                if val in {'tab-silent', 'tab-bg-silent'}:
+                    if new_behavior not in settings.keys():
+                        settings[new_behavior] = {}
+                    settings[new_behavior][scope] = 'silent'
+                    settings[new][scope] = val[:-len('-silent')]
+                else:
+                    settings[new][scope] = val
+            del settings[old]
+            self._mark_changed()
+
         # bindings.default can't be set in autoconfig.yml anymore, so ignore
         # old values.
         if 'bindings.default' in settings:

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -49,7 +49,7 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         via_ipc: Whether the request was made via IPC.
         force_window: Whether to force opening in a window.
         force_tab: Whether to force opening in a tab.
-        force_target: Override the new_instance_open.target config
+        force_target: Override the new_instance.target config
         no_raise: suppress target window raising
 
     Return:
@@ -62,8 +62,8 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         # Initial main window
         return 0
 
-    open_target = config.val.new_instance_open.target
-    open_behavior = config.val.new_instance_open.behavior
+    open_target = config.val.new_instance.target
+    open_behavior = config.val.new_instance.behavior
 
     # Apply any target overrides, ordered by precedence
     if force_target is not None:
@@ -111,7 +111,7 @@ def mark_window(window):
 def get_target_window():
     """Get the target window for new tabs, or None if none exist."""
     try:
-        win_mode = config.val.new_instance_open.target_window
+        win_mode = config.val.new_instance.target_window
         if win_mode == 'last-focused':
             return objreg.last_focused_window()
         elif win_mode == 'first-opened':

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -49,7 +49,7 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         via_ipc: Whether the request was made via IPC.
         force_window: Whether to force opening in a window.
         force_tab: Whether to force opening in a tab.
-        force_target: Override the new_instance_open_target config
+        force_target: Override the new_instance_open.target config
         no_raise: suppress target window raising
 
     Return:
@@ -62,7 +62,8 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         # Initial main window
         return 0
 
-    open_target = config.val.new_instance_open_target
+    open_target = config.val.new_instance_open.target
+    open_behavior = config.val.new_instance_open.behavior
 
     # Apply any target overrides, ordered by precedence
     if force_target is not None:
@@ -71,43 +72,46 @@ def get_window(via_ipc, force_window=False, force_tab=False,
         open_target = 'window'
     if force_tab and open_target == 'window':
         # Command sent via IPC
-        open_target = 'tab-silent'
+        open_target = 'tab'
+        open_behavior = 'silent'
 
     window = None
-    should_raise = False
 
     # Try to find the existing tab target if opening in a tab
     if open_target != 'window':
         window = get_target_window()
-        should_raise = open_target not in ['tab-silent', 'tab-bg-silent']
 
     # Otherwise, or if no window was found, create a new one
     if window is None:
         window = MainWindow(private=None)
         window.show()
-        should_raise = True
+        open_behavior = 'activate'
 
-    if should_raise and not no_raise:
+    if open_behavior == 'activate' and not no_raise:
         raise_window(window)
+    elif open_behavior == 'mark':
+        mark_window(window)
 
     return window.win_id
 
 
-def raise_window(window, alert=True):
+def raise_window(window):
     """Raise the given MainWindow object."""
     window.setWindowState(window.windowState() & ~Qt.WindowMinimized)
     window.setWindowState(window.windowState() | Qt.WindowActive)
     window.raise_()
     window.activateWindow()
 
-    if alert:
-        QApplication.instance().alert(window)
+
+def mark_window(window):
+    """Mark the given MainWindow object as urgent."""
+    QApplication.instance().alert(window)
 
 
 def get_target_window():
     """Get the target window for new tabs, or None if none exist."""
     try:
-        win_mode = config.val.new_instance_open_target_window
+        win_mode = config.val.new_instance_open.target_window
         if win_mode == 'last-focused':
             return objreg.last_focused_window()
         elif win_mode == 'first-opened':

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -182,7 +182,7 @@ def open_path(quteproc, server, path):
       tab.
     - With "... in a new window", it's opened in a new window.
     - With "... in a private window" it's opened in a new private window.
-    - With "... as a URL", it's opened according to new_instance_open.target.
+    - With "... as a URL", it's opened according to new_instance.target.
     """
     path = path.replace('(port)', str(server.port))
 

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -182,7 +182,7 @@ def open_path(quteproc, server, path):
       tab.
     - With "... in a new window", it's opened in a new window.
     - With "... in a private window" it's opened in a new private window.
-    - With "... as a URL", it's opened according to new_instance_open_target.
+    - With "... as a URL", it's opened according to new_instance_open.target.
     """
     path = path.replace('(port)', str(server.port))
 

--- a/tests/end2end/features/invoke.feature
+++ b/tests/end2end/features/invoke.feature
@@ -6,24 +6,24 @@ Feature: Invoking a new process
     Background:
         Given I clean up open tabs
 
-    Scenario: Using new_instance_open.target = tab
-        When I set new_instance_open.target to tab
+    Scenario: Using new_instance.target = tab
+        When I set new_instance.target to tab
         And I open data/title.html
         And I open data/search.html as a URL
         Then the following tabs should be open:
             - data/title.html
             - data/search.html (active)
 
-    Scenario: Using new_instance_open.target = tab-bg
-        When I set new_instance_open.target to tab-bg
+    Scenario: Using new_instance.target = tab-bg
+        When I set new_instance.target to tab-bg
         And I open data/title.html
         And I open data/search.html as a URL
         Then the following tabs should be open:
             - data/title.html (active)
             - data/search.html
 
-    Scenario: Using new_instance_open.target = window
-        When I set new_instance_open.target to window
+    Scenario: Using new_instance.target = window
+        When I set new_instance.target to window
         And I open data/title.html
         And I open data/search.html as a URL
         Then the session should look like:
@@ -36,9 +36,9 @@ Feature: Invoking a new process
               - history:
                 - url: http://localhost:*/data/search.html
 
-    Scenario: Using new_instance_open.target_window = last-opened
-        When I set new_instance_open.target to tab
-        And I set new_instance_open.target_window to last-opened
+    Scenario: Using new_instance.target_window = last-opened
+        When I set new_instance.target to tab
+        And I set new_instance.target_window to last-opened
         And I open data/title.html
         And I open data/search.html in a new window
         And I open data/hello.txt as a URL
@@ -54,9 +54,9 @@ Feature: Invoking a new process
               - history:
                 - url: http://localhost:*/data/hello.txt
 
-    Scenario: Using new_instance_open.target_window = first-opened
-        When I set new_instance_open.target to tab
-        And I set new_instance_open.target_window to first-opened
+    Scenario: Using new_instance.target_window = first-opened
+        When I set new_instance.target to tab
+        And I set new_instance.target_window to first-opened
         And I open data/title.html
         And I open data/search.html in a new window
         And I open data/hello.txt as a URL
@@ -75,8 +75,8 @@ Feature: Invoking a new process
     # issue #1060
 
     Scenario: Using target_window = first-opened after tab-give
-        When I set new_instance_open.target to tab
-        And I set new_instance_open.target_window to first-opened
+        When I set new_instance.target to tab
+        And I set new_instance.target_window to first-opened
         And I open data/title.html
         And I open data/search.html in a new tab
         And I run :tab-give
@@ -95,7 +95,7 @@ Feature: Invoking a new process
                 - url: http://localhost:*/data/search.html
 
     Scenario: Opening a new qutebrowser instance with no parameters
-        When I set new_instance_open.target to tab
+        When I set new_instance.target to tab
         And I set url.start_pages to ["http://localhost:(port)/data/hello.txt"]
         And I open data/title.html
         And I spawn a new window

--- a/tests/end2end/features/invoke.feature
+++ b/tests/end2end/features/invoke.feature
@@ -6,24 +6,24 @@ Feature: Invoking a new process
     Background:
         Given I clean up open tabs
 
-    Scenario: Using new_instance_open_target = tab
-        When I set new_instance_open_target to tab
+    Scenario: Using new_instance_open.target = tab
+        When I set new_instance_open.target to tab
         And I open data/title.html
         And I open data/search.html as a URL
         Then the following tabs should be open:
             - data/title.html
             - data/search.html (active)
 
-    Scenario: Using new_instance_open_target = tab-bg
-        When I set new_instance_open_target to tab-bg
+    Scenario: Using new_instance_open.target = tab-bg
+        When I set new_instance_open.target to tab-bg
         And I open data/title.html
         And I open data/search.html as a URL
         Then the following tabs should be open:
             - data/title.html (active)
             - data/search.html
 
-    Scenario: Using new_instance_open_target = window
-        When I set new_instance_open_target to window
+    Scenario: Using new_instance_open.target = window
+        When I set new_instance_open.target to window
         And I open data/title.html
         And I open data/search.html as a URL
         Then the session should look like:
@@ -36,9 +36,9 @@ Feature: Invoking a new process
               - history:
                 - url: http://localhost:*/data/search.html
 
-    Scenario: Using new_instance_open_target_window = last-opened
-        When I set new_instance_open_target to tab
-        And I set new_instance_open_target_window to last-opened
+    Scenario: Using new_instance_open.target_window = last-opened
+        When I set new_instance_open.target to tab
+        And I set new_instance_open.target_window to last-opened
         And I open data/title.html
         And I open data/search.html in a new window
         And I open data/hello.txt as a URL
@@ -54,9 +54,9 @@ Feature: Invoking a new process
               - history:
                 - url: http://localhost:*/data/hello.txt
 
-    Scenario: Using new_instance_open_target_window = first-opened
-        When I set new_instance_open_target to tab
-        And I set new_instance_open_target_window to first-opened
+    Scenario: Using new_instance_open.target_window = first-opened
+        When I set new_instance_open.target to tab
+        And I set new_instance_open.target_window to first-opened
         And I open data/title.html
         And I open data/search.html in a new window
         And I open data/hello.txt as a URL
@@ -75,8 +75,8 @@ Feature: Invoking a new process
     # issue #1060
 
     Scenario: Using target_window = first-opened after tab-give
-        When I set new_instance_open_target to tab
-        And I set new_instance_open_target_window to first-opened
+        When I set new_instance_open.target to tab
+        And I set new_instance_open.target_window to first-opened
         And I open data/title.html
         And I open data/search.html in a new tab
         And I run :tab-give
@@ -95,7 +95,7 @@ Feature: Invoking a new process
                 - url: http://localhost:*/data/search.html
 
     Scenario: Opening a new qutebrowser instance with no parameters
-        When I set new_instance_open_target to tab
+        When I set new_instance_open.target to tab
         And I set url.start_pages to ["http://localhost:(port)/data/hello.txt"]
         And I open data/title.html
         And I spawn a new window

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -546,7 +546,7 @@ class QuteProc(testprocess.Process):
         settings = [
             ('messages.timeout', '0'),
             ('auto_save.interval', '0'),
-            ('new_instance_open.target_window', 'last-opened')
+            ('new_instance.target_window', 'last-opened')
         ]
         if not self.request.config.webengine:
             settings.append(('content.ssl_strict', 'false'))

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -546,7 +546,7 @@ class QuteProc(testprocess.Process):
         settings = [
             ('messages.timeout', '0'),
             ('auto_save.interval', '0'),
-            ('new_instance_open_target_window', 'last-opened')
+            ('new_instance_open.target_window', 'last-opened')
         ]
         if not self.request.config.webengine:
             settings.append(('content.ssl_strict', 'false'))

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -225,6 +225,22 @@ class TestYaml:
         assert 'tabs.persist_mode_on_change' not in data
         assert data['tabs.mode_on_change']['global'] == expected
 
+    @pytest.mark.parametrize('target', ['tab', 'tab-silent'])
+    def test_merge_new_instance(self, yaml, autoconfig, target):
+        """Tests for migration of new_instance_open_target."""
+        autoconfig.write({'new_instance_open_target': {'global': target}})
+        yaml.load()
+        yaml._save()
+
+        data = autoconfig.read()
+        assert 'new_instance_open_target' not in data
+        migrated_target = target.replace('-silent', '')
+        assert data['new_instance.target']['global'] == migrated_target
+        if target.endswith('-silent'):
+            assert data['new_instance.behavior']['global'] == 'silent'
+        else:
+            assert 'new_instance.behavior' not in data.keys()
+
     def test_bindings_default(self, yaml, autoconfig):
         """Make sure bindings.default gets removed from autoconfig.yml."""
         autoconfig.write({'bindings.default': {'global': '{}'}})


### PR DESCRIPTION
Fixes #2603

I tested this under i3 and KDE Plasma in both cases the highlighting of the window now works every time.
I have not tested this under Windows or on a Mac. On a Mac this might lead to different behaviour, since the dock bouncing was only mentioned for the `alert` method in the QT docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3434)
<!-- Reviewable:end -->
