### PR TITLE
Use WebEngine's view-source scheme for "view-source" command

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -733,7 +733,6 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)
     @cmdutils.argument('horizontal', flag='x')
-
     def scroll_to_perc(self, perc: float = None, horizontal=False, count=None):
         """Scroll to a specific percentage of the page.
 
@@ -1516,7 +1515,9 @@ class CommandDispatcher:
 
         if tab.backend == usertypes.Backend.QtWebEngine:
             url = QUrl('view-source:{}'.format(current_url.toString()))
-            self._tabbed_browser.tabopen(url, background=True)
+            new_tab = self._tabbed_browser.tabopen(url, background=True,
+                related=True)
+            new_tab.data.viewing_source = True
             return
 
         def show_source_cb(source):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1513,6 +1513,11 @@ class CommandDispatcher:
             message.error(str(e))
             return
 
+        if tab.backend == usertypes.Backend.QtWebEngine:
+            url = QUrl('view-source:{}'.format(current_url.toString()))
+            self._tabbed_browser.tabopen(url, background=True)
+            return
+
         def show_source_cb(source):
             """Show source as soon as it's ready."""
             # WORKAROUND for https://github.com/PyCQA/pylint/issues/491
@@ -1527,6 +1532,8 @@ class CommandDispatcher:
             new_tab = self._tabbed_browser.tabopen()
             new_tab.set_html(highlighted)
             new_tab.data.viewing_source = True
+            new_tab.url = lambda requested=False: QUrl(
+                'Source: {}'.format(current_url.toDisplayString()))
 
         tab.dump_async(show_source_cb)
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -733,6 +733,7 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)
     @cmdutils.argument('horizontal', flag='x')
+
     def scroll_to_perc(self, perc: float = None, horizontal=False, count=None):
         """Scroll to a specific percentage of the page.
 
@@ -758,8 +759,8 @@ class CommandDispatcher:
         else:
             x = None
             y = perc
-
         self._current_widget().scroller.to_perc(x, y)
+
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', count=True)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -408,7 +408,6 @@ class WebEngineScroller(browsertab.AbstractScroller):
     def to_perc(self, x=None, y=None):
         pos_x = 0
         pos_y = 0
-        page = self._widget.page()
         contents_size = self._widget.page().contentsSize()
         scrollable_x = contents_size.width() - self._widget.width()
         scrollable_y = contents_size.height() - self._widget.height()
@@ -416,7 +415,8 @@ class WebEngineScroller(browsertab.AbstractScroller):
             pos_x = x / 100.0 * scrollable_x
         if y:
             pos_y = y / 100.0 * scrollable_y
-        self._tab.run_js_async('window.scrollTo({}, {})'.format(str(pos_x), str(pos_y)))
+        js_code = 'window.scrollTo({}, {})'.format(str(pos_x), str(pos_y))
+        self._tab.run_js_async(js_code)
 
     def to_point(self, point):
         js_code = javascript.assemble('window', 'scroll', point.x(), point.y())

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -406,8 +406,17 @@ class WebEngineScroller(browsertab.AbstractScroller):
         return self._pos_perc
 
     def to_perc(self, x=None, y=None):
-        js_code = javascript.assemble('scroll', 'to_perc', x, y)
-        self._tab.run_js_async(js_code)
+        pos_x = 0
+        pos_y = 0
+        page = self._widget.page()
+        contents_size = self._widget.page().contentsSize()
+        scrollable_x = contents_size.width() - self._widget.width()
+        scrollable_y = contents_size.height() - self._widget.height()
+        if x:
+            pos_x = x / 100.0 * scrollable_x
+        if y:
+            pos_y = y / 100.0 * scrollable_y
+        self._tab.run_js_async('window.scrollTo({}, {})'.format(str(pos_x), str(pos_y)))
 
     def to_point(self, point):
         js_code = javascript.assemble('window', 'scroll', point.x(), point.y())

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -415,7 +415,7 @@ class WebEngineScroller(browsertab.AbstractScroller):
             pos_x = x / 100.0 * scrollable_x
         if y:
             pos_y = y / 100.0 * scrollable_y
-        js_code = 'window.scrollTo({}, {})'.format(str(pos_x), str(pos_y))
+        js_code = javascript.assemble('window', 'scrollTo', pos_x, pos_y)
         self._tab.run_js_async(js_code)
 
     def to_point(self, point):


### PR DESCRIPTION
For WebKit backend, properly set the tab's URL to show "source: URL"

Resolves #2948
Resolves #2395

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3516)
<!-- Reviewable:end -->
