### PR TITLE
Greasemonkey: support regexes in @include and @exclude.

### DIFF
--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -177,10 +177,10 @@ class GreasemonkeyManager(QObject):
                 elif script.run_at == 'document-idle':
                     self._run_idle.append(script)
                 else:
-                    log.greasemonkey.warning("Script {} has invalid run-at "
-                                             "defined, defaulting to "
-                                             "document-end"
-                                             .format(script_path))
+                    if script.run_at:
+                        log.greasemonkey.warning(
+                            "Script {} has invalid run-at defined, "
+                            "defaulting to document-end".format(script_path))
                     # Default as per
                     # https://wiki.greasespot.net/Metadata_Block#.40run-at
                     self._run_end.append(script)

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -196,10 +196,11 @@ class GreasemonkeyManager(QObject):
         if url.scheme() not in self.greaseable_schemes:
             return MatchingScripts(url, [], [], [])
 
+        string_url = url.toString(QUrl.FullyEncoded)
+
         def _match(pattern):
             # For include and exclude rules if they start and end with '/' they
             # should be treated as a (ecma syntax) regular expression.
-            string_url = url.toString(QUrl.FullyEncoded)
             if pattern.startswith('/') and pattern.endswith('/'):
                 matches = re.search(pattern[1:-1], string_url, flags=re.I)
                 return matches is not None

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -201,7 +201,8 @@ class GreasemonkeyManager(QObject):
             # should be treated as a (ecma syntax) regular expression.
             string_url = url.toString(QUrl.FullyEncoded)
             if pattern.startswith('/') and pattern.endswith('/'):
-                return re.search(pattern[1:-1], string_url) is not None
+                matches = re.search(pattern[1:-1], string_url, flags=re.I)
+                return matches is not None
 
             # Otherwise they are glob expressions.
             return fnmatch.fnmatch(string_url, pattern)

--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -19,6 +19,7 @@
 """Tests for qutebrowser.browser.greasemonkey."""
 
 import logging
+import textwrap
 
 import pytest
 import py.path  # pylint: disable=no-name-in-module
@@ -26,7 +27,7 @@ from PyQt5.QtCore import QUrl
 
 from qutebrowser.browser import greasemonkey
 
-test_gm_script = """
+test_gm_script = r"""
 // ==UserScript==
 // @name qutebrowser test userscript
 // @namespace invalid.org
@@ -68,6 +69,31 @@ def test_all():
 def test_get_scripts_by_url(url, expected_matches):
     """Check Greasemonkey include/exclude rules work."""
     _save_script(test_gm_script, 'test.user.js')
+    gm_manager = greasemonkey.GreasemonkeyManager()
+
+    scripts = gm_manager.scripts_for(QUrl(url))
+    assert (len(scripts.start + scripts.end + scripts.idle) ==
+            expected_matches)
+
+
+@pytest.mark.parametrize("url, expected_matches", [
+    # included
+    ('https://github.com/qutebrowser/qutebrowser/', 1),
+    # neither included nor excluded
+    ('http://aaaaaaaaaa.com/', 0),
+    # excluded takes priority
+    ('http://github.com/foo', 0),
+])
+def test_regex_includes_scripts_for(url, expected_matches):
+    """Ensure our GM @*clude support supports regular expressions."""
+    gh_dark_example = textwrap.dedent(r"""
+        // ==UserScript==
+        // @include     /^https?://((gist|guides|help|raw|status|developer)\.)?github\.com/((?!generated_pages\/preview).)*$/
+        // @exclude     /https?://github\.com/foo/
+        // @run-at document-start
+        // ==/UserScript==
+    """)
+    _save_script(gh_dark_example, 'test.user.js')
     gm_manager = greasemonkey.GreasemonkeyManager()
 
     scripts = gm_manager.scripts_for(QUrl(url))


### PR DESCRIPTION
Like the spec says, if a value for the @include or @exclude rules starts
and ends with a '/' it should be parsed as a regular expression.
https://wiki.greasespot.net/Include_and_exclude_rules
Technically an ECMAScript syntax regular expression, but I am not sure of
the differences and I assume they are far fewer than the similarities.
One that I did see mentioned was that javascript RegExp doesn't support
unicode. Although it apparently does support a 'u' flag now.
Anyway, I'm just being lazy and passing is blindly to the python re module. Also I haven't used that much so hopefully I am not using the returned thing wrong.

Note that code will only be ran for QtWebkit and QWebEngine < 5.8
we rely on the builtin support for metadata it QWebEngine for most
things greasemonkey related. Sadly it seems that they missed the regex
requirement too. I've opened a ticket to track that https://bugreports.qt.io/browse/QTBUG-65484 It should be a similarly small change to support it there but I don't work with C++ much so I'm hoping someone else will pick it up. If they don't in a week... or two, I'll have a crack.

Edit: ammended to do a proper slice, escape a thing in the regex, do the NoneType comparison in a way that satisfies Mr Flake.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3443)
<!-- Reviewable:end -->
