### PR TITLE
Add Option url.open_base_url

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1448,8 +1448,7 @@ url.incdec_segments:
 url.open_base_url:
   type: Bool
   default: false
-  desc: Invoking `:open {shortcut}` (without argument), where {shortcut} is a search engine shortcut
-    will open the base url of the shortcut instead of using the default search engine.
+  desc: Open base URL of the searchengine if a searchengine shortcut is invoked without parameters.
 
 url.searchengines:
   default:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1445,6 +1445,12 @@ url.incdec_segments:
   desc: URL segments where `:navigate increment/decrement` will search for
     a number.
 
+url.open_base_url:
+  type: Bool
+  default: false
+  desc: Invoking `:open {shortcut}` (without argument), where {shortcut} is a search engine shortcut
+    will open the base url of the shortcut instead of using the default search engine.
+
 url.searchengines:
   default:
     DEFAULT: https://duckduckgo.com/?q={}

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -103,8 +103,7 @@ def _get_search_url(txt):
     template = config.val.url.searchengines[engine]
     url = qurl_from_user_input(template.format(urllib.parse.quote(term)))
 
-    if config.val.url.open_base_url and \
-            term in config.val.url.searchengines.keys():
+    if config.val.url.open_base_url and term in config.val.url.searchengines:
         url = qurl_from_user_input(config.val.url.searchengines[term])
         url.setPath(None)
         url.setFragment(None)

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -103,12 +103,10 @@ def _get_search_url(txt):
     template = config.val.url.searchengines[engine]
     url = qurl_from_user_input(template.format(urllib.parse.quote(term)))
 
-    if config.val.url.open_base_url:
-        try:
-            search_url = urllib.parse.urlparse(config.val.url.searchengines[term])
-            url = QUrl('{}://{}'.format(search_url.scheme, search_url.netloc))
-        except KeyError:
-            pass
+    if config.val.url.open_base_url and \
+            term in config.val.url.searchengines.keys():
+        search_url = urllib.parse.urlparse(config.val.url.searchengines[term])
+        url = QUrl('{}://{}'.format(search_url.scheme, search_url.netloc))
     qtutils.ensure_valid(url)
     return url
 

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -102,6 +102,13 @@ def _get_search_url(txt):
         engine = 'DEFAULT'
     template = config.val.url.searchengines[engine]
     url = qurl_from_user_input(template.format(urllib.parse.quote(term)))
+
+    if config.val.url.open_base_url:
+        try:
+            search_url = urllib.parse.urlparse(config.val.url.searchengines[term])
+            url = QUrl('{}://{}'.format(search_url.scheme, search_url.netloc))
+        except KeyError:
+            pass
     qtutils.ensure_valid(url)
     return url
 

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -105,8 +105,10 @@ def _get_search_url(txt):
 
     if config.val.url.open_base_url and \
             term in config.val.url.searchengines.keys():
-        search_url = urllib.parse.urlparse(config.val.url.searchengines[term])
-        url = QUrl('{}://{}'.format(search_url.scheme, search_url.netloc))
+        url = qurl_from_user_input(config.val.url.searchengines[term])
+        url.setPath(None)
+        url.setFragment(None)
+        url.setQuery(None)
     qtutils.ensure_valid(url)
     return url
 

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -277,8 +277,8 @@ class TestFuzzyUrl:
 def test_special_urls(url, special):
     assert urlutils.is_special_url(QUrl(url)) == special
 
-@pytest.mark.parametrize('open_base_url', [True, False])
 
+@pytest.mark.parametrize('open_base_url', [True, False])
 @pytest.mark.parametrize('url, host, query', [
     ('testfoo', 'www.example.com', 'q=testfoo'),
     ('test testfoo', 'www.qutebrowser.org', 'q=testfoo'),
@@ -311,7 +311,6 @@ def test_get_search_url(config_stub, url, host, query, open_base_url):
     ('test', 'www.qutebrowser.org', ''),
     ('test-with-dash', 'www.example.org', ''),
 ])
-
 def test_get_search_url_open_base_url(config_stub, url, host, query):
     """Test _get_search_url() with url.open_base_url_enabled.
 
@@ -321,6 +320,7 @@ def test_get_search_url_open_base_url(config_stub, url, host, query):
         query: The expected search query.
     """
     test_get_search_url(config_stub, url, host, query, True)
