### PR TITLE
Add option to only show favicons for pinned tabs

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -114,6 +114,10 @@ class TabData:
     netrc_used = attr.ib(False)
     input_mode = attr.ib(usertypes.KeyMode.normal)
 
+    def should_show_icon(self):
+        return (config.val.tabs.favicons.show == 'always' or
+                config.val.tabs.favicons.show == 'pinned' and self.pinned)
+
 
 class AbstractAction:
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -502,7 +502,7 @@ class CommandDispatcher:
         idx = new_tabbed_browser.widget.indexOf(newtab)
 
         new_tabbed_browser.widget.set_page_title(idx, cur_title)
-        if config.val.tabs.favicons.show:
+        if curtab.data.should_show_icon():
             new_tabbed_browser.widget.setTabIcon(idx, curtab.icon())
             if config.val.tabs.tabs_are_windows:
                 new_tabbed_browser.widget.window().setWindowIcon(curtab.icon())

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1252,9 +1252,14 @@ tabs.favicons.scale:
     `tabs.padding`.
 
 tabs.favicons.show:
-  default: true
-  type: Bool
-  desc: Show favicons in the tab bar.
+  default: always
+  type:
+    name: String
+    valid_values:
+      - always: Always show favicons.
+      - never: Always hide favicons.
+      - pinned: Show favicons only on pinned tabs.
+  desc: When to show favicons in the tab bar.
 
 tabs.last_close:
   default: ignore

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -268,6 +268,15 @@ class YamlConfig(QObject):
             del settings['bindings.default']
             self._mark_changed()
 
+        # Option to show favicons only for pinned tabs changed the type of
+        # tabs.favicons.show from Bool to String
+        name = 'tabs.favicons.show'
+        if name in settings:
+            for scope, val in settings[name].items():
+                if isinstance(val, bool):
+                    settings[name][scope] = 'always' if val else 'never'
+                    self._mark_changed()
+
         return settings
 
     def _validate(self, settings):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -531,16 +531,8 @@ class TabbedBrowser(QWidget):
 
     def _update_favicons(self):
         """Update favicons when config was changed."""
-        for i, tab in enumerate(self.widgets()):
-            if config.val.tabs.favicons.show:
-                self.widget.setTabIcon(i, tab.icon())
-                if config.val.tabs.tabs_are_windows:
-                    self.widget.window().setWindowIcon(tab.icon())
-            else:
-                self.widget.setTabIcon(i, QIcon())
-                if config.val.tabs.tabs_are_windows:
-                    window = self.widget.window()
-                    window.setWindowIcon(self.default_window_icon)
+        for tab in self.widgets():
+            self.widget.update_tab_favicon(tab)
 
     @pyqtSlot()
     def on_load_started(self, tab):
@@ -559,7 +551,7 @@ class TabbedBrowser(QWidget):
             tab.data.keep_icon = False
         else:
             if (config.val.tabs.tabs_are_windows and
-                    config.val.tabs.favicons.show):
+                    tab.data.should_show_icon()):
                 self.widget.window().setWindowIcon(self.default_window_icon)
         if idx == self.widget.currentIndex():
             self._update_window_title()
@@ -623,7 +615,7 @@ class TabbedBrowser(QWidget):
             tab: The WebView where the title was changed.
             icon: The new icon
         """
-        if not config.val.tabs.favicons.show:
+        if not tab.data.should_show_icon():
             return
         try:
             idx = self._tab_index(tab)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -108,6 +108,7 @@ class TabWidget(QTabWidget):
 
         bar.set_tab_data(idx, 'pinned', pinned)
         tab.data.pinned = pinned
+        self.update_tab_favicon(tab)
         self.update_tab_title(idx)
 
     def tab_indicator_color(self, idx):
@@ -299,6 +300,19 @@ class TabWidget(QTabWidget):
         # It's possible for url to be invalid, but the caller will handle that.
         qtutils.ensure_valid(url)
         return url
+
+    def update_tab_favicon(self, tab: QWidget):
+        """Update favicon of the given tab."""
+        idx = self.indexOf(tab)
+
+        if tab.data.should_show_icon():
+            self.setTabIcon(idx, tab.icon())
+            if config.val.tabs.tabs_are_windows:
+                self.window().setWindowIcon(tab.icon())
+        else:
+            self.setTabIcon(idx, QIcon())
+            if config.val.tabs.tabs_are_windows:
+                self.window().setWindowIcon(self.window().windowIcon())
 
 
 class TabBar(QTabBar):
@@ -906,7 +920,7 @@ class TabBarStyle(QCommonStyle):
         # reserve space for favicon when tab bar is vertical (issue #1968)
         position = config.val.tabs.position
         if (position in [QTabWidget.East, QTabWidget.West] and
-                config.val.tabs.favicons.show):
+                config.val.tabs.favicons.show != 'never'):
             tab_icon_size = icon_size
         else:
             actual_size = opt.icon.actualSize(icon_size, icon_mode, icon_state)

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -266,6 +266,9 @@ class FakeWebTab(browsertab.AbstractTab):
     def shutdown(self):
         pass
 
+    def icon(self):
+        return self.windowIcon()
+
 
 class FakeSignal:
 

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -233,6 +233,22 @@ class TestYaml:
         data = autoconfig.read()
         assert 'bindings.default' not in data
 
+    @pytest.mark.parametrize('show',
+                             [True, False, 'always', 'never', 'pinned'])
+    def test_tabs_favicons_show(self, yaml, autoconfig, show):
+        """Tests for migration of tabs.favicons.show."""
+        autoconfig.write({'tabs.favicons.show': {'global': show}})
+
+        yaml.load()
+        yaml._save()
+
+        data = autoconfig.read()
+        if isinstance(show, bool):
+            when = 'always' if show else 'never'
+        else:
+            when = show
+        assert data['tabs.favicons.show']['global'] == when
+
     def test_renamed_key_unknown_target(self, monkeypatch, yaml,
                                         autoconfig):
         """A key marked as renamed with invalid name should raise an error."""


### PR DESCRIPTION
Closes #3440 

Options modelled after ``tabs.show``: ``always``, ``never`` and ``pinned``.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3680)
<!-- Reviewable:end -->
