### PR TITLE
[count] now used to override win_id if provided for tag-give cmd

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -533,14 +533,18 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('win_id', completion=miscmodels.window)
-    def tab_give(self, win_id: int = None):
+    @cmdutils.argument('count', count=True)
+    def tab_give(self, win_id: int = None, count=None):
         """Give the current tab to a new or existing window if win_id given.
 
         If no win_id is given, the tab will get detached into a new window.
 
         Args:
             win_id: The window ID of the window to give the current tab to.
+            count: [count] overrides win_id (index starts at 1 for win_id=0)
         """
+        if count:
+            win_id = count-1
         if win_id == self._win_id:
             raise cmdexc.CommandError("Can't give a tab to the same window")
 

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -249,7 +249,6 @@ def test_failing_unwatch(qtbot, caplog, monkeypatch):
     assert caplog.records[-1].msg == message
 
 
-
 @pytest.mark.parametrize('text, caret_position, result', [
     ('', 0, (1, 1)),
     ('a', 0, (1, 1)),


### PR DESCRIPTION
Resolves #3548

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3575)
<!-- Reviewable:end -->
