### PR TITLE
Set some PRAGMAs to optimize the history database.

### DIFF
--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -115,6 +115,11 @@ def init(db_path):
         raise SqliteError("Failed to open sqlite database at {}: {}"
                           .format(db_path, error.text()), error)
 
+    # Enable write-ahead-logging and reduce disk write frequency
+    # see https://sqlite.org/pragma.html and issues #2930 and #3507
+    Query("PRAGMA journal_mode=WAL").run()
+    Query("PRAGMA synchronous=NORMAL").run()
+
 
 def close():
     """Close the SQL connection."""


### PR DESCRIPTION
Enable write-ahead-logging and reduce the synchronous level to NORMAL.
This should reduce the number of writes to disk and avoid some of the
hangs users are experiencing.

Resolves #3507.
Resolves #2930 (optimistically, reopen if not fixed).

See https://sqlite.org/pragma.html and https://www.sqlite.org/wal.html.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3509)
<!-- Reviewable:end -->
