### PR TITLE
Change host file parsing

### DIFF
--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -236,7 +236,7 @@ class HostBlocker:
             log.misc.error("Failed to parse: {!r}".format(line))
             return False
 
-        if '.' not in host and not host.endswith('.localdomain'):
+        if '.' in host and not host.endswith('.localdomain'):
             self._blocked_hosts.add(host)
 
         return True

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -94,13 +94,7 @@ class HostBlocker:
         _done_count: How many files have been read successfully.
         _local_hosts_file: The path to the blocked-hosts file.
         _config_hosts_file: The path to a blocked-hosts in ~/.config
-
-    Class attributes:
-        WHITELISTED: Hosts which never should be blocked.
     """
-
-    WHITELISTED = ('localhost', 'localhost.localdomain', 'broadcasthost',
-                   'local')
 
     def __init__(self):
         self._blocked_hosts = set()
@@ -242,7 +236,7 @@ class HostBlocker:
             log.misc.error("Failed to parse: {!r}".format(line))
             return False
 
-        if host not in self.WHITELISTED:
+        if '.' not in host and not host.endswith('.localdomain'):
             self._blocked_hosts.add(host)
 
         return True

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -228,16 +228,13 @@ class HostBlocker:
         parts = line.split()
         if len(parts) == 1:
             # "one host per line" format
-            host = parts[0]
-        elif len(parts) == 2:
-            # /etc/hosts format
-            host = parts[1]
+            hosts = [parts[0]]
         else:
-            log.misc.error("Failed to parse: {!r}".format(line))
-            return False
+            hosts = parts[1:]
 
-        if '.' in host and not host.endswith('.localdomain'):
-            self._blocked_hosts.add(host)
+        for host in hosts:
+            if '.' in host and not host.endswith('.localdomain'):
+                self._blocked_hosts.add(host)
 
         return True
 

--- a/qutebrowser/browser/adblock.py
+++ b/qutebrowser/browser/adblock.py
@@ -230,6 +230,7 @@ class HostBlocker:
             # "one host per line" format
             hosts = [parts[0]]
         else:
+            # /etc/hosts format
             hosts = parts[1:]
 
         for host in hosts:

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -94,7 +94,6 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
         name: name to give to the blocklist file
         line_format: 'etc_hosts'  -->  /etc/hosts format
                     'one_per_line'  -->  one host per line format
-                    'all_on_one_line' --> pathological example with one line
                     'not_correct'  -->  Not a correct hosts file format.
     """
     blocklist_file = directory / name
@@ -107,8 +106,6 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
         elif line_format == 'one_per_line':
             for host in blocked_hosts:
                 blocklist.write(host + '\n')
-        elif line_format == 'all_on_one_line':
-            blocklist.write('127.0.0.1 ' + ' '.join(blocked_hosts) + '\n')
         elif line_format == 'not_correct':
             for host in blocked_hosts:
                 blocklist.write(host + ' This is not a correct hosts file\n')

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -94,6 +94,7 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
         name: name to give to the blocklist file
         line_format: 'etc_hosts'  -->  /etc/hosts format
                     'one_per_line'  -->  one host per line format
