### PR TITLE
WIP: Add hints to <summary> elements

### DIFF
--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -41,8 +41,8 @@ Group = enum.Enum('Group', ['all', 'links', 'images', 'url', 'inputs'])
 
 SELECTORS = {
     Group.all: ('a, area, textarea, select, input:not([type=hidden]), button, '
-                'frame, iframe, link, [onclick], [onmousedown], [role=link], '
-                '[role=option], [role=button], img, '
+                'frame, iframe, link, summary, [onclick], [onmousedown], '
+                '[role=link], [role=option], [role=button], img, '
                 # Angular 1 selectors
                 '[ng-click], [ngClick], [data-ng-click], [x-ng-click]'),
     Group.links: 'a[href], area[href], link[href], [role=link][href]',


### PR DESCRIPTION

The reaction button on PRs and comments on GitHub for example is a `<summary>` that couldn't be triggered with hints. This PR fixes that.

PS: Still WIP because I'll add some tests when I have the chance
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3676)
<!-- Reviewable:end -->
