### PR TITLE
Moved suspended indicator to right side of tab title

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -480,7 +480,7 @@ def qute_back(url):
     """
     html = jinja.render(
         'back.html',
-        title='Suspended: ' + urllib.parse.unquote(url.fragment()))
+        title=urllib.parse.unquote(url.fragment()) + ' (Suspended)')
     return 'text/html', html
 
 


### PR DESCRIPTION
Hi,

I enjoy using this browser greatly. I also enjoy the lazy-loading feature because I tend to hoard tabs. One thing I dislike about the behavior of this feature, though, is the 'Suspended: ' message in front of the title. I put my tabs on the right, and have the bar not very wide. This makes it hard to find the tab I'm looking for because most of the title is ellipsized. Here's an example: 
![Screenshot](https://pcbx.us/muny/cewn.png)

This commit moves the indicator text to the right side instead. I don't very much care for its existence, but I do understand why it's there. Maybe there can be an option to have it enabled? Or maybe the status color of the tab could change when the tab is suspended, something orange-ish?

Thanks,
Kevin

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3805)
<!-- Reviewable:end -->
