### PR TITLE
view-source command now using scheme

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -119,8 +119,10 @@ class AbstractAction:
     action_class = None
     action_base = None
 
-    def __init__(self):
+    def __init__(self, tab, win_id):
         self._widget = None
+        self._tab = tab
+        self._win_id = win_id
 
     def exit_fullscreen(self):
         """Exit the fullscreen mode."""
@@ -137,7 +139,7 @@ class AbstractAction:
             raise WebTabError("{} is not a valid web action!".format(name))
         self._widget.triggerPageAction(member)
 
-    def show_source(self, win_id, url):
+    def show_source(self):
         """Show the source of the current page in a new tab."""
         raise NotImplementedError
 

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -139,6 +139,10 @@ class AbstractAction:
             raise WebTabError("{} is not a valid web action!".format(name))
         self._widget.triggerPageAction(member)
 
+    def show_source(self, dispatcher, url):
+        """Show the source of the current page in a new tab."""
+        raise NotImplementedError
+
 
 class AbstractPrinting:
 

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -94,7 +94,6 @@ class TabData:
         keep_icon: Whether the (e.g. cloned) icon should not be cleared on page
                    load.
         inspector: The QWebInspector used for this webview.
-        viewing_source: Set if we're currently showing a source view.
         override_target: Override for open_target for fake clicks (like hints).
                          Only used for QtWebKit.
         pinned: Flag to pin the tab.
@@ -102,7 +101,6 @@ class TabData:
     """
 
     keep_icon = attr.ib(False)
-    viewing_source = attr.ib(False)
     inspector = attr.ib(None)
     override_target = attr.ib(None)
     pinned = attr.ib(False)
@@ -139,7 +137,7 @@ class AbstractAction:
             raise WebTabError("{} is not a valid web action!".format(name))
         self._widget.triggerPageAction(member)
 
-    def show_source(self, dispatcher, url):
+    def show_source(self, win_id, url):
         """Show the source of the current page in a new tab."""
         raise NotImplementedError
 
@@ -727,7 +725,6 @@ class AbstractTab(QWidget):
     def _on_load_started(self):
         self._progress = 0
         self._has_ssl_errors = False
-        self.data.viewing_source = False
         self._set_load_status(usertypes.LoadStatus.loading)
         self.load_started.emit()
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -29,9 +29,6 @@ from PyQt5.QtWidgets import QApplication, QTabBar, QDialog
 from PyQt5.QtCore import Qt, QUrl, QEvent, QUrlQuery
 from PyQt5.QtGui import QKeyEvent
 from PyQt5.QtPrintSupport import QPrintDialog, QPrintPreviewDialog
-import pygments
-import pygments.lexers
-import pygments.formatters
 
 from qutebrowser.commands import userscripts, cmdexc, cmdutils, runners
 from qutebrowser.config import config, configdata
@@ -758,6 +755,7 @@ class CommandDispatcher:
         else:
             x = None
             y = perc
+
         self._current_widget().scroller.to_perc(x, y)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
@@ -1503,15 +1501,15 @@ class CommandDispatcher:
     def view_source(self):
         """Show the source of the current page in a new tab."""
         tab = self._current_widget()
-        if tab.data.viewing_source:
-            raise cmdexc.CommandError("Already viewing source!")
-
         try:
             current_url = self._current_url()
         except cmdexc.CommandError as e:
             message.error(str(e))
             return
-        tab.action.show_source(self, current_url)
+        if current_url.scheme() == 'view-source':
+            raise cmdexc.CommandError("Already viewing source!")
+
+        tab.action.show_source(self._win_id, current_url)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        debug=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1511,33 +1511,7 @@ class CommandDispatcher:
         except cmdexc.CommandError as e:
             message.error(str(e))
             return
-
-        if tab.backend == usertypes.Backend.QtWebEngine:
-            # use view-source: scheme to show page source for webengine
-            url = QUrl('view-source:{}'.format(current_url.toString()))
-            new_tab = self._tabbed_browser.tabopen(
-                url, background=True, related=True)
-            new_tab.data.viewing_source = True
-            return
-
-        def show_source_cb(source):
-            """Show source as soon as it's ready."""
-            # WORKAROUND for https://github.com/PyCQA/pylint/issues/491
-            # pylint: disable=no-member
-            lexer = pygments.lexers.HtmlLexer()
-            formatter = pygments.formatters.HtmlFormatter(
-                full=True, linenos='table',
-                title='Source for {}'.format(current_url.toDisplayString()))
-            # pylint: enable=no-member
-            highlighted = pygments.highlight(source, lexer, formatter)
-
-            new_tab = self._tabbed_browser.tabopen()
-            new_tab.set_html(highlighted)
-            new_tab.data.viewing_source = True
-            new_tab.url = lambda requested=False: QUrl(
-                'Source: {}'.format(current_url.toDisplayString()))
-
-        tab.dump_async(show_source_cb)
+        tab.action.show_source(self, current_url)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        debug=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1509,7 +1509,7 @@ class CommandDispatcher:
         if current_url.scheme() == 'view-source':
             raise cmdexc.CommandError("Already viewing source!")
 
