### PR TITLE
Don't crash first completion update with min_chars.

### DIFF
--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -60,7 +60,7 @@ class Completer(QObject):
         self._timer.setSingleShot(True)
         self._timer.setInterval(0)
         self._timer.timeout.connect(self._update_completion)
-        self._last_cursor_pos = None
+        self._last_cursor_pos = -1
         self._last_text = None
         self._last_completion_func = None
         self._cmd.update_completion.connect(self.schedule_completion_update)

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -313,3 +313,22 @@ def test_quickcomplete_flicker(status_command_stub, completer_obj,
     completer_obj.on_selection_changed('http://example.com')
     completer_obj.schedule_completion_update()
     assert not completion_widget_stub.set_model.called
+
+
+def test_min_chars(status_command_stub, completer_obj, completion_widget_stub,
+                   config_stub, key_config_stub):
+    """Test that an update is delayed until min_chars characters are input."""
+    config_stub.val.completion.min_chars = 3
+
+    # Test #3635, where min_chars could crash the first update
+    _set_cmd_prompt(status_command_stub, ':set c|')
+    completer_obj.schedule_completion_update()
+    assert completion_widget_stub.set_model.call_count == 0
+
+    _set_cmd_prompt(status_command_stub, ':set co|')
+    completer_obj.schedule_completion_update()
+    assert completion_widget_stub.set_model.call_count == 0
+
+    _set_cmd_prompt(status_command_stub, ':set com|')
+    completer_obj.schedule_completion_update()
+    assert completion_widget_stub.set_model.call_count == 1


### PR DESCRIPTION
When min_chars is nonzero, if the first command that opens the
completion has < min_chars on the word under the cursor, it triggers a
check for a condition where last_cursor_pos is None.

By setting last_cursor_pos=-1 we ensure that the completer always
updates the first time it is opened, and that there is never a check
against None.

This adds a test for the min_chars feature.

Resolves #3635.