### PR TITLE
Add a keepass userscript

### DIFF
--- a/misc/userscripts/qute-keepass
+++ b/misc/userscripts/qute-keepass
@@ -17,8 +17,11 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-USAGE = """This userscript allows for insertion of usernames and passwords from keepass
-databases using pykeepass. Since it is a userscript, it must be run from qutebrowser.
+# pylint: disable=bad-builtin
+
+USAGE = """This userscript allows for insertion of usernames and passwords from
+keepass databases using pykeepass. Since it is a userscript, it must be run from
+qutebrowser.
 
 A sample invocation of this script is:
 
@@ -28,14 +31,29 @@ And a sample binding
 
 :bind --mode=insert <ctrl-i> spawn --userscript qute-keepass -p ~/KeePassFiles/MainDatabase.kdbx
 
-login information is inserted by emulating key events using qutebrowser's
-fake-key command in this manner: [USERNAME]<Tab>[PASSWORD], which is compatible
-with almost all login forms.
+-p or --path is a required argument.
 
-Dependencies: pykeepass (in python3), PyQt5
+--keyfile-path allows you to specify a keepass keyfile. If you only use a
+  keyfile, also add --no-password as well. Specifying --no-password without
+  --keyfile-path will lead to an error.
+
+login information is inserted using :insert-text and :fake-key <Tab>, which
+means you must have a cursor in position before initiating this userscript. If
+you do not do this, you will get 'element not editable' errors.
+
+If keepass takes a while to open the DB, you might want to consider reducing
+the number of transform rounds in your database settings.
+
+Dependencies: pykeepass (in python3), PyQt5. Without pykeepass, you will get an
+exit code of 100.
+
+********************!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!******************
 
 WARNING: The login details are viewable as plaintext in qutebrowser's debug log
