### PR TITLE
Add :version --paste

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -476,3 +476,10 @@ def qute_configdiff(url):
     else:
         data = config.instance.dump_userconfig().encode('utf-8')
         return 'text/plain', data
+
+
+@add_handler('pastebin-version')
+def qute_pastebin_version(url):  # transfusion: pylint: disable=unused-argument
+    """Handler that pastebins the version string."""
+    utils.pastebin_version()
+    return 'text/plain', b'Paste called.'

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -481,5 +481,5 @@ def qute_configdiff(url):
 @add_handler('pastebin-version')
 def qute_pastebin_version(_url):
     """Handler that pastebins the version string."""
-    utils.pastebin_version()
+    version.pastebin_version()
     return 'text/plain', b'Paste called.'

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -479,7 +479,7 @@ def qute_configdiff(url):
 
 
 @add_handler('pastebin-version')
-def qute_pastebin_version(url):  # transfusion: pylint: disable=unused-argument
+def qute_pastebin_version(_url):
     """Handler that pastebins the version string."""
     utils.pastebin_version()
     return 'text/plain', b'Paste called.'

--- a/qutebrowser/html/version.html
+++ b/qutebrowser/html/version.html
@@ -1,4 +1,17 @@
 {% extends "base.html" %}
+
+{% block script %}
+var paste_version = function(){
+  xhr = new XMLHttpRequest();
+  xhr.open("GET", "qute://pastebin-version");
+  xhr.send();
+}
+{% endblock %}
+
+{% block style %}
+#paste { margin: auto; display: block; }
+{% endblock %}
+
 {% block content %}
 {{ super() }}
 <h1>Version info</h1>
@@ -23,4 +36,5 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <a href="http://www.gnu.org/licenses/">
 http://www.gnu.org/licenses/</a> or open <a href="qute://gpl">qute://gpl</a>.
 </p>
+<button id="paste" onclick="paste_version()">Pastebin Version Info</button>
 {% endblock %}

--- a/qutebrowser/html/version.html
+++ b/qutebrowser/html/version.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 
 {% block script %}
-var paste_version = function(){
-  xhr = new XMLHttpRequest();
+function paste_version() {
+  const xhr = new XMLHttpRequest();
   xhr.open("GET", "qute://pastebin-version");
   xhr.send();
 }
@@ -36,5 +36,5 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <a href="http://www.gnu.org/licenses/">
 http://www.gnu.org/licenses/</a> or open <a href="qute://gpl">qute://gpl</a>.
 </p>
-<button id="paste" onclick="paste_version()">Pastebin Version Info</button>
+<button id="paste" onclick="paste_version()">Yank Pastebin URL for Version Info</button>
 {% endblock %}

--- a/qutebrowser/misc/pastebin.py
+++ b/qutebrowser/misc/pastebin.py
@@ -42,20 +42,23 @@ class PastebinClient(QObject):
     """
 
     API_URL = 'https://crashes.qutebrowser.org/api/'
+    MISC_API_URL = 'http://paste.the-compiler.org/api/'
     success = pyqtSignal(str)
     error = pyqtSignal(str)
 
-    def __init__(self, client, parent=None):
+    def __init__(self, client, parent=None, api_url=API_URL):
         """Constructor.
 
         Args:
             client: The HTTPClient to use. Will be reparented.
+            api_url: The Stikked pastebin endpoint to use.
         """
         super().__init__(parent)
         client.setParent(self)
         client.error.connect(self.error)
         client.success.connect(self.on_client_success)
         self._client = client
+        self.api_url = api_url
 
     def paste(self, name, title, text, parent=None):
         """Paste the text into a pastebin and return the URL.
@@ -74,7 +77,7 @@ class PastebinClient(QObject):
         }
         if parent is not None:
             data['reply'] = parent
-        url = QUrl(urllib.parse.urljoin(self.API_URL, 'create'))
+        url = QUrl(urllib.parse.urljoin(self.api_url, 'create'))
         self._client.post(url, data)
 
     @pyqtSlot(str)

--- a/qutebrowser/misc/pastebin.py
+++ b/qutebrowser/misc/pastebin.py
@@ -42,7 +42,7 @@ class PastebinClient(QObject):
     """
 
     API_URL = 'https://crashes.qutebrowser.org/api/'
-    MISC_API_URL = 'http://paste.the-compiler.org/api/'
+    MISC_API_URL = 'https://paste.the-compiler.org/api/'
     success = pyqtSignal(str)
     error = pyqtSignal(str)
 
@@ -58,7 +58,7 @@ class PastebinClient(QObject):
         client.error.connect(self.error)
         client.success.connect(self.on_client_success)
         self._client = client
-        self.api_url = api_url
+        self._api_url = api_url
 
     def paste(self, name, title, text, parent=None):
         """Paste the text into a pastebin and return the URL.
