### PR TITLE
Use HTTPStatus enum from Python 3.5+

### DIFF
--- a/tests/end2end/fixtures/test_webserver.py
+++ b/tests/end2end/fixtures/test_webserver.py
@@ -22,6 +22,7 @@
 import json
 import urllib.request
 import urllib.error
+from http import HTTPStatus
 
 import pytest
 
@@ -52,11 +53,38 @@ def test_server(server, qtbot, path, content, expected):
 
 
 @pytest.mark.parametrize('line, verb, path, equal', [
-    ({'verb': 'GET', 'path': '/', 'status': 200}, 'GET', '/', True),
-    ({'verb': 'GET', 'path': '/foo/', 'status': 200}, 'GET', '/foo', True),
+    ({'verb': 'GET', 'path': '/', 'status': HTTPStatus.OK}, 'GET', '/', True),
+    ({'verb': 'GET', 'path': '/foo/', 'status': HTTPStatus.OK},
+     'GET', '/foo', True),
+    ({'verb': 'GET', 'path': '/relative-redirect', 'status': HTTPStatus.FOUND},
+     'GET', '/relative-redirect', True),
+    ({'verb': 'GET', 'path': '/absolute-redirect', 'status': HTTPStatus.FOUND},
+     'GET', '/absolute-redirect', True),
+    ({'verb': 'GET', 'path': '/redirect-to', 'status': HTTPStatus.FOUND},
+     'GET', '/redirect-to', True),
+    ({'verb': 'GET', 'path': '/redirect-self', 'status': HTTPStatus.FOUND},
+     'GET', '/redirect-self', True),
+    ({'verb': 'GET', 'path': '/content-size', 'status': HTTPStatus.OK},
+     'GET', '/content-size', True),
+    ({'verb': 'GET', 'path': '/twenty-mb', 'status': HTTPStatus.OK},
+     'GET', '/twenty-mb', True),
+    ({'verb': 'GET', 'path': '/500-inline',
+      'status': HTTPStatus.INTERNAL_SERVER_ERROR}, 'GET', '/500-inline', True),
+    ({'verb': 'GET', 'path': '/basic-auth/user1/password1',
+      'status': HTTPStatus.UNAUTHORIZED},
+     'GET', '/basic-auth/user1/password1', True),
+    ({'verb': 'GET', 'path': '/drip', 'status': HTTPStatus.OK},
+     'GET', '/drip', True),
+    ({'verb': 'GET', 'path': '/404', 'status': HTTPStatus.NOT_FOUND},
+     'GET', '/404', True),
 
-    ({'verb': 'GET', 'path': '/', 'status': 200}, 'GET', '/foo', False),
-    ({'verb': 'POST', 'path': '/', 'status': 200}, 'GET', '/', False),
+    ({'verb': 'GET', 'path': '/', 'status': HTTPStatus.OK},
+     'GET', '/foo', False),
+    ({'verb': 'POST', 'path': '/', 'status': HTTPStatus.OK},
+     'GET', '/', False),
+    ({'verb': 'GET', 'path': '/basic-auth/user/password',
+      'status': HTTPStatus.UNAUTHORIZED},
+     'GET', '/basic-auth/user/passwd', False),
 ])
 def test_expected_request(server, line, verb, path, equal):
     expected = server.ExpectedRequest(verb, path)

--- a/tests/end2end/fixtures/webserver.py
+++ b/tests/end2end/fixtures/webserver.py
@@ -23,7 +23,7 @@ import re
 import sys
 import json
 import os.path
-import http.client
+from http import HTTPStatus
 
 import attr
 import pytest
@@ -65,28 +65,28 @@ class Request(testprocess.Line):
         # WORKAROUND for https://github.com/PyCQA/pylint/issues/399 (?)
         # pylint: disable=no-member
         path_to_statuses = {
-            '/favicon.ico': [http.client.NOT_FOUND],
-            '/does-not-exist': [http.client.NOT_FOUND],
-            '/does-not-exist-2': [http.client.NOT_FOUND],
-            '/404': [http.client.NOT_FOUND],
+            '/favicon.ico': [HTTPStatus.NOT_FOUND],
+            '/does-not-exist': [HTTPStatus.NOT_FOUND],
+            '/does-not-exist-2': [HTTPStatus.NOT_FOUND],
+            '/404': [HTTPStatus.NOT_FOUND],
 
-            '/redirect-later': [http.client.FOUND],
-            '/redirect-self': [http.client.FOUND],
-            '/redirect-to': [http.client.FOUND],
-            '/relative-redirect': [http.client.FOUND],
-            '/absolute-redirect': [http.client.FOUND],
+            '/redirect-later': [HTTPStatus.FOUND],
+            '/redirect-self': [HTTPStatus.FOUND],
+            '/redirect-to': [HTTPStatus.FOUND],
+            '/relative-redirect': [HTTPStatus.FOUND],
+            '/absolute-redirect': [HTTPStatus.FOUND],
 
-            '/cookies/set': [http.client.FOUND],
+            '/cookies/set': [HTTPStatus.FOUND],
 
-            '/500-inline': [http.client.INTERNAL_SERVER_ERROR],
+            '/500-inline': [HTTPStatus.INTERNAL_SERVER_ERROR],
         }
         for i in range(15):