-        tab.action.show_source(self._win_id, current_url)
+        tab.action.show_source()
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        debug=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1515,8 +1515,8 @@ class CommandDispatcher:
         if tab.backend == usertypes.Backend.QtWebEngine:
             # use view-source: scheme to show page source for webengine
             url = QUrl('view-source:{}'.format(current_url.toString()))
-            new_tab = self._tabbed_browser.tabopen(url, background=True,
-                related=True)
+            new_tab = self._tabbed_browser.tabopen(
+                url, background=True, related=True)
             new_tab.data.viewing_source = True
             return
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -758,7 +758,6 @@ class CommandDispatcher:
         else:
             x = None
             y = perc
-
         self._current_widget().scroller.to_perc(x, y)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
@@ -1513,6 +1512,14 @@ class CommandDispatcher:
             message.error(str(e))
             return
 
+        if tab.backend == usertypes.Backend.QtWebEngine:
+            # use view-source: scheme to show page source for webengine
+            url = QUrl('view-source:{}'.format(current_url.toString()))
+            new_tab = self._tabbed_browser.tabopen(url, background=True,
+                related=True)
+            new_tab.data.viewing_source = True
+            return
+
         def show_source_cb(source):
             """Show source as soon as it's ready."""
             # WORKAROUND for https://github.com/PyCQA/pylint/issues/491
@@ -1527,6 +1534,8 @@ class CommandDispatcher:
             new_tab = self._tabbed_browser.tabopen()
             new_tab.set_html(highlighted)
             new_tab.data.viewing_source = True
+            new_tab.url = lambda requested=False: QUrl(
+                'Source: {}'.format(current_url.toDisplayString()))
 
         tab.dump_async(show_source_cb)
 

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -172,7 +172,7 @@ class WebHistory(sql.SqlTable):
     @pyqtSlot(QUrl, QUrl, str)
     def add_from_tab(self, url, requested_url, title):
         """Add a new history entry as slot, called from a BrowserTab."""
-        if any(url.scheme() == 'data' or
+        if any(url.scheme() in ('data', 'view-source') or
                (url.scheme(), url.host()) == ('qute', 'back')
                for url in (url, requested_url)):
             return

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -99,6 +99,13 @@ class WebEngineAction(browsertab.AbstractAction):
         """Save the current page."""
         self._widget.triggerPageAction(QWebEnginePage.SavePage)
 
+    def show_source(self, dispatcher, url):
+        # use view-source: scheme to show page source for webengine
+        url = QUrl('view-source:{}'.format(url.toString()))
+        new_tab = dispatcher._tabbed_browser.tabopen(
+            url, background=True, related=True)
+        new_tab.data.viewing_source = True
+
 
 class WebEnginePrinting(browsertab.AbstractPrinting):
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -99,18 +99,16 @@ class WebEngineAction(browsertab.AbstractAction):
         """Save the current page."""
         self._widget.triggerPageAction(QWebEnginePage.SavePage)
 
-    def show_source(self, win_id, url):
+    def show_source(self):
         try:
             self._widget.triggerPageAction(QWebEnginePage.ViewSource)
         except AttributeError:
             # Qt < 5.8
-            # note: it's not possible to build the QUrl object by setting the
-            # scheme using setScheme('view-source').
-            # QUrl does the right thing when URL prefix is "view-source:".
-            new_url = QUrl('view-source:' + url.toString())
-            tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                        window=win_id)
-            tabbed_browser.tabopen(new_url, background=False, related=True)
+            url_str = self._tab.url().toString(QUrl.RemoveUserInfo)
+            new_url = QUrl('view-source:' + url_str)
+            tb = objreg.get('tabbed-browser', scope='window',
+                            window=self._win_id)
+            tb.tabopen(new_url, background=False, related=True)
 
 
 class WebEnginePrinting(browsertab.AbstractPrinting):