@@ -77,7 +77,7 @@ class PastebinClient(QObject):
         }
         if parent is not None:
             data['reply'] = parent
-        url = QUrl(urllib.parse.urljoin(self.api_url, 'create'))
+        url = QUrl(urllib.parse.urljoin(self._api_url, 'create'))
         self._client.post(url, data)
 
     @pyqtSlot(str)

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -370,7 +370,11 @@ def nop():
 @cmdutils.register()
 @cmdutils.argument('win_id', win_id=True)
 def version(win_id, paste=False):
-    """Show version information."""
+    """Show version information.
+
+    Args:
+        paste: Paste to pastebin.
+    """
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     tabbed_browser.openurl(QUrl('qute://version'), newtab=True)

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -369,8 +369,11 @@ def nop():
 
 @cmdutils.register()
 @cmdutils.argument('win_id', win_id=True)
-def version(win_id):
+def version(win_id, paste=False):
     """Show version information."""
     tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                 window=win_id)
     tabbed_browser.openurl(QUrl('qute://version'), newtab=True)
+
+    if paste:
+        utils.pastebin_version()

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -380,4 +380,4 @@ def version(win_id, paste=False):
     tabbed_browser.openurl(QUrl('qute://version'), newtab=True)
 
     if paste:
-        utils.pastebin_version()
+        utils.version.pastebin_version()

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -39,6 +39,7 @@ from qutebrowser.utils import log, objreg, usertypes, message, debug, utils
 from qutebrowser.commands import cmdutils, runners, cmdexc
 from qutebrowser.config import config, configdata
 from qutebrowser.misc import consolewidget
+from qutebrowser.utils.version import pastebin_version
 
 
 @cmdutils.register(maxsplit=1, no_cmd_split=True, no_replace_variables=True)
@@ -380,4 +381,4 @@ def version(win_id, paste=False):
     tabbed_browser.openurl(QUrl('qute://version'), newtab=True)
 
     if paste:
-        utils.version.pastebin_version()
+        pastebin_version()

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -920,8 +920,7 @@ def yaml_dump(data, f=None):
 
 
 def pastebin_version():
-    """Pastebins version and logs to messages"""
-
+    """Pastebin the version and log the url to messages."""
     app = qutebrowser.utils.objreg.get('app')
     http_client = httpclient.HTTPClient()
 
@@ -938,9 +937,10 @@ def pastebin_version():
         qutebrowser.utils.message.info("Failed to pastebin version"
                                        " info: {}".format(text))
 
+    misc_api = pastebin.PastebinClient.MISC_API_URL
     pbclient = pastebin.PastebinClient(http_client, parent=app,
-                                       api_url=
-                                       pastebin.PastebinClient.MISC_API_URL)
+                                       api_url=misc_api)
+
     pbclient.success.connect(_on_paste_version_success)
     pbclient.error.connect(_on_paste_version_err)
 

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -36,7 +36,7 @@ import shlex
 import getpass
 
 import attr
-from PyQt5.QtCore import Qt, QUrl, pyqtSlot
+from PyQt5.QtCore import Qt, QUrl
 from PyQt5.QtGui import QKeySequence, QColor, QClipboard, QDesktopServices
 from PyQt5.QtWidgets import QApplication
 import pkg_resources
@@ -49,9 +49,7 @@ except ImportError:  # pragma: no cover
     YAML_C_EXT = False
 
 import qutebrowser
-from qutebrowser.utils import qtutils, log, debug, message, version
-from qutebrowser.misc import httpclient, pastebin
-
+from qutebrowser.utils import qtutils, log, debug
 
 fake_clipboard = None
 log_clipboard = False
@@ -917,34 +915,3 @@ def yaml_dump(data, f=None):
         return None
     else:
         return yaml_data.decode('utf-8')
