### PR TITLE
Add correct maximum and minimum value for tabs.switching_delay 

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1327,8 +1327,8 @@ tabs.show_switching_delay:
   default: 800
   type:
     name: Int
-    minval: -2147483648
-    maxval: 2147483647
+    minval: 0
+    maxval: maxint
   desc: "Duration (in milliseconds) to show the tab bar before hiding it when
     tabs.show is set to 'switching'."
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1325,7 +1325,10 @@ tabs.show:
 
 tabs.show_switching_delay:
   default: 800
-  type: Int
+  type:
+    name: Int
+    minval: -2147483648
+    maxval: 2147483647
   desc: "Duration (in milliseconds) to show the tab bar before hiding it when
     tabs.show is set to 'switching'."
 


### PR DESCRIPTION
This Pull Request tries to fix Issue#3629 

I was not sure about whether to set minval to 0 or not as negative values seem pretty useless for this option.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3733)
<!-- Reviewable:end -->

[edit by @jgkamat to link issues: Closes #3629]