@@ -609,7 +607,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self.search = WebEngineSearch(parent=self)
         self.printing = WebEnginePrinting()
         self.elements = WebEngineElements(self)
-        self.action = WebEngineAction()
+        self.action = WebEngineAction(self, win_id)
         self._set_widget(widget)
         self._connect_signals()
         self.backend = usertypes.Backend.QtWebEngine

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -99,12 +99,18 @@ class WebEngineAction(browsertab.AbstractAction):
         """Save the current page."""
         self._widget.triggerPageAction(QWebEnginePage.SavePage)
 
-    def show_source(self, dispatcher, url):
-        # use view-source: scheme to show page source for webengine
-        url = QUrl('view-source:{}'.format(url.toString()))
-        new_tab = dispatcher._tabbed_browser.tabopen(
-            url, background=True, related=True)
-        new_tab.data.viewing_source = True
+    def show_source(self, win_id, url):
+        try:
+            self._widget.triggerPageAction(QWebEnginePage.ViewSource)
+        except AttributeError:
+            # Qt < 5.8
+            # note: it's not possible to build the QUrl object by setting the
+            # scheme using setScheme('view-source').
+            # QUrl does the right thing when URL prefix is "view-source:".
+            new_url = QUrl('view-source:' + url.toString())
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                        window=win_id)
+            tabbed_browser.tabopen(new_url, background=False, related=True)
 
 
 class WebEnginePrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -106,10 +106,10 @@ class WebEngineAction(browsertab.AbstractAction):
             # Qt < 5.8
             tb = objreg.get('tabbed-browser', scope='window',
                             window=self._win_id)
-            url_str = self._tab.url().toString(QUrl.RemoveUserInfo)
+            urlstr = self._tab.url().toString(QUrl.RemoveUserInfo)
             # The original URL becomes the path of a view-source: URL
             # (without a host), but query/fragment should stay.
-            url = QUrl('view-source:' + url_str)
+            url = QUrl('view-source:' + urlstr)
             tb.tabopen(url, background=False, related=True)
 
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -104,11 +104,13 @@ class WebEngineAction(browsertab.AbstractAction):
             self._widget.triggerPageAction(QWebEnginePage.ViewSource)
         except AttributeError:
             # Qt < 5.8
-            url_str = self._tab.url().toString(QUrl.RemoveUserInfo)
-            new_url = QUrl('view-source:' + url_str)
             tb = objreg.get('tabbed-browser', scope='window',
                             window=self._win_id)
-            tb.tabopen(new_url, background=False, related=True)
+            url_str = self._tab.url().toString(QUrl.RemoveUserInfo)
+            # The original URL becomes the path of a view-source: URL
+            # (without a host), but query/fragment should stay.
+            url = QUrl('view-source:' + url_str)
+            tb.tabopen(url, background=False, related=True)
 
 
 class WebEnginePrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -613,7 +613,7 @@ class WebEngineTab(browsertab.AbstractTab):
             utils.read_file('javascript/caret.js'),
         ])
         script = QWebEngineScript()
-        script.setInjectionPoint(QWebEngineScript.DocumentCreation)
+        script.setInjectionPoint(QWebEngineScript.DocumentReady)
         script.setSourceCode(js_code)
 
         page = self._widget.page()

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -71,10 +71,10 @@ class WebKitAction(browsertab.AbstractAction):
             new_tab = tb.tabopen(background=False, related=True)
             # The original URL becomes the path of a view-source: URL
             # (without a host), but query/fragment should stay.
-            url = QUrl('view-source:' + url_str)
+            url = QUrl('view-source:' + urlstr)
             new_tab.set_html(highlighted, url)
 
-        url_str = self._tab.url().toString(QUrl.RemoveUserInfo)
+        urlstr = self._tab.url().toString(QUrl.RemoveUserInfo)
         self._tab.dump_async(show_source_cb)
 
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -23,6 +23,10 @@ import re
 import functools
 import xml.etree.ElementTree
 
+import pygments
+import pygments.lexers
+import pygments.formatters
+
 import sip
 from PyQt5.QtCore import (pyqtSlot, Qt, QEvent, QUrl, QPoint, QTimer, QSizeF,
                           QSize)
@@ -49,6 +53,25 @@ class WebKitAction(browsertab.AbstractAction):
     def save_page(self):
         """Save the current page."""
         raise browsertab.UnsupportedOperationError
