### PR TITLE
Fix win_id 0 always being included in :tab-take completion

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -110,7 +110,7 @@ def _buffer(skip_win_id=None):
     model = completionmodel.CompletionModel(column_widths=(6, 40, 54))
 
     for win_id in objreg.window_registry:
-        if skip_win_id and win_id == skip_win_id:
+        if skip_win_id is not None and win_id == skip_win_id:
             continue
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=win_id)

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -618,6 +618,29 @@ def test_other_buffer_completion(qtmodeltester, fake_web_tab, app_stub,
     })
 
 
+def test_other_buffer_completion_id0(qtmodeltester, fake_web_tab, app_stub,
+                                     win_registry, tabbed_browser_stubs, info):
+    tabbed_browser_stubs[0].widget.tabs = [
+        fake_web_tab(QUrl('https://github.com'), 'GitHub', 0),
+        fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia', 1),
+        fake_web_tab(QUrl('https://duckduckgo.com'), 'DuckDuckGo', 2),
+    ]
+    tabbed_browser_stubs[1].widget.tabs = [
+        fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
+    ]
+    info.win_id = 0
+    model = miscmodels.other_buffer(info=info)
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        '1': [
+            ('1/1', 'https://wiki.archlinux.org', 'ArchWiki'),
+        ],
+    })
+
+
 def test_window_completion(qtmodeltester, fake_web_tab, tabbed_browser_stubs,
                            info):
     tabbed_browser_stubs[0].widget.tabs = [


### PR DESCRIPTION
Closes #3800.

We were counting on `skip_win_id` being truthy when skipping window id's, and `0` seems to be considered falsy in python :(

I don't think we need tests for this, it seems like too much of an edge case. If you think they will help, I'll add them though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3802)
<!-- Reviewable:end -->