-
-
-def pastebin_version():
-    """Pastebin the version and log the url to messages."""
-    app = QApplication.instance()
-    http_client = httpclient.HTTPClient()
-
-    def _get_paste_title():
-        return "qute version info {}".format(qutebrowser.__version__)
-
-    @pyqtSlot(str)
-    def _on_paste_version_success(url):
-        set_clipboard(url)
-        message.info("Version url {} yanked to clipboard.".format(url))
-        pbclient.deleteLater()
-
-    @pyqtSlot(str)
-    def _on_paste_version_err(text):
-        message.error("Failed to pastebin version"
-                      " info: {}".format(text))
-        pbclient.deleteLater()
-
-    misc_api = pastebin.PastebinClient.MISC_API_URL
-    pbclient = pastebin.PastebinClient(http_client, parent=app,
-                                       api_url=misc_api)
-
-    pbclient.success.connect(_on_paste_version_success)
-    pbclient.error.connect(_on_paste_version_err)
-
-    pbclient.paste(getpass.getuser(), _get_paste_title(),
-                   version.version())

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -939,9 +939,9 @@ def pastebin_version():
                       " info: {}".format(text))
         pbclient.deleteLater()
 
-    MISC_API = pastebin.PastebinClient.MISC_API_URL
+    misc_api = pastebin.PastebinClient.MISC_API_URL
     pbclient = pastebin.PastebinClient(http_client, parent=app,
-                                       api_url=MISC_API)
+                                       api_url=misc_api)
 
     pbclient.success.connect(_on_paste_version_success)
     pbclient.error.connect(_on_paste_version_err)

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -50,6 +50,7 @@ except ImportError:  # pragma: no cover
 import qutebrowser
 from qutebrowser.utils import qtutils, log, debug
 
+
 fake_clipboard = None
 log_clipboard = False
 

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -931,11 +931,13 @@ def pastebin_version():
     def _on_paste_version_success(url):
         set_clipboard(url)
         message.info("Version url {} yanked to clipboard.".format(url))
+        pbclient.deleteLater()
 
     @pyqtSlot(str)
     def _on_paste_version_err(text):
         message.error("Failed to pastebin version"
                       " info: {}".format(text))
+        pbclient.deleteLater()
 
     MISC_API = pastebin.PastebinClient.MISC_API_URL
     pbclient = pastebin.PastebinClient(http_client, parent=app,

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -33,7 +33,6 @@ import functools
 import contextlib
 import socket
 import shlex
-import getpass
 
 import attr
 from PyQt5.QtCore import Qt, QUrl

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -49,7 +49,7 @@ except ImportError:  # pragma: no cover
     YAML_C_EXT = False
 
 import qutebrowser
-from qutebrowser.utils import qtutils, log, debug
+from qutebrowser.utils import qtutils, log, debug, message, version
 from qutebrowser.misc import httpclient, pastebin
 
 
@@ -921,7 +921,7 @@ def yaml_dump(data, f=None):
 
 def pastebin_version():
     """Pastebin the version and log the url to messages."""
-    app = qutebrowser.utils.objreg.get('app')
+    app = QApplication.instance()
     http_client = httpclient.HTTPClient()
 
     def _get_paste_title():
@@ -929,20 +929,20 @@ def pastebin_version():
 
     @pyqtSlot(str)
     def _on_paste_version_success(url):
-        qutebrowser.utils.message.info("Version info pastebinned"
-                                       " to: {}".format(url))
+        set_clipboard(url)
+        message.info("Version url {} yanked to clipboard.".format(url))
 
     @pyqtSlot(str)
     def _on_paste_version_err(text):
-        qutebrowser.utils.message.info("Failed to pastebin version"
-                                       " info: {}".format(text))
+        message.error("Failed to pastebin version"
+                      " info: {}".format(text))
 
-    misc_api = pastebin.PastebinClient.MISC_API_URL
+    MISC_API = pastebin.PastebinClient.MISC_API_URL
     pbclient = pastebin.PastebinClient(http_client, parent=app,
-                                       api_url=misc_api)
+                                       api_url=MISC_API)
 
     pbclient.success.connect(_on_paste_version_success)
     pbclient.error.connect(_on_paste_version_err)
 
     pbclient.paste(getpass.getuser(), _get_paste_title(),
-                   qutebrowser.utils.version.version())
+                   version.version())

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -66,7 +66,7 @@ class DistributionInfo:
     pretty = attr.ib()
 
 
-PASTEBIN_URL = None
+pastebin_url = None
 Distribution = enum.Enum(
     'Distribution', ['unknown', 'ubuntu', 'debian', 'void', 'arch',
                      'gentoo', 'fedora', 'opensuse', 'linuxmint', 'manjaro'])
