### PR TITLE
Changes tabs.width to tabs.width.bar

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -252,7 +252,7 @@
 |<<tabs.title.alignment,tabs.title.alignment>>|Alignment of the text inside of tabs.
 |<<tabs.title.format,tabs.title.format>>|Format to use for the tab title.
 |<<tabs.title.format_pinned,tabs.title.format_pinned>>|Format to use for the tab title for pinned tabs. The same placeholders like for `tabs.title.format` are defined.
-|<<tabs.width,tabs.width>>|Width (in pixels or as percentage of the window) of the tab bar if it's vertical.
+|<<tabs.width.bar,tabs.width.bar>>|Width (in pixels or as percentage of the window) of the tab bar if it's vertical.
 |<<tabs.wrap,tabs.wrap>>|Wrap when changing tabs.
 |<<url.auto_search,url.auto_search>>|What search to start when something else than a URL is entered.
 |<<url.default_page,url.default_page>>|Page to open if :open -t/-b/-w is used without URL.
@@ -2946,8 +2946,8 @@ Type: <<types,FormatString>>
 
 Default: +pass:[{index}]+
 
-[[tabs.width]]
-=== tabs.width
+[[tabs.width.bar]]
+=== tabs.width.bar
 Width (in pixels or as percentage of the window) of the tab bar if it's vertical.
 
 Type: <<types,PercOrInt>>


### PR DESCRIPTION
I think this is meant to be _tabs.width.bar_ as _tabs.width_ is not a valid
option according to _config.py_ and does not seem to appear
anywhere else

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3564)
<!-- Reviewable:end -->
