### PR TITLE
show current bindings when calling "bind" command without arguments

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -441,6 +441,8 @@ def qute_bindings(_url):
     bindings = {}
     defaults = config.val.bindings.default
     modes = set(defaults.keys()).union(config.val.bindings.commands)
+    modes.remove('normal')
+    modes = ['normal'] + sorted(list(modes))
     for mode in modes:
         bindings[mode] = config.key_instance.get_bindings_for(mode)
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -432,7 +432,7 @@ def qute_bindings(url):
     for mode in "normal hint command insert passthrough".split():
         bindings[mode] = config.key_instance.get_bindings_for(mode)
 
-    html = jinja.render('bindings.html', title='bindings',
+    html = jinja.render('bindings.html', title='Bindings',
                         bindings=bindings)
     return 'text/html', html
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -438,8 +438,8 @@ def qute_settings(url):
 @add_handler('bindings')
 def qute_bindings(url):
     """Handler for qute://bindings View qute bindings."""
+    assert url
 
-    _url = url
     bindings = {}
     for mode in "normal hint command insert passthrough".split():
         bindings[mode] = config.key_instance.get_bindings_for(mode)

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -439,6 +439,7 @@ def qute_settings(url):
 def qute_bindings(url):
     """Handler for qute://bindings View qute bindings."""
 
+    _url = url
     bindings = {}
     for mode in "normal hint command insert passthrough".split():
         bindings[mode] = config.key_instance.get_bindings_for(mode)

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -37,7 +37,7 @@ from PyQt5.QtCore import QUrlQuery, QUrl
 import qutebrowser
 from qutebrowser.config import config, configdata, configexc, configdiff
 from qutebrowser.utils import (version, utils, jinja, log, message, docutils,
-                               objreg, urlutils, usertypes)
+                               objreg, urlutils)
 from qutebrowser.misc import objects
 
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -37,7 +37,7 @@ from PyQt5.QtCore import QUrlQuery, QUrl
 import qutebrowser
 from qutebrowser.config import config, configdata, configexc, configdiff
 from qutebrowser.utils import (version, utils, jinja, log, message, docutils,
-                               objreg, urlutils)
+                               objreg, urlutils, usertypes)
 from qutebrowser.misc import objects
 
 
@@ -421,6 +421,20 @@ def _qute_settings_set(url):
     except configexc.Error as e:
         message.error(str(e))
         return 'text/html', b'error: ' + str(e).encode('utf-8')
+
+
+@add_handler('bindings')
+def qute_bindings(url):
+    """Handler for qute://bindings View qute bindings."""
+
+    bindings = {}
+    html = ''
+    for mode in "normal hint command insert passthrough".split():
+        bindings[mode] = config.key_instance.get_bindings_for(mode)
+
+    html = jinja.render('bindings.html', title='bindings',
+                        bindings=bindings)
+    return 'text/html', html
 
 
 @add_handler('settings')

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -436,12 +436,12 @@ def qute_settings(url):
 
 
 @add_handler('bindings')
-def qute_bindings(url):
-    """Handler for qute://bindings View qute bindings."""
-    assert url
-
+def qute_bindings(_url):
+    """Handler for qute://bindings. View keybindings."""
     bindings = {}
