### PR TITLE
Use QUTE_DATA_DIR in readability userscript

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -13,7 +13,13 @@
 from __future__ import absolute_import
 import codecs, os
 
-tmpfile=os.path.expanduser('~/.local/share/qutebrowser/userscripts/readability.html')
+if 'QUTE_DATA_DIR' in os.environ:
+    tmpfile = os.path.join(os.environ['QUTE_DATA_DIR'],
+                           'userscripts/readability.html')
+else:
+    tmpfile = os.path.expanduser(
+        '~/.local/share/qutebrowser/userscripts/readability.html')
+
 if not os.path.exists(os.path.dirname(tmpfile)):
     os.makedirs(os.path.dirname(tmpfile))
 

--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -13,12 +13,10 @@
 from __future__ import absolute_import
 import codecs, os
 
-if 'QUTE_DATA_DIR' in os.environ:
-    tmpfile = os.path.join(os.environ['QUTE_DATA_DIR'],
-                           'userscripts/readability.html')
-else:
-    tmpfile = os.path.expanduser(
-        '~/.local/share/qutebrowser/userscripts/readability.html')
+tmpfile = os.path.join(
+    os.environ.get('QUTE_DATA_DIR',
+                   os.path.expanduser('~/.local/share/qutebrowser')),
+    'userscripts/readability.html')
 
 if not os.path.exists(os.path.dirname(tmpfile)):
     os.makedirs(os.path.dirname(tmpfile))


### PR DESCRIPTION
I poked in the readability userscript, and I found it's hardcoding the data dir for readability.html, this PR changes it to use the QUTE_DATA_DIR environment variable.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3610)
<!-- Reviewable:end -->
