### PR TITLE
Save input mode PER TAB

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -646,6 +646,7 @@ class AbstractTab(QWidget):
         # self.action = AbstractAction()
 
         self.data = TabData()
+        self._input_mode = usertypes.KeyMode.normal
         self._layout = miscwidgets.WrapperLayout(self)
         self._widget = None
         self._progress = 0

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -633,11 +633,16 @@ class TabbedBrowser(tabwidget.TabWidget):
                               "index {}".format(idx))
             return
 
+        if self._now_focused is not None:
+            # save current input mode before switching tab
+            self._now_focused._input_mode = modeman.instance(self._win_id).mode
+            
         log.modes.debug("Current tab changed, focusing {!r}".format(tab))
         tab.setFocus()
         for mode in [usertypes.KeyMode.hint, usertypes.KeyMode.insert,
                      usertypes.KeyMode.caret, usertypes.KeyMode.passthrough]:
             modeman.leave(self._win_id, mode, 'tab changed', maybe=True)
+        modeman.enter(self._win_id, tab._input_mode, 'restore input mode for tab')
         if self._now_focused is not None:
             objreg.register('last-focused-tab', self._now_focused, update=True,
                             scope='window', window=self._win_id)


### PR DESCRIPTION
New code to save/restore input mode PER TAB when switching to another tab

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3479)
<!-- Reviewable:end -->
