### PR TITLE
Fix minimum size for vertical and shrunk tabs

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -494,8 +494,8 @@ class TabBar(QTabBar):
                              self.iconSize().width()) + icon_padding
 
         pinned = self._tab_pinned(index)
-        if pinned:
-            # Never consider ellipsis an option for pinned tabs
+        if not self.vertical and pinned and config.val.tabs.pinned.shrink:
+            # Never consider ellipsis an option for horizontal pinned tabs
             ellipsis = False
         return self._minimum_tab_size_hint_helper(self.tabText(index),
                                                   icon_width, ellipsis,

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -61,6 +61,60 @@ class TestTabWidget:
         with qtbot.waitExposed(widget):
             widget.show()
 
+    # Sizing tests
+
+    def test_tab_size_same(self, widget, fake_web_tab):
+        """Ensure by default, all tab sizes are the same."""
+        num_tabs = 10
+        for i in range(num_tabs):
+            widget.addTab(fake_web_tab(), 'foobar' + str(i))
+
+        first_size = widget.tabBar().tabSizeHint(0)
+        first_size_min = widget.tabBar().minimumTabSizeHint(0)
+
+        for i in range(num_tabs):
+            assert first_size == widget.tabBar().tabSizeHint(i)
+            assert first_size_min == widget.tabBar().minimumTabSizeHint(i)
+
+    @pytest.mark.parametrize("shrink_pinned", [True, False])
+    @pytest.mark.parametrize("vertical", [True, False])
+    def test_pinned_size(self, widget, fake_web_tab, config_stub,
+                         shrink_pinned, vertical):
+        """Ensure by default, pinned min sizes are forced to title.
+
+        If pinned.shrink is not true, then all tabs should be the same
+
+        If tabs are vertical, all tabs should be the same"""
+        num_tabs = 10
+        for i in range(num_tabs):
+            widget.addTab(fake_web_tab(), 'foobar' + str(i))
+
+        # Set pinned title format longer than unpinned
+        config_stub.val.tabs.title.format_pinned = "_" * 20
+        config_stub.val.tabs.title.format = "_" * 2
+        config_stub.val.tabs.pinned.shrink = shrink_pinned
+        if vertical:
+            # Use pixel width so we don't need to mock main-window
+            config_stub.val.tabs.width = 50
+            config_stub.val.tabs.position = "left"
+
+        pinned_num = [1, num_tabs - 1]
+        for tab in pinned_num:
+            widget.set_tab_pinned(widget.widget(tab), True)
+
+        first_size = widget.tabBar().tabSizeHint(0)
+        first_size_min = widget.tabBar().minimumTabSizeHint(0)
+
+        for i in range(num_tabs):
+            if i in pinned_num and shrink_pinned and not vertical:
+                assert (first_size.width() <
+                        widget.tabBar().tabSizeHint(i).width())
+                assert (first_size_min.width() <
+                        widget.tabBar().minimumTabSizeHint(i).width())
+            else:
+                assert first_size == widget.tabBar().tabSizeHint(i)
+                assert first_size_min == widget.tabBar().minimumTabSizeHint(i)
+
     @pytest.mark.parametrize("num_tabs", [4, 10])
     def test_update_tab_titles_benchmark(self, benchmark, widget,
                                          qtbot, fake_web_tab, num_tabs):


### PR DESCRIPTION
This fixes two bugs in #3692, where the minimum size for pinned tabs changed the size of vertical tabbars, and where unshrunk tabs were still behaving like pinned tabs (having a minimum size of their contents).


```
<s4ro> [14:55:21] Hello, in latest git (b67a03115) the tab width
    configuration seems to be broken
<The-Compiler> [14:56:26] nonamethanks: ctrl-c copies, ctrl-enter
    (with :open -t) opens multiple links
<The-Compiler> [14:56:33] s4ro: how so? (also cc jgkamat)
<s4ro> [14:57:22] The-Compiler: I have vertical tabs and now it always
    displays the host name no matter the which is the width set
<nonamethanks> [14:58:01] well crap, i had no idea. Thanks! That's
    pretty much exactly what i needed lol
<s4ro> [14:58:04] The-Compiler: removing {host} from tab name restrict
    automatically the width
<The-Compiler> [14:59:45] s4ro: I don't follow, sorry :)
<ipstone> [15:00:56] newbie question: is there a good tutorial of
    qutebrowser? There are a lot of info, but perhaps because
    qutebrowser is so configurable, sometimes I got lost. It will be
    good to find the more general way to use qutebrowser, setting up
    etc.
<The-Compiler> [15:01:27] ipstone: there's the documentation in :help,
    but nothing more tutorial/manual-like
<parchd> [15:01:47] The-Compiler: wow, didn't know about those
    options. Thanks.
<s4ro> [15:01:59] It looks like the option tabs.width is now ignored
    and and the width of the vertical tab bar depends on the {host}
    length
<The-Compiler> [15:02:40] s4ro: I can't reproduce that (after :set
    tabs.title.format {host} and :set tabs position left)
<The-Compiler> [15:03:43] (the tab bar's width doesn't change here, no
    matter what the text is)
<s4ro> [15:07:32] ok, the problem seems to be related only to pinned
    tabs
<s4ro> [15:08:44] tabs.title.format_pinned
<The-Compiler> [15:10:50] s4ro: true, that seems unintended - can you
    open an issue please?
```

Closes #3754

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3752)
<!-- Reviewable:end -->
