### PR TITLE
Support rapid hinting mode in yanking

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -22,6 +22,7 @@
 import collections
 import functools
 import math
+import os
 import re
 import html
 import enum
@@ -253,7 +254,7 @@ class HintActions:
             except utils.ClipboardEmptyError:
                 pass
             else:
-                new_content = old_content + '\n' + new_content
+                new_content = os.linesep.join([old_content, new_content])
         utils.set_clipboard(new_content, selection=sel)
 
         msg = "Yanked URL to {}: {}".format(

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -922,7 +922,8 @@ class HintManager(QObject):
         except HintingError as e:
             message.error(str(e))
 
-        self._context.first_run = False
+        if self._context is not None:
+            self._context.first_run = False
 
     @cmdutils.register(instance='hintmanager', scope='tab',
                        modes=[usertypes.KeyMode.hint])

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -510,11 +510,13 @@ def sanitize_filename(name, replacement='_'):
 
 def set_clipboard(data, selection=False):
     """Set the clipboard to some given data."""
+    global fake_clipboard
     if selection and not supports_selection():
         raise SelectionUnsupportedError
     if log_clipboard:
         what = 'primary selection' if selection else 'clipboard'
         log.misc.debug("Setting fake {}: {}".format(what, json.dumps(data)))
+        fake_clipboard = data
     else:
         mode = QClipboard.Selection if selection else QClipboard.Clipboard
         QApplication.clipboard().setText(data, mode=mode)

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -599,7 +599,8 @@ def check_open_tabs(quteproc, request, tabs):
                          r'contain "(?P<content>.*)"'))
 def clipboard_contains(quteproc, server, what, content):
     expected = content.replace('(port)', str(server.port))
-    expected = expected.replace('\\n', os.linesep)
+    expected = expected.replace('\\n', '\n')
+    expected = expected.replace('(linesep)', os.linesep)
     quteproc.wait_for(message='Setting fake {}: {}'.format(
         what, json.dumps(expected)))
 

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -599,7 +599,7 @@ def check_open_tabs(quteproc, request, tabs):
                          r'contain "(?P<content>.*)"'))
 def clipboard_contains(quteproc, server, what, content):
     expected = content.replace('(port)', str(server.port))
-    expected = expected.replace('\\n', '\n')
+    expected = expected.replace('\\n', os.linesep)
     quteproc.wait_for(message='Setting fake {}: {}'.format(
         what, json.dumps(expected)))
 

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -127,7 +127,7 @@ Feature: Using hints
         And I run :follow-hint a
         And I run :follow-hint s
         And I run :leave-mode
-        Then the clipboard should contain "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt"
+        Then the clipboard should contain "http://localhost:(port)/data/hello.txt(linesep)http://localhost:(port)/data/hello2.txt"
 
     Scenario: Rapid hinting
         When I open data/hints/rapid.html in a new tab

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -120,6 +120,15 @@ Feature: Using hints
         And I hint with args "links yank" and follow a
         Then the clipboard should contain "javascript:window.location.href='/data/hello.txt'"
 
+    Scenario: Rapid yanking
+        When I run :debug-set-fake-clipboard
+        And I open data/hints/rapid.html
+        And I hint with args "links yank --rapid"
+        And I run :follow-hint a
+        And I run :follow-hint s
+        And I run :leave-mode
+        Then the clipboard should contain "http://localhost:(port)/data/hello.txt\nhttp://localhost:(port)/data/hello2.txt"
+
     Scenario: Rapid hinting
         When I open data/hints/rapid.html in a new tab
         And I run :tab-only

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -651,6 +651,7 @@ class TestGetSetClipboard:
                          autospec=True)
         clipboard = m()
         clipboard.text.return_value = 'mocked clipboard text'
+        mocker.patch('qutebrowser.utils.utils.fake_clipboard', None)
         return clipboard
 
     def test_set(self, clipboard_mock, caplog):


### PR DESCRIPTION
Implements #3824 

I took care of clearing clipboard on first yank by adding `num` to `HintContext`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3825)
<!-- Reviewable:end -->
