### PR TITLE
Change to StevenBlack unified host by default

### DIFF
--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -234,16 +234,13 @@ class HostBlocker:
         parts = line.split()
         if len(parts) == 1:
             # "one host per line" format
-            host = parts[0]
-        elif len(parts) == 2:
-            # /etc/hosts format
-            host = parts[1]
+            hosts = [parts[0]]
         else:
-            log.misc.error("Failed to parse: {!r}".format(line))
-            return False
+            hosts = parts[1:]
 
-        if host not in self.WHITELISTED:
-            self._blocked_hosts.add(host)
+        for host in hosts:
+            if host not in self.WHITELISTED:
+                self._blocked_hosts.add(host)
 
         return True
 
@@ -270,6 +267,7 @@ class HostBlocker:
             line_count += 1
             ok = self._parse_line(line)
             if not ok:
+                message.error("adblock: read error occurred for line: {}".format(line))
                 error_count += 1
 
         log.misc.debug("{}: read {} lines".format(byte_io.name, line_count))

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -267,7 +267,12 @@ class HostBlocker:
             line_count += 1
             ok = self._parse_line(line)
             if not ok:
-                message.error("adblock: read error occurred for line: {}".format(line))
+                try:
+                    log.misc.debug("adblock: read error for line: "
+                                   .format(line.decode('utf-8')))
+                except UnicodeDecodeError:
+                    log.misc.debug("invalid unicode in line {}."
+                                   .format(line_count))
                 error_count += 1
 
         log.misc.debug("{}: read {} lines".format(byte_io.name, line_count))

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -24,7 +24,6 @@ import os.path
 import functools
 import posixpath
 import zipfile
-import fnmatch
 import re
 
 from qutebrowser.browser import downloads
@@ -101,7 +100,7 @@ class HostBlocker:
         WHITELISTED: Hosts which never should be blocked.
     """
 
-    WHITELISTED = ('[^\.]+', '.*\.localdomain')
+    WHITELISTED = (r'[^\.]+', r'.*\.localdomain')
 
     def __init__(self):
         self._blocked_hosts = set()
@@ -269,7 +268,7 @@ class HostBlocker:
             ok = self._parse_line(line)
             if not ok:
                 try:
-                    log.misc.debug("adblock: read error for line: "
+                    log.misc.debug("adblock: read error for line: {}"
                                    .format(line.decode('utf-8')))
                 except UnicodeDecodeError:
                     log.misc.debug("invalid unicode in line {}."

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -425,11 +425,7 @@ content.host_blocking.enabled:
 
 content.host_blocking.lists:
   default:
-    - "https://www.malwaredomainlist.com/hostslist/hosts.txt"
-    - "http://someonewhocares.org/hosts/hosts"
-    - "http://winhelp2002.mvps.org/hosts.zip"
-    - "http://malwaredomains.lehigh.edu/files/justdomains.zip"
-    - "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&mimetype=plaintext"
+    - "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
   type:
     name: List
     valtype: Url

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -125,7 +125,8 @@ def assert_urls(host_blocker, blocked=BLOCKLIST_HOSTS,
     for str_url in urls_to_check:
         url = QUrl(str_url)
         host = url.host()
-        if host in blocked and not adblock.is_whitelisted_host(host, whitelist):
+        if (host in blocked and
+           not adblock.is_whitelisted_host(host, whitelist=whitelist)):
             assert host_blocker.is_blocked(url)
         else:
             assert not host_blocker.is_blocked(url)

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -115,17 +115,17 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
 
 
 def assert_urls(host_blocker, blocked=BLOCKLIST_HOSTS,
-                whitelisted=WHITELISTED_HOSTS, urls_to_check=URLS_TO_CHECK):
+                whitelist=WHITELISTED_HOSTS, urls_to_check=URLS_TO_CHECK):
     """Test if Urls to check are blocked or not by HostBlocker.
 
-    Ensure URLs in 'blocked' and not in 'whitelisted' are blocked.
+    Ensure URLs in 'blocked' and not in 'whitelist' are blocked.
     All other URLs must not be blocked.
     """
-    whitelisted = list(whitelisted) + list(host_blocker.WHITELISTED)
+    whitelist = list(whitelist) + list(host_blocker.WHITELISTED)
     for str_url in urls_to_check:
         url = QUrl(str_url)
         host = url.host()
-        if host in blocked and host not in whitelisted:
+        if host in blocked and not adblock.is_whitelisted_host(host, whitelist):
             assert host_blocker.is_blocked(url)
         else:
             assert not host_blocker.is_blocked(url)
@@ -244,7 +244,7 @@ def test_successful_update(config_stub, basedir, download_stub,
             current_download.successful = True
             current_download.finished.emit()
     host_blocker.read_hosts()
-    assert_urls(host_blocker, whitelisted=[])
+    assert_urls(host_blocker, whitelist=[])
 
 
 def test_failed_dl_update(config_stub, basedir, download_stub,
@@ -274,7 +274,7 @@ def test_failed_dl_update(config_stub, basedir, download_stub,
         with caplog.at_level(logging.ERROR):
             current_download.finished.emit()
     host_blocker.read_hosts()
-    assert_urls(host_blocker, whitelisted=[])
+    assert_urls(host_blocker, whitelist=[])
 
 
 @pytest.mark.parametrize('location', ['content', 'comment'])
@@ -314,7 +314,7 @@ def test_invalid_utf8(config_stub, download_stub, tmpdir, data_tmpdir,
         current_download.finished.emit()
 
     host_blocker.read_hosts()
-    assert_urls(host_blocker, whitelisted=[])
+    assert_urls(host_blocker, whitelist=[])
 
 
 def test_invalid_utf8_compiled(config_stub, config_tmpdir, data_tmpdir,


### PR DESCRIPTION
This changes the default host block list into a single unified blocklist rather than over several files with possible duplications. It includes more sources (56k vs 44k or so).

One line in the file consistently lead to an error:
::1 localhost ip6-localhost...

The problem was that it failed to parse if there was more than one host per line. I've added a bandaid fix to that in this. I need to wait for the tests to complete to see what issues arose

closes #3739

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3758)
<!-- Reviewable:end -->
