### PR TITLE
Always display plain titles in tab tooltips

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -148,9 +148,13 @@ class TabWidget(QTabWidget):
         title = '' if fmt is None else fmt.format(**fields)
         tabbar = self.tabBar()
 
+        # Only change the tab title if it changes, setting the tab title causes
+        # a size recalculation which is slow.
         if tabbar.tabText(idx) != title:
             tabbar.setTabText(idx, title)
-            tabbar.setTabToolTip(idx, title)
+
+        # always show only plain title in tooltips
+        tabbar.setTabToolTip(idx, fields['title'])
 
     def get_tab_fields(self, idx):
         """Get the tab field data."""


### PR DESCRIPTION
Switch tooltips to always display page titles rather than the contents of the tab's text from `title_format`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3751)
<!-- Reviewable:end -->
