### PR TITLE
Greasemonkey @require support

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -238,11 +238,14 @@ class FileDownloadTarget(_DownloadTarget):
 
     Attributes:
         filename: Filename where the download should be saved.
+        force_overwrite: Whether to overwrite the target without
+                         prompting the user.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename, force_overwrite=False):
         # pylint: disable=super-init-not-called
         self.filename = filename
+        self.force_overwrite = force_overwrite
 
     def suggested_filename(self):
         return os.path.basename(self.filename)
@@ -738,7 +741,8 @@ class AbstractDownloadItem(QObject):
         if isinstance(target, FileObjDownloadTarget):
             self._set_fileobj(target.fileobj, autoclose=False)
         elif isinstance(target, FileDownloadTarget):
-            self._set_filename(target.filename)
+            self._set_filename(
+                target.filename, force_overwrite=target.force_overwrite)
         elif isinstance(target, OpenFileDownloadTarget):
             try:
                 fobj = temp_download_manager.get_tmpfile(self.basename)

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -25,12 +25,11 @@ import json
 import fnmatch
 import functools
 import glob
-import base64
 
 import attr
 from PyQt5.QtCore import pyqtSignal, QObject, QUrl
 
-from qutebrowser.utils import log, standarddir, jinja, objreg
+from qutebrowser.utils import log, standarddir, jinja, objreg, utils
 from qutebrowser.commands import cmdutils
 from qutebrowser.browser import downloads
 
@@ -217,13 +216,10 @@ class GreasemonkeyManager(QObject):
         log.greasemonkey.debug("Loaded script: {}".format(script.name))
 
     def _required_url_to_file_path(self, url):
-        # TODO: Save to a more readable name
-        # cf https://stackoverflow.com/questions/295135/turn-a-string-into-a-valid-filename
-        name = str(base64.urlsafe_b64encode(bytes(url, 'utf8')), encoding='utf8')
         requires_dir = os.path.join(_scripts_dir(), 'requires')
         if not os.path.exists(requires_dir):
             os.mkdir(requires_dir)
-        return os.path.join(requires_dir, name)
+        return os.path.join(requires_dir, utils.sanitize_filename(url))
 
     def _on_required_download_finished(self, script, download):
         self._in_progress_dls.remove(download)

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -276,7 +276,8 @@ class GreasemonkeyManager(QObject):
         download_manager = objreg.get('qtnetwork-download-manager')
 
         for url, target_path in required_dls:
-            target = downloads.FileDownloadTarget(target_path)
+            target = downloads.FileDownloadTarget(target_path,
+                                                  force_overwrite=True)
             download = download_manager.get(QUrl(url), target=target,
                                             auto_remove=True)
             download.requested_url = url

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -192,16 +192,23 @@ class GreasemonkeyManager(QObject):
                 script = GreasemonkeyScript.parse(script_file.read())
                 if not script.name:
                     script.name = script_filename
-
-                if script.requires:
-                    log.greasemonkey.debug(
-                        "Deferring script until requirements are "
-                        "fulfilled: {}".format(script.name))
-                    self._get_required_scripts(script, force)
-                else:
-                    self._add_script(script)
-
+                self.add_script(script, force)
         self.scripts_reloaded.emit()
+
+    def add_script(self, script, force=False):
+        """Add a GreasemonkeyScript to this manager.
+
+        Args:
+            force: Fetch and overwrite any dependancies which are
+                   already locally cached.
+        """
+        if script.requires:
+            log.greasemonkey.debug(
+                "Deferring script until requirements are "
+                "fulfilled: {}".format(script.name))
+            self._get_required_scripts(script, force)
+        else:
+            self._add_script(script)
 
     def _add_script(self, script):
         if script.run_at == 'document-start':

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -25,6 +25,7 @@ import json
 import fnmatch
 import functools
 import glob
+import textwrap
 
 import attr
 from PyQt5.QtCore import pyqtSignal, QObject, QUrl
@@ -122,10 +123,11 @@ class GreasemonkeyScript:
 
     def add_required_script(self, source):
         """Add the source of a required script to this script."""
-        # NOTE: If source also contains a greasemonkey metadata block then
-        # QWebengineScript will parse that instead of the actual one.
-        # Adding an indent to source would stop that.
-        self._code = "\n".join([source, self._code])
+        # The additional source is indented in case it also contains a
+        # metadata block. Because we pass everything at once to
+        # QWebEngineScript and that would parse the first metadata block
+        # found as the valid one.
+        self._code = "\n".join([textwrap.indent(source, "    "), self._code])
 
 
 @attr.s

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -23,13 +23,16 @@ import re
 import os
 import json
 import fnmatch
