### PR TITLE
Preserve a backup if editor callback fails.

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -54,7 +54,6 @@ class CommandDispatcher:
     cmdutils.register() decorators are run, currentWidget() will return None.
 
     Attributes:
-        _editor: The ExternalEditor object.
         _win_id: The window ID the CommandDispatcher is associated with.
         _tabbed_browser: The TabbedBrowser used.
     """
@@ -1655,7 +1654,7 @@ class CommandDispatcher:
         tab = self._current_widget()
         tab.elements.find_focused(self._open_editor_cb)
 
-    def on_file_updated(self, elem, text):
+    def on_file_updated(self, elem, text, backup):
         """Write the editor text into the form field and clean up tempfile.
 
         Callback for GUIProcess when the edited text was updated.
@@ -1663,12 +1662,15 @@ class CommandDispatcher:
         Args:
             elem: The WebElementWrapper which was modified.
             text: The new text to insert.
+            backup: Callable to request a backup.
         """
         try:
             elem.set_value(text)
         except webelem.OrphanedError as e:
+            backup()
             message.error('Edited element vanished')
         except webelem.Error as e:
+            backup()
             raise cmdexc.CommandError(str(e))
 
     @cmdutils.register(instance='command-dispatcher', maxsplit=0,

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -128,6 +128,7 @@ Feature: Opening external editors
         And I run :tab-close
         And I kill the waiting editor
         Then the error "Edited element vanished" should be shown
+        And the message "Backup at *" should be shown
 
     # Could not get signals working on Windows
     @posix


### PR DESCRIPTION
Currently the editor deletes its temp file whenever editing is finished.
With this patch, the file will not be deleted if the editor callback
encounters an exception.

One example is if the tab containing the edited element is closed. The
editor errors with "Edited element vanished", but with this patch it
will also print "Backup at ..." so the user does not lose their work.

Resolves #1596.

Passing a callback through the signal to set the flag is a bit weird,
but was the best I came up with. Other ideas were:

- Replace the signal with a callback that could return True/False to
  indicate whether a backup was needed. I wasn't sure how this would
  affect threading.
- Pass ExternalEditor through the signal so the caller can set the flag
  directly. This exposes a much larger API to the caller and you can't
  define the signal with an ExternalEditor arg anyways, because that
  requires referencing ExternalEditor in its own class body.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3641)
<!-- Reviewable:end -->
