### PR TITLE
Add a tabs.min_width setting

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1413,7 +1413,7 @@ tabs.min_width:
     minval: -1
     maxval: maxint
   desc: >-
-    Minimum width (in pixels) of tabs (-1 to use min text contents size for min width).
+    Minimum width (in pixels) of tabs (-1 for the default minimum size behavior).
 
     This setting only applies when tabs are horizontal.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1406,6 +1406,16 @@ tabs.width:
   desc: "Width (in pixels or as percentage of the window) of the tab bar if
     it's vertical."
 
+tabs.min_width:
+  default: -1
+  type:
+    name: Int
+    minval: -1
+  desc: >-
+    Minimum width (in pixels) of tabs (-1 to use text contents for min width).
+
+    This setting only applies when tabs are horizontal.
+
 tabs.width.indicator:
   renamed: tabs.indicator.width
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1411,10 +1411,13 @@ tabs.min_width:
   type:
     name: Int
     minval: -1
+    maxval: maxint
   desc: >-
-    Minimum width (in pixels) of tabs (-1 to use text contents for min width).
+    Minimum width (in pixels) of tabs (-1 to use min text contents size for min width).
 
     This setting only applies when tabs are horizontal.
+
+    This setting does not apply to pinned tabs, unless `tabs.pinned.shrink` is False.
 
 tabs.width.indicator:
   renamed: tabs.indicator.width

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -562,6 +562,12 @@ class TabBar(QTabBar):
         Return:
             A QSize.
         """
+        if self.count() == 0:
+            # This happens on startup on macOS.
+            # We return it directly rather than setting `size' because we don't
+            # want to ensure it's valid in this special case.
+            return QSize()
+
         minimum_size = self.minimumTabSizeHint(index)
         height = minimum_size.height()
         if self.vertical:
@@ -574,11 +580,6 @@ class TabBar(QTabBar):
             else:
                 width = int(confwidth)
             size = QSize(max(minimum_size.width(), width), height)
-        elif self.count() == 0:
-            # This happens on startup on macOS.
-            # We return it directly rather than setting `size' because we don't
-            # want to ensure it's valid in this special case.
-            return QSize()
         else:
             if config.val.tabs.pinned.shrink:
                 pinned = self._tab_pinned(index)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -358,7 +358,8 @@ class TabBar(QTabBar):
         # Clear _minimum_tab_size_hint_helper cache when appropriate
         if option in ["tabs.indicator.padding",
                       "tabs.padding",
-                      "tabs.indicator.width"]:
+                      "tabs.indicator.width",
+                      "tabs.min_width"]:
             self._minimum_tab_size_hint_helper.cache_clear()
 
     def _on_show_switching_delay_changed(self):
@@ -495,13 +496,13 @@ class TabBar(QTabBar):
             # Never consider ellipsis an option for pinned tabs
             ellipsis = False
         return self._minimum_tab_size_hint_helper(self.tabText(index),
-                                                  icon_width,
-                                                  ellipsis)
+                                                  icon_width, ellipsis,
+                                                  pinned)
 
     @functools.lru_cache(maxsize=2**9)
     def _minimum_tab_size_hint_helper(self, tab_text: str,
                                       icon_width: int,
-                                      ellipsis: bool) -> QSize:
+                                      ellipsis: bool, pinned: bool) -> QSize:
         """Helper function to cache tab results.
 
         Config values accessed in here should be added to _on_config_changed to
@@ -526,6 +527,9 @@ class TabBar(QTabBar):
         height = self.fontMetrics().height() + padding_v
         width = (text_width + icon_width +
                  padding_h + indicator_width)
+        min_width = config.val.tabs.min_width
+        if not pinned and not self.vertical and min_width > 0:
+            width = max(min_width, width)
         return QSize(width, height)
 
     def _pinned_statistics(self) -> (int, int):

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -478,7 +478,8 @@ class TabBar(QTabBar):
         Args:
             index: The index of the tab to get a size hint for.
             ellipsis: Whether to use ellipsis to calculate width
-                     instead of the tab's text. Forced to true for pinned tabs.
+                     instead of the tab's text.
+                     Forced to false for pinned tabs.
         Return:
             A QSize of the smallest tab size we can make.
         """

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -477,7 +477,7 @@ class TabBar(QTabBar):
         Args:
             index: The index of the tab to get a size hint for.
             ellipsis: Whether to use ellipsis to calculate width
-                     instead of the tab's text.
+                     instead of the tab's text. Forced to true for pinned tabs.
         Return:
             A QSize of the smallest tab size we can make.
         """
@@ -489,6 +489,11 @@ class TabBar(QTabBar):
         else:
             icon_width = min(icon.actualSize(self.iconSize()).width(),
                              self.iconSize().width()) + icon_padding
+
+        pinned = self._tab_pinned(index)
+        if pinned:
+            # Never consider ellipsis an option for pinned tabs
+            ellipsis = False
         return self._minimum_tab_size_hint_helper(self.tabText(index),
                                                   icon_width,
                                                   ellipsis)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -359,7 +359,8 @@ class TabBar(QTabBar):
         if option in ["tabs.indicator.padding",
                       "tabs.padding",
                       "tabs.indicator.width",
-                      "tabs.min_width"]:
+                      "tabs.min_width",
+                      "tabs.pinned.shrink"]:
             self._minimum_tab_size_hint_helper.cache_clear()
 
     def _on_show_switching_delay_changed(self):
@@ -529,7 +530,8 @@ class TabBar(QTabBar):
         width = (text_width + icon_width +
                  padding_h + indicator_width)
         min_width = config.val.tabs.min_width
-        if not pinned and not self.vertical and min_width > 0:
+        if (not self.vertical and min_width > 0 and
+                not pinned or not config.val.tabs.pinned.shrink):
             width = max(min_width, width)
         return QSize(width, height)
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -479,8 +479,8 @@ class TabBar(QTabBar):
         Args:
             index: The index of the tab to get a size hint for.
             ellipsis: Whether to use ellipsis to calculate width
-                     instead of the tab's text.
-                     Forced to false for pinned tabs.
+                      instead of the tab's text.
+                      Forced to False for pinned tabs.
         Return:
             A QSize of the smallest tab size we can make.
         """


### PR DESCRIPTION
This adds the setting requested in #3690.

- [x] Determine if this setting should apply if `tabs.pinned.shrink` is False too (it seems reasonable to me, I just want to think about it a little more)
- [x] See if polling pinned tabs here in this way impacts performance (and is it ignorable)

I also fixed a bug in pinned width calculation which this PR exposed, which caused pinned tabs to occasionally be counted as one-width if there was absolutely no space at all in the tabbar.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3692)
<!-- Reviewable:end -->
