### PR TITLE
Show '&' properly in completion widget.

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -203,9 +203,9 @@ class CompletionItemDelegate(QStyledItemDelegate):
             columns_to_filter = index.model().columns_to_filter(index)
             if index.column() in columns_to_filter and pattern:
                 repl = r'<span class="highlight">\g<0></span>'
-                text = re.sub(re.escape(pattern).replace(r'\ ', r'|'),
-                              repl, html.escape(self._opt.text),
-                              flags=re.IGNORECASE)
+                pat = html.escape(re.escape(pattern)).replace(r'\ ', r'|')
+                txt = html.escape(self._opt.text)
+                text = re.sub(pat, repl, txt, flags=re.IGNORECASE)
                 self._doc.setHtml(text)
             else:
                 self._doc.setPlainText(self._opt.text)


### PR DESCRIPTION
When highlighting the matched part of the text, we need to html-escape
the pattern used to find the matching text so it will replace terms that
have been escaped in the text, like &amp;.

Resolves #3508.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3510)
<!-- Reviewable:end -->
