### PR TITLE
Add support for scrolling in same origin frames

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -433,7 +433,8 @@ class WebEngineScroller(browsertab.AbstractScroller):
         self._tab.run_js_async(js_code)
 
     def delta(self, x=0, y=0):
-        self._tab.run_js_async(javascript.assemble('window', 'scrollBy', x, y))
+        js_code = javascript.assemble('scroll', 'delta_px', x, y)
+        self._tab.run_js_async(js_code)
 
     def delta_page(self, x=0, y=0):
         js_code = javascript.assemble('scroll', 'delta_page', x, y)
@@ -636,8 +637,8 @@ class WebEngineTab(browsertab.AbstractTab):
         js_code = '\n'.join([
             '"use strict";',
             'window._qutebrowser = window._qutebrowser || {};',
-            utils.read_file('javascript/scroll.js'),
             utils.read_file('javascript/webelem.js'),
+            utils.read_file('javascript/scroll.js'),
             utils.read_file('javascript/caret.js'),
         ])
         script = QWebEngineScript()

--- a/qutebrowser/javascript/.eslintrc.yaml
+++ b/qutebrowser/javascript/.eslintrc.yaml
@@ -56,3 +56,4 @@ rules:
      no-bitwise: "off"
      no-ternary: "off"
      max-lines: "off"
+     max-params: ["error", 4]

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -282,12 +282,13 @@ window._qutebrowser.webelem = (function() {
         if ("contentWindow" in elem) {
             const frame = elem.contentWindow;
             if (iframe_same_domain(frame) &&
-                "frameElement" in elem.contentWindow) {
+                "frameElement" in frame) {
                 return func(frame);
             }
         }
         return null;
     }
+    funcs.call_if_frame = call_if_frame;
 
     funcs.find_focused = () => {
         const elem = document.activeElement;

--- a/tests/end2end/data/scroll/frame.html
+++ b/tests/end2end/data/scroll/frame.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Hinting inside an iframe</title>
+    </head>
+    <body>
+        <iframe id="scroll-frame" style="margin: 50px;" src="/data/scroll/simple.html"></iframe>
+
+    </body>
+
+    <script>
+        let frame = document.getElementById("scroll-frame");
+        const win = frame.contentWindow;
+        win.addEventListener('scroll', () =>  {
+            console.log("scroll y px: " + win.scrollY);
+        });
+        console.log(frame);
+    </script>
+</html>

--- a/tests/end2end/features/scroll.feature
+++ b/tests/end2end/features/scroll.feature
@@ -231,7 +231,7 @@ Feature: Scrolling
     Scenario: :scroll-to-perc with count and argument
         When I run :scroll-to-perc 0 with count 50
         Then the page should be scrolled vertically
-        
+
     # https://github.com/qutebrowser/qutebrowser/issues/1821
     @issue3572
     Scenario: :scroll-to-perc without doctype
@@ -332,3 +332,23 @@ Feature: Scrolling
         And I run :tab-next
         And I run :jseval --world main checkAnchor()
         Then "[*] [PASS] Positions equal: *" should be logged
+
+    ## frame scrolling
+
+    Scenario: Scrolling pixel-wise in a frame
+        When I open data/scroll/frame.html
+        And I run :tab-only
+        And I run :hint
+        And I run :follow-hint a
+        And I run :scroll-px 0 100
+        Then the javascript message "scroll y px: 100" should be logged
+
+    Scenario: Scrolling to a position in a frame
+        When I open data/scroll/frame.html
+        And I run :tab-only
+        And I run :hint
+        And I run :follow-hint a
+        And I run :scroll-px 0 100
+        And I run :scroll-to-perc 0
+        Then the javascript message "scroll y px: 100" should be logged
+        And the javascript message "scroll y px: 0" should be logged


### PR DESCRIPTION
Part of https://github.com/qutebrowser/qutebrowser/issues/3569, even though I didn't actually put it on that issue :P. This is essentially #3371 for `scroll.js` instead of `webelem.js`.

We can finally scroll stuff (in webengine) for javadocs! 
![peek 2018-03-08 22-37](https://user-images.githubusercontent.com/4349709/37189246-4a7fb21e-2321-11e8-8e35-e15c523d1246.gif)


I tried adding a couple tests, but I think more thourough tests might not be worth it. Would you like a `:scroll-page` test?

I haven't done any testing on webkit yet, I'll do that when I get a chance (let's see what passes on CI)

After this, I want to add a focus class for frames, so it's easier to select which frame has focus with hints.