### PR TITLE
add basic completion to file dialog

### DIFF
--- a/tests/unit/mainwindow/test_prompt.py
+++ b/tests/unit/mainwindow/test_prompt.py
@@ -81,6 +81,14 @@ class TestFileCompletion:
             for _ in range(3):
                 qtbot.keyPress(prompt._lineedit, Qt.Key_Backspace)
 
+        # foo should get completed from f
+        prompt.item_focus('next')
+        assert prompt._lineedit.text() == str(testdir / 'foo')
+
+        # Deleting /[foo]
+        for _ in range(3):
+            qtbot.keyPress(prompt._lineedit, Qt.Key_Backspace)
+
         # We should now show / again, so tabbing twice gives us .. -> bar
         prompt.item_focus('next')
         prompt.item_focus('next')


### PR DESCRIPTION
There are some code duplications and I'm not sure if it actually needs to sit in a seperate method. I'm also not sure if completion should be just enabled by having a configuration variable. 

~~It also would be nice to set the text back to the entered text on wrapping around.~~ (done in second commit)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3606)
<!-- Reviewable:end -->