+import functools
 import glob
+import base64
 
 import attr
 from PyQt5.QtCore import pyqtSignal, QObject, QUrl
 
 from qutebrowser.utils import log, standarddir, jinja, objreg
 from qutebrowser.commands import cmdutils
+from qutebrowser.browser import downloads
 
 
 def _scripts_dir():
@@ -45,6 +48,7 @@ class GreasemonkeyScript:
         self._code = code
         self.includes = []
         self.excludes = []
+        self.requires = []
         self.description = None
         self.name = None
         self.namespace = None
@@ -66,6 +70,8 @@ class GreasemonkeyScript:
                 self.run_at = value
             elif name == 'noframes':
                 self.runs_on_sub_frames = False
+            elif name == 'require':
+                self.requires.append(value)
 
     HEADER_REGEX = r'// ==UserScript==|\n+// ==/UserScript==\n'
     PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s*(?P<val>.*)'
@@ -93,7 +99,7 @@ class GreasemonkeyScript:
         """Return the processed JavaScript code of this script.
 
         Adorns the source code with GM_* methods for Greasemonkey
-        compatibility and wraps it in an IFFE to hide it within a
+        compatibility and wraps it in an IIFE to hide it within a
         lexical scope. Note that this means line numbers in your
         browser's debugger/inspector will not match up to the line
         numbers in the source script directly.
@@ -114,6 +120,13 @@ class GreasemonkeyScript:
             'excludes': self.excludes,
             'run-at': self.run_at,
         })
+
+    def add_required_script(self, source):
+        """Add the source of a required script to this script."""
+        # NOTE: If source also contains a greasemonkey metadata block then
+        # QWebengineScript will parse that instead of the actual one.
+        # Adding an indent to source would stop that.
+        self._code = "\n".join([source, self._code])
 
 
 @attr.s
@@ -145,6 +158,11 @@ class GreasemonkeyManager(QObject):
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self._run_start = []
+        self._run_end = []
+        self._run_idle = []
+        self._in_progress_dls = []
+
         self.load_scripts()
 
     @cmdutils.register(name='greasemonkey-reload',
@@ -170,22 +188,106 @@ class GreasemonkeyManager(QObject):
                 if not script.name:
                     script.name = script_filename
 
-                if script.run_at == 'document-start':
-                    self._run_start.append(script)
-                elif script.run_at == 'document-end':
-                    self._run_end.append(script)
-                elif script.run_at == 'document-idle':
-                    self._run_idle.append(script)
+                if script.requires:
+                    log.greasemonkey.debug(
+                        "Deferring script until requirements are "
+                        "fulfilled: {}".format(script.name))
+                    self._get_required_scripts(script)
                 else:
-                    if script.run_at:
-                        log.greasemonkey.warning(
-                            "Script {} has invalid run-at defined, "
-                            "defaulting to document-end".format(script_path))
-                    # Default as per
-                    # https://wiki.greasespot.net/Metadata_Block#.40run-at
-                    self._run_end.append(script)
-                log.greasemonkey.debug("Loaded script: {}".format(script.name))
+                    self._add_script(script)
+
         self.scripts_reloaded.emit()
+
+    def _add_script(self, script):
+        if script.run_at == 'document-start':
+            self._run_start.append(script)
+        elif script.run_at == 'document-end':
+            self._run_end.append(script)
+        elif script.run_at == 'document-idle':
+            self._run_idle.append(script)
+        else:
+            if script.run_at:
+                log.greasemonkey.warning("Script {} has invalid run-at "
+                                         "defined, defaulting to "
+                                         "document-end"
+                                         .format(script.name))
+                # Default as per
+                # https://wiki.greasespot.net/Metadata_Block#.40run-at
+            self._run_end.append(script)
+        log.greasemonkey.debug("Loaded script: {}".format(script.name))
+
+    def _required_url_to_file_path(self, url):
+        # TODO: Save to a more readable name
+        # cf https://stackoverflow.com/questions/295135/turn-a-string-into-a-valid-filename
+        name = str(base64.urlsafe_b64encode(bytes(url, 'utf8')), encoding='utf8')
+        requires_dir = os.path.join(_scripts_dir(), 'requires')
+        if not os.path.exists(requires_dir):
+            os.mkdir(requires_dir)
+        return os.path.join(requires_dir, name)
+
+    def _on_required_download_finished(self, script, download):
+        self._in_progress_dls.remove(download)
+        if not self._add_script_with_requires(script):
+            log.greasemonkey.debug(
+                "Finished download {} for script {} "
+                "but some requirements are still pending"
+                .format(download.basename, script.name))
+
+    def _add_script_with_requires(self, script, quiet=False):
+        """Add a script with pending downloads to this GreasemonkeyManager.
+
+        Specifically a script that has dependancies specified via an
+        `@require` rule.
+
+        Args:
+            script: The GreasemonkeyScript to add.
+            quiet: True to suppress the scripts_reloaded signal after
+                   adding `script`.
+        Returns: True if the script was added, False if there are still
+                 dependancies being downloaded.
+        """
+        # See if we are still waiting on any required scripts for this one
+        for dl in self._in_progress_dls:
+            if dl.requested_url in script.requires:
+                return False
+
+        # Need to add the required scripts to the IIFE now
+        for url in reversed(script.requires):
+            target_path = self._required_url_to_file_path(url)
+            log.greasemonkey.debug(
+                "Adding required script for {} to IIFE: {}"
+                .format(script.name, url))
+            with open(target_path, encoding='utf8') as f:
+                script.add_required_script(f.read())
+
+        self._add_script(script)
+        if not quiet:
+            self.scripts_reloaded.emit()
+        return True
+
+    def _get_required_scripts(self, script):
+        required_dls = [(url, self._required_url_to_file_path(url))
+                        for url in script.requires]
+        required_dls = [(url, path) for (url, path) in required_dls
+                        if not os.path.exists(path)]
+        if not required_dls:
+            # All the files exist so we don't have to deal with
+            # potentially not having a download manager yet
+            # TODO: Consider supporting force reloading.
+            self._add_script_with_requires(script, quiet=True)
+            return
+
+        download_manager = objreg.get('qtnetwork-download-manager')
+
+        for url, target_path in required_dls:
+            target = downloads.FileDownloadTarget(target_path)
+            download = download_manager.get(QUrl(url), target=target,
+                                            auto_remove=True)
+            download.requested_url = url
+            self._in_progress_dls.append(download)
+            download.finished.connect(
+                functools.partial(self._on_required_download_finished,
+                                  script, download))
 
     def scripts_for(self, url):
         """Fetch scripts that are registered to run for url.

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -287,9 +287,12 @@ class GreasemonkeyManager(QObject):
                                             auto_remove=True)
             download.requested_url = url
             self._in_progress_dls.append(download)
