### PR TITLE
Improve performance of startup and shutdown with many tabs

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -253,7 +253,10 @@ class TabbedBrowser(tabwidget.TabWidget):
     def shutdown(self):
         """Try to shut down all tabs cleanly."""
         self.shutting_down = True
-        for tab in self.widgets():
+        # Reverse tabs so we don't have to recacluate tab titles over and over
+        # Removing first causes [2..-1] to be recomputed
+        # Removing the last causes nothing to be recomputed
+        for tab in reversed(self.widgets()):
             self._remove_tab(tab)
 
     def tab_close_prompt_if_pinned(

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -150,8 +150,9 @@ class TabWidget(QTabWidget):
         title = '' if fmt is None else fmt.format(**fields)
         tabbar = self.tabBar()
 
-        tabbar.setTabText(idx, title)
-        tabbar.setTabToolTip(idx, title)
+        if tabbar.tabText(idx) != title:
+            tabbar.setTabText(idx, title)
+            tabbar.setTabToolTip(idx, title)
 
     def get_tab_fields(self, idx):
         """Get the tab field data."""

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -110,8 +110,6 @@ class TabWidget(QTabWidget):
         tab.data.pinned = pinned
         self._update_tab_title(idx)
 
-        bar.refresh()
-
     def tab_indicator_color(self, idx):
         """Get the tab indicator color for the given index."""
         return self.tabBar().tab_indicator_color(idx)

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -261,6 +261,9 @@ class FakeWebTab(browsertab.AbstractTab):
     def load_status(self):
         return self._load_status
 
+    def shutdown(self):
+        pass
+
 
 class FakeSignal:
 

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -23,7 +23,7 @@ import pytest
 
 from PyQt5.QtGui import QIcon, QPixmap
 
-from qutebrowser.mainwindow import tabwidget
+from qutebrowser.mainwindow import tabwidget, tabbedbrowser
 from qutebrowser.utils import usertypes
 
 
@@ -34,6 +34,14 @@ class TestTabWidget:
     @pytest.fixture
     def widget(self, qtbot, monkeypatch, config_stub):
         w = tabwidget.TabWidget(0)
+        qtbot.addWidget(w)
+        monkeypatch.setattr(tabwidget.objects, 'backend',
+                            usertypes.Backend.QtWebKit)
+        return w
+
+    @pytest.fixture
+    def browser(self, qtbot, monkeypatch, config_stub):
+        w = tabbedbrowser.TabbedBrowser(win_id=0, private=False)
         qtbot.addWidget(w)
         monkeypatch.setattr(tabwidget.objects, 'backend',
                             usertypes.Backend.QtWebKit)
@@ -53,15 +61,29 @@ class TestTabWidget:
         with qtbot.waitExposed(widget):
             widget.show()
 
+    @pytest.mark.parametrize("num_tabs", [4, 10])
     def test_update_tab_titles_benchmark(self, benchmark, widget,
-                                         qtbot, fake_web_tab):
+                                         qtbot, fake_web_tab, num_tabs):
         """Benchmark for update_tab_titles."""
-        widget.addTab(fake_web_tab(), 'foobar')
-        widget.addTab(fake_web_tab(), 'foobar2')
-        widget.addTab(fake_web_tab(), 'foobar3')
-        widget.addTab(fake_web_tab(), 'foobar4')
+        for i in range(num_tabs):
+            widget.addTab(fake_web_tab(), 'foobar' + str(i))
 
         with qtbot.waitExposed(widget):
             widget.show()
 
         benchmark(widget._update_tab_titles)
+
+    @pytest.mark.parametrize("num_tabs", [4, 10])
+    def test_add_remove_tab_benchmark(self, benchmark, browser,
+                                      qtbot, fake_web_tab, num_tabs):
+        """Benchmark for addTab and removeTab."""
+        def _run_bench():
+            for i in range(num_tabs):
+                browser.addTab(fake_web_tab(), 'foobar' + str(i))
+
+            with qtbot.waitExposed(browser):
+                browser.show()
+
+            browser.shutdown()
+
+        benchmark(_run_bench)


### PR DESCRIPTION
I tested this all on ~80 about:blank tabs.

We call 'update_tab_titles' a lot of times which calls 'setTabText' on
every tab. 'setTabText' calls tabSizeHint and minTabSizeHint on every
tab as well, meaning this is an n^2 operation repeated many times.

First, this prevents setTabText from being called unless it's needed,
removing most of the work done.

Second, I remove tabs in reverse, to avoid recomputing the above for
every tab on shutdown (which is at least n^3)


The next target for optimization is paintEvent in tabWidget, as that 
seems to be the biggest issue after this patch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3582)
<!-- Reviewable:end -->
