### PR TITLE
Add special cases of double quoted variables

### DIFF
--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -65,6 +65,7 @@ def replace_variables(win_id, arglist):
             QUrl.DecodeReserved | QUrl.RemovePassword),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
+        'suburl': lambda: '{url}'
     }
     values = {}
     args = []

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -68,7 +68,11 @@ def replace_variables(win_id, arglist):
     }
     for key in list(variables):
         modified_key = '{' + key + '}'
-        variables[modified_key] = lambda: modified_key
+
+        def key_function(modified_key):
+            return lambda: modified_key
+
+        variables[modified_key] = key_function(modified_key)
     values = {}
     args = []
     tabbed_browser = objreg.get('tabbed-browser', scope='window',

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -65,11 +65,10 @@ def replace_variables(win_id, arglist):
             QUrl.DecodeReserved | QUrl.RemovePassword),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
-        '{url}': lambda: '{url}',
-        '{url:pretty}': lambda: '{url:pretty}',
-        '{clipboard}': lambda: '{clipboard}',
-        '{primary}': lambda: '{primary}',
     }
+    for key in list(variables):
+        modified_key = '{' + key + '}'
+        variables[modified_key] = lambda: modified_key
     values = {}
     args = []
     tabbed_browser = objreg.get('tabbed-browser', scope='window',

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -65,10 +65,10 @@ def replace_variables(win_id, arglist):
             QUrl.DecodeReserved | QUrl.RemovePassword),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
-        'suburl': lambda: '{url}',
-        'suburl:pretty': lambda: '{url:pretty}',
-        'subclipboard': lambda: '{clipboard}',
-        'subprimary': lambda: '{primary}',
+        '{url}': lambda: '{url}',
+        '{url:pretty}': lambda: '{url:pretty}',
+        '{clipboard}': lambda: '{clipboard}',
+        '{primary}': lambda: '{primary}',
     }
     values = {}
     args = []

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -68,11 +68,7 @@ def replace_variables(win_id, arglist):
     }
     for key in list(variables):
         modified_key = '{' + key + '}'
-
-        def key_function(modified_key):
-            return lambda: modified_key
-
-        variables[modified_key] = key_function(modified_key)
+        variables[modified_key] = lambda x=modified_key: x
     values = {}
     args = []
     tabbed_browser = objreg.get('tabbed-browser', scope='window',

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -65,7 +65,10 @@ def replace_variables(win_id, arglist):
             QUrl.DecodeReserved | QUrl.RemovePassword),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
-        'suburl': lambda: '{url}'
+        'suburl': lambda: '{url}',
+        'suburl:pretty': lambda: '{url:pretty}',
+        'subclipboard': lambda: '{clipboard}',
+        'subprimary': lambda: '{primary}',
     }
     values = {}
     args = []

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -436,6 +436,11 @@ Feature: Various utility commands.
         And I run :message-info {clipboard}bar{url}
         Then the message "foobarhttp://localhost:*/hello.txt" should be shown
 
+    Scenario: escaping {{url}} variable
+        When I open data/hello.txt
+        And I run :message-info foo{{url}}bar
+        Then the message "foo{url}bar" should be shown
+
     @xfail_norun
     Scenario: {url} in clipboard should not be expanded
         When I open data/hello.txt


### PR DESCRIPTION
This commit is a small extension to the variable substitution which simply remaps '{{url}}' to '{url}' for example.

It's a small change but should be considered temporary until better argument parsing comes along. It could be seen as a negative change as it infact adds some _more_ special cases, however I think this will be trivial to handle when said rework arrives.

See issues #1861 and #2017 for more information.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3562)
<!-- Reviewable:end -->