-            download.finished.connect(
-                functools.partial(self._on_required_download_finished,
-                                  script, download))
+            if download.successful:
+                self._on_required_download_finished(script, download)
+            else:
+                download.finished.connect(
+                    functools.partial(self._on_required_download_finished,
+                                      script, download))
 
     def scripts_for(self, url):
         """Fetch scripts that are registered to run for url.

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -123,7 +123,7 @@
     // Mock the greasemonkey 4.0 async API.
     const GM = {};
     GM.info = GM_info;
-    Object.entries({
+    const entries = {
         'log': GM_log,
         'addStyle': GM_addStyle,
         'deleteValue': GM_deleteValue,
@@ -132,7 +132,9 @@
         'openInTab': GM_openInTab,
         'setValue': GM_setValue,
         'xmlHttpRequest': GM_xmlhttpRequest,
-    }).forEach(([newKey, old]) => {
+    }
+    for (newKey in entries) {
+        let old = entries[newKey];
         if (old && (typeof GM[newKey] == 'undefined')) {
             GM[newKey] = function(...args) {
                 return new Promise((resolve, reject) => {
@@ -144,7 +146,7 @@
                 });
             };
         }
-    });
+    };
 
     const unsafeWindow = window;
 

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -110,6 +110,42 @@
         }
     }
 
+    // Stub these two so that the gm4 polyfill script doesn't try to
+    // create broken versions as attributes of window.
+    function GM_getResourceText(caption, commandFunc, accessKey) {
+        console.error(`${GM_info.script.name} called unimplemented GM_getResourceText`);
+    }
+
+    function GM_registerMenuCommand(caption, commandFunc, accessKey) {
+        console.error(`${GM_info.script.name} called unimplemented GM_registerMenuCommand`);
+    }
+
+    // Mock the greasemonkey 4.0 async API.
+    const GM = {};
+    GM.info = GM_info;
+    Object.entries({
+        'log': GM_log,
+        'addStyle': GM_addStyle,
+        'deleteValue': GM_deleteValue,
+        'getValue': GM_getValue,
+        'listValues': GM_listValues,
+        'openInTab': GM_openInTab,
+        'setValue': GM_setValue,
+        'xmlHttpRequest': GM_xmlhttpRequest,
+    }).forEach(([newKey, old]) => {
+        if (old && (typeof GM[newKey] == 'undefined')) {
+            GM[newKey] = function(...args) {
+                return new Promise((resolve, reject) => {
+                    try {
+                        resolve(old(...args));
+                    } catch (e) {
+                        reject(e);
+                    }
+                });
+            };
+        }
+    });
+
     const unsafeWindow = window;
 
     // ====== The actual user script source ====== //

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -523,3 +523,12 @@ class ModelValidator:
 @pytest.fixture
 def model_validator(qtmodeltester):
     return ModelValidator(qtmodeltester)
+
+
+@pytest.fixture
+def download_stub(win_registry, tmpdir, stubs):
+    """Register a FakeDownloadManager."""
+    stub = stubs.FakeDownloadManager(tmpdir)
+    objreg.register('qtnetwork-download-manager', stub)
+    yield
+    objreg.delete('qtnetwork-download-manager')

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -530,5 +530,5 @@ def download_stub(win_registry, tmpdir, stubs):
     """Register a FakeDownloadManager."""
     stub = stubs.FakeDownloadManager(tmpdir)
     objreg.register('qtnetwork-download-manager', stub)
-    yield
+    yield stub
     objreg.delete('qtnetwork-download-manager')

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -572,7 +572,7 @@ class FakeDownloadItem(QObject):
         super().__init__(parent)
         self.fileobj = fileobj
         self.name = name
-        self.successful = True
+        self.successful = False
 
 
 class FakeDownloadManager:
@@ -581,6 +581,7 @@ class FakeDownloadManager:
 
     def __init__(self, tmpdir):
         self._tmpdir = tmpdir
+        self.downloads = []
 
     @contextlib.contextmanager
     def _open_fileobj(self, target):
@@ -603,4 +604,5 @@ class FakeDownloadManager:
             download_item = FakeDownloadItem(target.fileobj, name=url.path())
             with (self._tmpdir / url.path()).open('rb') as fake_url_file:
                 shutil.copyfileobj(fake_url_file, download_item.fileobj)
+        self.downloads.append(download_item)
         return download_item

--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -128,3 +128,33 @@ def test_load_emits_signal(qtbot):
     gm_manager = greasemonkey.GreasemonkeyManager()
     with qtbot.wait_signal(gm_manager.scripts_reloaded):
         gm_manager.load_scripts()
+
+
+def test_required_scripts_are_included(download_stub, tmpdir):
+    test_require_script = textwrap.dedent("""
+        // ==UserScript==
+        // @name qutebrowser test userscript
+        // @namespace invalid.org
+        // @include http://localhost:*/data/title.html
+        // @match http://trolol*
+        // @exclude https://badhost.xxx/*
+        // @run-at document-start
+        // @require http://localhost/test.js
+        // ==/UserScript==
+        console.log("Script is running.");
+    """)
+    _save_script(test_require_script, 'requiring.user.js')
+    with open(str(tmpdir / 'test.js'), 'w', encoding='UTF-8') as f:
+        f.write("REQUIRED SCRIPT")
+
+    gm_manager = greasemonkey.GreasemonkeyManager()
+    assert len(gm_manager._in_progress_dls) == 1
+    for download in gm_manager._in_progress_dls:
+        download.finished.emit()
+
+    scripts = gm_manager.all_scripts()
+    assert len(scripts) == 1
+    assert "REQUIRED SCRIPT" in scripts[0].code()
+    # Additionally check that the base script is still being parsed correctly
+    assert "Script is running." in scripts[0].code()
+    assert scripts[0].excludes


### PR DESCRIPTION
This PR adds support for fetching scripts that greasemonkey user scripts specify as dependancies via the `@require` rule. And delaying the injection of said scripts into webpages until the dependancies have been fetched.

Also I have included a commit to mock the new greasemonkey 4.0 promises based API. Because the motivation for this work was getting the https://github.com/StylishThemes/GitHub-Dark-Script userjs to work and it was hard to test without. (It also requires regex `@includes` support and cross origin GM_xhr requests though.)

I made a change to the download manager to support overwriting files without prompting, see the commit message for that one for an alternative way of doing it.

I am using the download_stub fixture from the test_adblock.py and made a change to it to support file targets, as opposed to just fileobj targets.

Apart from that I think it is all straightforward.

Edit: rebased in fixes for lint, flake and spellcheck.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3456)
<!-- Reviewable:end -->

  
  