### PR TITLE
Fix broken language links in contributing

### DIFF
--- a/doc/contributing.asciidoc
+++ b/doc/contributing.asciidoc
@@ -44,8 +44,8 @@ be easy to solve]
 If you prefer C++ or Javascript to Python, see the relevant issues which involve
 work in those languages:
 
-* https://github.com/qutebrowser/qutebrowser/issues?utf8=%E2%9C%93&q=is%3Aopen%20is%3Aissue%20label%3Ac%2B%2B[C++] (mostly work on Qt, the library behind qutebrowser)
-* https://github.com/qutebrowser/qutebrowser/issues?q=is%3Aopen+is%3Aissue+label%3Ajavascript[JavaScript]
+* https://github.com/qutebrowser/qutebrowser/issues?q=is%3Aopen+is%3Aissue+label%3A%22language%3A+c%2B%2B%22[C++] (mostly work on Qt, the library behind qutebrowser)
+* https://github.com/qutebrowser/qutebrowser/issues?q=is%3Aopen+is%3Aissue+label%3A%22language%3A+javascript%22[JavaScript]
 
 There are also some things to do if you don't want to write code:
 


### PR DESCRIPTION
The language tags were changed (I think) at some point, which broke these links, making them show 'zero issues'. This fixes that!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3602)
<!-- Reviewable:end -->
