### PR TITLE
Handle invalid URLs on Apple events

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -840,7 +840,11 @@ class Application(QApplication):
     def event(self, e):
         """Handle macOS FileOpen events."""
         if e.type() == QEvent.FileOpen:
-            open_url(e.url(), no_raise=True)
+            url = e.url()
+            if url.isValid():
+                open_url(url, no_raise=True)
+            else:
+                message.error("Invalid URL: {}".format(url.errorString()))
         else:
             return super().event(e)
 


### PR DESCRIPTION
Fixes crash upon receiving invalid URL in OSX open event, as reported in #3633.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3637)
<!-- Reviewable:end -->
