### PR TITLE
scripts: filter history records

### DIFF
--- a/scripts/hist_importer.py
+++ b/scripts/hist_importer.py
@@ -142,7 +142,8 @@ def run():
     source, dest = args.source, args.dest
     query = {
         'firefox': 'select url,title,last_visit_date/1000000 as date '
-                   'from moz_places',
+                   'from moz_places where url like "http%" or url '
+                   'like "ftp%" or url like "file://%"',
         'chrome': 'select url,title,last_visit_time/10000000 as date '
                   'from urls',
     }


### PR DESCRIPTION
We don't need to import history records about `moz-extensions`, `about` pages, `dactyl` and so on...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3464)
<!-- Reviewable:end -->
