### PR TITLE
Ignore duplicate search requests on webengine

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1778,10 +1778,10 @@ class CommandDispatcher:
         """
         self.set_mark("'")
         tab = self._current_widget()
-        if tab.search.search_displayed:
-            tab.search.clear()
 
         if not text:
+            if tab.search.search_displayed:
+                tab.search.clear()
             return
 
         options = {

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -183,7 +183,7 @@ class WebEngineSearch(browsertab.AbstractSearch):
 
     def search(self, text, *, ignore_case='never', reverse=False,
                result_cb=None):
-        # When duplicate searching, don't search again (webkit behavior)
+        # Don't go to next entry on duplicate search
         if self.text == text and self.search_displayed:
             log.webview.debug("Ignoring duplicate search request"
                               " for {}".format(text))

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -183,6 +183,11 @@ class WebEngineSearch(browsertab.AbstractSearch):
 
     def search(self, text, *, ignore_case='never', reverse=False,
                result_cb=None):
+        # When duplicate searching, don't search again (webkit behavior)
+        if self.text == text and self.search_displayed:
+            log.webview.debug("Ignoring duplicate search request")
+            return
+
         self.text = text
         self._flags = QWebEnginePage.FindFlags(0)
         if self._is_case_sensitive(ignore_case):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -185,7 +185,8 @@ class WebEngineSearch(browsertab.AbstractSearch):
                result_cb=None):
         # When duplicate searching, don't search again (webkit behavior)
         if self.text == text and self.search_displayed:
-            log.webview.debug("Ignoring duplicate search request")
+            log.webview.debug("Ignoring duplicate search request"
+                              " for {}".format(text))
             return
 
         self.text = text

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -146,8 +146,14 @@ class WebKitSearch(browsertab.AbstractSearch):
 
     def search(self, text, *, ignore_case='never', reverse=False,
                result_cb=None):
-        self.search_displayed = True
+        # Don't go to next entry on duplicate search
+        if self.text == text and self.search_displayed:
+            log.webview.debug("Ignoring duplicate search request"
+                              " for {}".format(text))
+            return
+
         self.text = text
+        self.search_displayed = True
         self._flags = QWebPage.FindWrapsAroundDocument
         if self._is_case_sensitive(ignore_case):
             self._flags |= QWebPage.FindCaseSensitively

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -52,7 +52,6 @@ Feature: Searching on a page
         And I wait for "search didn't find blub" in the log
         Then the warning "Text 'blub' not found on page!" should be shown
 
-    @qtwebkit_skip: Supported by default on qtwebkit
     Scenario: Searching text duplicates
         When I run :search foo
         And I wait for "search found foo" in the log

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -52,6 +52,13 @@ Feature: Searching on a page
         And I wait for "search didn't find blub" in the log
         Then the warning "Text 'blub' not found on page!" should be shown
 
+    @qtwebkit_skip: Supported by default on qtwebkit
+    Scenario: Searching text duplicates
+        When I run :search foo
+        And I wait for "search found foo" in the log
+        And I run :search foo
+        Then "Ignoring duplicate search request for foo" should be logged
+
     ## search.ignore_case
 
     Scenario: Searching text with search.ignore_case = always


### PR DESCRIPTION
I discovered that #3511 was only an issue on webengine, as duplicate search requests seemed to be ignored on qtwebkit (from the backend). 

I think that ignoring the duplicate search requests is the best idea on qtwebengine, since the alternative (ignoring search on enter) feels a bit hacky to me. 

Let me know if the other way is preferred. 

I also changed the behavior of clearing when searching to only clear when needed, which seems to both reduce a lot of flickering when incsearching for me, and also allows the duplicate search filtering to work (previously, it would clear even when the search didn't go through). 

Let me know if anything seems amiss.

Fixes #3511

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3626)
<!-- Reviewable:end -->
