### PR TITLE
Greasemonkey: don't inject JS into dead frames

### DIFF
--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -22,6 +22,7 @@
 import html
 import functools
 
+import sip
 from PyQt5.QtCore import pyqtSlot, pyqtSignal, Qt, QUrl, QPoint
 from PyQt5.QtGui import QDesktopServices
 from PyQt5.QtNetwork import QNetworkReply, QNetworkRequest
@@ -302,6 +303,10 @@ class BrowserPage(QWebPage):
         Args:
             frame: The QWebFrame to inject the user scripts into.
         """
+        if sip.isdeleted(frame):
+            log.greasemonkey.debug("_inject_userjs called for deleted frame!")
+            return
+
         url = frame.url()
         if url.isEmpty():
             url = frame.requestedUrl()


### PR DESCRIPTION
Hopefully closes #3627

This feels like fixing the symptom instead of the problem but I am not
sure how such a situation would arise. Never the less, the crash logs
clearly show that `_inject_userjs()` is being called with a deleted
frame sometimes. It is being called from a closure that gets triggered
on frame.loadFinished so I am not sure how frame could be deleted at
that time unless:

* the error message is misleading and it is actually some reference to
  the object that is no longer valid
* the frame gets deleted from some other handler of loadFinished.

No need to take similar action in webengine/webview.py because that doesn't handle subframes anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3666)
<!-- Reviewable:end -->
