### PR TITLE
Delete QWebEngineDownloadItem objects when wrapper object is deleted

### DIFF
--- a/qutebrowser/browser/webengine/webenginedownloads.py
+++ b/qutebrowser/browser/webengine/webenginedownloads.py
@@ -45,6 +45,10 @@ class DownloadItem(downloads.AbstractDownloadItem):
         qt_item.downloadProgress.connect(self.stats.on_download_progress)
         qt_item.stateChanged.connect(self._on_state_changed)
 
+        # Ensure wrapped qt_item is deleted manually when the wrapper object
+        # is deleted. See https://github.com/qutebrowser/qutebrowser/issues/3373
+        self.destroyed.connect(self._qt_item.deleteLater)
+
     def _is_page_download(self):
         """Check if this item is a page (i.e. mhtml) download."""
         return (self._qt_item.savePageFormat() !=


### PR DESCRIPTION
Closes #3373 

On IRC, we discussed deleting the `_qt_item` object when we receive a `remove_requested` signal, however, I think that deleting it when the wrapper object is destroyed is a better solution, because it has a lower chance of the wrapper and the C++ object becoming disconnected, for example, due to a bug on the python side. Let me know if you prefer to do it the other way if you still think it is better, though.

I still want to do more testing, but from what I see so far, this seems to cause no problems for me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3555)
<!-- Reviewable:end -->
