### PR TITLE
Fixed keyhint handling of key_mappings

### DIFF
--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -446,7 +446,7 @@ class MainWindow(QWidget):
 
         # key hint popup
         for mode, parser in keyparsers.items():
-            parser.keystring_updated.connect(functools.partial(
+            parser.bindings_matched.connect(functools.partial(
                 self._keyhint.update_keyhint, mode.name))
 
         # messages


### PR DESCRIPTION
This makes sure the keyhint widget shows all possible bindings, including those that result from key_mappings.

For example if you set key_mappings to `{'ä': ']'}`, and bind `äb` and `]c`, pressing `ä` will show both options as keyhints.

It also refactors the keyhint widget so it doesn't have to search through all the bindings.