### PR TITLE
Clear unpinned tabs before prompting user with :tab-only

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -256,7 +256,9 @@ class TabbedBrowser(tabwidget.TabWidget):
         for tab in self.widgets():
             self._remove_tab(tab)
 
-    def tab_close_prompt_if_pinned(self, tab, force, yes_action):
+    def tab_close_prompt_if_pinned(
+            self, tab, force, yes_action,
+            text="Are you sure you want to close a pinned tab?"):
         """Helper method for tab_close.
 
         If tab is pinned, prompt. If not, run yes_action.
@@ -265,7 +267,7 @@ class TabbedBrowser(tabwidget.TabWidget):
         if tab.data.pinned and not force:
             message.confirm_async(
                 title='Pinned Tab',
-                text="Are you sure you want to close a pinned tab?",
+                text=text,
                 yes_action=yes_action, default=False, abort_on=[tab.destroyed])
         else:
             yes_action()

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1183,7 +1183,7 @@ Feature: Tab management
         And I run :tab-pin
         And I run :tab-next
         And I run :tab-only
-        And I wait for "*want to close a pinned tab*" in the log
+        And I wait for "*want to close pinned tabs*" in the log
         And I run :prompt-accept yes
         Then the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
@@ -1195,7 +1195,7 @@ Feature: Tab management
         And I run :tab-pin
         And I run :tab-next
         And I run :tab-only
-        And I wait for "*want to close a pinned tab*" in the log
+        And I wait for "*want to close pinned tabs*" in the log
         And I run :prompt-accept no
         Then the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)


### PR DESCRIPTION
Closes #3461

If anyone thinks the new behavior seems wrong, let me know.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3467)
<!-- Reviewable:end -->
