### PR TITLE
Use the instance attribute instead of querying the registry

### DIFF
--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -429,7 +429,6 @@ class MainWindow(QWidget):
         status = self._get_object('statusbar')
         keyparsers = self._get_object('keyparsers')
         completion_obj = self._get_object('completion')
-        tabs = self._get_object('tabbed-browser')
         cmd = self._get_object('status-command')
         message_bridge = self._get_object('message-bridge')
         mode_manager = self._get_object('mode-manager')
@@ -449,7 +448,7 @@ class MainWindow(QWidget):
             status.keystring.setText)
         cmd.got_cmd[str].connect(self._commandrunner.run_safely)
         cmd.got_cmd[str, int].connect(self._commandrunner.run_safely)
-        cmd.returnPressed.connect(tabs.on_cmd_return_pressed)
+        cmd.returnPressed.connect(self.tabbed_browser.on_cmd_return_pressed)
 
         # key hint popup
         for mode, parser in keyparsers.items():
@@ -467,25 +466,31 @@ class MainWindow(QWidget):
         message_bridge.s_maybe_reset_text.connect(status.txt.maybe_reset_text)
 
         # statusbar
-        tabs.current_tab_changed.connect(status.on_tab_changed)
+        self.tabbed_browser.current_tab_changed.connect(status.on_tab_changed)
 
-        tabs.cur_progress.connect(status.prog.setValue)
-        tabs.cur_load_finished.connect(status.prog.hide)
-        tabs.cur_load_started.connect(status.prog.on_load_started)
+        self.tabbed_browser.cur_progress.connect(status.prog.setValue)
+        self.tabbed_browser.cur_load_finished.connect(status.prog.hide)
+        self.tabbed_browser.cur_load_started.connect(
+            status.prog.on_load_started)
 
-        tabs.cur_scroll_perc_changed.connect(status.percentage.set_perc)
-        tabs.tab_index_changed.connect(status.tabindex.on_tab_index_changed)
+        self.tabbed_browser.cur_scroll_perc_changed.connect(
+            status.percentage.set_perc)
+        self.tabbed_browser.tab_index_changed.connect(
+            status.tabindex.on_tab_index_changed)
 
-        tabs.cur_url_changed.connect(status.url.set_url)
-        tabs.cur_url_changed.connect(functools.partial(
-            status.backforward.on_tab_cur_url_changed, tabs=tabs))
-        tabs.cur_link_hovered.connect(status.url.set_hover_url)
-        tabs.cur_load_status_changed.connect(status.url.on_load_status_changed)
-        tabs.cur_fullscreen_requested.connect(self._on_fullscreen_requested)
-        tabs.cur_fullscreen_requested.connect(status.maybe_hide)
+        self.tabbed_browser.cur_url_changed.connect(status.url.set_url)
+        self.tabbed_browser.cur_url_changed.connect(functools.partial(
+            status.backforward.on_tab_cur_url_changed,
+            tabs=self.tabbed_browser))
+        self.tabbed_browser.cur_link_hovered.connect(status.url.set_hover_url)
+        self.tabbed_browser.cur_load_status_changed.connect(
+            status.url.on_load_status_changed)
+        self.tabbed_browser.cur_fullscreen_requested.connect(
+            self._on_fullscreen_requested)
+        self.tabbed_browser.cur_fullscreen_requested.connect(status.maybe_hide)
 
         # command input / completion
-        mode_manager.left.connect(tabs.on_mode_left)
+        mode_manager.left.connect(self.tabbed_browser.on_mode_left)
         cmd.clear_completion_selection.connect(
             completion_obj.on_clear_completion_selection)
         cmd.hide_completion.connect(completion_obj.hide)


### PR DESCRIPTION
Hi, I decided to start working on #1716 as a hobby (not even sure if I'll be able to finish it, so nothing official), and since it'll force me to review almost the entire codebase I figured it would be a good opportunity to propose small/aesthetic changes while I'm at it.

In this case I noticed the same object being accessed via two different references: an instance attribute and using the object registry. I guess the first one makes more sense. Let me know if this makes sense.

Love your browser 👍

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3544)
<!-- Reviewable:end -->