@@ -460,18 +460,18 @@ def pastebin_version():
         message.info("Version url {} yanked to clipboard.".format(url))
 
     def _on_paste_version_success(url):
-        global PASTEBIN_URL
+        global pastebin_url
         _yank_url(url)
         pbclient.deleteLater()
-        PASTEBIN_URL = url
+        pastebin_url = url
 
     def _on_paste_version_err(text):
         message.error("Failed to pastebin version"
                       " info: {}".format(text))
         pbclient.deleteLater()
 
-    if PASTEBIN_URL:
-        _yank_url(PASTEBIN_URL)
+    if pastebin_url:
+        _yank_url(pastebin_url)
         return
 
     app = QApplication.instance()

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -65,6 +65,7 @@ class DistributionInfo:
     pretty = attr.ib()
 
 
+PASTEBIN_URL = None
 Distribution = enum.Enum(
     'Distribution', ['unknown', 'ubuntu', 'debian', 'void', 'arch',
                      'gentoo', 'fedora', 'opensuse', 'linuxmint', 'manjaro'])
@@ -453,21 +454,30 @@ def opengl_vendor():  # pragma: no cover
 
 def pastebin_version():
     """Pastebin the version and log the url to messages."""
-    app = QApplication.instance()
-    http_client = httpclient.HTTPClient()
-
     def _get_paste_title():
         return "qute version info {}".format(qutebrowser.__version__)
 
-    def _on_paste_version_success(url):
+    def _yank_url(url):
         utils.set_clipboard(url)
         message.info("Version url {} yanked to clipboard.".format(url))
+
+    def _on_paste_version_success(url):
+        global PASTEBIN_URL
+        _yank_url(url)
         pbclient.deleteLater()
+        PASTEBIN_URL = url
 
     def _on_paste_version_err(text):
         message.error("Failed to pastebin version"
                       " info: {}".format(text))
         pbclient.deleteLater()
+
+    if PASTEBIN_URL:
+        _yank_url(PASTEBIN_URL)
+        return
+
+    app = QApplication.instance()
+    http_client = httpclient.HTTPClient()
 
     misc_api = pastebin.PastebinClient.MISC_API_URL
     pbclient = pastebin.PastebinClient(http_client, parent=app,

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -29,6 +29,7 @@ import importlib
 import collections
 import enum
 import datetime
+import getpass
 
 import attr
 import pkg_resources
@@ -486,5 +487,5 @@ def pastebin_version():
     pbclient.success.connect(_on_paste_version_success)
     pbclient.error.connect(_on_paste_version_err)
 
-    pbclient.paste(utils.getpass.getuser(), _get_paste_title(),
+    pbclient.paste(getpass.getuser(), _get_paste_title(),
                    version())

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -485,4 +485,5 @@ def pastebin_version():
     pbclient.error.connect(_on_paste_version_err)
 
     pbclient.paste(getpass.getuser(),
-        "qute version info {}".format(qutebrowser.__version__), version())
+                   "qute version info {}".format(qutebrowser.__version__),
+                   version())

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -455,9 +455,6 @@ def opengl_vendor():  # pragma: no cover
 
 def pastebin_version():
     """Pastebin the version and log the url to messages."""
-    def _get_paste_title():
-        return "qute version info {}".format(qutebrowser.__version__)
-
     def _yank_url(url):
         utils.set_clipboard(url)
         message.info("Version url {} yanked to clipboard.".format(url))
@@ -487,5 +484,5 @@ def pastebin_version():
     pbclient.success.connect(_on_paste_version_success)
     pbclient.error.connect(_on_paste_version_err)
 
-    pbclient.paste(getpass.getuser(), _get_paste_title(),
-                   version())
+    pbclient.paste(getpass.getuser(),
+        "qute version info {}".format(qutebrowser.__version__), version())


### PR DESCRIPTION
This PR is a work in progress, continuing on from the work done by @Transfusion in PR #3480 

Currently this applies all the code review changes suggested to the commit in the previous PR.
It's not completely satisfactory yet, in the following ways:

1. It instantly pastes when running, making the button pointless. - wasn't a bug, the button is meant to be there all the time, my bad
2. It doesn't store the url anywhere incase the command is ran again in the same session. The version shouldn't change for a given session. - done

I think this is now done, pending a code style review of course. Shadiest thing is using a global variable to store the paste url in. Alternatively, perhaps it could be stored in the registry?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3567)
<!-- Reviewable:end -->
