### PR TITLE
Add --first flag to :hint

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -172,6 +172,7 @@ class HintContext:
     tab = attr.ib(None)
     group = attr.ib(None)
     hint_mode = attr.ib(None)
+    first = attr.ib(False)
 
     def get_args(self, urlstr):
         """Get the arguments, with {hint-url} replaced by the given URL."""
@@ -612,6 +613,9 @@ class HintManager(QObject):
         modeman.enter(self._win_id, usertypes.KeyMode.hint,
                       'HintManager.start')
 
+        if self._context.first:
+            self._fire(strings[0])
+            return
         # to make auto_follow == 'always' work
         self._handle_auto_follow()
 
@@ -620,7 +624,8 @@ class HintManager(QObject):
     @cmdutils.argument('win_id', win_id=True)
     def start(self,  # pylint: disable=keyword-arg-before-vararg
               group=webelem.Group.all, target=Target.normal,
-              *args, win_id, mode=None, add_history=False, rapid=False):
+              *args, win_id, mode=None, add_history=False, rapid=False,
+              first=False):
         """Start hinting.
 
         Args:
@@ -632,6 +637,7 @@ class HintManager(QObject):
             add_history: Whether to add the spawned or yanked link to the
                          browsing history.
             group: The element types to hint.
+            first: Click the first hinted element without prompting.
 
                 - `all`: All clickable elements.
                 - `links`: Only links.
@@ -713,6 +719,7 @@ class HintManager(QObject):
         self._context.rapid = rapid
         self._context.hint_mode = mode
         self._context.add_history = add_history
+        self._context.first = first
         try:
             self._context.baseurl = tabbed_browser.current_url()
         except qtutils.QtValueError:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2271,6 +2271,7 @@ bindings.default:
       ;R: hint --rapid links window
       ;d: hint links download
       ;t: hint inputs
+      gi: hint inputs --first
       h: scroll left
       j: scroll down
       k: scroll up

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -509,3 +509,17 @@ Feature: Using hints
         And I press the key "hello"
         And I press the key "<Enter>"
         Then data/hello.txt should be loaded
+
+    Scenario: Using --first with normal links
+        When I open data/hints/html/simple.html
+        And I hint with args "all --first"
+        Then data/hello.txt should be loaded
+
+    Scenario: Using --first with inputs
+        When I open data/hints/input.html
+        And I hint with args "inputs --first"
+        And I wait for "Entering mode KeyMode.insert (reason: clicking input)" in the log
+        # ensure we clicked the first element
+        And I run :jseval console.log(document.activeElement.id == "qute-input");
+        And I run :leave-mode
+        Then the javascript message "true" should be logged


### PR DESCRIPTION
This PR adds a `--first` flag to `:hint`, which just clicks the first element hinted.

I usually try to avoid taking easy issues, but this issue has been sitting for several years and has a lot of activity.

I'm not entirely sure if we should bind this to`gi` by default, because I think the intuitive (from vim) behavior of that is a bit different from what `--first` provides. Something like `gi` (focus last input) is going to come in #3433 automatically when entering insert mode normally though, so the binding is free. If you think `:hint inputs --first` should bind to `gi`, let me know and I'll add it.

If anyone is considering using this, you might want to consider setting `hints.auto_follow.always` and just binding to `:hint links`, as that gives you hints only when there's more than one option.

Another idea I had would be adding a `--autofollow` flag instead of `--first`, which could take arguments, such as 'first', 'last', 'large', etc. I'm not sure whether it's worth the complexity (probably no one would use it).

Closes #219.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3789)
<!-- Reviewable:end -->
