### PR TITLE
Add check for self._reply is None in qutebrowser\browser\qtnetworkdownloads.py", line 314

### DIFF
--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -311,6 +311,8 @@ class DownloadItem(downloads.AbstractDownloadItem):
     @pyqtSlot()
     def _on_read_timer_timeout(self):
         """Read some bytes from the QNetworkReply periodically."""
+        if self._reply is None:
+            return
         if not self._reply.isOpen():
             raise OSError("Reply is closed!")
         data = self._reply.read(1024)

--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -169,6 +169,7 @@ class DownloadItem(downloads.AbstractDownloadItem):
             self._reply = None
         if self.fileobj is not None:
             self.fileobj.close()
+            self._read_timer.stop()
         self.cancelled.emit()
 
     @pyqtSlot()


### PR DESCRIPTION
Reported browser crash in IRC April 3 2018:

20:41:36 ERROR: Uncaught exception
Traceback (most recent call last):
  File "C:\Program Files\qutebrowser\qutebrowser\browser\qtnetworkdownloads.py", line 314, in _on_read_timer_timeout
    if not self._reply.isOpen():
AttributeError: 'NoneType' object has no attribute 'isOpen'

This PR adds:

        if self._reply is None:
            return

Before the line that reads self._reply.isOpen()

Caveat: The guy did say he was using Qt 5.9 but I don't think it hurts to have this check anyway.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3809)
<!-- Reviewable:end -->

[edit by @jgkamat to link issues: closes #3808]