### PR TITLE
Per Url zoom.default

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -356,12 +356,12 @@ class AbstractZoom(QObject):
         self._default_zoom_changed = False
         self._init_neighborlist()
         config.instance.changed.connect(self._on_config_changed)
-        # tab._widget isn't initialised at this point so we can't use
+        # tab._widget isn't initialized at this point so we can't use
         # tab.url() to get the per-url default zoom.
         self._zoom_factor = float(config.val.zoom.default) / 100
         self._tab.url_changed.connect(self._on_url_changed)
 
-    def _on_url_changed(self, url):
+    def _on_url_changed(self):
         # NOTE: If a new page is requested and the request is slow to
         # return data then this can be called while the "old" page is
         # still displayed.
@@ -390,7 +390,6 @@ class AbstractZoom(QObject):
         self._neighborlist = usertypes.NeighborList(
             levels, mode=usertypes.NeighborList.Modes.edge)
         try:
-            current_url = self._tab.url()
             default_zoom = config.instance.get('zoom.default',
                                                url=self._tab.url())
         except AttributeError:
@@ -441,9 +440,11 @@ class AbstractZoom(QObject):
         self._set_factor_internal(factor)
 
     def factor(self) -> float:
+        """Return the current zoom level of the tab as a float."""
         return self._zoom_factor
 
     def apply_default(self) -> None:
+        """Set the zoom level of the current tab back to the default."""
         default_zoom = config.instance.get('zoom.default',
                                            url=self._tab.url())
         self._zoom_factor = float(default_zoom) / 100

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -413,7 +413,8 @@ class AbstractZoom(QObject):
         return self._zoom_factor
 
     def apply_default(self) -> None:
-        self._set_factor_internal(float(config.val.zoom.default) / 100)
+        self._zoom_factor = float(config.val.zoom.default) / 100
+        self._set_factor_internal(self._zoom_factor)
 
     def reapply(self) -> None:
         self._set_factor_internal(self._zoom_factor)

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -356,13 +356,29 @@ class AbstractZoom(QObject):
         self._default_zoom_changed = False
         self._init_neighborlist()
         config.instance.changed.connect(self._on_config_changed)
+        # tab._widget isn't initialised at this point so we can't use
+        # tab.url() to get the per-url default zoom.
         self._zoom_factor = float(config.val.zoom.default) / 100
+        self._tab.url_changed.connect(self._on_url_changed)
+
+    def _on_url_changed(self, url):
+        # NOTE: If a new page is requested and the request is slow to
+        # return data then this can be called while the "old" page is
+        # still displayed.
+        if self._default_zoom_changed:
+            # TODO: If someone has changed the zoom level for this tab
+            # then navigates to a tab with a custom default zoom should
+            # we change the tab zoom or expect people to press '='?
+            return
+        self.apply_default()
 
     @pyqtSlot(str)
     def _on_config_changed(self, option: str) -> None:
         if option in ['zoom.levels', 'zoom.default']:
             if not self._default_zoom_changed:
-                factor = float(config.val.zoom.default) / 100
+                default_zoom = config.instance.get('zoom.default',
+                                                   url=self._tab.url())
+                factor = float(default_zoom) / 100
                 self.set_factor(factor)
             self._init_neighborlist()
 
@@ -373,7 +389,14 @@ class AbstractZoom(QObject):
         levels = config.val.zoom.levels
         self._neighborlist = usertypes.NeighborList(
             levels, mode=usertypes.NeighborList.Modes.edge)
-        self._neighborlist.fuzzyval = config.val.zoom.default
+        try:
+            current_url = self._tab.url()
+            default_zoom = config.instance.get('zoom.default',
+                                               url=self._tab.url())
+        except AttributeError:
+            # If called from init self._tab isn't setup yet so tab.url() fails
+            default_zoom = config.val.zoom.default
+        self._neighborlist.fuzzyval = default_zoom
 
     def apply_offset(self, offset: int) -> None:
         """Increase/Decrease the zoom level by the given offset.
@@ -391,19 +414,27 @@ class AbstractZoom(QObject):
     def _set_factor_internal(self, factor: float) -> None:
         raise NotImplementedError
 
-    def set_factor(self, factor: float, *, fuzzyval: bool = True) -> None:
+    def set_factor(self, factor: float, *, fuzzyval=True,
+                   or_default: bool = False) -> None:
         """Zoom to a given zoom factor.
 
         Args:
             factor: The zoom factor as float.
             fuzzyval: Whether to set the NeighborLists fuzzyval.
