### PR TITLE
Greasemonkey: fix early GM_addStyle with fast sites.

### DIFF
--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -100,11 +100,8 @@
 
         const head = document.getElementsByTagName("head")[0];
         if (head === undefined) {
-            document.onreadystatechange = function() {
-                if (document.readyState === "interactive") {
-                    document.getElementsByTagName("head")[0].appendChild(oStyle);
-                }
-            };
+            // no head yet, stick it whereever
+            document.documentElement.appendChild(oStyle);
         } else {
             head.appendChild(oStyle);
         }


### PR DESCRIPTION
nemanjan00 reported this script not having any effect https://gist.github.com/nemanjan00/01537ec65cd672d1f125170c7807f400/raw/da850e49cc28bc9c94e1a3fb564939eaa2e0aa77/duckduckgo-deepdark.user.js

It turns out that the previous implementation of GM_addStyle was relying
on `document.onreadystatechange` when the script ran early enough that
there was no `head` element. That event wasn't getting fired for the
main frame of duckduckgo.com for whatever reason. Maybe using
`DOMContentLoaded` or something would have worked but I just copied the
fallback in the above linked script which seems to work just fine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3792)
<!-- Reviewable:end -->