-    for mode in "normal hint command insert passthrough".split():
+    defaults = config.val.bindings.default
+    modes = set(defaults.keys()).union(config.val.bindings.commands)
+    for mode in modes:
         bindings[mode] = config.key_instance.get_bindings_for(mode)
 
     html = jinja.render('bindings.html', title='Bindings',

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -96,7 +96,8 @@ class ConfigCommands:
     @cmdutils.register(instance='config-commands', maxsplit=1,
                        no_cmd_split=True, no_replace_variables=True)
     @cmdutils.argument('command', completion=configmodel.bind)
-    def bind(self, key, command=None, *, mode='normal', default=False):
+    @cmdutils.argument('win_id', win_id=True)
+    def bind(self, win_id, key=None, command=None, *, mode='normal', default=False):
         """Bind a key to a command.
 
         Args:
@@ -108,6 +109,13 @@ class ConfigCommands:
                   available modes.
             default: If given, restore a default binding.
         """
+
+        if key is None:
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                        window=win_id)
+            tabbed_browser.openurl(QUrl('qute://bindings'), newtab=True)
+            return
+
         if command is None:
             if default:
                 # :bind --default: Restore default

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -110,7 +110,6 @@ class ConfigCommands:
                   available modes.
             default: If given, restore a default binding.
         """
-
         if key is None:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=win_id)

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -97,7 +97,8 @@ class ConfigCommands:
                        no_cmd_split=True, no_replace_variables=True)
     @cmdutils.argument('command', completion=configmodel.bind)
     @cmdutils.argument('win_id', win_id=True)
-    def bind(self, win_id, key=None, command=None, *, mode='normal', default=False):
+    def bind(self, win_id, key=None, command=None, *, mode='normal',
+             default=False):
         """Bind a key to a command.
 
         Args:

--- a/qutebrowser/html/bindings.html
+++ b/qutebrowser/html/bindings.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block style %}
+html { margin:20px; }
+table { width:100%; border: 1px solid grey; border-collapse: collapse; margin:10px; }
+tr,td,p { margin:0; padding: 1px; }
+th, td { border: 1px solid grey; }
+th { background: lightgrey; }
+th pre { color: grey; text-align: left; }
+.key { width: 25%; }
+.command { width: 75% }
+{% endblock %}
+
+{% block content %}
+<header><h1>{{ title }}</h1></header>
+{% for mode, binding in bindings.items() %}
+<h2>Mode = {{ mode }}</h2>
+<table>
+    <tr>
+        <th>Key</th>
+        <th>Command</th>
+    </tr>
+  {% for key,command in binding.items() %}
+    <tr>
+      <td class="key">
+        <p>{{ key }}</p>
+      </td>
+      <td class="command">
+        <p>{{ command }}</p>
+      </td>
+    </tr>
+  {% endfor %}
+</table>
+{% endfor %}
+
+{% endblock %}

--- a/qutebrowser/html/bindings.html
+++ b/qutebrowser/html/bindings.html
@@ -1,6 +1,7 @@
 {% extends "styled.html" %}
 
 {% block style %}
+{{ super() }}
 th { text-align:left; }
 .key { width: 25%; }
 .command { width: 75% }

--- a/qutebrowser/html/bindings.html
+++ b/qutebrowser/html/bindings.html
@@ -10,7 +10,7 @@ th { text-align:left; }
 {% block content %}
 <header><h1>{{ title }}</h1></header>
 {% for mode, binding in bindings.items() %}
-<h2>Mode = {{ mode }}</h2>
+<h2>{{ mode | capitalize }} mode</h2>
 <table>
     <tr>
         <th>Key</th>

--- a/qutebrowser/html/bindings.html
+++ b/qutebrowser/html/bindings.html
@@ -1,12 +1,7 @@
-{% extends "base.html" %}
+{% extends "styled.html" %}
 
 {% block style %}
-html { margin:20px; }
-table { width:100%; border: 1px solid grey; border-collapse: collapse; margin:10px; }
-tr,td,p { margin:0; padding: 1px; }
-th, td { border: 1px solid grey; }
-th { background: lightgrey; }
-th pre { color: grey; text-align: left; }
+th { text-align:left; }
 .key { width: 25%; }
 .command { width: 75% }
 {% endblock %}

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -429,6 +429,16 @@ class TestBind:
         """Get a dict with no bindings."""
         return {'normal': {}}
 
