### PR TITLE
Clear old search results on webkit

### DIFF
--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -153,6 +153,9 @@ class WebKitSearch(browsertab.AbstractSearch):
                               " for {}".format(text))
             return
 
+        # Clear old search results, this is done automatically on other backends
+        self.clear()
+
         self.text = text
         self.search_displayed = True
         self._flags = QWebPage.FindWrapsAroundDocument


### PR DESCRIPTION
Fixes old search results showing up after #3626 

Pretty simple fix, but let me know if anyone finds issues with it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3659)
<!-- Reviewable:end -->
