### PR TITLE
Change default blocklist to StevenBlack combined

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -425,11 +425,7 @@ content.host_blocking.enabled:
 
 content.host_blocking.lists:
   default:
-    - "https://www.malwaredomainlist.com/hostslist/hosts.txt"
-    - "http://someonewhocares.org/hosts/hosts"
-    - "http://winhelp2002.mvps.org/hosts.zip"
-    - "http://malwaredomains.lehigh.edu/files/justdomains.zip"
-    - "https://pgl.yoyo.org/adservers/serverlist.php?hostformat=hosts&mimetype=plaintext"
+    - "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
   type:
     name: List
     valtype: Url


### PR DESCRIPTION
This PR simply changes the default block list to the singular combined blocklist found at https://github.com/StevenBlack/hosts

As is, the blocklist parsing visibly chokes on one particular line which features more than one host on the line. This will be solved by a line parsing change in a following PR.

closes #3739 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3763)
<!-- Reviewable:end -->
