### PR TITLE
use up to date cheatsheet images from repo instead of qutebrowser.org

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -44,8 +44,8 @@ Documentation
 In addition to the topics mentioned in this README, the following documents are
 available:
 
-* https://qutebrowser.org/img/cheatsheet-big.png[Key binding cheatsheet]: +
-image:https://qutebrowser.org/img/cheatsheet-small.png["qutebrowser key binding cheatsheet",link="https://qutebrowser.org/img/cheatsheet-big.png"]
+* https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png[Key binding cheatsheet]: +
+image:https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-small.png["qutebrowser key binding cheatsheet",link="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png"]
 * link:doc/quickstart.asciidoc[Quick start guide]
 * https://www.shortcutfoo.com/app/dojos/qutebrowser[Free training course] to remember those key bindings
 * link:doc/faq.asciidoc[Frequently asked questions]

--- a/scripts/asciidoc2html.py
+++ b/scripts/asciidoc2html.py
@@ -85,9 +85,9 @@ class AsciiDoc:
 
         # patch image links to use local copy
         replacements = [
-            ("https://qutebrowser.org/img/cheatsheet-big.png",
+            ("https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png",
              "qute://help/img/cheatsheet-big.png"),
-            ("https://qutebrowser.org/img/cheatsheet-small.png",
+            ("https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-small.png",
              "qute://help/img/cheatsheet-small.png")
         ]
         asciidoc_args = ['-a', 'source-highlighter=pygments']


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3617)
<!-- Reviewable:end -->
