### PR TITLE
Fix searching with leading arguments and ';;'

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1778,14 +1778,16 @@ class CommandDispatcher:
                             replace=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
-                       maxsplit=0)
-    def search(self, text="", reverse=False):
+                       maxsplit=0, star_args_optional=True)
+    def search(self, *text, reverse=False):
         """Search for a text on the current page. With no text, clear results.
 
         Args:
             text: The text to search for.
             reverse: Reverse search direction.
         """
+        text = ' '.join(text)
+
         self.set_mark("'")
         tab = self._current_widget()
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1778,16 +1778,14 @@ class CommandDispatcher:
                             replace=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
-                       maxsplit=0, star_args_optional=True, no_cmd_split=True)
-    def search(self, *text, reverse=False):
+                       maxsplit=0)
+    def search(self, text="", reverse=False):
         """Search for a text on the current page. With no text, clear results.
 
         Args:
             text: The text to search for.
             reverse: Reverse search direction.
         """
-        text = ' '.join(text)
-
         self.set_mark("'")
         tab = self._current_widget()
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1778,7 +1778,7 @@ class CommandDispatcher:
                             replace=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
-                       maxsplit=0, star_args_optional=True)
+                       maxsplit=0, star_args_optional=True, no_cmd_split=True)
     def search(self, *text, reverse=False):
         """Search for a text on the current page. With no text, clear results.
 

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -75,7 +75,6 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
             '?': lambda search: search_fn(self._win_id, ["-r", "--", search]),
         }
 
-
     def prefix(self):
         """Get the currently entered command prefix."""
         text = self.text()

--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -19,6 +19,8 @@
 
 """The commandline in the statusbar."""
 
+import functools
+
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QSize
 from PyQt5.QtWidgets import QSizePolicy
 
@@ -69,10 +71,12 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         self.textChanged.connect(self.updateGeometry)
         self.textChanged.connect(self._incremental_search)
 
-        search_fn = cmdutils.cmd_dict['search'].run
+        dispatcher = objreg.get('command-dispatcher',
+                                scope='window', window=self._win_id)
+        search_fn = dispatcher.search
         self.search_prefixes = {
-            '/': lambda search: search_fn(self._win_id, ["--", search]),
-            '?': lambda search: search_fn(self._win_id, ["-r", "--", search]),
+            '/': search_fn,
+            '?': functools.partial(search_fn, reverse=True)
         }
 
     def prefix(self):

--- a/tests/end2end/data/search.html
+++ b/tests/end2end/data/search.html
@@ -16,6 +16,7 @@
             BAZ<br/>
             space travel<br/>
             /slash<br/>
+            -r reversed<br/>
             <a class="toselect" href="hello.txt">follow me!</a><br/>
         </p>
     </body>

--- a/tests/end2end/data/search.html
+++ b/tests/end2end/data/search.html
@@ -17,6 +17,7 @@
             space travel<br/>
             /slash<br/>
             -r reversed<br/>
+            ;; semicolons<br/>
             <a class="toselect" href="hello.txt">follow me!</a><br/>
         </p>
     </body>

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -45,6 +45,12 @@ Feature: Searching on a page
         And I wait for "search found /slash" in the log
         Then "/slash" should be found
 
+    Scenario: Searching with arguments at start of search term
+        When I run :set-cmd-text -s /-r reversed
+        And I run :command-accept
+        And I wait for "search found -r reversed" in the log
+        Then "-r reversed" should be found
+
     # This doesn't work because this is QtWebKit behavior.
     @xfail_norun
     Scenario: Searching text with umlauts

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -51,6 +51,11 @@ Feature: Searching on a page
         And I wait for "search found -r reversed" in the log
         Then "-r reversed" should be found
 
+    Scenario: Searching with semicolons in search term
+        When I run :search ;; semi
+        And I wait for "search found ;; semi" in the log
+        Then ";; semi" should be found
+
     # This doesn't work because this is QtWebKit behavior.
     @xfail_norun
     Scenario: Searching text with umlauts

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -40,19 +40,23 @@ Feature: Searching on a page
         Then "space " should be found
 
     Scenario: Searching with / and slash in search term (issue 507)
-        When I run :set-cmd-text -s //slash
+        When I run :set-cmd-text //slash
         And I run :command-accept
         And I wait for "search found /slash" in the log
         Then "/slash" should be found
 
     Scenario: Searching with arguments at start of search term
-        When I run :set-cmd-text -s /-r reversed
+        When I run :set-cmd-text /-r reversed
         And I run :command-accept
         And I wait for "search found -r reversed" in the log
         Then "-r reversed" should be found
 
     Scenario: Searching with semicolons in search term
-        When I run :search ;; semi
+        When I run :set-cmd-text /;
+        And I run :fake-key -g ;
+        And I run :fake-key -g <space>
+        And I run :fake-key -g semi
+        And I run :command-accept
         And I wait for "search found ;; semi" in the log
         Then ";; semi" should be found
 


### PR DESCRIPTION
Previously, slash searching for things like `-m qutebrowser` would result in an error complaining about "unrecognized argument: qutebrowser".

This PR tries to fix this. Instead of taking a single string, I take in a varargs (as `["--", "-m", "qutebrowser"]` is a valid input).

Let me know if anything seems wrong.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3796)
<!-- Reviewable:end -->
