### PR TITLE
Greasemonkey: fix default include value

### DIFF
--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -92,7 +92,7 @@ class GreasemonkeyScript:
             props = ""
         script = cls(re.findall(cls.PROPS_REGEX, props), source)
         script.script_meta = props
-        if not props:
+        if not script.includes:
             script.includes = ['*']
         return script
 


### PR DESCRIPTION
Greasemonkey scripts are supposed to default to running on all pages.
@jgkamat and @nemanjan00 reported some script not running on all pages
unless they either removed (or broke) the metadata block or added an
include directive. Indeed I had a logic error when it only defaulted to
being included on all pages when no metadata block at all was included.
Whoops.

This bug applies to webengine 5.7.1 and webkit backends.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3803)
<!-- Reviewable:end -->
