### PR TITLE
Show version for POSIX OSes

### DIFF
--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -269,6 +269,8 @@ def _os_info():
         else:
             versioninfo = '.'.join(versioninfo)
         osver = ', '.join([e for e in [release, versioninfo, machine] if e])
+    elif utils.is_posix:
+        osver = ' '.join(platform.uname())
     else:
         osver = '?'
     lines.append('OS Version: {}'.format(osver))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -246,6 +246,8 @@ def apply_fake_os(monkeypatch, request):
     elif name == 'linux':
         linux = True
         posix = True
+    elif name == 'posix':
+        posix = True
     else:
         raise ValueError("Invalid fake_os {}".format(name))
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -707,6 +707,15 @@ class TestOsInfo:
         expected = ['OS Version: {}'.format(mac_ver_str)]
         assert ret == expected
 
+    @pytest.mark.fake_os('posix')
+    def test_posix_fake(self, monkeypatch):
+        """Test with a fake posix platform."""
+        uname_tuple = ('PosixOS', 'localhost', '1.0', '1.0', 'i386', 'i386')
+        monkeypatch.setattr(version.platform, 'uname', lambda: uname_tuple)
+        ret = version._os_info()
+        expected = ['OS Version: %s' % ' '.join(uname_tuple)]
+        assert ret == expected
+
     @pytest.mark.fake_os('unknown')
     def test_unknown_fake(self):
         """Test with a fake unknown platform."""
@@ -727,6 +736,11 @@ class TestOsInfo:
     @pytest.mark.mac
     def test_mac_real(self):
         """Make sure there are no exceptions with a real macOS."""
+        version._os_info()
+
+    @pytest.mark.posix
+    def test_posix_real(self):
+        """Make sure there are no exceptions with a real posix."""
         version._os_info()
 
 


### PR DESCRIPTION
For POSIX OSes other than Linux and macOS set OS Version to
platform.uname() instead of showing 'OS Version: ?'.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3700)
<!-- Reviewable:end -->