-(qute://log) and might be shared if you decide to submit a crash report!"""
+(qute://log) and could be compromised if you decide to submit a crash report!
+
+********************!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!******************
+"""
 
 import argparse
 import enum
@@ -44,7 +62,6 @@ import os
 import shlex
 import subprocess
 import sys
-
 
 from PyQt5.QtCore import QUrl
 from PyQt5.QtWidgets import QApplication, QInputDialog, QLineEdit
@@ -61,13 +78,19 @@ argument_parser = argparse.ArgumentParser(
     epilog=USAGE)
 argument_parser.add_argument('url', nargs='?', default=os.getenv('QUTE_URL'))
 argument_parser.add_argument('--path', '-p', required=True,
-                             help='Path to the keepass db')
+                             help='Path to the keepass db.')
+argument_parser.add_argument('--keyfile-path', '-k', default=None,
+                             help='Path to a keepass keyfile')
+argument_parser.add_argument('--no-password', action='store_true',
+                             help='True if no password is required.'
+                             'Only allowed with --keyfile-path')
 argument_parser.add_argument(
     '--dmenu-invocation', '-d', default='dmenu',
     help='Invocation used to execute a dmenu-provider')
 argument_parser.add_argument(
     '--dmenu-format', '-f', default='{title}: {username}',
-    help='Format string for keys to display in dmenu. Must be unique.')
+    help='Format string for keys to display in dmenu.'
+    ' Must generate a unique string.')
 argument_parser.add_argument(
     '--no-insert-mode', '-n', dest='insert_mode', action='store_false',
     help="Don't automatically enter insert mode")
@@ -82,6 +105,7 @@ group.add_argument('--password-only', '-w',
 
 CMD_DELAY = 50
 
+
 class ExitCodes(enum.IntEnum):
     """Stores various exit codes groups to use."""
     SUCCESS = 0
@@ -89,7 +113,7 @@ class ExitCodes(enum.IntEnum):
     # 1 is automatically used if Python throws an exception
     NO_CANDIDATES = 2
     USER_QUIT = 3
-    DB_OPEN_FAIL = 3
+    DB_OPEN_FAIL = 4
 
     INTERNAL_ERROR = 10
 
@@ -101,6 +125,7 @@ def qute_command(command):
 
 
 def stderr(to_print):
+    """Extra functionality to echo out errors to qb ui."""
     print(to_print, file=sys.stderr)
     qute_command('message-error "{}"'.format(to_print))
 
@@ -122,7 +147,7 @@ def get_password():
         QLineEdit.Password)
     if not ok:
         stderr('Password Prompt Rejected.')
-        return ExitCodes.USER_QUIT
+        sys.exit(ExitCodes.USER_QUIT)
     return text
 
 
@@ -130,9 +155,19 @@ def find_candidates(args, host):
     """Finds candidates that match host"""
     file_path = os.path.expanduser(args.path)
 
-    # TODO find a way to keep the db open, so we don't open it every time.
+    # TODO find a way to keep the db open, so we don't open (and query
+    # password) it every time
+
+    pw = None
+    if not args.no_password:
+        pw = get_password()
+
+    kf = args.keyfile_path
+    if kf:
+        kf = os.path.expanduser(kf)
+
     try:
-        kp = pykeepass.PyKeePass(file_path, password=get_password())
+        kp = pykeepass.PyKeePass(file_path, password=pw, keyfile=kf)
     except Exception as e:
         stderr("There was an error opening the DB: {}".format(str(e)))
 
@@ -173,13 +208,14 @@ def run(args):
 
     # Create a map so we can get turn the resulting string from dmenu back into
     # a candidate
-    candidates_map = dict(zip(map(
-        functools.partial(candidate_to_str, args), candidates), candidates))
+    candidates_strs = list(map(functools.partial(candidate_to_str, args),
+                               candidates))
+    candidates_map = dict(zip(candidates_strs, candidates))
 
     if len(candidates) == 1:
         selection = candidates.pop()
     else:
-        selection = dmenu(candidates_map.keys(),
+        selection = dmenu(candidates_strs,
                           args.dmenu_invocation,
                           args.io_encoding)
 
@@ -196,9 +232,12 @@ def run(args):
     elif args.password_only:
         qute_command('insert-text {}{}'.format(password, insert_mode))
     else:
-        # Enter username and password using fake-key and <Tab> (which seems to
-        # work almost universally), then switch back into insert-mode, so the
-        # form can be directly submitted by hitting enter afterwards
+        # Enter username and password using insert-key and fake-key <Tab>
+        # (which supports more passwords than fake-key only), then switch back
+        # into insert-mode, so the form can be directly submitted by hitting
+        # enter afterwards. It dosen't matter when we go into insert mode, but
+        # the other commands need to be be executed sequentially, so we add
+        # delays with later.
         qute_command('insert-text {} ;;'
                      'later {} fake-key <Tab> ;;'
                      'later {} insert-text {}{}'

--- a/misc/userscripts/qute-keepass
+++ b/misc/userscripts/qute-keepass
@@ -17,10 +17,8 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=bad-builtin
-
-USAGE = """This userscript allows for insertion of usernames and passwords from
-keepass databases using pykeepass. Since it is a userscript, it must be run from
+"""This userscript allows for insertion of usernames and passwords from keepass
+databases using pykeepass. Since it is a userscript, it must be run from
 qutebrowser.
 
 A sample invocation of this script is:
@@ -34,8 +32,8 @@ And a sample binding
 -p or --path is a required argument.
 
 --keyfile-path allows you to specify a keepass keyfile. If you only use a
-  keyfile, also add --no-password as well. Specifying --no-password without
-  --keyfile-path will lead to an error.
+keyfile, also add --no-password as well. Specifying --no-password without
+--keyfile-path will lead to an error.
 
 login information is inserted using :insert-text and :fake-key <Tab>, which
 means you must have a cursor in position before initiating this userscript. If
@@ -53,7 +51,10 @@ WARNING: The login details are viewable as plaintext in qutebrowser's debug log
 (qute://log) and could be compromised if you decide to submit a crash report!
 
 ********************!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!******************
+
 """
+
+# pylint: disable=bad-builtin
 
 import argparse
 import enum
@@ -68,22 +69,29 @@ from PyQt5.QtWidgets import QApplication, QInputDialog, QLineEdit
 
 try:
     import pykeepass
-except ImportError:
-    print("pykeepass not found!", file=sys.stderr)
+except ImportError as e:
+    print("pykeepass not found: {}".format(str(e)), file=sys.stderr)
+
+    # Since this is a common error, try to print it to the FIFO if we can.
+    if 'QUTE_FIFO' in os.environ:
+        with open(os.environ['QUTE_FIFO'], 'w') as fifo:
+            fifo.write('message-error "pykeepass failed to be imported."\n')
+            fifo.flush()
     sys.exit(100)
 
 argument_parser = argparse.ArgumentParser(
-    description=__doc__,
+    description="Fill passwords using keepass.",
     formatter_class=argparse.RawDescriptionHelpFormatter,
-    epilog=USAGE)
+    epilog=__doc__)
 argument_parser.add_argument('url', nargs='?', default=os.getenv('QUTE_URL'))
 argument_parser.add_argument('--path', '-p', required=True,
                              help='Path to the keepass db.')
 argument_parser.add_argument('--keyfile-path', '-k', default=None,
                              help='Path to a keepass keyfile')
-argument_parser.add_argument('--no-password', action='store_true',
-                             help='True if no password is required.'
-                             'Only allowed with --keyfile-path')
+argument_parser.add_argument(
+    '--no-password', action='store_true',
+    help='Supply if no password is required to unlock this database. '
+    'Only allowed with --keyfile-path')
 argument_parser.add_argument(
     '--dmenu-invocation', '-d', default='dmenu',
     help='Invocation used to execute a dmenu-provider')
@@ -98,9 +106,9 @@ argument_parser.add_argument(
     '--io-encoding', '-i', default='UTF-8',
     help='Encoding used to communicate with subprocesses')
 group = argument_parser.add_mutually_exclusive_group()
-group.add_argument('--username-only', '-e',
+group.add_argument('--username-fill-only', '-e',
                    action='store_true', help='Only insert username')
-group.add_argument('--password-only', '-w',
+group.add_argument('--password-fill-only', '-w',
                    action='store_true', help='Only insert password')
 
 CMD_DELAY = 50
@@ -228,9 +236,9 @@ def run(args):
     username, password = candidate_to_secret(selection)
 
     insert_mode = ';; enter-mode insert' if args.insert_mode else ''
-    if args.username_only:
+    if args.username_fill_only:
         qute_command('insert-text {}{}'.format(username, insert_mode))
-    elif args.password_only:
+    elif args.password_fill_only:
         qute_command('insert-text {}{}'.format(password, insert_mode))
     else:
         # Enter username and password using insert-key and fake-key <Tab>

--- a/misc/userscripts/qute-keepass
+++ b/misc/userscripts/qute-keepass
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+
+# Copyright 2018 Jay Kamat <jaygkamat@gmail.com>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+USAGE = """This userscript allows for insertion of usernames and passwords from keepass
+databases using pykeepass. Since it is a userscript, it must be run from qutebrowser.
+
+A sample invocation of this script is:
+
+:spawn --userscript qute-keepass -p ~/KeePassFiles/MainDatabase.kdbx
+
+And a sample binding
+
+:bind --mode=insert <ctrl-i> spawn --userscript qute-keepass -p ~/KeePassFiles/MainDatabase.kdbx
+
+login information is inserted by emulating key events using qutebrowser's
+fake-key command in this manner: [USERNAME]<Tab>[PASSWORD], which is compatible
+with almost all login forms.
+
+Dependencies: pykeepass (in python3), PyQt5
+
+WARNING: The login details are viewable as plaintext in qutebrowser's debug log
+(qute://log) and might be shared if you decide to submit a crash report!"""
+
+import argparse
+import enum
+import functools
+import os
+import shlex
+import subprocess
+import sys
+
+
+from PyQt5.QtCore import QUrl
+from PyQt5.QtWidgets import QApplication, QInputDialog, QLineEdit
+
+try:
+    import pykeepass
+except ImportError:
+    print("pykeepass not found!", file=sys.stderr)
+    sys.exit(100)
+
+argument_parser = argparse.ArgumentParser(
+    description=__doc__,
+    formatter_class=argparse.RawDescriptionHelpFormatter,
+    epilog=USAGE)
+argument_parser.add_argument('url', nargs='?', default=os.getenv('QUTE_URL'))
+argument_parser.add_argument('--path', '-p', required=True,
+                             help='Path to the keepass db')
+argument_parser.add_argument(
+    '--dmenu-invocation', '-d', default='dmenu',
+    help='Invocation used to execute a dmenu-provider')
+argument_parser.add_argument(
+    '--dmenu-format', '-f', default='{title}: {username}',
+    help='Format string for keys to display in dmenu. Must be unique.')
+argument_parser.add_argument(
+    '--no-insert-mode', '-n', dest='insert_mode', action='store_false',
+    help="Don't automatically enter insert mode")
+argument_parser.add_argument(
+    '--io-encoding', '-i', default='UTF-8',
+    help='Encoding used to communicate with subprocesses')
+group = argument_parser.add_mutually_exclusive_group()
+group.add_argument('--username-only', '-e',
+                   action='store_true', help='Only insert username')
+group.add_argument('--password-only', '-w',
+                   action='store_true', help='Only insert password')
+
+
+class ExitCodes(enum.IntEnum):
+    """Stores various exit codes groups to use."""
+    SUCCESS = 0
+    FAILURE = 1
+    # 1 is automatically used if Python throws an exception
+    NO_CANDIDATES = 2
+    USER_QUIT = 3
+    DB_OPEN_FAIL = 3
+
+    INTERNAL_ERROR = 10
+
+
+def qute_command(command):
+    with open(os.environ['QUTE_FIFO'], 'w') as fifo:
+        fifo.write(command + '\n')
+        fifo.flush()
+
+
+def stderr(to_print):
+    print(to_print, file=sys.stderr)
+    qute_command('message-error "{}"'.format(to_print))
+
+
+def dmenu(items, invocation, encoding):
+    """Runs dmenu with given arguments."""
+    command = shlex.split(invocation)
+    process = subprocess.run(command, input='\n'.join(items).encode(encoding),
+                             stdout=subprocess.PIPE)
+    return process.stdout.decode(encoding).strip()
+
+
+def get_password():
+    """Get a keepass db password from user."""
+    _app = QApplication(sys.argv)
+    text, ok = QInputDialog.getText(
+        None, "KeePass DB Password",
+        "Please enter your KeePass Master Password",
+        QLineEdit.Password)
+    if not ok:
+        stderr('Password Prompt Rejected.')
+        return ExitCodes.USER_QUIT
+    return text
+
+
+def find_candidates(args, host):
+    """Finds candidates that match host"""
+    file_path = os.path.expanduser(args.path)
+
+    # TODO find a way to keep the db open, so we don't open it every time.
+    try:
+        kp = pykeepass.PyKeePass(file_path, password=get_password())
+    except Exception as e:
+        stderr("There was an error opening the DB: {}".format(str(e)))
+
+    return kp.find_entries(url="{}{}{}".format(".*", host, ".*"), regex=True)
+
+
+def candidate_to_str(args, candidate):
+    """Turns candidate into a human readable string for dmenu"""
+    return args.dmenu_format.format(title=candidate.title,
+                                    url=candidate.url,
+                                    username=candidate.username,
+                                    path=candidate.path,
+                                    uuid=candidate.uuid)
+
+
+def candidate_to_secret(candidate):
+    """Turns candidate into a generic (user, password) tuple"""
+    return (candidate.username, candidate.password)
+
+
+def run(args):
+    """Runs qute-keepass"""
+    if not args.url:
+        argument_parser.print_help()
+        return ExitCodes.FAILURE
+
+    url_host = QUrl(args.url).host()
+
+    if not url_host:
+        stderr('{} was not parsed as a valid URL!'.format(args.url))
+        return ExitCodes.INTERNAL_ERROR
+
+    # Find candidates matching the host of the given URL
+    candidates = find_candidates(args, url_host)
+    if not candidates:
+        stderr('No candidates for URL {!r} found!'.format(args.url))
+        return ExitCodes.NO_CANDIDATES
+
+    # Create a map so we can get turn the resulting string from dmenu back into
+    # a candidate
+    candidates_map = dict(zip(map(
+        functools.partial(candidate_to_str, args), candidates), candidates))
+
+    if len(candidates) == 1:
+        selection = candidates.pop()
+    else:
+        selection = dmenu(candidates_map.keys(),
+                          args.dmenu_invocation,
+                          args.io_encoding)
+
+    if selection not in candidates_map:
+        stderr("'{}' was not a valid entry!").format(selection)
+        return ExitCodes.USER_QUIT
+
+    selection = candidates_map[selection]
+    username, password = candidate_to_secret(selection)
+
+    insert_mode = ';; enter-mode insert' if args.insert_mode else ''
+    if args.username_only:
+        qute_command('fake-key {}{}'.format(username, insert_mode))
+    elif args.password_only:
+        qute_command('fake-key {}{}'.format(password, insert_mode))
+    else:
+        # Enter username and password using fake-key and <Tab> (which seems to
+        # work almost universally), then switch back into insert-mode, so the
+        # form can be directly submitted by hitting enter afterwards
+        qute_command('fake-key {} ;; fake-key <Tab> ;; fake-key {}{}'
+                     .format(username, password, insert_mode))
+
+    return ExitCodes.SUCCESS
+
+
+if __name__ == '__main__':
+    arguments = argument_parser.parse_args()
+    sys.exit(run(arguments))

--- a/misc/userscripts/qute-keepass
+++ b/misc/userscripts/qute-keepass
@@ -219,11 +219,12 @@ def run(args):
                           args.dmenu_invocation,
                           args.io_encoding)
 
-    if selection not in candidates_map:
-        stderr("'{}' was not a valid entry!").format(selection)
-        return ExitCodes.USER_QUIT
+        if selection not in candidates_map:
+            stderr("'{}' was not a valid entry!").format(selection)
+            return ExitCodes.USER_QUIT
 
-    selection = candidates_map[selection]
+        selection = candidates_map[selection]
+
     username, password = candidate_to_secret(selection)
 
     insert_mode = ';; enter-mode insert' if args.insert_mode else ''

--- a/misc/userscripts/qute-keepass
+++ b/misc/userscripts/qute-keepass
@@ -80,6 +80,7 @@ group.add_argument('--username-only', '-e',
 group.add_argument('--password-only', '-w',
                    action='store_true', help='Only insert password')
 
+CMD_DELAY = 50
 
 class ExitCodes(enum.IntEnum):
     """Stores various exit codes groups to use."""
@@ -191,15 +192,18 @@ def run(args):
 
     insert_mode = ';; enter-mode insert' if args.insert_mode else ''
     if args.username_only:
-        qute_command('fake-key {}{}'.format(username, insert_mode))
+        qute_command('insert-text {}{}'.format(username, insert_mode))
     elif args.password_only:
-        qute_command('fake-key {}{}'.format(password, insert_mode))
+        qute_command('insert-text {}{}'.format(password, insert_mode))
     else:
         # Enter username and password using fake-key and <Tab> (which seems to
         # work almost universally), then switch back into insert-mode, so the
         # form can be directly submitted by hitting enter afterwards
-        qute_command('fake-key {} ;; fake-key <Tab> ;; fake-key {}{}'
-                     .format(username, password, insert_mode))
+        qute_command('insert-text {} ;;'
+                     'later {} fake-key <Tab> ;;'
+                     'later {} insert-text {}{}'
+                     .format(username, CMD_DELAY,
+                             CMD_DELAY * 2, password, insert_mode))
 
     return ExitCodes.SUCCESS
 


### PR DESCRIPTION
This is a basic userscript to fill passwords from keepass. It follows some of the same structure as `qute-pass`, but it is mostly rewritten (keeping only a few functions) so it dosen't make sense to combine both into one userscript, as it would get very messy.

Some abnormalities.

- Unlike `pass`, which queries for passwords through pinentry, keepass has no such mechanism, so I must query for the password myself. I used `PyQt5` to do this.
- I decided to keep it very simple, searching for any url matching `.*(host).*`. I think this is fairly reasonable, and works for me.
- I'm using `insert-text` over `fake-key`, as `fake-key` does interpretation of the input. For example, one of my passwords broke because it contained `<x>`. `:insert-text "<x>` works as expected, and should reduce the amount of issues due to complex passwords
- In order to use `insert-text` I had to delay invocations with `:later`, which is a bit hacky, but is worth it to use `:insert-text`
- This opens the database every time the userscript is called. I personally would like to insert my master password every time, but this can get annoying for others. I'm not sure if there is a good way to keep around the db handle, but I'll leave that for another day (or someone else).
- This uses [pykeepass](https://github.com/pschmitt/pykeepass), which is pretty good from the limited testing I've done of it, but is slower to unlock files than keepassxc.

This needs a bit of cleanup and final touches, but is definetly usable in this state right now. Let me know if anyone sees any issues :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3756)
<!-- Reviewable:end -->