+
+    def show_source(self, dispatcher, url):
+        def show_source_cb(source):
+            """Show source as soon as it's ready."""
+            # WORKAROUND for https://github.com/PyCQA/pylint/issues/491
+            # pylint: disable=no-member
+            lexer = pygments.lexers.HtmlLexer()
+            formatter = pygments.formatters.HtmlFormatter(
+                full=True, linenos='table',
+                title='view-source:{}'.format(url.toDisplayString()))
+            # pylint: enable=no-member
+            highlighted = pygments.highlight(source, lexer, formatter)
+
+            new_tab = dispatcher._tabbed_browser.tabopen()
+            new_tab.set_html(highlighted)
+            new_tab.data.viewing_source = True
+            new_tab.url = lambda requested=False: QUrl(
+                'view-source:' + url.toDisplayString())
+        dispatcher._current_widget().dump_async(show_source_cb)
 
 
 class WebKitPrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -62,16 +62,17 @@ class WebKitAction(browsertab.AbstractAction):
             # pylint: disable=no-member
             lexer = pygments.lexers.HtmlLexer()
             formatter = pygments.formatters.HtmlFormatter(
-                full=True, linenos='table',
-                title='Source for {}'.format(url_str))
+                full=True, linenos='table')
             # pylint: enable=no-member
             highlighted = pygments.highlight(source, lexer, formatter)
 
-            base_url = QUrl('view-source:' + url_str)
             tb = objreg.get('tabbed-browser', scope='window',
                             window=self._win_id)
             new_tab = tb.tabopen(background=False, related=True)
-            new_tab.set_html(highlighted, base_url)
+            # The original URL becomes the path of a view-source: URL
+            # (without a host), but query/fragment should stay.
+            url = QUrl('view-source:' + url_str)
+            new_tab.set_html(highlighted, url)
 
         url_str = self._tab.url().toString(QUrl.RemoveUserInfo)
         self._tab.dump_async(show_source_cb)

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -69,7 +69,7 @@ Feature: Page history
     Scenario: History with view-source URL
         When I open data/title.html
         And I run :view-source
-        And I wait for regex "Changing title for idx \d+ to '(Source for |view-source:)(http://)?localhost:\d+/data/title.html'" in the log
+        And I wait for regex "Changing title for idx \d+ to 'view-source:(http://)?localhost:\d+/data/title.html'" in the log
         Then the history should contain:
             http://localhost:(port)/data/title.html Test title
 

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -69,7 +69,7 @@ Feature: Page history
     Scenario: History with view-source URL
         When I open data/title.html
         And I run :view-source
-        And I wait for "Changing title for idx * to 'view-source:http://localhost:*/data/title.html'" in the log
+        And I wait for regex "Changing title for idx \d+ to '(Source for |view-source:)(http://)?localhost:\d+/data/title.html'" in the log
         Then the history should contain:
             http://localhost:(port)/data/title.html Test title
 

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -69,7 +69,7 @@ Feature: Page history
     Scenario: History with view-source URL
         When I open data/title.html
         And I run :view-source
-        And I wait for "Changing title for idx * to 'Source for http://localhost:*/data/title.html'" in the log
+        And I wait for "Changing title for idx * to 'view-source:http://localhost:*/data/title.html'" in the log
         Then the history should contain:
             http://localhost:(port)/data/title.html Test title
 

--- a/tests/unit/browser/test_tab.py
+++ b/tests/unit/browser/test_tab.py
@@ -87,7 +87,7 @@ class Tab(browsertab.AbstractTab):
         self.search = browsertab.AbstractSearch(parent=self)
         self.printing = browsertab.AbstractPrinting()
         self.elements = browsertab.AbstractElements(self)
-        self.action = browsertab.AbstractAction()
+        self.action = browsertab.AbstractAction(self, self.win_id)
 
     def _install_event_filter(self):
         pass


### PR DESCRIPTION
Use WebEngine's view-source: scheme for "view-source" command.
Inject qutebrowser's JS files at DocumentReady
Also add missing URL when viewing source for WebKit.
    
Resolves #3490
Resolves #2395
Resolves #2948

A bit less intrusive than the last PR, but we still need to test this to make sure injecting Qutebrowser's JS files at DocumentReady instead of DocumentCreation does not cause problems elsewhere.

If you guys can try this on your end, I'll be running this code from now on and report any odd behavior.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3521)
<!-- Reviewable:end -->
