### PR TITLE
show hint at the bottom of link out of frame

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -124,7 +124,10 @@ class HintLabel(QLabel):
             return
         no_js = config.val.hints.find_implementation != 'javascript'
         rect = self.elem.rect_on_view(no_js=no_js)
-        self.move(rect.x(), rect.y())
+        if rect.y()<0 and (rect.y()+rect.height()-15>0):
+            self.move(rect.x(), rect.y()+rect.height()-15)
+        else:
+            self.move(rect.x(), rect.y())
 
     def cleanup(self):
         """Clean up this element and hide it."""

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -124,10 +124,7 @@ class HintLabel(QLabel):
             return
         no_js = config.val.hints.find_implementation != 'javascript'
         rect = self.elem.rect_on_view(no_js=no_js)
-        if rect.y()<0 and (rect.y()+rect.height()-15>0):
-            self.move(rect.x(), rect.y()+rect.height()-15)
-        else:
-            self.move(rect.x(), rect.y())
+        self.move(max(rect.x(),0),max(rect.y(),0))
 
     def cleanup(self):
         """Clean up this element and hide it."""

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -309,7 +309,7 @@ class AbstractWebElement(collections.abc.MutableMapping):
 
     def _mouse_pos(self):
         """Get the position to click/hover."""
-        # Click the center of the largest square fitting into the top/left
+        # Click the midpoint of top or bottom side of the largest square fitting into the top/left
         # corner of the rectangle, this will help if part of the <a> element
         # is hidden behind other elements
         # https://github.com/qutebrowser/qutebrowser/issues/1005
@@ -319,6 +319,11 @@ class AbstractWebElement(collections.abc.MutableMapping):
         else:
             rect.setHeight(rect.width())
         pos = rect.center()
+        if rect.y()<0 and (rect.y()+rect.height()-15>0):
+            pos.setY(rect.y()+rect.height()-15) 
+        else:
+            pos.setY(rect.y())
+
         if pos.x() < 0 or pos.y() < 0:
             raise Error("Element position is out of view!")
         return pos


### PR DESCRIPTION
I have fix [issue #3810](https://github.com/qutebrowser/qutebrowser/issues/3810). Now, if a clickable images that start out of frame will have their hints displayed at the left bottom corner. But still, if the picture shows less than 3px in the frame, the hint will not be displayed because there is not enough room for the label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3827)
<!-- Reviewable:end -->
