### PR TITLE
Pyinstaller: don't use upx

### DIFF
--- a/misc/qutebrowser.spec
+++ b/misc/qutebrowser.spec
@@ -58,14 +58,14 @@ exe = EXE(pyz,
           icon=icon,
           debug=False,
           strip=False,
-          upx=True,
+          upx=False,
           console=False )
 coll = COLLECT(exe,
                a.binaries,
                a.zipfiles,
                a.datas,
                strip=False,
-               upx=True,
+               upx=False,
                name='qutebrowser')
 
 app = BUNDLE(coll,


### PR DESCRIPTION
Having `upx=True` will compress the files with upx if it finds it in the `path` (not good!).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3767)
<!-- Reviewable:end -->
