### PR TITLE
Add --pygment argument to view-source

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -150,15 +150,15 @@ class AbstractAction:
             raise WebTabError("{} is not a valid web action!".format(name))
         self._widget.triggerPageAction(member)
 
-    def show_source(self, pygment=False):
+    def show_source(self, pygments=False):
         """Show the source of the current page in a new tab."""
         raise NotImplementedError
 
-    def _show_source_pygment(self):
+    def _show_source_pygments(self):
 
         def show_source_cb(source):
-            """show source as soon as it's ready."""
-            # workaround for https://github.com/pycqa/pylint/issues/491
+            """Show source as soon as it's ready."""
+            # WORKAROUND for https://github.com/PyCQA/pylint/issues/491
             # pylint: disable=no-member
             lexer = pygments.lexers.HtmlLexer()
             formatter = pygments.formatters.HtmlFormatter(

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -28,6 +28,10 @@ from PyQt5.QtCore import pyqtSignal, pyqtSlot, QUrl, QObject, QSizeF, Qt
 from PyQt5.QtGui import QIcon
 from PyQt5.QtWidgets import QWidget, QApplication
 
+import pygments
+import pygments.lexers
+import pygments.formatters
+
 from qutebrowser.keyinput import modeman
 from qutebrowser.config import config
 from qutebrowser.utils import (utils, objreg, usertypes, log, qtutils,
@@ -146,9 +150,32 @@ class AbstractAction:
             raise WebTabError("{} is not a valid web action!".format(name))
         self._widget.triggerPageAction(member)
 
-    def show_source(self):
+    def show_source(self, pygment=False):
         """Show the source of the current page in a new tab."""
         raise NotImplementedError
+
+    def _show_source_pygment(self):
+
+        def show_source_cb(source):
+            """show source as soon as it's ready."""
+            # workaround for https://github.com/pycqa/pylint/issues/491
+            # pylint: disable=no-member
+            lexer = pygments.lexers.HtmlLexer()
+            formatter = pygments.formatters.HtmlFormatter(
+                full=True, linenos='table')
+            # pylint: enable=no-member
+            highlighted = pygments.highlight(source, lexer, formatter)
+
+            tb = objreg.get('tabbed-browser', scope='window',
+                            window=self._tab.win_id)
+            new_tab = tb.tabopen(background=False, related=True)
+            # The original URL becomes the path of a view-source: URL
+            # (without a host), but query/fragment should stay.
+            url = QUrl('view-source:' + urlstr)
+            new_tab.set_html(highlighted, url)
+
+        urlstr = self._tab.url().toString(QUrl.RemoveUserInfo)
+        self._tab.dump_async(show_source_cb)
 
 
 class AbstractPrinting:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1513,7 +1513,8 @@ class CommandDispatcher:
             )
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def view_source(self, edit=False):
+    @cmdutils.argument('pygment')
+    def view_source(self, edit=False, pygment=False):
         """Show the source of the current page in a new tab.
 
         Args:
@@ -1532,7 +1533,7 @@ class CommandDispatcher:
             ed = editor.ExternalEditor(self._tabbed_browser)
             tab.dump_async(ed.edit)
         else:
-            tab.action.show_source()
+            tab.action.show_source(pygment)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        debug=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1513,12 +1513,15 @@ class CommandDispatcher:
             )
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    @cmdutils.argument('pygment')
-    def view_source(self, edit=False, pygment=False):
+    def view_source(self, edit=False, pygments=False):
         """Show the source of the current page in a new tab.
 
         Args:
             edit: Edit the source in the editor instead of opening a tab.
+            pygments: Use pygments to generate the view. This is always
+                      the case for QtWebKit. For QtWebEngine it may display
+                      slightly different source.
+                      Some JavaScript processing may be applied.
         """
         tab = self._current_widget()
         try:
@@ -1533,7 +1536,7 @@ class CommandDispatcher:
             ed = editor.ExternalEditor(self._tabbed_browser)
             tab.dump_async(ed.edit)
         else:
-            tab.action.show_source(pygment)
+            tab.action.show_source(pygments)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        debug=True)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -100,9 +100,9 @@ class WebEngineAction(browsertab.AbstractAction):
         """Save the current page."""
         self._widget.triggerPageAction(QWebEnginePage.SavePage)
 
-    def show_source(self, pygment):
-        if pygment:
-            self._show_source_pygment()
+    def show_source(self, pygments=False):
+        if pygments:
+            self._show_source_pygments()
             return
 
         try:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -100,7 +100,11 @@ class WebEngineAction(browsertab.AbstractAction):
         """Save the current page."""
         self._widget.triggerPageAction(QWebEnginePage.SavePage)
 
-    def show_source(self):
+    def show_source(self, pygment):
+        if pygment:
+            self._show_source_pygment()
+            return
+
         try:
             self._widget.triggerPageAction(QWebEnginePage.ViewSource)
         except AttributeError:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -23,10 +23,6 @@ import re
 import functools
 import xml.etree.ElementTree
 
-import pygments
-import pygments.lexers
-import pygments.formatters
-
 import sip
 from PyQt5.QtCore import (pyqtSlot, Qt, QEvent, QUrl, QPoint, QTimer, QSizeF,
                           QSize)
@@ -55,8 +51,8 @@ class WebKitAction(browsertab.AbstractAction):
         """Save the current page."""
         raise browsertab.UnsupportedOperationError
 
-    def show_source(self, pygment):
-        self._show_source_pygment()
+    def show_source(self, pygments=False):
+        self._show_source_pygments()
 
 
 class WebKitPrinting(browsertab.AbstractPrinting):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -55,28 +55,8 @@ class WebKitAction(browsertab.AbstractAction):
         """Save the current page."""
         raise browsertab.UnsupportedOperationError
 
-    def show_source(self):
-
-        def show_source_cb(source):
-            """Show source as soon as it's ready."""
-            # WORKAROUND for https://github.com/PyCQA/pylint/issues/491
-            # pylint: disable=no-member
-            lexer = pygments.lexers.HtmlLexer()
-            formatter = pygments.formatters.HtmlFormatter(
-                full=True, linenos='table')
-            # pylint: enable=no-member
-            highlighted = pygments.highlight(source, lexer, formatter)
-
-            tb = objreg.get('tabbed-browser', scope='window',
-                            window=self._tab.win_id)
-            new_tab = tb.tabopen(background=False, related=True)
-            # The original URL becomes the path of a view-source: URL
-            # (without a host), but query/fragment should stay.
-            url = QUrl('view-source:' + urlstr)
-            new_tab.set_html(highlighted, url)
-
-        urlstr = self._tab.url().toString(QUrl.RemoveUserInfo)
-        self._tab.dump_async(show_source_cb)
+    def show_source(self, pygment):
+        self._show_source_pygment()
 
 
 class WebKitPrinting(browsertab.AbstractPrinting):


### PR DESCRIPTION
The --pygment argument allows to use the pygment version of view-source
over the qtwebengine internal one.
This version is slightly different in what's processed before the site
is generated, so some javascript created texts can be available.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3654)
<!-- Reviewable:end -->