+
 
 @pytest.mark.parametrize('url', ['\n', ' ', '\n '])
 def test_get_search_url_invalid(url):

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -299,7 +299,7 @@ def test_get_search_url(config_stub, url, host, query, open_base_url):
     """
     config_stub.val.url.open_base_url = open_base_url
     url = urlutils._get_search_url(url)
-    if open_base_url and query == '':
+    if open_base_url and not query:
         assert not url.path()
         assert not url.fragment()
 

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -277,18 +277,27 @@ class TestFuzzyUrl:
 def test_special_urls(url, special):
     assert urlutils.is_special_url(QUrl(url)) == special
 
-
-@pytest.mark.parametrize('url, host, query', [
-    ('testfoo', 'www.example.com', 'q=testfoo'),
-    ('test testfoo', 'www.qutebrowser.org', 'q=testfoo'),
-    ('test testfoo bar foo', 'www.qutebrowser.org', 'q=testfoo bar foo'),
-    ('test testfoo ', 'www.qutebrowser.org', 'q=testfoo'),
-    ('!python testfoo', 'www.example.com', 'q=%21python testfoo'),
-    ('blub testfoo', 'www.example.com', 'q=blub testfoo'),
-    ('stripped ', 'www.example.com', 'q=stripped'),
-    ('test-with-dash testfoo', 'www.example.org', 'q=testfoo'),
+@pytest.mark.parametrize('url, host, query, open_base_url', [
+    ('testfoo', 'www.example.com', 'q=testfoo', False),
+    ('test testfoo', 'www.qutebrowser.org', 'q=testfoo', False),
+    ('test testfoo bar foo', 'www.qutebrowser.org', 'q=testfoo bar foo', False),
+    ('test testfoo ', 'www.qutebrowser.org', 'q=testfoo', False),
+    ('!python testfoo', 'www.example.com', 'q=%21python testfoo', False),
+    ('blub testfoo', 'www.example.com', 'q=blub testfoo', False),
+    ('stripped ', 'www.example.com', 'q=stripped', False),
+    ('test-with-dash testfoo', 'www.example.org', 'q=testfoo', False),
+    ('testfoo', 'www.example.com', 'q=testfoo', True),
+    ('test testfoo', 'www.qutebrowser.org', 'q=testfoo', True),
+    ('test testfoo bar foo', 'www.qutebrowser.org', 'q=testfoo bar foo', True),
+    ('test testfoo ', 'www.qutebrowser.org', 'q=testfoo', True),
+    ('!python testfoo', 'www.example.com', 'q=%21python testfoo', True),
+    ('blub testfoo', 'www.example.com', 'q=blub testfoo', True),
+    ('stripped ', 'www.example.com', 'q=stripped', True),
+    ('test-with-dash testfoo', 'www.example.org', 'q=testfoo', True),
+    ('test', 'www.qutebrowser.org', '', True),
+    ('test-with-dash', 'www.example.org', '', True),
 ])
-def test_get_search_url(url, host, query):
+def test_get_search_url(config_stub, url, host, query, open_base_url):
     """Test _get_search_url().
 
     Args:
