### PR TITLE
Add a way to view source in editor

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -806,7 +806,7 @@ class AbstractTab(QWidget):
         raise NotImplementedError
 
     def dump_async(self, callback, *, plain=False):
-        """Dump the current page to a file ascync.
+        """Dump the current page's html asynchronously.
 
         The given callback will be called with the result when dumping is
         complete.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1515,10 +1515,10 @@ class CommandDispatcher:
             return
         if current_url.scheme() == 'view-source':
             raise cmdexc.CommandError("Already viewing source!")
+
         if edit:
             ed = editor.ExternalEditor(self._tabbed_browser)
-
-            tab._widget.page().toHtml(ed.edit)
+            tab.dump_async(ed.edit)
         else:
             tab.action.show_source()
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1505,7 +1505,7 @@ class CommandDispatcher:
             )
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def view_source(self):
+    def view_source(self, edit=False):
         """Show the source of the current page in a new tab."""
         tab = self._current_widget()
         try:
@@ -1515,8 +1515,12 @@ class CommandDispatcher:
             return
         if current_url.scheme() == 'view-source':
             raise cmdexc.CommandError("Already viewing source!")
+        if editor:
+            ed = editor.ExternalEditor(self._tabbed_browser)
 
-        tab.action.show_source()
+            tab._widget.page().toHtml(ed.edit)
+        else:
+            tab.action.show_source()
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        debug=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1515,7 +1515,7 @@ class CommandDispatcher:
             return
         if current_url.scheme() == 'view-source':
             raise cmdexc.CommandError("Already viewing source!")
-        if editor:
+        if edit:
             ed = editor.ExternalEditor(self._tabbed_browser)
 
             tab._widget.page().toHtml(ed.edit)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1506,7 +1506,10 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def view_source(self, edit=False):
-        """Show the source of the current page in a new tab."""
+        """Show the source of the current page in a new tab.
+
+        Args:
+            edit: Open source in editor instead of tab."""
         tab = self._current_widget()
         try:
             current_url = self._current_url()


### PR DESCRIPTION
This PR handles suggestion #3539 

After this, using `:view-source --edit` will open the current page's source in the set editor.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3563)
<!-- Reviewable:end -->
