### PR TITLE
Add yank{,-primary} to the rapid hinting whitelist.

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -694,7 +694,8 @@ class HintManager(QObject):
         if rapid:
             if target in [Target.tab_bg, Target.window, Target.run,
                           Target.hover, Target.userscript, Target.spawn,
-                          Target.download, Target.normal, Target.current]:
+                          Target.download, Target.normal, Target.current,
+                          Target.yank, Target.yank_primary]:
                 pass
             elif target == Target.tab and config.val.tabs.background:
                 pass


### PR DESCRIPTION
Say I have a program watching the clipboard for interesting content. Maybe a download manager looking for URLs. And I am on a page with a list of links to ... linux distro ISOs. I would like to be able to
get an arbitrary selection of those links into my primary selection without being presented with a message telling me it makes no sense.

I have had that whole `if rapid:` block commented out locally for ever.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3716)
<!-- Reviewable:end -->