@@ -296,7 +305,12 @@ def test_get_search_url(url, host, query):
         host: The expected search machine host.
         query: The expected search query.
     """
+    config_stub.val.url.open_base_url = open_base_url
     url = urlutils._get_search_url(url)
+    if open_base_url and query == '':
+        assert url.path() == ''
+        assert url.fragment() == ''
+
     assert url.host() == host
     assert url.query() == query
 

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -277,25 +277,17 @@ class TestFuzzyUrl:
 def test_special_urls(url, special):
     assert urlutils.is_special_url(QUrl(url)) == special
 
-@pytest.mark.parametrize('url, host, query, open_base_url', [
-    ('testfoo', 'www.example.com', 'q=testfoo', False),
-    ('test testfoo', 'www.qutebrowser.org', 'q=testfoo', False),
-    ('test testfoo bar foo', 'www.qutebrowser.org', 'q=testfoo bar foo', False),
-    ('test testfoo ', 'www.qutebrowser.org', 'q=testfoo', False),
-    ('!python testfoo', 'www.example.com', 'q=%21python testfoo', False),
-    ('blub testfoo', 'www.example.com', 'q=blub testfoo', False),
-    ('stripped ', 'www.example.com', 'q=stripped', False),
-    ('test-with-dash testfoo', 'www.example.org', 'q=testfoo', False),
-    ('testfoo', 'www.example.com', 'q=testfoo', True),
-    ('test testfoo', 'www.qutebrowser.org', 'q=testfoo', True),
-    ('test testfoo bar foo', 'www.qutebrowser.org', 'q=testfoo bar foo', True),
-    ('test testfoo ', 'www.qutebrowser.org', 'q=testfoo', True),
-    ('!python testfoo', 'www.example.com', 'q=%21python testfoo', True),
-    ('blub testfoo', 'www.example.com', 'q=blub testfoo', True),
-    ('stripped ', 'www.example.com', 'q=stripped', True),
-    ('test-with-dash testfoo', 'www.example.org', 'q=testfoo', True),
-    ('test', 'www.qutebrowser.org', '', True),
-    ('test-with-dash', 'www.example.org', '', True),
+@pytest.mark.parametrize('open_base_url', [True, False])
+
+@pytest.mark.parametrize('url, host, query', [
+    ('testfoo', 'www.example.com', 'q=testfoo'),
+    ('test testfoo', 'www.qutebrowser.org', 'q=testfoo'),
+    ('test testfoo bar foo', 'www.qutebrowser.org', 'q=testfoo bar foo'),
+    ('test testfoo ', 'www.qutebrowser.org', 'q=testfoo'),
+    ('!python testfoo', 'www.example.com', 'q=%21python testfoo'),
+    ('blub testfoo', 'www.example.com', 'q=blub testfoo'),
+    ('stripped ', 'www.example.com', 'q=stripped'),
+    ('test-with-dash testfoo', 'www.example.org', 'q=testfoo'),
 ])
 def test_get_search_url(config_stub, url, host, query, open_base_url):
     """Test _get_search_url().
@@ -308,12 +300,27 @@ def test_get_search_url(config_stub, url, host, query, open_base_url):
     config_stub.val.url.open_base_url = open_base_url
     url = urlutils._get_search_url(url)
     if open_base_url and query == '':
-        assert url.path() == ''
-        assert url.fragment() == ''
+        assert not url.path()
+        assert not url.fragment()
 
     assert url.host() == host
     assert url.query() == query
 
+
+@pytest.mark.parametrize('url, host, query', [
+    ('test', 'www.qutebrowser.org', ''),
+    ('test-with-dash', 'www.example.org', ''),
+])
+
+def test_get_search_url_open_base_url(config_stub, url, host, query):
+    """Test _get_search_url() with url.open_base_url_enabled.
+
+    Args:
+        url: The "URL" to enter.
+        host: The expected search machine host.
+        query: The expected search query.
+    """
+    test_get_search_url(config_stub, url, host, query, True)
 
 @pytest.mark.parametrize('url', ['\n', ' ', '\n '])
 def test_get_search_url_invalid(url):

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -299,19 +299,15 @@ def test_get_search_url(config_stub, url, host, query, open_base_url):
     """
     config_stub.val.url.open_base_url = open_base_url
     url = urlutils._get_search_url(url)
-    if open_base_url and not query:
-        assert not url.path()
-        assert not url.fragment()
-
     assert url.host() == host
     assert url.query() == query
 
 
-@pytest.mark.parametrize('url, host, query', [
-    ('test', 'www.qutebrowser.org', ''),
-    ('test-with-dash', 'www.example.org', ''),
+@pytest.mark.parametrize('url, host', [
+    ('test', 'www.qutebrowser.org'),
+    ('test-with-dash', 'www.example.org'),
 ])
-def test_get_search_url_open_base_url(config_stub, url, host, query):
+def test_get_search_url_open_base_url(config_stub, url, host):
     """Test _get_search_url() with url.open_base_url_enabled.
 
     Args:
@@ -319,7 +315,12 @@ def test_get_search_url_open_base_url(config_stub, url, host, query):
         host: The expected search machine host.
         query: The expected search query.
     """
-    test_get_search_url(config_stub, url, host, query, True)
+    config_stub.val.url.open_base_url = True
+    url = urlutils._get_search_url(url)
+    assert not url.path()
+    assert not url.fragment()
+    assert not url.query()
+    assert url.host() == host
 
 
 @pytest.mark.parametrize('url', ['\n', ' ', '\n '])


### PR DESCRIPTION
when set to true, invoking a searchengine shortcut without argument
opens the baseurl of that searchengine instead of DEFAULT searchengine

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3604)
<!-- Reviewable:end -->