-            path_to_statuses['/redirect/{}'.format(i)] = [http.client.FOUND]
+            path_to_statuses['/redirect/{}'.format(i)] = [HTTPStatus.FOUND]
         for suffix in ['', '1', '2', '3', '4', '5', '6']:
             key = '/basic-auth/user{}/password{}'.format(suffix, suffix)
-            path_to_statuses[key] = [http.client.UNAUTHORIZED, http.client.OK]
+            path_to_statuses[key] = [HTTPStatus.UNAUTHORIZED, HTTPStatus.OK]
 
-        default_statuses = [http.client.OK, http.client.NOT_MODIFIED]
+        default_statuses = [HTTPStatus.OK, HTTPStatus.NOT_MODIFIED]
         # pylint: enable=no-member
 
         sanitized = QUrl('http://localhost' + self.path).path()  # Remove ?foo

--- a/tests/end2end/fixtures/webserver_sub.py
+++ b/tests/end2end/fixtures/webserver_sub.py
@@ -32,6 +32,7 @@ import time
 import signal
 import os
 import threading
+from http import HTTPStatus
 
 import cheroot.wsgi
 import flask
@@ -112,7 +113,7 @@ def redirect_n_times(n):
 def relative_redirect():
     """302 Redirect once."""
     response = app.make_response('')
-    response.status_code = 302
+    response.status_code = HTTPStatus.FOUND
     response.headers['Location'] = flask.url_for('root')
     return response
 
@@ -121,7 +122,7 @@ def relative_redirect():
 def absolute_redirect():
     """302 Redirect once."""
     response = app.make_response('')
-    response.status_code = 302
+    response.status_code = HTTPStatus.FOUND
     response.headers['Location'] = flask.url_for('root', _external=True)
     return response
 
@@ -133,7 +134,7 @@ def redirect_to():
     # werkzeug from "fixing" the URL. This endpoint should set the Location
     # header to the exact string supplied.
     response = app.make_response('')
-    response.status_code = 302
+    response.status_code = HTTPStatus.FOUND
     response.headers['Location'] = flask.request.args['url'].encode('utf-8')
     return response
 
@@ -149,7 +150,7 @@ def content_size():
     response = flask.Response(generate_bytes(), headers={
         "Content-Type": "application/octet-stream",
     })
-    response.status_code = 200
+    response.status_code = HTTPStatus.OK
     return response
 
 
@@ -163,7 +164,7 @@ def twenty_mb():
         "Content-Type": "application/octet-stream",
         "Content-Length": str(20 * 1024 * 1024),
     })
-    response.status_code = 200
+    response.status_code = HTTPStatus.OK
     return response
 
 
@@ -174,7 +175,7 @@ def internal_error_attachment():
         "Content-Type": "application/octet-stream",
         "Content-Disposition": 'inline; filename="attachment.jpg"',
     })
-    response.status_code = 500
+    response.status_code = HTTPStatus.INTERNAL_SERVER_ERROR
     return response
 
 
@@ -199,7 +200,7 @@ def basic_auth(user='user', passwd='passwd'):
     auth = flask.request.authorization
     if not auth or auth.username != user or auth.password != passwd:
         r = flask.make_response()
-        r.status_code = 401
+        r.status_code = HTTPStatus.UNAUTHORIZED
         r.headers = {'WWW-Authenticate': 'Basic realm="Fake Realm"'}
         return r
 
@@ -222,14 +223,14 @@ def drip():
         "Content-Type": "application/octet-stream",
         "Content-Length": str(numbytes),
     })
-    response.status_code = 200
+    response.status_code = HTTPStatus.OK
     return response
 
 
 @app.route('/404')
 def status_404():
     r = flask.make_response()
-    r.status_code = 404
+    r.status_code = HTTPStatus.NOT_FOUND
     return r
 
 


### PR DESCRIPTION
Part of #3020.
Very small refactor to use the new [HTTPStatus](https://docs.python.org/3/library/http.html#http.HTTPStatus) enum introduced in 3.5.
Added some more tests for all the changed endpoints to just be able to test these without having to run the whole end2end suite.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3599)
<!-- Reviewable:end -->
