### PR TITLE
Fix greasemonkey window scoping issues

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -30,6 +30,7 @@ markers =
     qtbug60673: Tests which are broken if the conversion from orange selection to real selection  is flaky
     fake_os: Fake utils.is_* to a fake operating system
     unicode_locale: Tests which need an unicode locale to work
+    qtwebkit6021_skip: Tests which would fail on WebKit version 602.1
 qt_log_level_fail = WARNING
 qt_log_ignore =
     ^SpellCheck: .*

--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -31,9 +31,10 @@ import attr
 from PyQt5.QtCore import pyqtSignal, QObject, QUrl
 
 from qutebrowser.utils import (log, standarddir, jinja, objreg, utils,
-                               javascript, urlmatch)
+                               javascript, urlmatch, version, usertypes)
 from qutebrowser.commands import cmdutils
 from qutebrowser.browser import downloads
+from qutebrowser.misc import objects
 
 
 def _scripts_dir():
@@ -108,13 +109,18 @@ class GreasemonkeyScript:
         browser's debugger/inspector will not match up to the line
         numbers in the source script directly.
         """
+        # Don't use Proxy on this webkit version, the support isn't there.
+        use_proxy = not (
+            objects.backend == usertypes.Backend.QtWebKit and
+            version.qWebKitVersion() == '602.1')
         template = jinja.js_environment.get_template('greasemonkey_wrapper.js')
         return template.render(
             scriptName=javascript.string_escape(
                 "/".join([self.namespace or '', self.name])),
             scriptInfo=self._meta_json(),
             scriptMeta=javascript.string_escape(self.script_meta),
-            scriptSource=self._code)
+            scriptSource=self._code,
+            use_proxy=use_proxy)
 
     def _meta_json(self):
         return json.dumps({

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -189,16 +189,11 @@
         // We can't return `this` or `qute_gm_window_proxy` from
         // `qute_gm_window_proxy.get('window')` because the Proxy implementation
         // does typechecking on read-only things. So we have to shadow `window`
-        // more conventionally here. Except we can't do it directly within
-        // with `with` scope because then it would get assigned to the
-        // proxy and we would get the same problem, so we have to make yet
-        // another nested scope.
-        (function() {
-          let window = qute_gm_window_proxy;
-          // ====== The actual user script source ====== //
+        // more conventionally here.
+        const window = qute_gm_window_proxy;
+        // ====== The actual user script source ====== //
 {{ scriptSource }}
-          // ====== End User Script ====== //
-        })();
+        // ====== End User Script ====== //
       };
     {% else %}
       // ====== The actual user script source ====== //

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -163,16 +163,16 @@
       const unsafeWindow = window;
       const qute_gm_window_shadow = {};  // stores local changes to window
       const qute_gm_windowProxyHandler = {
-        get: function(obj, prop) {
+        get: function(target, prop) {
           if (prop in qute_gm_window_shadow)
             return qute_gm_window_shadow[prop];
-          if (prop in obj) {
-            if (typeof obj[prop] === 'function' && typeof obj[prop].prototype == 'undefined')
+          if (prop in target) {
+            if (typeof target[prop] === 'function' && typeof target[prop].prototype == 'undefined')
               // Getting TypeError: Illegal Execution when callers try to execute
               // eg addEventListener from here because they were returned
               // unbound
-              return obj[prop].bind(obj);
-            return obj[prop];
+              return target[prop].bind(target);
+            return target[prop];
           }
         },
         set: function(target, prop, val) {

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -197,12 +197,11 @@
       // with `with` scope because then it would get assigned to the
       // proxy and we would get the same problem, so we have to make yet
       // another nested scope.
-      function qute_gm_window_scope() {  // why can't this be anonymous?
+      (function() {
         let window = qute_gm_window_proxy;
         // ====== The actual user script source ====== //
 {{ scriptSource }}
         // ====== End User Script ====== //
-      };
-      qute_gm_window_scope();
+      })();
     };
 })();

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -161,13 +161,16 @@
      * So let's try to use a Proxy on window and the possibly deprecated
      * `with` function to make that proxy shadow the global scope.
      * unsafeWindow should still be the actual global page window.
+     *
+     * There are other Proxy functions that we may need to override.
+     * set, get and has are definitely required.
      */
     const unsafeWindow = window;
-    let myWindow = {};
-    var windowProxyHandler = {
+    const qute_gm_window_shadow = {};  // stores local changes to window
+    const qute_gm_windowProxyHandler = {
       get: function(obj, prop) {
-        if (prop in myWindow)
-          return myWindow[prop];
+        if (prop in qute_gm_window_shadow)
+          return qute_gm_window_shadow[prop];
         if (prop in obj) {
           if (typeof obj[prop] === 'function' && typeof obj[prop].prototype == 'undefined')
             // Getting TypeError: Illegal Execution when callers try to execute
@@ -178,20 +181,28 @@
         }
       },
       set: function(target, prop, val) {
-        return myWindow[prop] = val;
+        return qute_gm_window_shadow[prop] = val;
+      },
+      has: function(target, key) {
+        return key in qute_gm_window_shadow || key in target;
       }
     };
-    var myProxy = new Proxy(unsafeWindow, windowProxyHandler);
+    const qute_gm_window_proxy = new Proxy(unsafeWindow, qute_gm_windowProxyHandler);
 
-    // ====== The actual user script source ====== //
-    with (myProxy) {
-      // can't assign window directly in with() scope because proxy doesn't
-      // allow assinging to things that a readonly on the target.
-      function blarg() {  // why can't this be anonymous?
-      var window = myProxy;
+    with (qute_gm_window_proxy) {
+      // We can't return `this` or `qute_gm_window_proxy` from
+      // `qute_gm_window_proxy.get('window')` because the Proxy implementation
+      // does typechecking on read-only things. So we have to shadow `window`
+      // more conventionally here. Except we can't do it directly within
+      // with `with` scope because then it would get assigned to the
+      // proxy and we would get the same problem, so we have to make yet
+      // another nested scope.
+      function qute_gm_window_scope() {  // why can't this be anonymous?
+        let window = qute_gm_window_proxy;
+        // ====== The actual user script source ====== //
 {{ scriptSource }}
+        // ====== End User Script ====== //
       };
-      blarg();
+      qute_gm_window_scope();
     };
-    // ====== End User Script ====== //
 })();

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -145,22 +145,16 @@
         }
     };
 
-    /* TamperMonkey allows assinging to `window` to change the visible global
-     * scope, without breaking other scripts. Eg if the page has set
-     * window.$ for an object for some reason (hello 4chan)
-     * - typeof $ === 'object'
-     * - typeof window.$ == 'undefined'
-     * - window.$ = function() {}
-     * - typeof $ === 'function'
-     * - typeof window.$ == 'function'
-     * Just shadowing `window` won't work because if you try to use '$'
-     * from the global scope you will still get the pages one.
-     * Additionally the userscript expects `window` to actually look
-     * like a fully featured browser window object.
-     *
-     * So let's try to use a Proxy on window and the possibly deprecated
-     * `with` function to make that proxy shadow the global scope.
-     * unsafeWindow should still be the actual global page window.
+    /* 
+     * Try to give userscripts an environment that they expect. Which
+     * seems to be that the global window object should look the same as
+     * the page's one and that if a script writes to an attribute of
+     * window it should be able to access that variable in the global
+     * scope.
+     * Use a Proxy to stop scripts from actually changing the global
+     * window (that's what unsafeWindow is for).
+     * Use the "with" statement to make the proxy provide what looks
+     * like global scope.
      *
      * There are other Proxy functions that we may need to override.
      * set, get and has are definitely required.
@@ -187,7 +181,8 @@
         return key in qute_gm_window_shadow || key in target;
       }
     };
-    const qute_gm_window_proxy = new Proxy(unsafeWindow, qute_gm_windowProxyHandler);
+    const qute_gm_window_proxy = new Proxy(
+      unsafeWindow, qute_gm_windowProxyHandler);
 
     with (qute_gm_window_proxy) {
       // We can't return `this` or `qute_gm_window_proxy` from

--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -145,58 +145,64 @@
         }
     };
 
-    /* 
-     * Try to give userscripts an environment that they expect. Which
-     * seems to be that the global window object should look the same as
-     * the page's one and that if a script writes to an attribute of
-     * window it should be able to access that variable in the global
-     * scope.
-     * Use a Proxy to stop scripts from actually changing the global
-     * window (that's what unsafeWindow is for).
-     * Use the "with" statement to make the proxy provide what looks
-     * like global scope.
-     *
-     * There are other Proxy functions that we may need to override.
-     * set, get and has are definitely required.
-     */
-    const unsafeWindow = window;
-    const qute_gm_window_shadow = {};  // stores local changes to window
-    const qute_gm_windowProxyHandler = {
-      get: function(obj, prop) {
-        if (prop in qute_gm_window_shadow)
-          return qute_gm_window_shadow[prop];
-        if (prop in obj) {
-          if (typeof obj[prop] === 'function' && typeof obj[prop].prototype == 'undefined')
-            // Getting TypeError: Illegal Execution when callers try to execute
-            // eg addEventListener from here because they were returned
-            // unbound
-            return obj[prop].bind(obj);
-          return obj[prop];
+    {% if use_proxy %}
+      /*
+       * Try to give userscripts an environment that they expect. Which
+       * seems to be that the global window object should look the same as
+       * the page's one and that if a script writes to an attribute of
+       * window it should be able to access that variable in the global
+       * scope.
+       * Use a Proxy to stop scripts from actually changing the global
+       * window (that's what unsafeWindow is for).
+       * Use the "with" statement to make the proxy provide what looks
+       * like global scope.
+       *
+       * There are other Proxy functions that we may need to override.
+       * set, get and has are definitely required.
+       */
+      const unsafeWindow = window;
+      const qute_gm_window_shadow = {};  // stores local changes to window
+      const qute_gm_windowProxyHandler = {
+        get: function(obj, prop) {
+          if (prop in qute_gm_window_shadow)
+            return qute_gm_window_shadow[prop];
+          if (prop in obj) {
+            if (typeof obj[prop] === 'function' && typeof obj[prop].prototype == 'undefined')
+              // Getting TypeError: Illegal Execution when callers try to execute
+              // eg addEventListener from here because they were returned
+              // unbound
+              return obj[prop].bind(obj);
+            return obj[prop];
+          }
+        },
+        set: function(target, prop, val) {
+          return qute_gm_window_shadow[prop] = val;
+        },
+        has: function(target, key) {
+          return key in qute_gm_window_shadow || key in target;
         }
-      },
-      set: function(target, prop, val) {
-        return qute_gm_window_shadow[prop] = val;
-      },
-      has: function(target, key) {
-        return key in qute_gm_window_shadow || key in target;
-      }
-    };
-    const qute_gm_window_proxy = new Proxy(
-      unsafeWindow, qute_gm_windowProxyHandler);
+      };
+      const qute_gm_window_proxy = new Proxy(
+        unsafeWindow, qute_gm_windowProxyHandler);
 
-    with (qute_gm_window_proxy) {
-      // We can't return `this` or `qute_gm_window_proxy` from
-      // `qute_gm_window_proxy.get('window')` because the Proxy implementation
-      // does typechecking on read-only things. So we have to shadow `window`
-      // more conventionally here. Except we can't do it directly within
-      // with `with` scope because then it would get assigned to the
-      // proxy and we would get the same problem, so we have to make yet
-      // another nested scope.
-      (function() {
-        let window = qute_gm_window_proxy;
-        // ====== The actual user script source ====== //
+      with (qute_gm_window_proxy) {
+        // We can't return `this` or `qute_gm_window_proxy` from
+        // `qute_gm_window_proxy.get('window')` because the Proxy implementation
+        // does typechecking on read-only things. So we have to shadow `window`
+        // more conventionally here. Except we can't do it directly within
+        // with `with` scope because then it would get assigned to the
+        // proxy and we would get the same problem, so we have to make yet
+        // another nested scope.
+        (function() {
+          let window = qute_gm_window_proxy;
+          // ====== The actual user script source ====== //
 {{ scriptSource }}
-        // ====== End User Script ====== //
-      })();
-    };
+          // ====== End User Script ====== //
+        })();
+      };
+    {% else %}
+      // ====== The actual user script source ====== //
+{{ scriptSource }}
+      // ====== End User Script ====== //
+    {% endif %}
 })();

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -223,8 +223,10 @@ def check_display(request):
 @pytest.fixture(autouse=True)
 def set_backend(monkeypatch, request):
     """Make sure the backend global is set."""
-    backend = (usertypes.Backend.QtWebEngine if request.config.webengine
-               else usertypes.Backend.QtWebKit)
+    if not request.config.webengine and version.qWebKitVersion:
+        backend = usertypes.Backend.QtWebKit
+    else:
+        backend = usertypes.Backend.QtWebEngine
     monkeypatch.setattr(objects, 'backend', backend)
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ from helpers import logfail
 from helpers.logfail import fail_on_logging
 from helpers.messagemock import message_mock
 from helpers.fixtures import *  # noqa: F403
-from qutebrowser.utils import qtutils, standarddir, usertypes, utils
+from qutebrowser.utils import qtutils, standarddir, usertypes, utils, version
 from qutebrowser.misc import objects
 
 import qutebrowser.app  # To register commands
@@ -77,6 +77,10 @@ def _apply_platform_markers(config, item):
          "https://bugreports.qt.io/browse/QTBUG-60673"),
         ('unicode_locale', sys.getfilesystemencoding() == 'ascii',
          "Skipped because of ASCII locale"),
+        ('qtwebkit6021_skip',
+         version.qWebKitVersion and
+         version.qWebKitVersion() == '602.1',
+         "Broken on WebKit 602.1")
     ]
 
     for searched_marker, condition, default_reason in markers:

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -43,10 +43,10 @@ import helpers.stubs as stubsmod
 import helpers.utils
 from qutebrowser.config import (config, configdata, configtypes, configexc,
                                 configfiles)
-from qutebrowser.utils import objreg, standarddir, utils
+from qutebrowser.utils import objreg, standarddir, utils, usertypes
 from qutebrowser.browser import greasemonkey
 from qutebrowser.browser.webkit import cookies
-from qutebrowser.misc import savemanager, sql
+from qutebrowser.misc import savemanager, sql, objects
 from qutebrowser.keyinput import modeman
 
 
@@ -360,9 +360,10 @@ def qnam(qapp):
 
 
 @pytest.fixture
-def webengineview(qtbot):
+def webengineview(qtbot, monkeypatch):
     """Get a QWebEngineView if QtWebEngine is available."""
     QtWebEngineWidgets = pytest.importorskip('PyQt5.QtWebEngineWidgets')
+    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
     view = QtWebEngineWidgets.QWebEngineView()
     qtbot.add_widget(view)
     return view
@@ -379,9 +380,10 @@ def webpage(qnam):
 
 
 @pytest.fixture
-def webview(qtbot, webpage):
+def webview(qtbot, webpage, monkeypatch):
     """Get a new QWebView object."""
     QtWebKitWidgets = pytest.importorskip('PyQt5.QtWebKitWidgets')
+    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebKit)
 
     view = QtWebKitWidgets.QWebView()
     qtbot.add_widget(view)

--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -165,6 +165,7 @@ class TestWindowIsolation:
 
     @pytest.fixture
     def setup(self):
+        # pylint: disable=attribute-defined-outside-init
         class SetupData:
             pass
         ret = SetupData()

--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -212,6 +212,8 @@ class TestWindowIsolation:
         page.runJavaScript(self.test_script, callback_checker.callback)
         callback_checker.check(self.expected)
 
+    # The JSCore in 602.1 doesn't fully support Proxy.
+    @pytest.mark.qtwebkit6021_skip
     def test_webkit(self, webview):
         elem = webview.page().mainFrame().documentElement()
         elem.evaluateJavaScript(self.setup_script)

--- a/tests/unit/javascript/test_js_execution.py
+++ b/tests/unit/javascript/test_js_execution.py
@@ -26,7 +26,7 @@ import pytest
 @pytest.mark.parametrize('js_enabled, expected', [(True, 2.0), (False, None)])
 def test_simple_js_webkit(webview, js_enabled, expected):
     """With QtWebKit, evaluateJavaScript works when JS is on."""
-    # If we get there (because of the webengineview fixture) we can be certain
+    # If we get there (because of the webview fixture) we can be certain
     # QtWebKit is available
     from PyQt5.QtWebKit import QWebSettings
     webview.settings().setAttribute(QWebSettings.JavascriptEnabled, js_enabled)
@@ -37,7 +37,7 @@ def test_simple_js_webkit(webview, js_enabled, expected):
 @pytest.mark.parametrize('js_enabled, expected', [(True, 2.0), (False, 2.0)])
 def test_element_js_webkit(webview, js_enabled, expected):
     """With QtWebKit, evaluateJavaScript on an element works with JS off."""
-    # If we get there (because of the webengineview fixture) we can be certain
+    # If we get there (because of the webview fixture) we can be certain
     # QtWebKit is available
     from PyQt5.QtWebKit import QWebSettings
     webview.settings().setAttribute(QWebSettings.JavascriptEnabled, js_enabled)


### PR DESCRIPTION
Someone reported that OneeChan wasn't working with our greasemonkey implementation, this highlighted an issue with how we were isolating the different scripts, at least compared to other more mature implementations. I tested with Tampermonkey and saw what kind of environment it provided:

1. `window` looks the same as the one the page sees, with any modifications made by the page
2. the global scope looks the same as the page one before the page made any modifications to it, so before javascript started running I suppose
3. saving something to an attribute of `window` make it accessible via the global scope (that is, just referring to it directly)

I tried looking at the TamperMonkey source to see how they did it but I couldn't figure it out. Possibly they just use the environment presented to them by chrome (and get `unsafeWindow` like [this](https://github.com/Tampermonkey/tampermonkey/blob/master/src/content.js#L480))

I am using the ES6 [Proxy](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy) feature to proxy the actual global window and allow for presenting local writes as a mask over top of it. There are some issues around the Proxy implementation does some [seemingly arbitrary type checking](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Proxy/handler/get#Invariants) against the target object, designed just to piss me off, that means I had to add another level of closure with another `window` shadow. There were further issues around unbound functions being returned from my `Proxy.get()` implementation, I don't know know why but I added a heuristic to bind those that need it.

I am using the [with](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/with) statement to make that window proxy look like the global scope. Apparently `with` is not cool anymore and if anyone knows how I can achieve this mess without using it that would be great.

PS: I tried again putting the greasemonkey script in a non-main world and that violated point 1 of the above list.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3793)
<!-- Reviewable:end -->
