### PR TITLE
Convert searched text to a selection when enetering caret mode

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -27,6 +27,7 @@ markers =
     no_invalid_lines: Don't fail on unparseable lines in end2end tests
     issue2478: Tests which are broken on Windows with QtWebEngine, https://github.com/qutebrowser/qutebrowser/issues/2478
     issue3572: Tests which are broken with QtWebEngine and Qt 5.10, https://github.com/qutebrowser/qutebrowser/issues/3572
+    qtbug60673: Tests which are broken if the conversion from orange selection to real selection  is flakey
     fake_os: Fake utils.is_* to a fake operating system
     unicode_locale: Tests which need an unicode locale to work
 qt_log_level_fail = WARNING

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -218,6 +218,13 @@ class WebEngineCaret(browsertab.AbstractCaret):
         if mode != usertypes.KeyMode.caret:
             return
 
+        # Clear search, replace with blue selection
+        if self._tab.search.search_displayed:
+            # We are currently in search mode.
+            # convert the search to a blue selection so we can operate on it
+            # https://bugreports.qt.io/browse/QTBUG-60673
+            self._tab.search.clear()
+
         self._tab.run_js_async(
             javascript.assemble('caret', 'setPlatform', sys.platform))
         self._js_call('setInitialCursor')

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -218,7 +218,6 @@ class WebEngineCaret(browsertab.AbstractCaret):
         if mode != usertypes.KeyMode.caret:
             return
 
-        # Clear search, replace with blue selection
         if self._tab.search.search_displayed:
             # We are currently in search mode.
             # convert the search to a blue selection so we can operate on it

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,11 @@ def _apply_platform_markers(config, item):
          qtutils.version_check('5.10', compiled=False, exact=True) and
          config.webengine and 'TRAVIS' in os.environ,
          "Broken with QtWebEngine with Qt 5.10 on Travis"),
+        ('qtbug60673',
+         qtutils.version_check('5.8') and
+         not qtutils.version_check('5.10') and
+         config.webengine,
+         "Broken on webengine due to qtbug60673"),
         ('unicode_locale', sys.getfilesystemencoding() == 'ascii',
          "Skipped because of ASCII locale"),
     ]

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -320,3 +320,25 @@ Feature: Caret mode
         And the following tabs should be open:
             - data/caret.html
             - data/hello.txt (active)
+
+    # Search + caret mode
+
+    Scenario: yanking a searched line
+        When I run :leave-mode
+        And I run :search fiv
+        And I wait for "search found fiv" in the log
+        And I run :enter-mode caret
+        And I run :move-to-end-of-line
+        And I run :yank selection
+        Then the clipboard should contain "five six"
+
+    Scenario: yanking a searched line with multiple matches
+        When I run :leave-mode
+        And I run :search w
+        And I wait for "search found w" in the log
+        And I run :search-next
+        And I wait for "next_result found w" in the log
+        And I run :enter-mode caret
+        And I run :move-to-end-of-line
+        And I run :yank selection
+        Then the clipboard should contain "wei drei"

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -323,6 +323,8 @@ Feature: Caret mode
 
     # Search + caret mode
 
+    # https://bugreports.qt.io/browse/QTBUG-60673
+    @qt!=5.8.0 @qt!=5.9.0 @qt!=5.9.1 @qt!=5.9.2 @qt!=5.9.3 @qt!=5.9.4
     Scenario: yanking a searched line
         When I run :leave-mode
         And I run :search fiv
@@ -332,6 +334,7 @@ Feature: Caret mode
         And I run :yank selection
         Then the clipboard should contain "five six"
 
+    @qt!=5.8.0 @qt!=5.9.0 @qt!=5.9.1 @qt!=5.9.2 @qt!=5.9.3 @qt!=5.9.4
     Scenario: yanking a searched line with multiple matches
         When I run :leave-mode
         And I run :search w

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -324,7 +324,7 @@ Feature: Caret mode
     # Search + caret mode
 
     # https://bugreports.qt.io/browse/QTBUG-60673
-    @qt!=5.8.0 @qt!=5.9.0 @qt!=5.9.1 @qt!=5.9.2 @qt!=5.9.3 @qt!=5.9.4
+    @qtbug60673
     Scenario: yanking a searched line
         When I run :leave-mode
         And I run :search fiv
@@ -334,7 +334,7 @@ Feature: Caret mode
         And I run :yank selection
         Then the clipboard should contain "five six"
 
-    @qt!=5.8.0 @qt!=5.9.0 @qt!=5.9.1 @qt!=5.9.2 @qt!=5.9.3 @qt!=5.9.4
+    @qtbug60673
     Scenario: yanking a searched line with multiple matches
         When I run :leave-mode
         And I run :search w


### PR DESCRIPTION
Converts the currently searched text to a selection when entering caret mode!

This is probably going to break on qt5.8 and 5.9 due to [this qtbug](https://bugreports.qt.io/browse/QTBUG-60673), we'll see if travis gets annoyed.

If it dosen't work on the qt version that's being run, should we print an error, or just let it be? 

Also, if someone could test this on 5.10, that would be nice (since the bug was supposed to be fixed in 5.10)!

Progress on #3583

![peek 2018-02-21 22-19](https://user-images.githubusercontent.com/4349709/36518649-5a53d922-1755-11e8-9d26-f9e881c2007f.gif)
(The missed search shown is #3511 by the way :P)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3620)
<!-- Reviewable:end -->
