### PR TITLE
Don't attempt completion if input starts with flag.

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -87,8 +87,6 @@ class Completer(QObject):
             # cursor on a flag or after an explicit split (--)
             return None
         log.completion.debug("Before removing flags: {}".format(before_cursor))
-        before_cursor = [x for x in before_cursor if not x.startswith('-')]
-        log.completion.debug("After removing flags: {}".format(before_cursor))
         if not before_cursor:
             # '|' or 'set|'
             log.completion.debug('Starting command completion')
@@ -99,6 +97,9 @@ class Completer(QObject):
             log.completion.debug("No completion for unknown command: {}"
                                  .format(before_cursor[0]))
             return None
+
+        before_cursor = [x for x in before_cursor if not x.startswith('-')]
+        log.completion.debug("After removing flags: {}".format(before_cursor))
         argpos = len(before_cursor) - 1
         try:
             func = cmd.get_pos_arg_info(argpos).completion

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -190,6 +190,7 @@ def _set_cmd_prompt(cmd, txt):
     (':gibberish nonesense |', None, '', []),
     ('/:help|', None, '', []),
     ('::bind|', 'command', ':bind', []),
+    (':-w open |', None, '', []),
 ])
 def test_update_completion(txt, kind, pattern, pos_args, status_command_stub,
                            completer_obj, completion_widget_stub, config_stub,


### PR DESCRIPTION
Always interpret the first word in the command string as the command to
offer completions for, even if that word looks like a flag.

Fixes #3460, where the command string `:-w open` would attempt to offer
completions for `open` but crash because the parsing was thrown off.
By moving the flag-stripping logic to _after_ we determine the command,
`:-w open` interprets `:-w` as the command. Since that is not a valid
command, we won't offer any completions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3468)
<!-- Reviewable:end -->
