### PR TITLE
Add feature to pastebin version string

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -460,3 +460,10 @@ def qute_configdiff(url):
     else:
         data = config.instance.dump_userconfig().encode('utf-8')
         return 'text/plain', data
+
+
+@add_handler('pastebin-version')
+def qute_pastebin_version(url):  # transfusion: pylint: disable=unused-argument
+    """Handler that pastebins the version string."""
+    utils.pastebin_version()
+    return 'text/plain', b'Paste called.'

--- a/qutebrowser/html/version.html
+++ b/qutebrowser/html/version.html
@@ -1,4 +1,17 @@
 {% extends "base.html" %}
+
+{% block script %}
+var paste_version = function(){
+  xhr = new XMLHttpRequest();
+  xhr.open("GET", "qute://pastebin-version");
+  xhr.send();
+}
+{% endblock %}
+
+{% block style %}
+#paste { margin: auto; display: block; }
+{% endblock %}
+
 {% block content %}
 {{ super() }}
 <h1>Version info</h1>
@@ -23,4 +36,5 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <a href="http://www.gnu.org/licenses/">
 http://www.gnu.org/licenses/</a> or open <a href="qute://gpl">qute://gpl</a>.
 </p>
+<button id="paste" onclick="paste_version()">Pastebin Version Info</button>
 {% endblock %}

--- a/qutebrowser/misc/pastebin.py
+++ b/qutebrowser/misc/pastebin.py
@@ -42,20 +42,23 @@ class PastebinClient(QObject):
     """
 
     API_URL = 'https://crashes.qutebrowser.org/api/'
+    MISC_API_URL = 'http://paste.the-compiler.org/api/'
     success = pyqtSignal(str)
     error = pyqtSignal(str)
 
-    def __init__(self, client, parent=None):
+    def __init__(self, client, parent=None, api_url=API_URL):
         """Constructor.
 
         Args:
             client: The HTTPClient to use. Will be reparented.
+            api_url: The Stikked pastebin endpoint to use.
         """
         super().__init__(parent)
         client.setParent(self)
         client.error.connect(self.error)
         client.success.connect(self.on_client_success)
         self._client = client
+        self.api_url = api_url
 
     def paste(self, name, title, text, parent=None):
         """Paste the text into a pastebin and return the URL.
@@ -74,7 +77,7 @@ class PastebinClient(QObject):
         }
         if parent is not None:
             data['reply'] = parent
-        url = QUrl(urllib.parse.urljoin(self.API_URL, 'create'))
+        url = QUrl(urllib.parse.urljoin(self.api_url, 'create'))
         self._client.post(url, data)
 
     @pyqtSlot(str)

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -369,8 +369,11 @@ def nop():
 
 @cmdutils.register()
 @cmdutils.argument('win_id', win_id=True)
-def version(win_id):
+def version(win_id, paste=False):
     """Show version information."""
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     tabbed_browser.openurl(QUrl('qute://version'), newtab=True)
+
+    if paste:
+        utils.pastebin_version()


### PR DESCRIPTION
Added a --paste flag to the :version command and a JS button with corresponding qutescheme URL in the Version debug page which pastes the version string and logs the resulting URL at INFO level to messages. Proposed by issue [#3256](https://github.com/qutebrowser/qutebrowser/issues/3256)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3480)
<!-- Reviewable:end -->
