### PR TITLE
Fix keyhints for special characters

### DIFF
--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -130,7 +130,7 @@ class KeyHintView(QLabel):
             ).format(
                 html.escape(prefix),
                 suffix_color,
-                html.escape(str(seq[len(prefix):])),
+                html.escape(str(seq)[len(prefix):]),
                 html.escape(cmd)
             )
         text = '<table>{}</table>'.format(text)

--- a/tests/unit/misc/test_keyhints.py
+++ b/tests/unit/misc/test_keyhints.py
@@ -92,6 +92,30 @@ def test_suggestions(keyhint, config_stub):
         ('a', 'yellow', 'c', 'message-info cmd-ac'))
 
 
+def test_suggestions_special(keyhint, config_stub):
+    """Test that special characters work properly as prefix."""
+    bindings = {'normal': {
+        '<Ctrl-C>a': 'message-info cmd-Cca',
+        '<Ctrl-C><Ctrl-C>': 'message-info cmd-CcCc',
+        '<Ctrl-C><Ctrl-X>': 'message-info cmd-CcCx',
+        'cbb': 'message-info cmd-cbb',
+        'xd': 'message-info cmd-xd',
+        'xe': 'message-info cmd-xe',
+    }}
+    default_bindings = {'normal': {
+        '<Ctrl-C>c': 'message-info cmd-Ccc',
+    }}
+    config_stub.val.bindings.default = default_bindings
+    config_stub.val.bindings.commands = bindings
+
+    keyhint.update_keyhint('normal', '<Ctrl+c>')
+    assert keyhint.text() == expected_text(
+        ('&lt;Ctrl+c&gt;', 'yellow', 'a', 'message-info cmd-Cca'),
+        ('&lt;Ctrl+c&gt;', 'yellow', 'c', 'message-info cmd-Ccc'),
+        ('&lt;Ctrl+c&gt;', 'yellow', '&lt;Ctrl+c&gt;', 'message-info cmd-CcCc'),
+        ('&lt;Ctrl+c&gt;', 'yellow', '&lt;Ctrl+x&gt;', 'message-info cmd-CcCx'))
+
+
 def test_suggestions_with_count(keyhint, config_stub, monkeypatch, stubs):
     """Test that a count prefix filters out commands that take no count."""
     monkeypatch.setattr('qutebrowser.commands.cmdutils.cmd_dict', {


### PR DESCRIPTION
The keyhint popup stops showing suffixes once you press a special character.

For ex:
```
:bind <Ctrl-C><Ctrl-C> message-info CcCc
:bind <Ctrl-C><Ctrl-X> message-info CcCx
```

Pressing `<Ctrl+c>` displays:
```
<Ctrl+c> message-info CcCc
<Ctrl+c> message-info CcCx
```

It's a trivial fix so just sending a PR instead of opening an issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3769)
<!-- Reviewable:end -->
