### PR TITLE
Use baseNode over anchorNode in follow-selected

### DIFF
--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -331,13 +331,13 @@ window._qutebrowser.webelem = (function() {
 
     // Function for returning a selection to python (so we can click it)
     funcs.find_selected_link = () => {
-        const elem = window.getSelection().anchorNode;
+        const elem = window.getSelection().baseNode;
         if (elem) {
             return serialize_elem(elem.parentNode);
         }
 
         const serialized_frame_elem = run_frames((frame) => {
-            const node = frame.window.getSelection().anchorNode;
+            const node = frame.window.getSelection().baseNode;
             if (node) {
                 return serialize_elem(node.parentNode, frame);
             }

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -225,15 +225,11 @@ Feature: Searching on a page
         Then the following tabs should be open:
             - data/search.html (active)
 
-    # Following a link selected via JS doesn't work in Qt 5.10 anymore.
-    @qt!=5.10
     Scenario: Follow a manually selected link
         When I run :jseval --file (testdata)/search_select.js
         And I run :follow-selected
         Then data/hello.txt should be loaded
 
-    # Following a link selected via JS doesn't work in Qt 5.10 anymore.
-    @qt!=5.10
     Scenario: Follow a manually selected link in a new tab
         When I run :window-only
         And I run :jseval --file (testdata)/search_select.js


### PR DESCRIPTION
baseNode isn't documented anywhere that I can find, but it seems to be getting us what anchorNode used to get us when selecting elements using javascript.

See https://stackoverflow.com/a/45246087 for the best information I could find on this.

Ideally we could figure out why anchorNode changed behavior in 5.10.1, or figure out what baseNode does. 

Let's see if this fixes the broken test on master first though, it dosen't seem to affect the behavior of :follow-selected when links are selected manually, for me at least.

(It might not be a good idea to use baseNode though, since it's not documented. I'll see if I can tweak the test and/or debug this further to try to avoid using this method, but this is what I have for now)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3624)
<!-- Reviewable:end -->
