### PR TITLE
Strip trailing slashes before saving bookmarks

### DIFF
--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -276,7 +276,8 @@ class BookmarkManager(UrlMarkManager):
             errstr = urlutils.get_errstring(url)
             raise InvalidUrlError(errstr)
 
-        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
+        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded |
+                              QUrl.StripTrailingSlash)
 
         if urlstr in self.marks:
             if toggle:

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -276,16 +276,18 @@ class BookmarkManager(UrlMarkManager):
             errstr = urlutils.get_errstring(url)
             raise InvalidUrlError(errstr)
 
-        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded |
-                              QUrl.StripTrailingSlash)
+        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
+        urlstr_noslash = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded |
+                                      QUrl.StripTrailingSlash)
+        # Check if both the slashed and slashless version is here
+        for urlstr_check in [urlstr_noslash, urlstr_noslash + '/']:
+            if urlstr_check in self.marks:
+                if toggle:
+                    self.delete(urlstr_check)
+                    return False
+                else:
+                    raise AlreadyExistsError("Bookmark already exists!")
 
-        if urlstr in self.marks:
-            if toggle:
-                self.delete(urlstr)
-                return False
-            else:
-                raise AlreadyExistsError("Bookmark already exists!")
-        else:
-            self.marks[urlstr] = title
-            self.changed.emit()
-            return True
+        self.marks[urlstr] = title
+        self.changed.emit()
+        return True

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -31,6 +31,14 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-add
         Then the error "Bookmark already exists!" should be shown
 
+    Scenario: Saving a duplicate bookmark with differing slashes
+        Given I have a fresh instance
+        When I open data/title.html
+        And I run :bookmark-add
+        And I open data/title.html/
+        And I run :bookmark-add
+        Then the error "Bookmark already exists!" should be shown
+
     Scenario: Loading a bookmark
         When I run :tab-only
         And I run :bookmark-load http://localhost:(port)/data/numbers/1.txt

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -39,6 +39,14 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-add
         Then the error "Bookmark already exists!" should be shown
 
+    Scenario: Saving a duplicate bookmark with differing slashes reverse
+        Given I have a fresh instance
+        When I open data/title.html/
+        And I run :bookmark-add
+        And I open data/title.html
+        And I run :bookmark-add
+        Then the error "Bookmark already exists!" should be shown
+
     Scenario: Loading a bookmark
         When I run :tab-only
         And I run :bookmark-load http://localhost:(port)/data/numbers/1.txt


### PR DESCRIPTION
Closes #3664

This might actually make the problem a bit worse in the short term, since top level sites redirect you to a slashed version (for example, `example.com` redirects to `http://example.com/`, and this would re-duplicate the bookmarks in that case.

A way around this is to strip the slash in this way, and then add it back. Does that seem like a good idea? 

Alternatively, I can create a 'slashed url' and an 'unslashed url' and check both against existing bookmarks, while actually using the user-supplied one.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3668)
<!-- Reviewable:end -->
