### PR TITLE
Updated PyYaml link

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -114,7 +114,7 @@ The following software and libraries are required to run qutebrowser:
 * http://fdik.org/pyPEG/[pyPEG2]
 * http://jinja.pocoo.org/[jinja2]
 * http://pygments.org/[pygments]
-* http://pyyaml.org/wiki/PyYAML[PyYAML]
+* https://github.com/yaml/pyyaml[PyYAML]
 * http://www.attrs.org/[attrs]
 
 The following libraries are optional:


### PR DESCRIPTION
http://pyyaml.org/wiki/PyYAML says:
> PyYAML is now maintained at https://github.com/yaml/pyyaml. This page is left for historical purposes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3543)
<!-- Reviewable:end -->
