### PR TITLE
Stop read timer when download is cancelled

### DIFF
--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -162,6 +162,7 @@ class DownloadItem(downloads.AbstractDownloadItem):
             QTimer.singleShot(0, lambda: self._die(reply.errorString()))
 
     def _do_cancel(self):
+        self._read_timer.stop()
         if self._reply is not None:
             self._reply.finished.disconnect(self._on_reply_finished)
             self._reply.abort()


### PR DESCRIPTION
After discovering that #3808 happened when a `:download` prompt was cancelled, I realized that the timer calling that method was never stopped in a cancel. The timer appears to still be active even at the end of the `cancel` method in downloads.py.

This fixes that.

Hopefully, this will solve #3808 (but I can't test, because I can't reproduce the error). Also see #3809 for an alternative solution.

```
09:43:29 DEBUG    downloads  downloads:cancel:538 cancelled
09:43:29 DEBUG    downloads  downloads:delete:557 Not deleting None
09:43:29 DEBUG    modes      modeman:leave:292 Ignoring leave request for KeyMode.prompt (reason left in other window) as we're in mode KeyMode.normal
09:43:29 DEBUG    modes      tabbedbrowser:on_mode_left:636 Left status-input mode, focusing <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=137 url='...'>
09:43:29 DEBUG    misc       app:on_focus_object_changed:840 Focus object changed: <PyQt5.QtWidgets.QWidget object at 0x00000228C9AEE9D8>
09:43:29 DEBUG    modes      modeman:_handle_keypress:194 match: 2, forward_unbound_keys: auto, passthrough: True, is_non_alnum: False, dry_run: False --> filter: True (focused: <PyQt5.QtWidgets.QWidget object at 0x00000228C9AEE9D8>)
09:43:29 ERROR    misc       crashsignal:exception_hook:216 Uncaught exception
Traceback (most recent call last):
  File "C:\Program Files\qutebrowser\qutebrowser\browser\qtnetworkdownloads.py", line 314, in _on_read_timer_timeout
    if not self._reply.isOpen():
AttributeError: 'NoneType' object has no attribute 'isOpen'
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3813)
<!-- Reviewable:end -->