+    def test_bind_no_args(self, commands, config_stub, no_bindings,
+                          tabbed_browser_stubs):
+        """Run ':bind'.
+
+        Should open qute://bindings."""
+        config_stub.val.bindings.default = no_bindings
+        config_stub.val.bindings.commands = no_bindings
+        commands.bind(win_id=0)
+        assert tabbed_browser_stubs[0].opened_url == QUrl('qute://bindings')
+
     @pytest.mark.parametrize('command', ['nop', 'nope'])
     def test_bind(self, commands, config_stub, no_bindings, key_config_stub,
                   command):
@@ -437,7 +447,7 @@ class TestBind:
         config_stub.val.bindings.default = no_bindings
         config_stub.val.bindings.commands = no_bindings
 
-        commands.bind('a', command)
+        commands.bind(0, 'a', command)
         assert key_config_stub.get_command('a', 'normal') == command
         yaml_bindings = config_stub._yaml['bindings.commands']['normal']
         assert yaml_bindings['a'] == command
@@ -474,7 +484,7 @@ class TestBind:
             'normal': {'c': 'message-info c'}
         }
 
-        commands.bind(key, mode=mode)
+        commands.bind(0, key, mode=mode)
 
         msg = message_mock.getmsg(usertypes.MessageLevel.info)
         assert msg.text == expected
@@ -486,7 +496,7 @@ class TestBind:
         """
         with pytest.raises(cmdexc.CommandError,
                            match='Invalid mode wrongmode!'):
-            commands.bind('a', 'nop', mode='wrongmode')
+            commands.bind(0, 'a', 'nop', mode='wrongmode')
 
     def test_bind_print_invalid_mode(self, commands):
         """Run ':bind --mode=wrongmode a'.
@@ -495,7 +505,7 @@ class TestBind:
         """
         with pytest.raises(cmdexc.CommandError,
                            match='Invalid mode wrongmode!'):
-            commands.bind('a', mode='wrongmode')
+            commands.bind(0, 'a', mode='wrongmode')
 
     @pytest.mark.parametrize('key', ['a', 'b', '<Ctrl-X>'])
     def test_bind_duplicate(self, commands, config_stub, key_config_stub, key):
@@ -510,12 +520,12 @@ class TestBind:
             'normal': {'b': 'nop'},
         }
 
-        commands.bind(key, 'message-info foo', mode='normal')
+        commands.bind(0, key, 'message-info foo', mode='normal')
         assert key_config_stub.get_command(key, 'normal') == 'message-info foo'
 
     def test_bind_none(self, commands, config_stub):
         config_stub.val.bindings.commands = None
-        commands.bind(',x', 'nop')
+        commands.bind(0, ',x', 'nop')
 
     def test_bind_default(self, commands, key_config_stub, config_stub):
         """Bind a key to its default."""
@@ -525,7 +535,7 @@ class TestBind:
         config_stub.val.bindings.commands = {'normal': {'a': bound_cmd}}
         assert key_config_stub.get_command('a', mode='normal') == bound_cmd
 
-        commands.bind('a', mode='normal', default=True)
+        commands.bind(0, 'a', mode='normal', default=True)
 
         assert key_config_stub.get_command('a', mode='normal') == default_cmd
 
@@ -539,7 +549,7 @@ class TestBind:
         Should show an error.
         """
         with pytest.raises(cmdexc.CommandError, match=expected):
-            commands.bind(key, mode=mode, default=True)
+            commands.bind(0, key, mode=mode, default=True)
 
     def test_unbind_none(self, commands, config_stub):
         config_stub.val.bindings.commands = None
@@ -563,7 +573,7 @@ class TestBind:
         }
         if key == 'c':
             # Test :bind and :unbind
-            commands.bind(key, 'nop')
+            commands.bind(0, key, 'nop')
 
         commands.unbind(key)
         assert key_config_stub.get_command(key, 'normal') is None


### PR DESCRIPTION
implement issue #24
currently only shows bindings for the following key modes: normal, hint, command, insert, passthrough

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3484)
<!-- Reviewable:end -->
