### PR TITLE
Greasemonkey: use UrlPatterns for match directives

### DIFF
--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -32,7 +32,7 @@ test_gm_script = r"""
 // @name qutebrowser test userscript
 // @namespace invalid.org
 // @include http://localhost:*/data/title.html
-// @match http://trolol*
+// @match http://*.trolol.com/*
 // @exclude https://badhost.xxx/*
 // @run-at document-start
 // ==/UserScript==
@@ -60,7 +60,7 @@ def test_all():
 
 @pytest.mark.parametrize("url, expected_matches", [
     # included
-    ('http://trololololololo.com/', 1),
+    ('http://trolol.com/', 1),
     # neither included nor excluded
     ('http://aaaaaaaaaa.com/', 0),
     # excluded


### PR DESCRIPTION
The greasemonkey `@match` directive is used to match urls against
chromium url patterns (as opposed to `@include` which treats its
argument as a glob expression). I was using fnmatch for both here
because I am lazy and knew someone else was going to implement chromium
url patterns for me eventually. Now it is done and I should switch to
using them instead. The most common failing case that this will fix is
something matching on `*://*.domain.com/*` because it wouldn't match
the url with no subdomain.

This codepath is only used on webengine 5.7.1 and webkit backends.

~NOTE: This PR conflicts with #3803 I just need to change that line to have `and not script.matches`. Probably should have put that commit at the start of this PR but it was a spur of the moment thing.~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3804)
<!-- Reviewable:end -->
