### PR TITLE
Fix minor doc typo in example code

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -264,7 +264,7 @@ get a string:
 .config.py:
 [source,python]
 ----
-print(str(config.configdir / 'config.py')
+print(str(config.configdir / 'config.py'))
 ----
 
 Handling errors


### PR DESCRIPTION
Just a minor typo fix.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3441)
<!-- Reviewable:end -->
