### PR TITLE
Add userscript to open 1Password Mini (mac)

### DIFF
--- a/misc/userscripts/mac-1password-mini
+++ b/misc/userscripts/mac-1password-mini
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+# This opens 1Password Mini with the domain of the current page filled in.
+# It does *not* provide auto-fill for the page.
+# It *only* works on macOS. (I don't know if there's an equivalent helper on
+# other platforms anyway)
+
+# Suggested mapping: `:bind <meta-\> spawn --userscript 1password-mini`
+
+domain=$QUTE_URL
+domain=${domain##*://} # remove protocol
+domain=${domain%%/*} # remove pathname
+domain=${domain%:*} # remove port
+domain=${domain##www.} # remove www. subdomain if present
+
+open "x-onepassword-helper://search/${domain}"

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -325,7 +325,7 @@ window._qutebrowser.caret = (function() {
                 if (color &&
                     (style.opacity < 1 &&
                         (color.alpha *= style.opacity),
-                        color.alpha !== 0 &&
+                    color.alpha !== 0 &&
                         (el.push(color), color.alpha === 1))) {
                     iter = !0;
                     break;


### PR DESCRIPTION
This opens 1Password Mini with the current domain filled in in the
search field.

This doesn't provide auto-fill.
It also works on macOS only AFAIK.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3730)
<!-- Reviewable:end -->
