### PR TITLE
Fix getting customized options

### DIFF
--- a/qutebrowser/completion/models/configmodel.py
+++ b/qutebrowser/completion/models/configmodel.py
@@ -36,8 +36,10 @@ def option(*, info):
 def customized_option(*, info):
     """A CompletionModel filled with set settings and their descriptions."""
     model = completionmodel.CompletionModel(column_widths=(20, 70, 10))
-    options = ((opt.name, opt.description, info.config.get_str(opt.name))
-               for opt, _value in info.config)
+    options = ((values.opt.name, values.opt.description,
+                info.config.get_str(values.opt.name))
+               for values in info.config
+               if values)
     model.add_category(listcategory.ListCategory("Customized options",
                                                  options))
     return model

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -173,6 +173,8 @@ PERFECT_FILES = [
      'completion/models/util.py'),
     ('tests/unit/completion/test_models.py',
      'completion/models/urlmodel.py'),
+    ('tests/unit/completion/test_models.py',
+     'completion/models/configmodel.py'),
     ('tests/unit/completion/test_histcategory.py',
      'completion/models/histcategory.py'),
     ('tests/unit/completion/test_listcategory.py',


### PR DESCRIPTION
Fixes #3649 and bumps the test coverage for `configmodel.py` to 100%.

@rcorre mind giving this a quick look?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3650)
<!-- Reviewable:end -->
