### PR TITLE
Fix Hinting on input ranges in qt5.9

### DIFF
--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -74,9 +74,8 @@ window._qutebrowser.webelem = (function() {
         try {
             return elem.selectionStart;
         } catch (err) {
-            if (err instanceof (frame
-                ? frame.DOMException
-                : DOMException) &&
+            if ((err instanceof DOMException ||
+                 (frame && err instanceof frame.DOMException)) &&
                 err.name === "InvalidStateError") {
                 // nothing to do, caret_position is already null
             } else {

--- a/tests/end2end/data/hints/issue3711.html
+++ b/tests/end2end/data/hints/issue3711.html
@@ -1,0 +1,13 @@
+<html>
+    <!-- https://github.com/qutebrowser/qutebrowser/issues/3711 -->
+    <head>
+        <title>Issue 3711</title>
+    </head>
+    <body>
+        <!--
+        Verify no hint error occurs when hinting input range elements in iframes on qt5.9
+        Possibly an issue in chrome.
+        -->
+        <input min="0" max="1" step="0.001" type="range">
+    </body>
+</html>

--- a/tests/end2end/data/hints/issue3711_frame.html
+++ b/tests/end2end/data/hints/issue3711_frame.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>Issue 3771 Parent Frame</title>
+    </head>
+    <body>
+        <iframe src="./issue3711.html"></iframe>
+    </body>
+</html>

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -249,6 +249,11 @@ Feature: Using hints
         And I hint with args "all current" and follow a
         Then no crash should happen
 
+    Scenario: No error when hinting ranged input in frames
+        When I open data/hints/issue3711_frame.html
+        And I hint with args "all current" and follow a
+        Then no crash should happen
+
     ### hints.auto_follow.timeout
 
     @not_mac @flaky


### PR DESCRIPTION
In qt5.9 (or the attached chrome version) there seems to be a bug where the exception thrown is a plain `DOMException` rather than a `frame.DOMException` if this kind of element is in a frame. 

I also added a test which passes for me on 5.9 (but fails on master), let's see if CI likes it for the other targets.

Closes https://github.com/qutebrowser/qutebrowser/issues/3711

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3713)
<!-- Reviewable:end -->