+                    'all_on_one_line' --> pathological example with one line
                     'not_correct'  -->  Not a correct hosts file format.
     """
     blocklist_file = directory / name
@@ -106,6 +107,8 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
         elif line_format == 'one_per_line':
             for host in blocked_hosts:
                 blocklist.write(host + '\n')
+        elif line_format == 'all_on_one_line':
+            blocklist.write('127.0.0.1 ' + ' '.join(blocked_hosts) + '\n')
         elif line_format == 'not_correct':
             for host in blocked_hosts:
                 blocklist.write(host + ' This is not a correct hosts file\n')
@@ -244,6 +247,15 @@ def test_successful_update(config_stub, basedir, download_stub,
             current_download.successful = True
             current_download.finished.emit()
     host_blocker.read_hosts()
+    assert_urls(host_blocker, whitelisted=[])
+
+
+def test_parsing_multiple_hosts_on_line(config_stub, basedir, download_stub,
+                           data_tmpdir, tmpdir, win_registry, caplog):
+    """Ensure multiple hosts on a line get parsed correctly"""
+    host_blocker = adblock.HostBlocker()
+    bytes_host_line = ' '.join(BLOCKLIST_HOSTS).encode('utf-8')
+    host_blocker._parse_line(bytes_host_line)
     assert_urls(host_blocker, whitelisted=[])
 
 

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -350,7 +350,7 @@ def test_blocking_with_whitelist(config_stub, basedir, download_stub,
     """Ensure hosts in content.host_blocking.whitelist are never blocked."""
     # Simulate adblock_update has already been run
     # by creating a file named blocked-hosts,
-    # Exclude localhost from it, since localhost is never blocked by list
+    # Exclude localhost from it as localhost is never blocked via list
     filtered_blocked_hosts = BLOCKLIST_HOSTS[1:]
     blocklist = create_blocklist(data_tmpdir,
                                  blocked_hosts=filtered_blocked_hosts,

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -250,7 +250,7 @@ def test_successful_update(config_stub, basedir, download_stub,
 def test_parsing_multiple_hosts_on_line(config_stub, basedir, download_stub,
                                         data_tmpdir, tmpdir, win_registry,
                                         caplog):
-    """Ensure multiple hosts on a line get parsed correctly"""
+    """Ensure multiple hosts on a line get parsed correctly."""
     host_blocker = adblock.HostBlocker()
     bytes_host_line = ' '.join(BLOCKLIST_HOSTS).encode('utf-8')
     host_blocker._parse_line(bytes_host_line)

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -114,14 +114,16 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
     return name
 
 
-def assert_urls(host_blocker, blocked=BLOCKLIST_HOSTS[1:],
+def assert_urls(host_blocker, blocked=BLOCKLIST_HOSTS,
                 whitelisted=WHITELISTED_HOSTS, urls_to_check=URLS_TO_CHECK):
     """Test if Urls to check are blocked or not by HostBlocker.
 
     Ensure URLs in 'blocked' and not in 'whitelisted' are blocked.
     All other URLs must not be blocked.
+
+    localhost is an example of a special case that shouldn't be blocked.
     """
-    whitelisted = list(whitelisted)
+    whitelisted = list(whitelisted) + ['localhost']
     for str_url in urls_to_check:
         url = QUrl(str_url)
         host = url.host()

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -114,14 +114,14 @@ def create_blocklist(directory, blocked_hosts=BLOCKLIST_HOSTS,
     return name
 
 
-def assert_urls(host_blocker, blocked=BLOCKLIST_HOSTS,
+def assert_urls(host_blocker, blocked=BLOCKLIST_HOSTS[1:],
                 whitelisted=WHITELISTED_HOSTS, urls_to_check=URLS_TO_CHECK):
     """Test if Urls to check are blocked or not by HostBlocker.
 
     Ensure URLs in 'blocked' and not in 'whitelisted' are blocked.
     All other URLs must not be blocked.
     """
-    whitelisted = list(whitelisted) + list(host_blocker.WHITELISTED)
+    whitelisted = list(whitelisted)
     for str_url in urls_to_check:
         url = QUrl(str_url)
         host = url.host()
@@ -341,7 +341,7 @@ def test_blocking_with_whitelist(config_stub, basedir, download_stub,
     """Ensure hosts in content.host_blocking.whitelist are never blocked."""
     # Simulate adblock_update has already been run
     # by creating a file named blocked-hosts,
-    # Exclude localhost from it, since localhost is in HostBlocker.WHITELISTED
+    # Exclude localhost from it, since localhost is never blocked by list
     filtered_blocked_hosts = BLOCKLIST_HOSTS[1:]
     blocklist = create_blocklist(data_tmpdir,
                                  blocked_hosts=filtered_blocked_hosts,

--- a/tests/unit/browser/test_adblock.py
+++ b/tests/unit/browser/test_adblock.py
@@ -248,7 +248,8 @@ def test_successful_update(config_stub, basedir, download_stub,
 
 
 def test_parsing_multiple_hosts_on_line(config_stub, basedir, download_stub,
-                           data_tmpdir, tmpdir, win_registry, caplog):
+                                        data_tmpdir, tmpdir, win_registry,
+                                        caplog):
     """Ensure multiple hosts on a line get parsed correctly"""
     host_blocker = adblock.HostBlocker()
     bytes_host_line = ' '.join(BLOCKLIST_HOSTS).encode('utf-8')


### PR DESCRIPTION
This PR consists of two main changes.

Firstly, WHITELISTED is removed as a hardcoded variable, and replaced in-place with a simpler pair of rules:
1) Don't let a hosts list blacklist "dotless" hosts like localhost.
2) Don't let a hosts list blacklist "*.localdomain" hosts.

Secondly, with the recent change to StevenBlack's combined blocklist, one line with multiple hosts on causes a visible error. This parses multiple hosts on a line, and adds a test for the new behaviour.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3765)
<!-- Reviewable:end -->
