### PR TITLE
Added surrounding gray box to launch command for Ubuntu + Tox

### DIFF
--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -426,7 +426,11 @@ Creating a wrapper script
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Running `tox` does not install a system-wide `qutebrowser` script. You can
-launch qutebrowser by doing `.venv/bin/python3 -m qutebrowser`.
+launch qutebrowser by doing:
+
+----
+.venv/bin/python3 -m qutebrowser
+----
 
 You can create a simple wrapper script to start qutebrowser somewhere in your
 `$PATH` (e.g. `/usr/local/bin/qutebrowser` or `~/bin/qutebrowser`):


### PR DESCRIPTION
Based on issue #3799 

A minor documentation fix that just makes the launch command when installing under those environments easier to find.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3820)
<!-- Reviewable:end -->

[edit by @jgkamat to link issues: Closes #3799]