### PR TITLE
docs(configuring.asciidoc): fix broken links

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -126,7 +126,7 @@ Note that qutebrowser does some Python magic so it's able to warn you about
 mistyped config settings. As an example, if you do `c.tabs.possition = "left"`,
 you'll get an error when starting.
 
-See the link:settings.html[settings help page] for all available settings. The
+See the link:settings.asciidoc[settings help page] for all available settings. The
 accepted values depend on the type of the option. Commonly used are:
 
 - Strings: `c.tabs.position = "left"`
@@ -202,7 +202,7 @@ preferred to use the `config.bind` command. Doing so ensures the commands are
 valid and normalizes different expressions which map to the same key.
 
 For details on how to specify keys and the available modes, see the
-link:settings.html#bindings.commands[documentation] for the `bindings.commands`
+link:settings.asciidoc#bindings.commands[documentation] for the `bindings.commands`
 setting.
 
 To bind a key:


### PR DESCRIPTION
Fixed broken links to settings page

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3777)
<!-- Reviewable:end -->
