### PR TITLE
Escape strings with string_escape rather than tojson

### DIFF
--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -30,7 +30,8 @@ import textwrap
 import attr
 from PyQt5.QtCore import pyqtSignal, QObject, QUrl
 
-from qutebrowser.utils import log, standarddir, jinja, objreg, utils
+from qutebrowser.utils import (log, standarddir, jinja, objreg, utils,
+                               javascript)
 from qutebrowser.commands import cmdutils
 from qutebrowser.browser import downloads
 
@@ -106,9 +107,10 @@ class GreasemonkeyScript:
         """
         template = jinja.js_environment.get_template('greasemonkey_wrapper.js')
         return template.render(
-            scriptName="/".join([self.namespace or '', self.name]),
+            scriptName=javascript.string_escape(
+                "/".join([self.namespace or '', self.name])),
             scriptInfo=self._meta_json(),
-            scriptMeta=self.script_meta,
+            scriptMeta=javascript.string_escape(self.script_meta),
             scriptSource=self._code)
 
     def _meta_json(self):

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -1,5 +1,5 @@
 (function() {
-    const _qute_script_id = "__gm_" + {{ scriptName | tojson }};
+    const _qute_script_id = "__gm_" + "{{ scriptName }}";
 
     function GM_log(text) {
         console.log(text);
@@ -7,7 +7,7 @@
 
     const GM_info = {
         'script': {{ scriptInfo }},
-        'scriptMetaStr': {{ scriptMeta | tojson }},
+        'scriptMetaStr': "{{ scriptMeta }}",
         'scriptWillUpdate': false,
         'version': "0.0.1",
         // so scripts don't expect exportFunction


### PR DESCRIPTION
This is a fairly naiive attempt to fix #3787.

instead of escaping js strings in jinja, I'm just escaping them with `javascript.string_escape`. 

Let me know if something seems off or if this seems bad for security reasons (?)

I verified this allows greasemonkey scripts (the ones that I tested at least) to run fine on jinja 2.8 from debian stable.

[cc: @toofar]

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3788)
<!-- Reviewable:end -->
