### PR TITLE
Display exception type in configfiles

### DIFF
--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -94,8 +94,8 @@ class ConfigErrorDesc:
     def __str__(self):
         if self.traceback:
             return '{} - {}: {}'.format(self.text,
-                                         self.exception.__class__.__name__,
-                                         self.exception)
+                                        self.exception.__class__.__name__,
+                                        self.exception)
         return '{}: {}'.format(self.text, self.exception)
 
     def with_text(self, text):

--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -93,7 +93,7 @@ class ConfigErrorDesc:
 
     def __str__(self):
         if self.traceback:
-            return '{} - {}: {} '.format(self.text,
+            return '{} - {}: {}'.format(self.text,
                                          self.exception.__class__.__name__,
                                          self.exception)
         return '{}: {}'.format(self.text, self.exception)

--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -92,7 +92,7 @@ class ConfigErrorDesc:
     traceback = attr.ib(None)
 
     def __str__(self):
-        return '{}: {}'.format(self.text, self.exception)
+        return '{}: {} '.format(self.text, repr(self.exception))
 
     def with_text(self, text):
         """Get a new ConfigErrorDesc with the given text appended."""

--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -92,9 +92,11 @@ class ConfigErrorDesc:
     traceback = attr.ib(None)
 
     def __str__(self):
-        return '{} - {}: {} '.format(self.text,
-                                     self.exception.__class__.__name__,
-                                     self.exception)
+        if self.traceback:
+            return '{} - {}: {} '.format(self.text,
+                                         self.exception.__class__.__name__,
+                                         self.exception)
+        return '{}: {}'.format(self.text, self.exception)
 
     def with_text(self, text):
         """Get a new ConfigErrorDesc with the given text appended."""

--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -93,7 +93,8 @@ class ConfigErrorDesc:
 
     def __str__(self):
         return '{} - {}: {} '.format(self.text,
-                                     self.exception.__class__.__name__, self.exception)
+                                     self.exception.__class__.__name__,
+                                     self.exception)
 
     def with_text(self, text):
         """Get a new ConfigErrorDesc with the given text appended."""

--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -92,7 +92,8 @@ class ConfigErrorDesc:
     traceback = attr.ib(None)
 
     def __str__(self):
-        return '{}: {} '.format(self.text, repr(self.exception))
+        return '{} - {}: {} '.format(self.text,
+                                     self.exception.__class__.__name__, self.exception)
 
     def with_text(self, text):
         """Get a new ConfigErrorDesc with the given text appended."""

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -419,7 +419,7 @@ def read_config_py(filename, raising=False):
         desc = configexc.ConfigErrorDesc("Error while compiling", e)
         raise configexc.ConfigFileErrors(basename, [desc])
     except SyntaxError as e:
-        desc = configexc.ConfigErrorDesc("Syntax Error", e,
+        desc = configexc.ConfigErrorDesc("Unhandled exception", e,
                                          traceback=traceback.format_exc())
         raise configexc.ConfigFileErrors(basename, [desc])
 

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -318,7 +318,7 @@ class TestSource:
 
         expected = ("Errors occurred while reading config.py:\n"
                     "  Unhandled exception - ZeroDivisionError:"
-                    " division by zero ")
+                    " division by zero")
         assert str(excinfo.value) == expected
 
 

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -309,6 +309,18 @@ class TestSource:
                     "  While setting 'foo': No option 'foo'")
         assert str(excinfo.value) == expected
 
+    def test_invalid_source(self, commands, config_tmpdir):
+        pyfile = config_tmpdir / 'config.py'
+        pyfile.write_text('1/0', encoding='utf-8')
+
+        with pytest.raises(cmdexc.CommandError) as excinfo:
+            commands.config_source()
+
+        expected = ("Errors occurred while reading config.py:\n"
+                    "  Unhandled exception - ZeroDivisionError:"
+                    " division by zero ")
+        assert str(excinfo.value) == expected
+
 
 class TestEdit:
 

--- a/tests/unit/config/test_configexc.py
+++ b/tests/unit/config/test_configexc.py
@@ -74,7 +74,7 @@ def test_config_file_errors_str(errors):
     assert str(errors).splitlines() == [
         'Errors occurred while reading config.py:',
         '  Error text 1: Exception 1',
-        '  Error text 2: Exception 2',
+        '  Error text 2 - Exception: Exception 2 ',
     ]
 
 

--- a/tests/unit/config/test_configexc.py
+++ b/tests/unit/config/test_configexc.py
@@ -74,7 +74,7 @@ def test_config_file_errors_str(errors):
     assert str(errors).splitlines() == [
         'Errors occurred while reading config.py:',
         '  Error text 1: Exception 1',
-        '  Error text 2 - Exception: Exception 2 ',
+        '  Error text 2 - Exception: Exception 2',
     ]
 
 

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -550,7 +550,7 @@ class TestConfigPy:
         assert len(excinfo.value.errors) == 1
         error = excinfo.value.errors[0]
         assert isinstance(error.exception, SyntaxError)
-        assert error.text == "Syntax Error"
+        assert error.text == "Unhandled exception"
         exception_text = 'invalid syntax (config.py, line 1)'
         assert str(error.exception) == exception_text
 


### PR DESCRIPTION
Solves (in a way) #3494 

I'm not 100% happy with this as a solution as it doesn't seem clear to me why `traceback.format_exc` isn't printing all the information. AFAIK it's meant to essentially do something like `*sys.exc_info()`

Throwing this PR in anyway, as @The-Compiler may have more knowledge about which area I should be looking at instead

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3561)
<!-- Reviewable:end -->

*edit by @The-Compiler to auto-close the issue: Fixes #3494*