+            or_default: If this tab hasn't had the default zoom factor
+                overriden then ignore the passed factor and just
+                re-apply the default one.
         """
         if fuzzyval:
             self._neighborlist.fuzzyval = int(factor * 100)
         if factor < 0:
             raise ValueError("Can't zoom to factor {}!".format(factor))
 
-        default_zoom_factor = float(config.val.zoom.default) / 100
+        default_zoom = config.instance.get('zoom.default',
+                                           url=self._tab.url())
+        default_zoom_factor = float(default_zoom) / 100
+        if or_default and not self._default_zoom_changed:
+            factor = default_zoom_factor
         self._default_zoom_changed = (factor != default_zoom_factor)
 
         self._zoom_factor = factor
@@ -413,7 +444,9 @@ class AbstractZoom(QObject):
         return self._zoom_factor
 
     def apply_default(self) -> None:
-        self._zoom_factor = float(config.val.zoom.default) / 100
+        default_zoom = config.instance.get('zoom.default',
+                                           url=self._tab.url())
+        self._zoom_factor = float(default_zoom) / 100
         self._set_factor_internal(self._zoom_factor)
 
     def reapply(self) -> None:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1139,7 +1139,7 @@ class WebEngineTab(browsertab.AbstractTab):
             return
         if self._saved_zoom is None:
             return
-        self.zoom.set_factor(self._saved_zoom)
+        self.zoom.set_factor(self._saved_zoom, or_default=True)
         self._saved_zoom = None
 
     def load_url(self, url, *, emit_before_load_started=True):

--- a/qutebrowser/components/zoomcommands.py
+++ b/qutebrowser/components/zoomcommands.py
@@ -85,7 +85,7 @@ def zoom(tab: apitypes.Tab,
             raise cmdutils.CommandError("zoom: Invalid int value {}"
                                         .format(level))
     else:
-        int_level = int(config.val.zoom.default)
+        int_level = int(config.get('zoom.default', url=tab.url()))
 
     try:
         tab.zoom.set_factor(int_level / 100)

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1873,6 +1873,7 @@ window.title_format:
 zoom.default:
   type: Perc
   default: 100%
+  supports_pattern: true
   desc: Default zoom level.
 
 zoom.levels:

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -168,7 +168,7 @@ class Values:
           With fallback=False, UNSET is returned.
         """
         self._check_pattern_support(url)
-        if url is not None:
+        if url is not None and url.isValid():
             for scoped in reversed(self._values):
                 if scoped.pattern is not None and scoped.pattern.matches(url):
                     return scoped.value


### PR DESCRIPTION
This change allows the `zoom.default` config setting to be configured using per-url settings. It consists of three main changes:

* Change all instances of `config.val.zoom.default` to config.instance.get('zoom.default', url=self._tab.url()) or similar,  see below for exceptions and caveats.
* Add a `AbstractTab.url_changed` listener to `AbstractZoom` to set the default zoom when navigating about.
* Modifying `AbstractZoom.set_factor()` and `WebEngineTab._restore_zoom()` to handle per url settings where the saved zoom value was the default zoom but no longer is after navigating.

Note the TODO I left in _on_url_changed: If someone sets a non-default zoom level for a tab then navigates to a page with a custom default zoom should we override the current tab zoom? I left it as ignoring the custom default zoom which is how everything currently works. This means that using url patterns with `zoom.default` is less useful for setting a custom zoom level for specific sites but then again, the name does say `zoom.default` not `zoom`.

Also there are two other small commits for related things that I ran into.

Oh I didn't add a test partly beause all the zoom tests are end2end ones.

## Caveats
Not all instances of `config.val.zoom.default` were changed because of issues with a circular dependancy at tab init time on the webengine backend. Getting the tab url depends on the tab widget being initialised and the function which sets the tab widget up (`AbstractTab._set_widget()` calls `zoom.set_default()`. This circular dependancy could probably be unpicked but I chose to just handle it by using the global zoom at init time and in `_init_neighborlist()` (which is called at init time as well as later) just fall back to the global setting on error. Or we could change `WebEngineTab.url()` to return `QUrl('')` if `_widget` hadn't been set yet.

The `AbstractTab.url_changed` signal can get fired when a navigation starts but before the new page has started to load, so the old one is still present. If the new page has a different default zoom the old page will change to that zoom at that point. I couldn't find a way around it (the other signals have their own problems) and in the usual case (fast internet, responsive sites) one wouldn't notice anyway.

`WebEngineTab._restore_zoom()` is a pain in the ass. I'm pretty sure I didn't break the fix but the `or_default` kwarg is a little weird. Other options:

* Make `AbstractZoom.factor()` take an optional `url` argument and it will return the zoom factor for that url instead of the current one. Have abstract tab pass in the url being navigated to. This works but
    feels like even more of a special-case than the current.
* Have `AbstractZoom.factor()` return some sentinal when the tab's default zoom hasn't been overriden. Returning something that isn't actually a float though would probably violate callers' expectations.
* Have `WebEngineTab._restore_zoom()` do more work to see if the tab is still using the default zoom and pass the appropriate default zoom to restore in that case rather than the saved one. Feels like an inversion of responsibilities.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3782)
<!-- Reviewable:end -->
