### PR TITLE
fix regression of #2778 which reappeared with qt 5.10 in combination …

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2197,10 +2197,6 @@ class CommandDispatcher:
 
         window = self._tabbed_browser.window()
         if window.isFullScreen():
-            window.setWindowState(
-                window.state_before_fullscreen & ~Qt.WindowFullScreen)
+            window.setWindowState(window.windowState() & ~Qt.WindowFullScreen)
         else:
-            window.state_before_fullscreen = window.windowState()
-            window.setWindowState(Qt.WindowFullScreen | window.state_before_fullscreen)
-        log.misc.debug('state before fullscreen: {}'.format(
-            debug.qflags_key(Qt, window.state_before_fullscreen)))
+            window.setWindowState(window.windowState() | Qt.WindowFullScreen)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2201,6 +2201,6 @@ class CommandDispatcher:
                 window.state_before_fullscreen & ~Qt.WindowFullScreen)
         else:
             window.state_before_fullscreen = window.windowState()
-            window.showFullScreen()
+            window.setWindowState(Qt.WindowFullScreen | window.state_before_fullscreen)
         log.misc.debug('state before fullscreen: {}'.format(
             debug.qflags_key(Qt, window.state_before_fullscreen)))

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -39,7 +39,7 @@ from qutebrowser.browser import (urlmarks, browsertab, inspector, navigate,
                                  webelem, downloads)
 from qutebrowser.keyinput import modeman
 from qutebrowser.utils import (message, usertypes, log, qtutils, urlutils,
-                               objreg, utils, debug, standarddir)
+                               objreg, utils, standarddir)
 from qutebrowser.utils.usertypes import KeyMode
 from qutebrowser.misc import editor, guiprocess
 from qutebrowser.completion.models import urlmodel, miscmodels

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2196,7 +2196,4 @@ class CommandDispatcher:
             return
 
         window = self._tabbed_browser.window()
-        if window.isFullScreen():
-            window.setWindowState(window.windowState() & ~Qt.WindowFullScreen)
-        else:
-            window.setWindowState(window.windowState() | Qt.WindowFullScreen)
+        window.setWindowState(window.windowState() ^ Qt.WindowFullScreen)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -134,7 +134,6 @@ class MainWindow(QWidget):
     Attributes:
         status: The StatusBar widget.
         tabbed_browser: The TabbedBrowser widget.
-        state_before_fullscreen: window state before activation of fullscreen.
         _downloadview: The DownloadView widget.
         _vbox: The main QVBoxLayout.
         _commandrunner: The main CommandRunner instance.
@@ -233,8 +232,6 @@ class MainWindow(QWidget):
         config.instance.changed.connect(self._on_config_changed)
 
         objreg.get("app").new_window.emit(self)
-
-        self.state_before_fullscreen = self.windowState()
 
     def _init_geometry(self, geometry):
         """Initialize the window geometry or load it from disk."""
@@ -497,12 +494,9 @@ class MainWindow(QWidget):
     def _on_fullscreen_requested(self, on):
         if not config.val.content.windowed_fullscreen:
             if on:
-                self.state_before_fullscreen = self.windowState()
-                self.setWindowState(Qt.WindowFullScreen | self.state_before_fullscreen)
+                self.setWindowState(self.windowState() | Qt.WindowFullScreen)
             elif self.isFullScreen():
-                self.setWindowState(self.state_before_fullscreen)
-        log.misc.debug('on: {}, state before fullscreen: {}'.format(
-            on, debug.qflags_key(Qt, self.state_before_fullscreen)))
+                self.setWindowState(self.windowState() & ~Qt.WindowFullScreen)
 
     @cmdutils.register(instance='main-window', scope='window')
     @pyqtSlot()

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -30,7 +30,7 @@ from PyQt5.QtWidgets import QWidget, QVBoxLayout, QApplication, QSizePolicy
 from qutebrowser.commands import runners, cmdutils
 from qutebrowser.config import config, configfiles
 from qutebrowser.utils import (message, log, usertypes, qtutils, objreg, utils,
-                               jinja, debug)
+                               jinja)
 from qutebrowser.mainwindow import messageview, prompt
 from qutebrowser.completion import completionwidget, completer
 from qutebrowser.keyinput import modeman

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -498,7 +498,7 @@ class MainWindow(QWidget):
         if not config.val.content.windowed_fullscreen:
             if on:
                 self.state_before_fullscreen = self.windowState()
-                self.showFullScreen()
+                self.setWindowState(Qt.WindowFullScreen | self.state_before_fullscreen)
             elif self.isFullScreen():
                 self.setWindowState(self.state_before_fullscreen)
         log.misc.debug('on: {}, state before fullscreen: {}'.format(


### PR DESCRIPTION
…with up-to-date KDE
This should also avoid an unneccessary KDE maximize animation when exiting fullscreen into maximized

Bug was the same as #2778:
- maximize window
- :fullscreen (makes window fullscreen as desired)
- :fullscreen (returnes to non-maximized window instead of a maximized one)

Seems the way to go is to keep all the flags the window state had and only toggle the fullscreen flag.
Nice to see that this also fixes the maximize animation problem.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3482)
<!-- Reviewable:end -->
