### PR TITLE
Bookmark revolution

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -76,10 +76,6 @@ It is possible to run or bind multiple commands by separating them with `;;`.
 |<<open,open>>|Open a URL in the current/[count]th tab.
 |<<open-editor,open-editor>>|Open an external editor with the currently selected form field.
 |<<print,print>>|Print the current/[count]th tab.
-|<<quickmark-add,quickmark-add>>|Add a new quickmark.
-|<<quickmark-del,quickmark-del>>|Delete a quickmark.
-|<<quickmark-load,quickmark-load>>|Load a quickmark.
-|<<quickmark-save,quickmark-save>>|Save the current page as a quickmark.
 |<<quit,quit>>|Quit qutebrowser.
 |<<record-macro,record-macro>>|Start or stop recording a macro.
 |<<reload,reload>>|Reload the current/[count]th tab.
@@ -824,53 +820,6 @@ Print the current/[count]th tab.
 
 ==== count
 The tab index to print.
-
-[[quickmark-add]]
-=== quickmark-add
-Syntax: +:quickmark-add 'url' 'name'+
-
-Add a new quickmark.
-
-You can view all saved quickmarks on the link:qute://bookmarks[bookmarks page].
-
-==== positional arguments
-* +'url'+: The url to add as quickmark.
-* +'name'+: The name for the new quickmark.
-
-[[quickmark-del]]
-=== quickmark-del
-Syntax: +:quickmark-del ['name']+
-
-Delete a quickmark.
-
-==== positional arguments
-* +'name'+: The name of the quickmark to delete. If not given, delete the quickmark for the current page (choosing one arbitrarily
- if there are more than one).
-
-
-==== note
-* This command does not split arguments after the last argument and handles quotes literally.
-
-[[quickmark-load]]
-=== quickmark-load
-Syntax: +:quickmark-load [*--tab*] [*--bg*] [*--window*] 'name'+
-
-Load a quickmark.
-
-==== positional arguments
-* +'name'+: The name of the quickmark to load.
-
-==== optional arguments
-* +*-t*+, +*--tab*+: Load the quickmark in a new tab.
-* +*-b*+, +*--bg*+: Load the quickmark in a new background tab.
-* +*-w*+, +*--window*+: Load the quickmark in a new window.
-
-==== note
-* This command does not split arguments after the last argument and handles quotes literally.
-
-[[quickmark-save]]
-=== quickmark-save
-Save the current page as a quickmark.
 
 [[quit]]
 === quit

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -520,7 +520,6 @@ Default:
 * +pass:[=]+: +pass:[zoom]+
 * +pass:[?]+: +pass:[set-cmd-text ?]+
 * +pass:[@]+: +pass:[run-macro]+
-* +pass:[B]+: +pass:[set-cmd-text -s :quickmark-load -t]+
 * +pass:[D]+: +pass:[tab-close -o]+
 * +pass:[F]+: +pass:[hint all tab]+
 * +pass:[G]+: +pass:[scroll-to-perc]+
@@ -545,7 +544,6 @@ Default:
 * +pass:[]]]+: +pass:[navigate next]+
 * +pass:[`]+: +pass:[enter-mode set_mark]+
 * +pass:[ad]+: +pass:[download-cancel]+
-* +pass:[b]+: +pass:[set-cmd-text -s :quickmark-load]+
 * +pass:[cd]+: +pass:[download-clear]+
 * +pass:[co]+: +pass:[tab-only]+
 * +pass:[d]+: +pass:[tab-close]+
@@ -573,7 +571,6 @@ Default:
 * +pass:[j]+: +pass:[scroll down]+
 * +pass:[k]+: +pass:[scroll up]+
 * +pass:[l]+: +pass:[scroll right]+
-* +pass:[m]+: +pass:[quickmark-save]+
 * +pass:[n]+: +pass:[search-next]+
 * +pass:[o]+: +pass:[set-cmd-text -s :open]+
 * +pass:[pP]+: +pass:[open -- {primary}]+
@@ -603,7 +600,6 @@ Default:
 * +pass:[wB]+: +pass:[set-cmd-text -s :bookmark-load -w]+
 * +pass:[wO]+: +pass:[set-cmd-text :open -w {url:pretty}]+
 * +pass:[wP]+: +pass:[open -w -- {primary}]+
-* +pass:[wb]+: +pass:[set-cmd-text -s :quickmark-load -w]+
 * +pass:[wf]+: +pass:[hint all window]+
 * +pass:[wh]+: +pass:[back -w]+
 * +pass:[wi]+: +pass:[inspector]+

--- a/doc/qutebrowser.1.asciidoc
+++ b/doc/qutebrowser.1.asciidoc
@@ -107,7 +107,7 @@ show it.
 
 - '~/.config/qutebrowser/config.py': Configuration file.
 - '~/.config/qutebrowser/autoconfig.yml': Configuration done via the GUI.
-- '~/.config/qutebrowser/quickmarks': Saved quickmarks.
+- '~/.config/qutebrowser/bookmarks/urls': Saved bookmarks.
 - '~/.local/share/qutebrowser/': Various state information.
 - '~/.cache/qutebrowser/': Temporary data.
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -474,10 +474,6 @@ def _init_modules(args, crash_handler):
     host_blocker.read_hosts()
     objreg.register('host-blocker', host_blocker)
 
-    log.init.debug("Initializing quickmarks...")
-    quickmark_manager = urlmarks.QuickmarkManager(qApp)
-    objreg.register('quickmark-manager', quickmark_manager)
-
     log.init.debug("Initializing bookmarks...")
     bookmark_manager = urlmarks.BookmarkManager(qApp)
     objreg.register('bookmark-manager', bookmark_manager)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1354,7 +1354,15 @@ class CommandDispatcher:
             unique: Refuse non-unique tags.
         """
         bookmark_manager = objreg.get('bookmark-manager')
-        url = QUrl(url or self._current_url())
+        url = QUrl(url)
+
+        try:
+            bookmark_manager.add(url, '', [])
+            message.info("Bookmarked {}".format(url.toDisplayString()))
+        except urlmarks.AlreadyExistsError:
+            pass
+        except urlmarks.Error as e:
+            raise cmdexc.CommandError(str(e))
 
         try:
             if remove or purge:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1337,7 +1337,7 @@ class CommandDispatcher:
             message.info(msg.format(url.toDisplayString()))
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    @cmdutils.argument('url', completion=urlmodel.bookmark)
+    @cmdutils.argument('url', completion=urlmodel.url)
     @cmdutils.argument('tags', completion=urlmodel.bookmark_tag)
     @cmdutils.argument('purge', flag='R')
     def bookmark_tag(self, url, *tags, remove=False, purge=False,

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1305,7 +1305,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def bookmark_add(self, url=None, title=None, toggle=False):
-        """Save the current page as a bookmark, or a specific url.
+        """Save the current page (or a specified url) as a bookmark.
 
         If no url and title are provided, then save the current page as a
         bookmark.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1339,7 +1339,9 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('url', completion=miscmodels.bookmark)
     @cmdutils.argument('tags', completion=miscmodels.bookmark_tag)
-    def bookmark_tag(self, url, *tags, remove=False, unique=False):
+    @cmdutils.argument('purge', flag='R')
+    def bookmark_tag(self, url, *tags, remove=False, purge=False,
+                     unique=False):
         """Modify bookmark tags for the given url.
 
         The given url will be bookmarked if it is not already.
@@ -1348,14 +1350,15 @@ class CommandDispatcher:
             url: url to save as a bookmark.
             tags: One or more tags to add.
             remove: Remove tags instead of adding.
+            purge: Remove tags, and remove the mark if it has no more tags.
             unique: Refuse non-unique tags.
         """
         bookmark_manager = objreg.get('bookmark-manager')
         url = QUrl(url or self._current_url())
 
         try:
-            if remove:
-                bookmark_manager.untag(url, tags)
+            if remove or purge:
+                bookmark_manager.untag(url, tags, purge=purge)
             else:
                 bookmark_manager.tag(url, tags, unique=unique)
         except urlmarks.Error as e:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1339,7 +1339,7 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('url', completion=miscmodels.bookmark)
     @cmdutils.argument('tags', completion=miscmodels.bookmark_tag)
-    def bookmark_tag(self, url, *tags, remove=False):
+    def bookmark_tag(self, url, *tags, remove=False, unique=False):
         """Modify bookmark tags for the given url.
 
         The given url will be bookmarked if it is not already.
@@ -1348,14 +1348,16 @@ class CommandDispatcher:
             url: url to save as a bookmark.
             tags: One or more tags to add.
             remove: Remove tags instead of adding.
+            unique: Refuse non-unique tags.
         """
         bookmark_manager = objreg.get('bookmark-manager')
         url = QUrl(url or self._current_url())
+
         try:
             if remove:
                 bookmark_manager.untag(url, tags)
             else:
-                bookmark_manager.tag(url, tags)
+                bookmark_manager.tag(url, tags, unique=unique)
         except urlmarks.Error as e:
             raise cmdexc.CommandError(str(e))
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1337,8 +1337,8 @@ class CommandDispatcher:
             message.info(msg.format(url.toDisplayString()))
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    @cmdutils.argument('url', completion=miscmodels.bookmark)
-    @cmdutils.argument('tags', completion=miscmodels.bookmark_tag)
+    @cmdutils.argument('url', completion=urlmodel.bookmark)
+    @cmdutils.argument('tags', completion=urlmodel.bookmark_tag)
     @cmdutils.argument('purge', flag='R')
     def bookmark_tag(self, url, *tags, remove=False, purge=False,
                      unique=False):
@@ -1367,7 +1367,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
-    @cmdutils.argument('tags', completion=miscmodels.bookmark_tag)
+    @cmdutils.argument('tags', completion=urlmodel.bookmark_tag)
     @cmdutils.argument('open_all', flag='a')
     def bookmark_load(self, *tags, tab=False, bg=False, window=False,
                       delete=False, open_all=False):
@@ -1400,7 +1400,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
-    @cmdutils.argument('url', completion=miscmodels.bookmark)
+    @cmdutils.argument('url', completion=urlmodel.bookmark)
     def bookmark_del(self, url=None):
         """Delete a bookmark.
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1326,15 +1326,8 @@ class CommandDispatcher:
             raise cmdexc.CommandError('Title must be provided if url has '
                                       'been provided')
         bookmark_manager = objreg.get('bookmark-manager')
-        if not url:
-            url = self._current_url()
-        else:
-            try:
-                url = urlutils.fuzzy_url(url)
-            except urlutils.InvalidUrlError as e:
-                raise cmdexc.CommandError(e)
-        if not title:
-            title = self._current_title()
+        url = QUrl(url or self._current_url())
+        title = title or self._current_title()
         try:
             was_added = bookmark_manager.add(url, title, [], toggle=toggle)
         except urlmarks.Error as e:
@@ -1356,11 +1349,7 @@ class CommandDispatcher:
             remove: Remove tags instead of adding.
         """
         bookmark_manager = objreg.get('bookmark-manager')
-        try:
-            url = urlutils.fuzzy_url(url)
-        except urlutils.InvalidUrlError as e:
-            raise cmdexc.CommandError(e)
-
+        url = QUrl(url or self._current_url())
         try:
             if remove:
                 bookmark_manager.untag(url, tags)
@@ -1412,13 +1401,11 @@ class CommandDispatcher:
             url: The url of the bookmark to delete. If not given, use the
                  current page's url.
         """
-        if url is None:
-            url = self._current_url().toString(QUrl.RemovePassword |
-                                               QUrl.FullyEncoded)
+        url = QUrl(url or self._current_url())
         try:
             objreg.get('bookmark-manager').delete(url)
-        except KeyError:
-            raise cmdexc.CommandError("Bookmark '{}' not found!".format(url))
+        except urlmarks.Error as e:
+            raise cmdexc.CommandError(e)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def follow_selected(self, *, tab=False):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1386,7 +1386,7 @@ class CommandDispatcher:
         if not title:
             title = self._current_title()
         try:
-            was_added = bookmark_manager.add(url, title, toggle=toggle)
+            was_added = bookmark_manager.add(url, title, [], toggle=toggle)
         except urlmarks.Error as e:
             raise cmdexc.CommandError(str(e))
         else:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1361,18 +1361,14 @@ class CommandDispatcher:
         except urlutils.InvalidUrlError as e:
             raise cmdexc.CommandError(e)
 
-        mark = bookmark_manager.get(url)
-        if not mark:
-            raise cmdexc.CommandError("Bookmark {} does not exist".format(
-                url.toDisplayString()))
+        try:
+            if remove:
+                bookmark_manager.untag(url, tags)
+            else:
+                bookmark_manager.tag(url, tags)
+        except urlmarks.Error as e:
+            raise cmdexc.CommandError(str(e))
 
-        if remove:
-            for t in tags:
-                mark.tags.remove(t)
-        else:
-            mark.tags.extend(tags)
-
-        bookmark_manager.update(mark)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1338,6 +1338,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('url', completion=miscmodels.bookmark)
+    @cmdutils.argument('tags', completion=miscmodels.bookmark_tag)
     def bookmark_tag(self, url, *tags, remove=False):
         """Modify bookmark tags for the given url.
 
@@ -1361,6 +1362,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
+    @cmdutils.argument('tags', completion=miscmodels.bookmark_tag)
     @cmdutils.argument('open_all', flag='a')
     def bookmark_load(self, *tags, tab=False, bg=False, window=False,
                       delete=False, open_all=False):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1364,7 +1364,6 @@ class CommandDispatcher:
         except urlmarks.Error as e:
             raise cmdexc.CommandError(str(e))
 
-
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
     @cmdutils.argument('tags', completion=urlmodel.bookmark_tag)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1343,6 +1343,38 @@ class CommandDispatcher:
             msg = "Bookmarked {}" if was_added else "Removed bookmark {}"
             message.info(msg.format(url.toDisplayString()))
 
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    @cmdutils.argument('url', completion=miscmodels.bookmark)
+    def bookmark_tag(self, url, *tags, remove=False):
+        """Modify bookmark tags for the given url.
+
+        The given url will be bookmarked if it is not already.
+
+        Args:
+            url: url to save as a bookmark.
+            tags: One or more tags to add.
+            remove: Remove tags instead of adding.
+        """
+        bookmark_manager = objreg.get('bookmark-manager')
+        try:
+            url = urlutils.fuzzy_url(url)
+        except urlutils.InvalidUrlError as e:
+            raise cmdexc.CommandError(e)
+
+        mark = bookmark_manager.get(url)
+        if not mark:
+            raise cmdexc.CommandError("Bookmark {} does not exist".format(
+                url.toDisplayString()))
+
+        if remove:
+            for t in tags:
+                mark.tags.remove(t)
+        else:
+            mark.tags.extend(tags)
+
+        bookmark_manager.update(mark)
+
+
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
     @cmdutils.argument('url', completion=miscmodels.bookmark)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1329,7 +1329,7 @@ class CommandDispatcher:
         url = QUrl(url or self._current_url())
         title = title or self._current_title()
         try:
-            was_added = bookmark_manager.add(url, title, [], toggle=toggle)
+            was_added = bookmark_manager.add(url, title, toggle=toggle)
         except urlmarks.Error as e:
             raise cmdexc.CommandError(str(e))
         else:
@@ -1357,7 +1357,7 @@ class CommandDispatcher:
         url = QUrl(url)
 
         try:
-            bookmark_manager.add(url, '', [])
+            bookmark_manager.add(url, '')
             message.info("Bookmarked {}".format(url.toDisplayString()))
         except urlmarks.AlreadyExistsError:
             pass

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -191,8 +191,7 @@ def data_for_url(url):
 @add_handler('bookmarks')
 def qute_bookmarks(_url):
     """Handler for qute://bookmarks. Display all quickmarks / bookmarks."""
-    bookmarks = sorted(objreg.get('bookmark-manager').marks.items(),
-                       key=lambda x: x[1])  # Sort by title
+    bookmarks = sorted(objreg.get('bookmark-manager'), key=lambda x: x.title)
     quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),
                         key=lambda x: x[0])  # Sort by name
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -190,15 +190,12 @@ def data_for_url(url):
 
 @add_handler('bookmarks')
 def qute_bookmarks(_url):
-    """Handler for qute://bookmarks. Display all quickmarks / bookmarks."""
+    """Handler for qute://bookmarks. Display all bookmarks."""
     bookmarks = sorted(objreg.get('bookmark-manager'), key=lambda x: x.title)
-    quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),
-                        key=lambda x: x[0])  # Sort by name
 
     html = jinja.render('bookmarks.html',
                         title='Bookmarks',
-                        bookmarks=bookmarks,
-                        quickmarks=quickmarks)
+                        bookmarks=bookmarks)
     return 'text/html', html
 
 

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -215,6 +215,13 @@ class BookmarkManager(QObject):
             raise DoesNotExistError("Bookmark '{}' not found!".format(urlstr))
         self.changed.emit()
 
+    def all_tags(self):
+        """Get the set of all defined tags."""
+        tags = set()
+        for m in self:
+            tags = tags.union(m.tags)
+        return tags
+
     def _urlstr(self, url):
         """Convert a QUrl into the string format used as a key."""
         if not url.isValid():

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -124,13 +124,12 @@ class BookmarkManager(QObject):
         save_manager.add_saveable('bookmark-manager', self.save, self.changed,
                                   filename=filename)
 
-    def add(self, url, title, tags, *, toggle=False):
+    def add(self, url, title, *, toggle=False):
         """Add a new bookmark.
 
         Args:
             url: The url to add as bookmark.
             title: The title for the new bookmark.
-            tags: The tags for the new bookmark.
             toggle: remove the bookmark instead of raising an error if it
                     already exists.
 
@@ -151,7 +150,7 @@ class BookmarkManager(QObject):
             else:
                 raise AlreadyExistsError("Bookmark already exists!")
         else:
-            self._marks[urlstr] = Bookmark(urlstr, title or '', tags or [])
+            self._marks[urlstr] = Bookmark(urlstr, title or '', [])
             # place new marks at the end
             self._marks.move_to_end(urlstr, last=False)
             self.changed.emit()

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -145,6 +145,8 @@ class BookmarkManager(QObject):
                 raise AlreadyExistsError("Bookmark already exists!")
         else:
             self._marks[urlstr] = Bookmark(urlstr, title or '', tags or [])
+            # place new marks at the end
+            self._marks.move_to_end(urlstr, last=False)
             self.changed.emit()
             return True
 
@@ -154,6 +156,11 @@ class BookmarkManager(QObject):
         self._lineparser.save()
 
     def get(self, url):
+        """Get a bookmark, or None if no such mark exists.
+
+        Args:
+            url: The QUrl of the mark to find.
+        """
         urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
         return self._marks.get(urlstr)
 

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -18,7 +18,7 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Managers for bookmarks and quickmarks.
+"""Manager for bookmarks.
 
 Note we violate our general QUrl rule by storing url strings in the marks
 OrderedDict. This is because we read them from a file at start and write them
@@ -71,166 +71,6 @@ class AlreadyExistsError(Error):
 Bookmark = collections.namedtuple('Bookmark', ['url', 'title', 'tags'])
 
 
-class UrlMarkManager(QObject):
-
-    """Base class for BookmarkManager and QuickmarkManager.
-
-    Attributes:
-        marks: An OrderedDict of all quickmarks/bookmarks.
-        _lineparser: The LineParser used for the marks
-
-    Signals:
-        changed: Emitted when anything changed.
-    """
-
-    changed = pyqtSignal()
-
-    def __init__(self, parent=None):
-        """Initialize and read quickmarks."""
-        super().__init__(parent)
-
-        self.marks = collections.OrderedDict()
-
-        self._init_lineparser()
-        for line in self._lineparser:
-            if not line.strip():
-                # Ignore empty or whitespace-only lines.
-                continue
-            self._parse_line(line)
-        self._init_savemanager(objreg.get('save-manager'))
-
-    def _init_lineparser(self):
-        raise NotImplementedError
-
-    def _parse_line(self, line):
-        raise NotImplementedError
-
-    def _init_savemanager(self, _save_manager):
-        raise NotImplementedError
-
-    def save(self):
-        """Save the marks to disk."""
-        self._lineparser.data = [' '.join(tpl) for tpl in self.marks.items()]
-        self._lineparser.save()
-
-    def delete(self, key):
-        """Delete a quickmark/bookmark.
-
-        Args:
-            key: The key to delete (name for quickmarks, URL for bookmarks.)
-        """
-        del self.marks[key]
-        self.changed.emit()
-
-
-class QuickmarkManager(UrlMarkManager):
-
-    """Manager for quickmarks.
-
-    The primary key for quickmarks is their *name*, this means:
-
-        - self.marks maps names to URLs.
-        - changed gets emitted with the name as first argument and the URL as
-          second argument.
-    """
-
-    def _init_lineparser(self):
-        self._lineparser = lineparser.LineParser(
-            standarddir.config(), 'quickmarks', parent=self)
-
-    def _init_savemanager(self, save_manager):
-        filename = os.path.join(standarddir.config(), 'quickmarks')
-        save_manager.add_saveable('quickmark-manager', self.save, self.changed,
-                                  filename=filename)
-
-    def _parse_line(self, line):
-        try:
-            key, url = line.rsplit(maxsplit=1)
-        except ValueError:
-            message.error("Invalid quickmark '{}'".format(line))
-        else:
-            self.marks[key] = url
-
-    def prompt_save(self, url):
-        """Prompt for a new quickmark name to be added and add it.
-
-        Args:
-            url: The quickmark url as a QUrl.
-        """
-        if not url.isValid():
-            urlutils.invalid_url_error(url, "save quickmark")
-            return
-        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
-        message.ask_async(
-            "Add quickmark:", usertypes.PromptMode.text,
-            functools.partial(self.quickmark_add, urlstr),
-            text="Please enter a quickmark name for<br/><b>{}</b>".format(
-                html.escape(url.toDisplayString())), url=urlstr)
-
-    @cmdutils.register(instance='quickmark-manager')
-    def quickmark_add(self, url, name):
-        """Add a new quickmark.
-
-        You can view all saved quickmarks on the
-        link:qute://bookmarks[bookmarks page].
-
-        Args:
-            url: The url to add as quickmark.
-            name: The name for the new quickmark.
-        """
-        # We don't raise cmdexc.CommandError here as this can be called async
-        # via prompt_save.
-        if not name:
-            message.error("Can't set mark with empty name!")
-            return
-        if not url:
-            message.error("Can't set mark with empty URL!")
-            return
-
-        def set_mark():
-            """Really set the quickmark."""
-            self.marks[name] = url
-            self.changed.emit()
-            log.misc.debug("Added quickmark {} for {}".format(name, url))
-
-        if name in self.marks:
-            message.confirm_async(
-                title="Override existing quickmark?",
-                yes_action=set_mark, default=True, url=url)
-        else:
-            set_mark()
-
-    def get_by_qurl(self, url):
-        """Look up a quickmark by QUrl, returning its name.
-
-        Takes O(n) time, where n is the number of quickmarks.
-        Use a name instead where possible.
-        """
-        qtutils.ensure_valid(url)
-        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
-
-        try:
-            index = list(self.marks.values()).index(urlstr)
-            key = list(self.marks.keys())[index]
-        except ValueError:
-            raise DoesNotExistError(
-                "Quickmark for '{}' not found!".format(urlstr))
-        return key
-
-    def get(self, name):
-        """Get the URL of the quickmark named name as a QUrl."""
-        if name not in self.marks:
-            raise DoesNotExistError(
-                "Quickmark '{}' does not exist!".format(name))
-        urlstr = self.marks[name]
-        try:
-            url = urlutils.fuzzy_url(urlstr, do_search=False)
-        except urlutils.InvalidUrlError as e:
-            raise InvalidUrlError(
-                "Invalid URL for quickmark {}: {}".format(name, str(e)))
-        return url
-
-
 class BookmarkManager(QObject):
 
     """Manager for bookmarks.
@@ -242,7 +82,7 @@ class BookmarkManager(QObject):
     changed = pyqtSignal()
 
     def __init__(self, parent=None):
-        """Initialize and read quickmarks."""
+        """Initialize and read bookmarks."""
         super().__init__(parent)
 
         self._marks = collections.OrderedDict()
@@ -318,10 +158,10 @@ class BookmarkManager(QObject):
         self._lineparser.save()
 
     def delete(self, key):
-        """Delete a quickmark/bookmark.
+        """Delete a bookmark.
 
         Args:
-            key: The key to delete (name for quickmarks, URL for bookmarks.)
+            key: The url of the bookmark to delete.
         """
         del self._marks[key]
         self.changed.emit()

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -27,16 +27,12 @@ to a file on shutdown, so it makes sense to keep them as strings here.
 
 import os
 import os.path
-import html
-import functools
 import collections
 import json
 
 from PyQt5.QtCore import pyqtSignal, QUrl, QObject
 
-from qutebrowser.utils import (message, usertypes, qtutils, urlutils,
-                               standarddir, objreg, log)
-from qutebrowser.commands import cmdutils
+from qutebrowser.utils import urlutils, standarddir, objreg
 from qutebrowser.misc import lineparser
 
 
@@ -156,6 +152,14 @@ class BookmarkManager(QObject):
         """Save the marks to disk."""
         self._lineparser.data = [json.dumps(m._asdict()) for m in self]
         self._lineparser.save()
+
+    def get(self, url):
+        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
+        return self._marks.get(urlstr)
+
+    def update(self, mark):
+        self._marks[mark.url] = mark
+        self.changed.emit()
 
     def delete(self, key):
         """Delete a bookmark.

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -199,12 +199,13 @@ class BookmarkManager(QObject):
         mark.tags.extend((t for t in tags if t not in mark.tags))
         self.changed.emit()
 
-    def untag(self, url, tags):
+    def untag(self, url, tags, purge=False):
         """Remove tags from a mark.
 
         Args:
             url: QUrl of the mark to modify.
             tags: List of tags to remove.
+            purge: Remove the mark if it has no tags left
         """
         mark = self.get(url)
         for t in tags:
@@ -212,6 +213,8 @@ class BookmarkManager(QObject):
                 mark.tags.remove(t)
             except ValueError:
                 pass
+        if purge and not mark.tags:
+            self.delete(url)
         self.changed.emit()
 
     def delete(self, key):

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -191,7 +191,7 @@ class BookmarkManager(QObject):
             unique: Raise NotUniqueError if one of the tags is already in use.
         """
         if unique:
-            violations = [t for t in tags if any(self.get_tagged(t))]
+            violations = [t for t in tags if any(self.get_tagged([t]))]
             if violations:
                 raise NotUniqueError("{} are not unique".format(violations))
         mark = self.get(url)

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -164,6 +164,15 @@ class BookmarkManager(QObject):
         urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
         return self._marks.get(urlstr)
 
+    def get_tagged(self, tags):
+        """Get all bookmarks that have all the provided tags.
+
+        Args:
+            tags: List of tags to filter by.
+        """
+        return (m for m in self._marks.values()
+                if all(t in m.tags for t in tags))
+
     def update(self, mark):
         self._marks[mark.url] = mark
         self.changed.emit()

--- a/qutebrowser/commands/command.py
+++ b/qutebrowser/commands/command.py
@@ -123,6 +123,7 @@ class Command:
         self.pos_args = []
         self.desc = None
         self.flags_with_args = []
+        self._has_vararg = False
 
         # This is checked by future @cmdutils.argument calls so they fail
         # (as they'd be silently ignored otherwise)
@@ -170,6 +171,8 @@ class Command:
 
     def get_pos_arg_info(self, pos):
         """Get an ArgInfo tuple for the given positional parameter."""
+        if pos >= len(self.pos_args) and self._has_vararg:
+            pos = len(self.pos_args) - 1
         name = self.pos_args[pos][0]
         return self._qute_args.get(name, ArgInfo())
 
@@ -233,6 +236,8 @@ class Command:
             log.commands.vdebug('Adding arg {} of type {} -> {}'.format(
                 param.name, typ, callsig))
             self.parser.add_argument(*args, **kwargs)
+            if param.kind == inspect.Parameter.VAR_POSITIONAL:
+                self._has_vararg = True
         return signature.parameters.values()
 
     def _param_to_argparse_kwargs(self, param, is_bool):

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -49,7 +49,7 @@ class Completer(QObject):
         _last_cursor_pos: The old cursor position so we avoid double completion
                           updates.
         _last_text: The old command text so we avoid double completion updates.
-        _last_completion_func: The completion function used for the last text.
+        _last_before_cursor: The prior value of before_cursor.
     """
 
     def __init__(self, *, cmd, win_id, parent=None):
@@ -62,7 +62,7 @@ class Completer(QObject):
         self._timer.timeout.connect(self._update_completion)
         self._last_cursor_pos = -1
         self._last_text = None
-        self._last_completion_func = None
+        self._last_before_cursor = None
         self._cmd.update_completion.connect(self.schedule_completion_update)
 
     def __repr__(self):
@@ -228,7 +228,7 @@ class Completer(QObject):
             # FIXME complete searches
             # https://github.com/qutebrowser/qutebrowser/issues/32
             completion.set_model(None)
-            self._last_completion_func = None
+            self._last_before_cursor = None
             return
 
         before_cursor, pattern, after_cursor = self._partition()
@@ -242,11 +242,11 @@ class Completer(QObject):
         if func is None:
             log.completion.debug('Clearing completion')
             completion.set_model(None)
-            self._last_completion_func = None
+            self._last_before_cursor = None
             return
 
-        if func != self._last_completion_func:
-            self._last_completion_func = func
+        if before_cursor != self._last_before_cursor:
+            self._last_before_cursor = before_cursor
             args = (x for x in before_cursor[1:] if not x.startswith('-'))
             with debug.log_time(log.completion, 'Starting {} completion'
                                 .format(func.__name__)):

--- a/qutebrowser/completion/models/configmodel.py
+++ b/qutebrowser/completion/models/configmodel.py
@@ -47,12 +47,12 @@ def customized_option(*, info):
     return model
 
 
-def value(optname, *_values, info):
+def value(optname, *values, info):
     """A CompletionModel filled with setting values.
 
     Args:
         optname: The name of the config option this model shows.
-        _values: The values already provided on the command line.
+        values: The values already provided on the command line.
         info: A CompletionInfo instance.
     """
     model = completionmodel.CompletionModel(column_widths=(30, 70, 0))
@@ -64,13 +64,18 @@ def value(optname, *_values, info):
 
     opt = info.config.get_opt(optname)
     default = opt.typ.to_str(opt.default)
-    cur_cat = listcategory.ListCategory(
-        "Current/Default",
-        [(current, "Current value"), (default, "Default value")])
-    model.add_category(cur_cat)
+    cur_def = []
+    if current not in values:
+        cur_def.append((current, "Current value"))
+    if default not in values:
+        cur_def.append((default, "Default value"))
+    if cur_def:
+        cur_cat = listcategory.ListCategory("Current/Default", cur_def)
+        model.add_category(cur_cat)
 
-    vals = opt.typ.complete()
-    if vals is not None:
+    vals = opt.typ.complete() or []
+    vals = [x for x in vals if x[0] not in values]
+    if vals:
         model.add_category(listcategory.ListCategory("Completions", vals))
     return model
 

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -56,8 +56,8 @@ def bookmark(*, info=None):  # pylint: disable=unused-argument
         bookmark_manager = objreg.get('bookmark-manager')
         bookmark_manager.delete(urlstr)
 
-    model = completionmodel.CompletionModel(column_widths=(30, 70, 0))
-    marks = ((m.url, m.title, str(m.tags))
+    model = completionmodel.CompletionModel(column_widths=(30, 50, 20))
+    marks = ((m.url, m.title, ' '.join(m.tags))
              for m in objreg.get('bookmark-manager'))
     model.add_category(listcategory.ListCategory('Bookmarks', marks,
                                                  delete_func=delete,

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -47,34 +47,6 @@ def helptopic(*, info):
     return model
 
 
-def bookmark(*, info=None):  # pylint: disable=unused-argument
-    """A CompletionModel filled with all bookmarks."""
-    def delete(data):
-        """Delete a bookmark from the completion menu."""
-        urlstr = data[0]
-        log.completion.debug('Deleting bookmark {}'.format(urlstr))
-        bookmark_manager = objreg.get('bookmark-manager')
-        bookmark_manager.delete(urlstr)
-
-    model = completionmodel.CompletionModel(column_widths=(30, 50, 20))
-    marks = ((m.url, m.title, ' '.join(m.tags))
-             for m in objreg.get('bookmark-manager'))
-    model.add_category(listcategory.ListCategory('Bookmarks', marks,
-                                                 delete_func=delete,
-                                                 sort=False))
-    return model
-
-
-def bookmark_tag(*args, info=None):  # pylint: disable=unused-argument
-    """A CompletionModel filled with all bookmark tags."""
-    model = completionmodel.CompletionModel(column_widths=(20, 80, 0))
-    bookmarks = objreg.get('bookmark-manager')
-    tags = ((t, '') for t in bookmarks.all_tags() if t not in args)
-    cat = listcategory.ListCategory('Tags', tags)
-    model.add_category(cat)
-    return model
-
-
 def session(*, info=None):  # pylint: disable=unused-argument
     """A CompletionModel filled with session names."""
     model = completionmodel.CompletionModel()

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -65,6 +65,16 @@ def bookmark(*, info=None):  # pylint: disable=unused-argument
     return model
 
 
+def bookmark_tag(*args, info=None):  # pylint: disable=unused-argument
+    """A CompletionModel filled with all bookmark tags."""
+    model = completionmodel.CompletionModel(column_widths=(20, 80, 0))
+    bookmarks = objreg.get('bookmark-manager')
+    tags = ((t, '') for t in bookmarks.all_tags() if t not in args)
+    cat = listcategory.ListCategory('Tags', tags)
+    model.add_category(cat)
+    return model
+
+
 def session(*, info=None):  # pylint: disable=unused-argument
     """A CompletionModel filled with session names."""
     model = completionmodel.CompletionModel()

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -74,7 +74,8 @@ def bookmark(*, info=None):  # pylint: disable=unused-argument
         bookmark_manager.delete(urlstr)
 
     model = completionmodel.CompletionModel(column_widths=(30, 70, 0))
-    marks = objreg.get('bookmark-manager').marks.items()
+    marks = ((m.url, m.title, str(m.tags))
+             for m in objreg.get('bookmark-manager'))
     model.add_category(listcategory.ListCategory('Bookmarks', marks,
                                                  delete_func=delete,
                                                  sort=False))

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -47,23 +47,6 @@ def helptopic(*, info):
     return model
 
 
-def quickmark(*, info=None):  # pylint: disable=unused-argument
-    """A CompletionModel filled with all quickmarks."""
-    def delete(data):
-        """Delete a quickmark from the completion menu."""
-        name = data[0]
-        quickmark_manager = objreg.get('quickmark-manager')
-        log.completion.debug('Deleting quickmark {}'.format(name))
-        quickmark_manager.delete(name)
-
-    model = completionmodel.CompletionModel(column_widths=(30, 70, 0))
-    marks = objreg.get('quickmark-manager').marks.items()
-    model.add_category(listcategory.ListCategory('Quickmarks', marks,
-                                                 delete_func=delete,
-                                                 sort=False))
-    return model
-
-
 def bookmark(*, info=None):  # pylint: disable=unused-argument
     """A CompletionModel filled with all bookmarks."""
     def delete(data):

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -49,7 +49,7 @@ def url(*, info):
     """
     model = completionmodel.CompletionModel(column_widths=(40, 50, 10))
 
-    bookmarks = [(m.url, m.title, str(m.tags)) for m in
+    bookmarks = [(m.url, m.title, ' '.join(m.tags)) for m in
                  objreg.get('bookmark-manager')]
 
     if bookmarks:

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -60,3 +60,24 @@ def url(*, info):
         hist_cat = histcategory.HistoryCategory(delete_func=_delete_history)
         model.add_category(hist_cat)
     return model
+
+
+def bookmark(*, info=None):  # pylint: disable=unused-argument
+    """A CompletionModel filled with all bookmarks."""
+    model = completionmodel.CompletionModel(column_widths=(30, 50, 20))
+    marks = ((m.url, m.title, ' '.join(m.tags))
+             for m in objreg.get('bookmark-manager'))
+    model.add_category(listcategory.ListCategory('Bookmarks', marks,
+                                                 delete_func=_delete_bookmark,
+                                                 sort=False))
+    return model
+
+
+def bookmark_tag(*args, info=None):  # pylint: disable=unused-argument
+    """A CompletionModel filled with all bookmark tags."""
+    model = completionmodel.CompletionModel(column_widths=(20, 80, 0))
+    bookmarks = objreg.get('bookmark-manager')
+    tags = ((t, '') for t in bookmarks.all_tags() if t not in args)
+    cat = listcategory.ListCategory('Tags', tags)
+    model.add_category(cat)
+    return model

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -42,29 +42,16 @@ def _delete_bookmark(data):
     bookmark_manager.delete(urlstr)
 
 
-def _delete_quickmark(data):
-    name = data[_TEXTCOL]
-    quickmark_manager = objreg.get('quickmark-manager')
-    log.completion.debug('Deleting quickmark {}'.format(name))
-    quickmark_manager.delete(name)
-
-
 def url(*, info):
-    """A model which combines bookmarks, quickmarks and web history URLs.
+    """A model which combines bookmarks and web history URLs.
 
     Used for the `open` command.
     """
     model = completionmodel.CompletionModel(column_widths=(40, 50, 10))
 
-    quickmarks = [(url, name) for (name, url)
-                  in objreg.get('quickmark-manager').marks.items()]
     bookmarks = [(m.url, m.title, str(m.tags)) for m in
                  objreg.get('bookmark-manager')]
 
-    if quickmarks:
-        model.add_category(listcategory.ListCategory(
-            'Quickmarks', quickmarks, delete_func=_delete_quickmark,
-            sort=False))
     if bookmarks:
         model.add_category(listcategory.ListCategory(
             'Bookmarks', bookmarks, delete_func=_delete_bookmark, sort=False))

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -58,7 +58,8 @@ def url(*, info):
 
     quickmarks = [(url, name) for (name, url)
                   in objreg.get('quickmark-manager').marks.items()]
-    bookmarks = objreg.get('bookmark-manager').marks.items()
+    bookmarks = [(m.url, m.title, str(m.tags)) for m in
+                 objreg.get('bookmark-manager')]
 
     if quickmarks:
         model.add_category(listcategory.ListCategory(

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2299,6 +2299,7 @@ bindings.default:
       PP: open -t -- {primary}
       wp: open -w -- {clipboard}
       wP: open -w -- {primary}
+      m: set-cmd-text -s :bookmark-tag {url}
       M: bookmark-add
       gb: set-cmd-text -s :bookmark-load
       gB: set-cmd-text -s :bookmark-load -t

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2299,10 +2299,6 @@ bindings.default:
       PP: open -t -- {primary}
       wp: open -w -- {clipboard}
       wP: open -w -- {primary}
-      m: quickmark-save
-      b: set-cmd-text -s :quickmark-load
-      B: set-cmd-text -s :quickmark-load -t
-      wb: set-cmd-text -s :quickmark-load -w
       M: bookmark-add
       gb: set-cmd-text -s :bookmark-load
       gB: set-cmd-text -s :bookmark-load -t

--- a/qutebrowser/html/bookmarks.html
+++ b/qutebrowser/html/bookmarks.html
@@ -51,10 +51,11 @@ th {
 {% if bookmarks|length %}
 <table class="bmarks">
     <tbody>
-    {% for url, title in bookmarks %}
+    {% for url, title, tags in bookmarks %}
     <tr>
         <td class="name"><a href="{{url}}">{{title | default(url, true)}}</a></td>
         <td class="url"><a href="{{url}}">{{url}}</a></td>
+        <td class="tags">{{tags}}</td>
     </tr>
     {% endfor %}
     </tbody>

--- a/qutebrowser/html/bookmarks.html
+++ b/qutebrowser/html/bookmarks.html
@@ -29,23 +29,6 @@ th {
 
 {% block content %}
 
-<h1>Quickmarks</h1>
-
-{% if quickmarks|length %}
-<table class="qmarks">
-    <tbody>
-    {% for name, url in quickmarks %}
-    <tr>
-        <td class="name"><a href="{{url}}">{{name}}</a></td>
-        <td class="url"><a href="{{url}}">{{url}}</a></td>
-    </tr>
-    {% endfor %}
-    </tbody>
-</table>
-{% else %}
-<span class="empty-msg">You have no quickmarks</span>
-{% endif %}
-
 <h1 id="bookmarks">Bookmarks</h1>
 
 {% if bookmarks|length %}

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -83,6 +83,8 @@ PERFECT_FILES = [
      'browser/webengine/certificateerror.py'),
     # ('tests/unit/browser/test_tab.py',
     #  'browser/tab.py'),
+    ('tests/unit/browser/test_urlmarks.py',
+     'browser/urlmarks.py'),
 
     ('tests/unit/keyinput/test_basekeyparser.py',
      'keyinput/basekeyparser.py'),

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -38,10 +38,6 @@ Feature: Using completion
         When I run :set-cmd-text -s :help
         Then the completion model should be helptopic
 
-    Scenario: Using quickmark completion
-        When I run :set-cmd-text -s :quickmark-load
-        Then the completion model should be quickmark
-
     Scenario: Using bookmark completion
         When I run :set-cmd-text -s :bookmark-load
         Then the completion model should be bookmark

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -115,8 +115,3 @@ Feature: Opening pages
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/9.txt
-
-    Scenario: Opening a quickmark
-        When I run :quickmark-add http://localhost:(port)/data/numbers/10.txt quickmarktest
-        And I run :open quickmarktest
-        Then data/numbers/10.txt should be loaded

--- a/tests/end2end/features/private.feature
+++ b/tests/end2end/features/private.feature
@@ -139,11 +139,11 @@ Feature: Using private browsing
         And I run :jseval localStorage.qute_private_test
         Then "No output or error" should be logged
 
-    Scenario: Opening quickmark in private window
+    Scenario: Opening bookmark in private window
         When I open data/numbers/1.txt in a private window
         And I run :window-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/2.txt two
-        And I run :quickmark-load two
+        And I run :bookmark-add http://localhost:(port)/data/numbers/2.txt two
+        And I run :bookmark-load http://localhost:(port)/data/numbers/2.txt 
         And I wait until data/numbers/2.txt is loaded
         Then the session should look like:
             windows:

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -100,6 +100,7 @@ Feature: Prompts
         Then the javascript message "Alert done" should be logged
         And the javascript message "notification permission granted" should be logged
 
+    # TODO: what can we use other than quickmark-save here?
     @qtwebengine_todo: Notifications are not implemented in QtWebEngine
     Scenario: Async question interrupted by async one
         When I set content.notifications to ask
@@ -398,6 +399,7 @@ Feature: Prompts
         Then the javascript message "confirm reply: false" should be logged
         And qutebrowser should quit
 
+    # TODO: what can I use instead of quickmark-save?
     Scenario: Using :prompt-open-download with a prompt which does not support it
         When I open data/hello.txt
         And I run :quickmark-save

--- a/tests/end2end/features/test_urlmarks_bdd.py
+++ b/tests/end2end/features/test_urlmarks_bdd.py
@@ -54,7 +54,7 @@ def _check_marks(quteproc, quickmarks, expected, contains):
     assert matched_line == contains, lines
 
 
-@bdd.then(bdd.parsers.parse('the bookmark file should contain "{line}"'))
+@bdd.then(bdd.parsers.parse("the bookmark file should contain '{line}'"))
 def bookmark_file_contains(quteproc, line):
     _check_marks(quteproc, quickmarks=False, expected=line, contains=True)
 

--- a/tests/end2end/features/test_urlmarks_bdd.py
+++ b/tests/end2end/features/test_urlmarks_bdd.py
@@ -26,19 +26,14 @@ from helpers import utils
 bdd.scenarios('urlmarks.feature')
 
 
-def _check_marks(quteproc, quickmarks, expected, contains):
+def _check_marks(quteproc, expected, contains):
     """Make sure the given line does (not) exist in the bookmarks.
 
     Args:
-        quickmarks: True to check the quickmarks file instead of bookmarks.
         expected: The line to search for.
         contains: True if the line should be there, False otherwise.
     """
-    if quickmarks:
-        mark_file = os.path.join(quteproc.basedir, 'config', 'quickmarks')
-    else:
-        mark_file = os.path.join(quteproc.basedir, 'config', 'bookmarks',
-                                 'urls')
+    mark_file = os.path.join(quteproc.basedir, 'config', 'bookmarks', 'urls')
 
     quteproc.clear_data()  # So we don't match old messages
     quteproc.send_cmd(':save')
@@ -56,19 +51,9 @@ def _check_marks(quteproc, quickmarks, expected, contains):
 
 @bdd.then(bdd.parsers.parse("the bookmark file should contain '{line}'"))
 def bookmark_file_contains(quteproc, line):
-    _check_marks(quteproc, quickmarks=False, expected=line, contains=True)
+    _check_marks(quteproc, expected=line, contains=True)
 
 
 @bdd.then(bdd.parsers.parse('the bookmark file should not contain "{line}"'))
 def bookmark_file_does_not_contain(quteproc, line):
-    _check_marks(quteproc, quickmarks=False, expected=line, contains=False)
-
-
-@bdd.then(bdd.parsers.parse('the quickmark file should contain "{line}"'))
-def quickmark_file_contains(quteproc, line):
-    _check_marks(quteproc, quickmarks=True, expected=line, contains=True)
-
-
-@bdd.then(bdd.parsers.parse('the quickmark file should not contain "{line}"'))
-def quickmark_file_does_not_contain(quteproc, line):
-    _check_marks(quteproc, quickmarks=True, expected=line, contains=False)
+    _check_marks(quteproc, expected=line, contains=False)

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -22,27 +22,22 @@ Feature: Bookmarks
         Then the error "Invalid URL *" should be shown
 
     Scenario: Saving a duplicate bookmark
-        Given I have a fresh instance
-        When I open data/title.html
-        And I run :bookmark-add
-        And I run :bookmark-add
+        When I run :bookmark-add data/numbers/10.txt Ten
+        And I run :bookmark-add data/numbers/10.txt Ten
         Then the error "Bookmark already exists!" should be shown
 
     Scenario: Tagging a bookmark
-        Given I have a fresh instance
-        When I run :bookmark-add http://example.com Example
-        And I run :bookmark-tag http://example.com foo bar
-        Then the bookmark file should contain '{"url": "http://example.com", "title": "Example", "tags": ["foo", "bar"]}'
+        When I run :bookmark-add data/numbers/11.txt Eleven
+        And I run :bookmark-tag data/numbers/11.txt foo bar
+        Then the bookmark file should contain '{"url": "data/numbers/11.txt", "title": "Eleven", "tags": ["foo", "bar"]}'
 
     Scenario: Removing tags from a bookmark
-        Given I have a fresh instance
-        When I run :bookmark-add http://example.com Example
-        And I run :bookmark-tag http://example.com foo bar baz
-        And I run :bookmark-tag http://example.com -r foo baz
-        Then the bookmark file should contain '{"url": "http://example.com", "title": "Example", "tags": ["bar"]}'
+        When I run :bookmark-add data/numbers/12.txt Twelve
+        And I run :bookmark-tag data/numbers/12.txt foo bar baz
+        And I run :bookmark-tag data/numbers/12.txt -r foo baz
+        Then the bookmark file should contain '{"url": "data/numbers/12.txt", "title": "Twelve", "tags": ["bar"]}'
 
     Scenario: Loading a bookmark
-        Given I have a fresh instance
         When I run :tab-only
         And I run :bookmark-add http://localhost:(port)/data/numbers/1.txt Example
         And I run :bookmark-tag http://localhost:(port)/data/numbers/1.txt one
@@ -133,8 +128,6 @@ Feature: Bookmarks
         Then the bookmark file should not contain "http://localhost:*/data/numbers/9.txt "
 
     Scenario: Listing bookmarks
-        Given I have a fresh instance
-        When I open data/title.html in a new tab
-        And I run :bookmark-add
+        When I run :bookmark-add data/numbers/13.txt "Test title Thirteen"
         And I open qute://bookmarks
-        Then the page should contain the plaintext "Test title"
+        Then the page should contain the plaintext "Test title Thirteen"

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -8,12 +8,12 @@ Feature: quickmarks and bookmarks
         When I open data/title.html
         And I run :bookmark-add
         Then the message "Bookmarked http://localhost:*/data/title.html" should be shown
-        And the bookmark file should contain "http://localhost:*/data/title.html Test title"
+        And the bookmark file should contain '{"url": "http://localhost:*/data/title.html", "title": "Test title", "tags": []}'
 
     Scenario: Saving a bookmark with a provided url and title
         When I run :bookmark-add http://example.com "some example title"
         Then the message "Bookmarked http://example.com" should be shown
-        And the bookmark file should contain "http://example.com some example title"
+        And the bookmark file should contain '{"url": "http://example.com", "title": "some example title", "tags": []}'
 
     Scenario: Saving a bookmark with a url but no title
         When I run :bookmark-add http://example.com

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -43,8 +43,11 @@ Feature: Bookmarks
         Then the bookmark file should contain '{"url": "http://example.com", "title": "Example", "tags": ["bar"]}'
 
     Scenario: Loading a bookmark
+        Given I have a fresh instance
         When I run :tab-only
-        And I run :bookmark-load http://localhost:(port)/data/numbers/1.txt
+        And I run :bookmark-add http://localhost:(port)/data/numbers/1.txt Example
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/1.txt one
+        And I run :bookmark-load one
         Then data/numbers/1.txt should be loaded
         And the following tabs should be open:
             - data/numbers/1.txt (active)
@@ -52,7 +55,9 @@ Feature: Bookmarks
     Scenario: Loading a bookmark in a new tab
         Given I open about:blank
         When I run :tab-only
-        And I run :bookmark-load -t http://localhost:(port)/data/numbers/2.txt
+        And I run :bookmark-add http://localhost:(port)/data/numbers/2.txt Example
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/2.txt two
+        And I run :bookmark-load -t two
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
             - about:blank
@@ -61,7 +66,9 @@ Feature: Bookmarks
     Scenario: Loading a bookmark in a background tab
         Given I open about:blank
         When I run :tab-only
-        And I run :bookmark-load -b http://localhost:(port)/data/numbers/3.txt
+        And I run :bookmark-add http://localhost:(port)/data/numbers/3.txt Example
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/3.txt three
+        And I run :bookmark-load -b three
         Then data/numbers/3.txt should be loaded
         And the following tabs should be open:
             - about:blank (active)
@@ -70,7 +77,9 @@ Feature: Bookmarks
     Scenario: Loading a bookmark in a new window
         Given I open about:blank
         When I run :tab-only
-        And I run :bookmark-load -w http://localhost:(port)/data/numbers/4.txt
+        And I run :bookmark-add http://localhost:(port)/data/numbers/4.txt Example
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/4.txt four
+        And I run :bookmark-load -w four
         And I wait until data/numbers/4.txt is loaded
         Then the session should look like:
             windows:
@@ -86,7 +95,11 @@ Feature: Bookmarks
                   url: http://localhost:*/data/numbers/4.txt
 
     Scenario: Loading a bookmark with -t and -b
-        When I run :bookmark-load -t -b about:blank
+        Given I open about:blank
+        When I run :tab-only
+        And I run :bookmark-add http://localhost:(port)/data/numbers/5.txt Example
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/5.txt five
+        And I run :bookmark-load -t -b five
         Then the error "Only one of -t/-b/-w/-p can be given!" should be shown
 
     Scenario: Deleting a bookmark which does not exist
@@ -94,10 +107,9 @@ Feature: Bookmarks
         Then the error "Bookmark 'doesnotexist' not found!" should be shown
 
     Scenario: Deleting a bookmark
-        When I open data/numbers/5.txt
-        And I run :bookmark-add
-        And I run :bookmark-del http://localhost:(port)/data/numbers/5.txt
-        Then the bookmark file should not contain "http://localhost:*/data/numbers/5.txt "
+        When I run :bookmark-add data/numbers/6.txt six
+        And I run :bookmark-del http://localhost:(port)/data/numbers/6.txt
+        Then the bookmark file should not contain "http://localhost:*/data/numbers/6.txt "
 
     Scenario: Deleting the current page's bookmark if it doesn't exist
         When I open data/hello.txt
@@ -105,21 +117,21 @@ Feature: Bookmarks
         Then the error "Bookmark 'http://localhost:(port)/data/hello.txt' not found!" should be shown
 
     Scenario: Deleting the current page's bookmark
-        When I open data/numbers/6.txt
-        And I run :bookmark-add
-        And I run :bookmark-del
-        Then the bookmark file should not contain "http://localhost:*/data/numbers/6.txt "
-
-    Scenario: Toggling a bookmark
         When I open data/numbers/7.txt
         And I run :bookmark-add
-        And I run :bookmark-add --toggle
+        And I run :bookmark-del
         Then the bookmark file should not contain "http://localhost:*/data/numbers/7.txt "
 
-    Scenario: Loading a bookmark with --delete
-        When I run :bookmark-add http://localhost:(port)/data/numbers/8.txt "eight"
-        And I run :bookmark-load -d http://localhost:(port)/data/numbers/8.txt
+    Scenario: Toggling a bookmark
+        When I open data/numbers/8.txt
+        And I run :bookmark-add
+        And I run :bookmark-add --toggle
         Then the bookmark file should not contain "http://localhost:*/data/numbers/8.txt "
+
+    Scenario: Loading a bookmark with --delete
+        When I run :bookmark-add http://localhost:(port)/data/numbers/9.txt "nine"
+        And I run :bookmark-load -d http://localhost:(port)/data/numbers/9.txt
+        Then the bookmark file should not contain "http://localhost:*/data/numbers/9.txt "
 
     Scenario: Listing bookmarks
         Given I have a fresh instance

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -103,7 +103,13 @@ Feature: Bookmarks
     Scenario: Deleting a bookmark
         When I run :bookmark-add data/numbers/6.txt six
         And I run :bookmark-del http://localhost:(port)/data/numbers/6.txt
-        Then the bookmark file should not contain "http://localhost:*/data/numbers/6.txt "
+        Then the bookmark file should not contain "http://localhost:*/data/numbers/6.txt"
+
+    Scenario: Purge a bookmark by tag removal
+        When I run :bookmark-add data/numbers/13.txt title
+        When I run :bookmark-tag data/numbers/13.txt thirteen
+        And I run :bookmark-tag data/numbers/13.txt -R thirteen
+        Then the bookmark file should not contain "*data/numbers/13.txt*"
 
     Scenario: Deleting the current page's bookmark if it doesn't exist
         When I open data/hello.txt

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -29,6 +29,19 @@ Feature: Bookmarks
         And I run :bookmark-add
         Then the error "Bookmark already exists!" should be shown
 
+    Scenario: Tagging a bookmark
+        Given I have a fresh instance
+        When I run :bookmark-add http://example.com Example
+        And I run :bookmark-tag http://example.com foo bar
+        Then the bookmark file should contain '{"url": "http://example.com", "title": "Example", "tags": ["foo", "bar"]}'
+
+    Scenario: Removing tags from a bookmark
+        Given I have a fresh instance
+        When I run :bookmark-add http://example.com Example
+        And I run :bookmark-tag http://example.com foo bar baz
+        And I run :bookmark-tag http://example.com -r foo baz
+        Then the bookmark file should contain '{"url": "http://example.com", "title": "Example", "tags": ["bar"]}'
+
     Scenario: Loading a bookmark
         When I run :tab-only
         And I run :bookmark-load http://localhost:(port)/data/numbers/1.txt

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -18,6 +18,11 @@ Feature: Bookmarks
         Then the message "Bookmarked data/numbers/14.txt" should be shown
         And the bookmark file should contain '{"url": "data/numbers/14.txt", "title": "", "tags": ["one", "two"]}'
 
+    Scenario: Saving a bookmark with a non-unique tag and --unique
+        When I run :bookmark-tag data/numbers/15.txt one
+        And I run :bookmark-tag data/numbers/16.txt --unique one
+        Then the error "['one'] are not unique" should be shown
+
     Scenario: Saving a bookmark with a url but no title
         When I run :bookmark-add http://example.com
         Then the error "Title must be provided if url has been provided" should be shown

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -78,6 +78,19 @@ Feature: Bookmarks
             - about:blank (active)
             - data/numbers/3.txt
 
+    Scenario: Loading multiple bookmarks in tabs
+        Given I open about:blank
+        When I run :tab-only
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/17.txt multi
+        And I run :bookmark-tag http://localhost:(port)/data/numbers/18.txt multi
+        And I run :bookmark-load -at multi
+        Then data/numbers/17.txt should be loaded
+        And data/numbers/18.txt should be loaded
+        And the following tabs should be open:
+            - about:blank
+            - data/numbers/18.txt
+            - data/numbers/17.txt (active)
+
     Scenario: Loading a bookmark in a new window
         Given I open about:blank
         When I run :tab-only

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -1,8 +1,6 @@
 # vim: ft=cucumber fileencoding=utf-8 sts=4 sw=4 et:
 
-Feature: quickmarks and bookmarks
-
-    ## bookmarks
+Feature: Bookmarks
 
     Scenario: Saving a bookmark
         When I open data/title.html
@@ -110,126 +108,8 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-load -d http://localhost:(port)/data/numbers/8.txt
         Then the bookmark file should not contain "http://localhost:*/data/numbers/8.txt "
 
-    ## quickmarks
-
-    Scenario: Saving a quickmark (:quickmark-add)
-        When I run :quickmark-add http://localhost:(port)/data/numbers/9.txt nine
-        Then the quickmark file should contain "nine http://localhost:*/data/numbers/9.txt"
-
-    Scenario: Saving a quickmark (:quickmark-save)
-        When I open data/numbers/10.txt
-        And I run :quickmark-save
-        And I wait for "Entering mode KeyMode.prompt (reason: question asked)" in the log
-        And I press the keys "ten"
-        And I press the keys "<Enter>"
-        Then the quickmark file should contain "ten http://localhost:*/data/numbers/10.txt"
-
-    Scenario: Saving a duplicate quickmark (without override)
-        When I run :quickmark-add http://localhost:(port)/data/numbers/11.txt eleven
-        And I run :quickmark-add http://localhost:(port)/data/numbers/11_2.txt eleven
-        And I wait for "Entering mode KeyMode.yesno (reason: question asked)" in the log
-        And I run :prompt-accept no
-        Then the quickmark file should contain "eleven http://localhost:*/data/numbers/11.txt"
-
-    Scenario: Saving a duplicate quickmark (with override)
-        When I run :quickmark-add http://localhost:(port)/data/numbers/12.txt twelve
-        And I run :quickmark-add http://localhost:(port)/data/numbers/12_2.txt twelve
-        And I wait for "Entering mode KeyMode.yesno (reason: question asked)" in the log
-        And I run :prompt-accept yes
-        Then the quickmark file should contain "twelve http://localhost:*/data/numbers/12_2.txt"
-
-    Scenario: Adding a quickmark with an empty name
-        When I run :quickmark-add about:blank ""
-        Then the error "Can't set mark with empty name!" should be shown
-
-    Scenario: Adding a quickmark with an empty URL
-        When I run :quickmark-add "" foo
-        Then the error "Can't set mark with empty URL!" should be shown
-
-    Scenario: Loading a quickmark
-        Given I have a fresh instance
-        When I run :quickmark-add http://localhost:(port)/data/numbers/13.txt thirteen
-        And I run :quickmark-load thirteen
-        Then data/numbers/13.txt should be loaded
-        And the following tabs should be open:
-            - data/numbers/13.txt (active)
-
-    Scenario: Loading a quickmark in a new tab
-        Given I open about:blank
-        When I run :tab-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/14.txt fourteen
-        And I run :quickmark-load -t fourteen
-        Then data/numbers/14.txt should be loaded
-        And the following tabs should be open:
-            - about:blank
-            - data/numbers/14.txt (active)
-
-    Scenario: Loading a quickmark in a background tab
-        Given I open about:blank
-        When I run :tab-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/15.txt fifteen
-        And I run :quickmark-load -b fifteen
-        Then data/numbers/15.txt should be loaded
-        And the following tabs should be open:
-            - about:blank (active)
-            - data/numbers/15.txt
-
-    Scenario: Loading a quickmark in a new window
-        Given I open about:blank
-        When I run :tab-only
-        And I run :quickmark-add http://localhost:(port)/data/numbers/16.txt sixteen
-        And I run :quickmark-load -w sixteen
-        And I wait until data/numbers/16.txt is loaded
-        Then the session should look like:
-            windows:
-            - tabs:
-              - active: true
-                history:
-                - active: true
-                  url: about:blank
-            - tabs:
-              - active: true
-                history:
-                - active: true
-                  url: http://localhost:*/data/numbers/16.txt
-
-    Scenario: Loading a quickmark which does not exist
-        When I run :quickmark-load -b doesnotexist
-        Then the error "Quickmark 'doesnotexist' does not exist!" should be shown
-
-    Scenario: Loading a quickmark with -t and -b
-        When I run :quickmark-add http://localhost:(port)/data/numbers/17.txt seventeen
-        When I run :quickmark-load -t -b seventeen
-        Then the error "Only one of -t/-b/-w/-p can be given!" should be shown
-
-    Scenario: Deleting a quickmark which does not exist
-        When I run :quickmark-del doesnotexist
-        Then the error "Quickmark 'doesnotexist' not found!" should be shown
-
-    Scenario: Deleting a quickmark
-        When I run :quickmark-add http://localhost:(port)/data/numbers/18.txt eighteen
-        And I run :quickmark-del eighteen
-        Then the quickmark file should not contain "eighteen http://localhost:*/data/numbers/18.txt "
-
-    Scenario: Deleting the current page's quickmark if it has none
-        When I open data/hello.txt
-        And I run :quickmark-del
-        Then the error "Quickmark for 'http://localhost:(port)/data/hello.txt' not found!" should be shown
-
-    Scenario: Deleting the current page's quickmark
-        When I open data/numbers/19.txt
-        And I run :quickmark-add http://localhost:(port)/data/numbers/19.txt nineteen
-        And I run :quickmark-del
-        Then the quickmark file should not contain "nineteen http://localhost:*/data/numbers/19.txt"
-
-    Scenario: Listing quickmarks
-        When I run :quickmark-add http://localhost:(port)/data/numbers/20.txt twenty
-        And I run :quickmark-add http://localhost:(port)/data/numbers/21.txt twentyone
-        And I open qute://bookmarks
-        Then the page should contain the plaintext "twenty"
-        And the page should contain the plaintext "twentyone"
-
     Scenario: Listing bookmarks
+        Given I have a fresh instance
         When I open data/title.html in a new tab
         And I run :bookmark-add
         And I open qute://bookmarks

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -18,9 +18,8 @@ Feature: Bookmarks
         Then the error "Title must be provided if url has been provided" should be shown
 
     Scenario: Saving a bookmark with an invalid url
-        When I set url.auto_search to never
-        And I run :bookmark-add foo! "some example title"
-        Then the error "Invalid URL" should be shown
+        When I run :bookmark-add "ht tp://example.com" "some example title"
+        Then the error "Invalid URL *" should be shown
 
     Scenario: Saving a duplicate bookmark
         Given I have a fresh instance

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -13,6 +13,11 @@ Feature: Bookmarks
         Then the message "Bookmarked http://example.com" should be shown
         And the bookmark file should contain '{"url": "http://example.com", "title": "some example title", "tags": []}'
 
+    Scenario: Saving a bookmark with tags
+        When I run :bookmark-tag data/numbers/14.txt one two
+        Then the message "Bookmarked data/numbers/14.txt" should be shown
+        And the bookmark file should contain '{"url": "data/numbers/14.txt", "title": "", "tags": ["one", "two"]}'
+
     Scenario: Saving a bookmark with a url but no title
         When I run :bookmark-add http://example.com
         Then the error "Title must be provided if url has been provided" should be shown
@@ -102,8 +107,8 @@ Feature: Bookmarks
 
     Scenario: Deleting a bookmark
         When I run :bookmark-add data/numbers/6.txt six
-        And I run :bookmark-del http://localhost:(port)/data/numbers/6.txt
-        Then the bookmark file should not contain "http://localhost:*/data/numbers/6.txt"
+        And I run :bookmark-del data/numbers/6.txt
+        Then the bookmark file should not contain "*data/numbers/6.txt*"
 
     Scenario: Purge a bookmark by tag removal
         When I run :bookmark-add data/numbers/13.txt title

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -44,7 +44,7 @@ import helpers.utils
 from qutebrowser.config import (config, configdata, configtypes, configexc,
                                 configfiles)
 from qutebrowser.utils import objreg, standarddir, utils
-from qutebrowser.browser import greasemonkey
+from qutebrowser.browser import greasemonkey, urlmarks
 from qutebrowser.browser.webkit import cookies
 from qutebrowser.misc import savemanager, sql
 from qutebrowser.keyinput import modeman
@@ -286,11 +286,12 @@ def quickmark_manager_stub(stubs):
 
 
 @pytest.fixture
-def bookmark_manager_stub(stubs):
-    """Fixture which provides a fake bookmark manager object."""
-    stub = stubs.BookmarkManagerStub()
-    objreg.register('bookmark-manager', stub)
-    yield stub
+def bookmark_manager_mock():
+    """Fixture which provides a mocked bookmark manager object."""
+    m = unittest.mock.Mock(spec=urlmarks.BookmarkManager)
+    m.__iter__ = unittest.mock.Mock(return_value=iter([]))
+    objreg.register('bookmark-manager', m)
+    yield m
     objreg.delete('bookmark-manager')
 
 

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -277,15 +277,6 @@ def host_blocker_stub(stubs):
 
 
 @pytest.fixture
-def quickmark_manager_stub(stubs):
-    """Fixture which provides a fake quickmark manager object."""
-    stub = stubs.QuickmarkManagerStub()
-    objreg.register('quickmark-manager', stub)
-    yield stub
-    objreg.delete('quickmark-manager')
-
-
-@pytest.fixture
 def bookmark_manager_mock():
     """Fixture which provides a mocked bookmark manager object."""
     m = unittest.mock.Mock(spec=urlmarks.BookmarkManager)

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -427,30 +427,6 @@ class StatusBarCommandStub(QLineEdit):
         return self.text()[0]
 
 
-class UrlMarkManagerStub(QObject):
-
-    """Stub for the quickmark-manager or bookmark-manager object."""
-
-    added = pyqtSignal(str, str)
-    removed = pyqtSignal(str)
-
-    def __init__(self, parent=None):
-        super().__init__(parent)
-        self.marks = {}
-
-    def delete(self, key):
-        del self.marks[key]
-        self.removed.emit(key)
-
-
-class QuickmarkManagerStub(UrlMarkManagerStub):
-
-    """Stub for the quickmark-manager object."""
-
-    def quickmark_del(self, key):
-        self.delete(key)
-
-
 class HostBlockerStub:
 
     """Stub for the host-blocker object."""

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -443,13 +443,6 @@ class UrlMarkManagerStub(QObject):
         self.removed.emit(key)
 
 
-class BookmarkManagerStub(UrlMarkManagerStub):
-
-    """Stub for the bookmark-manager object."""
-
-    pass
-
-
 class QuickmarkManagerStub(UrlMarkManagerStub):
 
     """Stub for the quickmark-manager object."""

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -100,6 +100,15 @@ class TestBookmarkTag:
         bookmark_manager_mock.tag.assert_called_with(
             QUrl('http://example.com'),
             ('bar', 'baz'),
+            unique=False,
+        )
+
+    def test_tag_unique(self, command_dispatcher, bookmark_manager_mock):
+        command_dispatcher.bookmark_tag('http://example.com', 'a', unique=True)
+        bookmark_manager_mock.tag.assert_called_with(
+            QUrl('http://example.com'),
+            ('a',),
+            unique=True,
         )
 
     def test_tag_remove(self, command_dispatcher, bookmark_manager_mock):

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -53,7 +53,7 @@ class TestBookmarkAdd:
     def test_add(self, command_dispatcher, bookmark_manager_mock):
         command_dispatcher.bookmark_add('example.com', 'Example Site')
         bookmark_manager_mock.add.assert_called_with(
-            QUrl('example.com'), 'Example Site', [], toggle=False)
+            QUrl('example.com'), 'Example Site', toggle=False)
 
     def test_no_url_or_title(self, command_dispatcher, tabbed_browser,
                              bookmark_manager_mock, current_tab):
@@ -61,7 +61,7 @@ class TestBookmarkAdd:
         tabbed_browser.current_url.return_value = QUrl('example.com')
         command_dispatcher.bookmark_add()
         bookmark_manager_mock.add.assert_called_with(
-            QUrl('example.com'), 'Example Site', [], toggle=False)
+            QUrl('example.com'), 'Example Site', toggle=False)
 
     def test_no_title(self, command_dispatcher, tabbed_browser,
                       bookmark_manager_mock):
@@ -81,7 +81,7 @@ class TestBookmarkAdd:
         command_dispatcher.bookmark_add('example.com', 'Example Site',
                                         toggle=True)
         bookmark_manager_mock.add.assert_called_with(
-            QUrl('example.com'), 'Example Site', [], toggle=True)
+            QUrl('example.com'), 'Example Site', toggle=True)
         assert message_mock.getmsg().text == 'Bookmarked example.com'
 
     def test_toggle_off(self, command_dispatcher, bookmark_manager_mock,
@@ -90,7 +90,7 @@ class TestBookmarkAdd:
         command_dispatcher.bookmark_add('example.com', 'Example Site',
                                         toggle=True)
         bookmark_manager_mock.add.assert_called_with(
-            QUrl('example.com'), 'Example Site', [], toggle=True)
+            QUrl('example.com'), 'Example Site', toggle=True)
         assert message_mock.getmsg().text == 'Removed bookmark example.com'
 
 
@@ -100,7 +100,7 @@ class TestBookmarkTag:
         bookmark_manager_mock.add.side_effect = urlmarks.AlreadyExistsError()
         command_dispatcher.bookmark_tag('http://example.com', 'bar', 'baz')
         bookmark_manager_mock.add.assert_called_once_with(
-            QUrl('http://example.com'), '', [],
+            QUrl('http://example.com'), '',
         )
         bookmark_manager_mock.tag.assert_called_once_with(
             QUrl('http://example.com'),
@@ -111,7 +111,7 @@ class TestBookmarkTag:
     def test_tag_new(self, command_dispatcher, bookmark_manager_mock):
         command_dispatcher.bookmark_tag('http://example.com', 'bar', 'baz')
         bookmark_manager_mock.add.assert_called_once_with(
-            QUrl('http://example.com'), '', [],
+            QUrl('http://example.com'), '',
         )
         bookmark_manager_mock.tag.assert_called_once_with(
             QUrl('http://example.com'),

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -111,12 +111,19 @@ class TestBookmarkTag:
             unique=True,
         )
 
-    def test_tag_remove(self, command_dispatcher, bookmark_manager_mock):
+    @pytest.mark.parametrize('remove, purge', [
+        (True, False),
+        (True, True),
+        (False, True),
+    ])
+    def test_tag_remove(self, command_dispatcher, bookmark_manager_mock,
+                        remove, purge):
         command_dispatcher.bookmark_tag('http://example.com', 'bar', 'baz',
-                                        remove=True)
+                                        remove=remove, purge=purge)
         bookmark_manager_mock.untag.assert_called_with(
             QUrl('http://example.com'),
             ('bar', 'baz'),
+            purge=purge,
         )
 
     def test_error(self, command_dispatcher, bookmark_manager_mock):

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -31,13 +31,13 @@ pytestmark = pytest.mark.usefixtures('redirect_webengine_data')
 
 @pytest.fixture
 def tabbed_browser():
-    return mock.Mock(spec=tabbedbrowser.TabbedBrowser)
+    return mock.Mock(autospec=tabbedbrowser.TabbedBrowser)
 
 
 @pytest.fixture
 def current_tab(tabbed_browser):
         tab = mock.Mock(spec=browsertab.AbstractTab)
-        tabbed_browser.currentWidget.return_value = tab
+        tabbed_browser.widget.currentWidget.return_value = tab
         return tab
 
 

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -1,0 +1,85 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2018 Ryan Roden-Corrent (rcorre) <ryan@rcorre.net>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest import mock
+
+from PyQt5.QtCore import QUrl
+
+import pytest
+
+from qutebrowser.commands import cmdexc
+from qutebrowser.browser import commands, urlmarks
+from qutebrowser.mainwindow import tabbedbrowser
+
+pytestmark = pytest.mark.usefixtures('redirect_webengine_data')
+
+@pytest.fixture
+def tabbed_browser():
+    return mock.Mock(spec=tabbedbrowser.TabbedBrowser)
+
+@pytest.fixture
+def command_dispatcher(tabbed_browser, config_stub):
+    config_stub.auto_search = 'never'
+    return commands.CommandDispatcher(0, tabbed_browser)
+
+
+class TestBookmarkAdd:
+
+    def test_add(self, command_dispatcher, bookmark_manager_mock):
+        command_dispatcher.bookmark_add('example.com', 'Example Site')
+        bookmark_manager_mock.add.assert_called_with(
+            QUrl('http://example.com'), 'Example Site', [], toggle=False)
+
+    def test_no_url_or_title(self, command_dispatcher, tabbed_browser,
+                             bookmark_manager_mock):
+        tab = mock.Mock()
+        tab.title.return_value = 'Example Site'
+        tabbed_browser.currentWidget.return_value = tab
+        tabbed_browser.current_url.return_value = QUrl('example.com')
+        command_dispatcher.bookmark_add()
+        bookmark_manager_mock.add.assert_called_with(
+            QUrl('example.com'), 'Example Site', [], toggle=False)
+
+    def test_no_title(self, command_dispatcher, tabbed_browser,
+                      bookmark_manager_mock):
+        with pytest.raises(cmdexc.CommandError) as excinfo:
+            command_dispatcher.bookmark_add('example.com')
+        assert str(excinfo.value) == \
+            'Title must be provided if url has been provided'
+
+    def test_dupe(self, command_dispatcher, bookmark_manager_mock):
+        bookmark_manager_mock.add.side_effect = urlmarks.AlreadyExistsError
+        with pytest.raises(cmdexc.CommandError):
+            command_dispatcher.bookmark_add('example.com', 'Example Site')
+
+    def test_toggle_on(self, command_dispatcher, bookmark_manager_mock,
+                       message_mock):
+        bookmark_manager_mock.add.return_value = True
+        command_dispatcher.bookmark_add('example.com', 'Example Site', toggle=True)
+        bookmark_manager_mock.add.assert_called_with(
+            QUrl('http://example.com'), 'Example Site', [], toggle=True)
+        assert message_mock.getmsg().text == 'Bookmarked http://example.com'
+
+    def test_toggle_off(self, command_dispatcher, bookmark_manager_mock,
+                        message_mock):
+        bookmark_manager_mock.add.return_value = False
+        command_dispatcher.bookmark_add('example.com', 'Example Site', toggle=True)
+        bookmark_manager_mock.add.assert_called_with(
+            QUrl('http://example.com'), 'Example Site', [], toggle=True)
+        assert message_mock.getmsg().text == 'Removed bookmark http://example.com'

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -29,6 +29,7 @@ from qutebrowser.mainwindow import tabbedbrowser
 
 pytestmark = pytest.mark.usefixtures('redirect_webengine_data')
 
+
 @pytest.fixture
 def tabbed_browser():
     return mock.Mock(autospec=tabbedbrowser.TabbedBrowser)
@@ -36,9 +37,9 @@ def tabbed_browser():
 
 @pytest.fixture
 def current_tab(tabbed_browser):
-        tab = mock.Mock(spec=browsertab.AbstractTab)
-        tabbed_browser.widget.currentWidget.return_value = tab
-        return tab
+    tab = mock.Mock(spec=browsertab.AbstractTab)
+    tabbed_browser.widget.currentWidget.return_value = tab
+    return tab
 
 
 @pytest.fixture
@@ -173,7 +174,7 @@ class TestBookmarkLoad:
     @pytest.mark.parametrize('open_all', [True, False])
     @pytest.mark.parametrize('delete', [True, False])
     def test_tab(self, command_dispatcher, bookmark_manager_mock,
-                      tabbed_browser, in_args, out_args, open_all, delete):
+                 tabbed_browser, in_args, out_args, open_all, delete):
         bookmark_manager_mock.get_tagged.return_value = [
             urlmarks.Bookmark(url='example.com/1', title='', tags=[]),
             urlmarks.Bookmark(url='example.com/2', title='', tags=[]),
@@ -195,7 +196,7 @@ class TestBookmarkLoad:
                     mock.call('example.com/1'),
                     mock.call('example.com/2'),
                     mock.call('example.com/3'),
-            ])
+                ])
         else:
             tabbed_browser.tabopen.assert_called_once_with(
                 QUrl('example.com/1'), **out_args,
@@ -207,7 +208,7 @@ class TestBookmarkLoad:
 
     @pytest.mark.parametrize('private', [True, False])
     def test_window(self, command_dispatcher, bookmark_manager_mock,
-                         mocker, tabbed_browser, private):
+                    mocker, tabbed_browser, private):
         tabbed_browser.private = private
         m = mocker.patch('qutebrowser.browser.commands.mainwindow.MainWindow')
         bookmark_manager_mock.get_tagged.return_value = [

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -130,3 +130,104 @@ class TestBookmarkTag:
                 'Bookmark http://example.com does not exist'
         bookmark_manager_mock.get.assert_called_with(
             QUrl('http://example.com'))
+
+
+class TestBookmarkLoad:
+
+    def test_no_tags(self, command_dispatcher):
+        with pytest.raises(cmdexc.CommandError) as excinfo:
+            command_dispatcher.bookmark_load()
+        assert str(excinfo.value) == 'No tags provided'
+
+    @pytest.mark.parametrize('delete', [True, False])
+    def test_open(self, command_dispatcher, bookmark_manager_mock,
+                  tabbed_browser, delete):
+        tab = mock.Mock()
+        tabbed_browser.currentWidget.return_value = tab
+        bookmark_manager_mock.get_tagged.return_value = [
+            urlmarks.Bookmark(url='example.com/1', title='', tags=[]),
+            urlmarks.Bookmark(url='example.com/2', title='', tags=[]),
+        ]
+
+        command_dispatcher.bookmark_load('foo', delete=delete)
+
+        bookmark_manager_mock.get_tagged.assert_called_once_with(('foo',))
+        tab.openurl.assert_called_once_with(QUrl('example.com/1'))
+
+        if delete:
+            bookmark_manager_mock.delete.assert_called_once_with(
+                'example.com/1'
+            )
+
+    @pytest.mark.parametrize('in_args, out_args', [
+        ({'tab': True}, {'background': False, 'related': False}),
+        ({'bg': True}, {'background': True, 'related': False}),
+    ])
+    @pytest.mark.parametrize('open_all', [True, False])
+    @pytest.mark.parametrize('delete', [True, False])
+    def test_open_tab(self, command_dispatcher, bookmark_manager_mock,
+                      tabbed_browser, in_args, out_args, open_all, delete):
+        bookmark_manager_mock.get_tagged.return_value = [
+            urlmarks.Bookmark(url='example.com/1', title='', tags=[]),
+            urlmarks.Bookmark(url='example.com/2', title='', tags=[]),
+            urlmarks.Bookmark(url='example.com/3', title='', tags=[]),
+        ]
+
+        command_dispatcher.bookmark_load('foo', open_all=open_all,
+                                         delete=delete, **in_args)
+
+        bookmark_manager_mock.get_tagged.assert_called_once_with(('foo',))
+        if open_all:
+            tabbed_browser.tabopen.assert_has_calls([
+                mock.call(QUrl('example.com/1'), **out_args),
+                mock.call(QUrl('example.com/2'), **out_args),
+                mock.call(QUrl('example.com/3'), **out_args),
+            ])
+            if delete:
+                bookmark_manager_mock.delete.assert_has_calls([
+                    mock.call('example.com/1'),
+                    mock.call('example.com/2'),
+                    mock.call('example.com/3'),
+            ])
+        else:
+            tabbed_browser.tabopen.assert_called_once_with(
+                QUrl('example.com/1'), **out_args,
+            )
+            if delete:
+                bookmark_manager_mock.delete.assert_called_once_with(
+                    'example.com/1'
+                )
+
+    @pytest.mark.parametrize('private', [True, False])
+    def test_open_window(self, command_dispatcher, bookmark_manager_mock,
+                         mocker, tabbed_browser, private):
+        tabbed_browser.private = private
+        m = mocker.patch('qutebrowser.browser.commands.mainwindow.MainWindow')
+        bookmark_manager_mock.get_tagged.return_value = [
+            urlmarks.Bookmark(url='example.com/1', title='', tags=[]),
+            urlmarks.Bookmark(url='example.com/2', title='', tags=[]),
+        ]
+
+        command_dispatcher.bookmark_load('foo', window=True)
+
+        m.assert_called_once_with(private=private)
+
+    @pytest.mark.parametrize('args', [
+        {'tab': True, 'bg': True},
+        {'tab': True, 'window': True},
+        {'bg': True, 'window': True},
+    ])
+    def test_invalid(self, command_dispatcher, bookmark_manager_mock, args):
+        bookmark_manager_mock.get_tagged.return_value = [
+            urlmarks.Bookmark(url='example.com/1', title='', tags=[])
+        ]
+
+        with pytest.raises(cmdexc.CommandError) as excinfo:
+            command_dispatcher.bookmark_load('foo', **args)
+        assert str(excinfo.value) == 'Only one of -t/-b/-w/-p can be given!'
+
+
+    def test_open_all_invalid(self, command_dispatcher):
+        with pytest.raises(cmdexc.CommandError) as excinfo:
+            command_dispatcher.bookmark_load('foo', open_all=True)
+        assert str(excinfo.value) == '-a requires one of -t/-b/-w'

--- a/tests/unit/browser/test_commands.py
+++ b/tests/unit/browser/test_commands.py
@@ -96,9 +96,24 @@ class TestBookmarkAdd:
 
 class TestBookmarkTag:
 
-    def test_tag(self, command_dispatcher, bookmark_manager_mock):
+    def test_tag_existing(self, command_dispatcher, bookmark_manager_mock):
+        bookmark_manager_mock.add.side_effect = urlmarks.AlreadyExistsError()
         command_dispatcher.bookmark_tag('http://example.com', 'bar', 'baz')
-        bookmark_manager_mock.tag.assert_called_with(
+        bookmark_manager_mock.add.assert_called_once_with(
+            QUrl('http://example.com'), '', [],
+        )
+        bookmark_manager_mock.tag.assert_called_once_with(
+            QUrl('http://example.com'),
+            ('bar', 'baz'),
+            unique=False,
+        )
+
+    def test_tag_new(self, command_dispatcher, bookmark_manager_mock):
+        command_dispatcher.bookmark_tag('http://example.com', 'bar', 'baz')
+        bookmark_manager_mock.add.assert_called_once_with(
+            QUrl('http://example.com'), '', [],
+        )
+        bookmark_manager_mock.tag.assert_called_once_with(
             QUrl('http://example.com'),
             ('bar', 'baz'),
             unique=False,

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -249,6 +249,28 @@ def test_untag(bm_file, fake_save_manager, qtbot, old, remove, new):
     assert bm.get(url).tags == new
 
 
+@pytest.mark.parametrize('old, remove, removed', [
+    (['foo'], ['foo'], True),
+    (['foo', 'bar'], ['foo', 'bar'], True),
+    (['foo', 'bar'], ['foo'], False),
+    (['foo', 'bar'], ['foo', 'bar', 'baz'], True),
+    ([], ['foo', 'bar'], True),
+])
+def test_untag_purge(bm_file, fake_save_manager, qtbot, old, remove, removed):
+    bm = urlmarks.BookmarkManager()
+    url = QUrl('http://example.com')
+    bm.add(url, 'Example Site', old)
+
+    with qtbot.wait_signal(bm.changed):
+        bm.untag(url, remove, purge=True)
+
+    if removed:
+        with pytest.raises(urlmarks.DoesNotExistError):
+            bm.get(url)
+    else:
+        bm.get(url)
+
+
 def test_invalid_url(bm_file, fake_save_manager):
     bm = urlmarks.BookmarkManager()
     url = QUrl('ht tp://example.com')

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -153,6 +153,31 @@ def test_get(bm_file, fake_save_manager, qtbot):
     assert bm.get(QUrl('http://example.com/nope')) is None
 
 
+def test_get_tagged(bm_file, fake_save_manager, qtbot):
+    bm = urlmarks.BookmarkManager()
+
+    bm.add(QUrl('http://example.com/1'), 'Example', ['foo', 'bar'])
+    bm.add(QUrl('http://example.com/2'), 'Example', ['foo', 'baz'])
+    bm.add(QUrl('http://example.com/3'), 'Example', ['foo', 'baz', 'biz'])
+    bm.add(QUrl('http://example.com/4'), 'Example', [])
+
+    assert [m.url for m in bm.get_tagged(['foo'])] == [
+        'http://example.com/3',
+        'http://example.com/2',
+        'http://example.com/1',
+    ]
+
+    assert [m.url for m in bm.get_tagged(['bar'])] == [
+        'http://example.com/1',
+    ]
+
+    assert [m.url for m in bm.get_tagged(['baz', 'biz'])] == [
+        'http://example.com/3',
+    ]
+
+    assert list(bm.get_tagged(['nope'])) == []
+
+
 def test_update(bm_file, fake_save_manager, qtbot):
     bm = urlmarks.BookmarkManager()
 

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -72,16 +72,16 @@ def test_add(bm_file, fake_save_manager, qtbot):
     with qtbot.wait_signal(bm.changed):
         bm.add(QUrl('http://example.com/notitle'), '', [])
     assert list(bm) == [
-        urlmarks.Bookmark('http://example.com', 'Example Site', []),
         urlmarks.Bookmark('http://example.com/notitle', '', []),
+        urlmarks.Bookmark('http://example.com', 'Example Site', []),
     ]
 
     with qtbot.wait_signal(bm.changed):
         bm.add(QUrl('http://example.com/tagged'), '', ['some', 'tag'])
     assert list(bm) == [
-        urlmarks.Bookmark('http://example.com', 'Example Site', []),
-        urlmarks.Bookmark('http://example.com/notitle', '', []),
         urlmarks.Bookmark('http://example.com/tagged', '', ['some', 'tag']),
+        urlmarks.Bookmark('http://example.com/notitle', '', []),
+        urlmarks.Bookmark('http://example.com', 'Example Site', []),
     ]
 
 
@@ -120,8 +120,8 @@ def test_delete(bm_file, fake_save_manager, qtbot):
     with qtbot.wait_signal(bm.changed):
         bm.delete('http://example.com/bar')
     assert list(bm) == [
-        urlmarks.Bookmark('http://example.com/foo', 'Foo', []),
         urlmarks.Bookmark('http://example.com/baz', 'Baz', []),
+        urlmarks.Bookmark('http://example.com/foo', 'Foo', []),
     ]
 
 
@@ -133,9 +133,9 @@ def test_save(bm_file, fake_save_manager, qtbot):
     bm.add(QUrl('http://example.com/tags'), '', ['a', 'b'])
     bm.save()
     assert bm_file.read().splitlines() == [
-        '{"url": "http://example.com", "title": "Example Site", "tags": []}',
-        '{"url": "http://example.com/notitle", "title": "", "tags": []}',
         '{"url": "http://example.com/tags", "title": "", "tags": ["a", "b"]}',
+        '{"url": "http://example.com/notitle", "title": "", "tags": []}',
+        '{"url": "http://example.com", "title": "Example Site", "tags": []}',
     ]
 
 
@@ -144,13 +144,13 @@ def test_get(bm_file, fake_save_manager, qtbot):
 
     bm.add(QUrl('http://example.com'), 'Example Site', ['a', 'b'])
 
-    assert bm.get('http://example.com') == urlmarks.Bookmark(
+    assert bm.get(QUrl('http://example.com')) == urlmarks.Bookmark(
         url='http://example.com',
         title='Example Site',
         tags=['a', 'b'],
     )
 
-    assert bm.get('http://example.com/nope') is None
+    assert bm.get(QUrl('http://example.com/nope')) is None
 
 
 def test_update(bm_file, fake_save_manager, qtbot):
@@ -167,4 +167,4 @@ def test_update(bm_file, fake_save_manager, qtbot):
     with qtbot.wait_signal(bm.changed):
         bm.update(newmark)
 
-    assert bm.get('http://example.com') == newmark
+    assert bm.get(QUrl('http://example.com')) == newmark

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -62,7 +62,7 @@ def test_init(bm_file, fake_save_manager):
 
 
 def test_init_empty(config_tmpdir, fake_save_manager):
-    bm = urlmarks.BookmarkManager()
+    urlmarks.BookmarkManager()
     path = config_tmpdir / 'bookmarks' / 'urls'
     path.ensure()
 
@@ -284,6 +284,7 @@ def test_invalid_url(bm_file, fake_save_manager):
     with pytest.raises(urlmarks.InvalidUrlError):
         bm.delete(url)
 
+
 def all_tags(bm_file, fake_save_manager):
     bm = urlmarks.BookmarkManager()
     bm.add('http://example.com/foo', '', [])
@@ -291,4 +292,4 @@ def all_tags(bm_file, fake_save_manager):
     bm.add('http://example.com/baz', '', ['biz', 'bar', 'baz'])
     bm.add('http://example.com/buz', '', ['buz', 'foo', 'baz'])
 
-    assert bm.all_tags == set(['foo', 'bar', 'baz', 'biz', 'buz'])
+    assert bm.all_tags == {'foo', 'bar', 'baz', 'biz', 'buz'}

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -295,17 +295,17 @@ def test_invalid_url(bm_file, fake_save_manager):
         bm.delete(url)
 
 
-def all_tags(bm_file, fake_save_manager):
+def test_all_tags(bm_file, fake_save_manager):
     bm = urlmarks.BookmarkManager()
-    bm.add('http://example.com/foo', '', [])
+    bm.add(QUrl('http://example.com/foo'), '')
 
-    bm.add('http://example.com/bar', '')
-    bm.tag('http://example.com/bar', ['bar'])
+    bm.add(QUrl('http://example.com/bar'), '')
+    bm.tag(QUrl('http://example.com/bar'), ['bar'])
 
-    bm.add('http://example.com/baz', '')
-    bm.tag('http://example.com/baz', ['biz', 'bar', 'baz'])
+    bm.add(QUrl('http://example.com/baz'), '')
+    bm.tag(QUrl('http://example.com/baz'), ['biz', 'bar', 'baz'])
 
-    bm.add('http://example.com/buz', '')
-    bm.tag('http://example.com/buz', ['buz', 'foo', 'baz'])
+    bm.add(QUrl('http://example.com/buz'), '')
+    bm.tag(QUrl('http://example.com/buz'), ['buz', 'foo', 'baz'])
 
-    assert bm.all_tags == {'foo', 'bar', 'baz', 'biz', 'buz'}
+    assert bm.all_tags() == {'foo', 'bar', 'baz', 'biz', 'buz'}

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -238,3 +238,12 @@ def test_invalid_url(bm_file, fake_save_manager):
         bm.untag(url, ['one', 'two'])
     with pytest.raises(urlmarks.InvalidUrlError):
         bm.delete(url)
+
+def all_tags(bm_file, fake_save_manager):
+    bm = urlmarks.BookmarkManager()
+    bm.add('http://example.com/foo', '', [])
+    bm.add('http://example.com/bar', '', ['bar'])
+    bm.add('http://example.com/baz', '', ['biz', 'bar', 'baz'])
+    bm.add('http://example.com/buz', '', ['buz', 'foo', 'baz'])
+
+    assert bm.all_tags == set(['foo', 'bar', 'baz', 'biz', 'buz'])

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -137,3 +137,34 @@ def test_save(bm_file, fake_save_manager, qtbot):
         '{"url": "http://example.com/notitle", "title": "", "tags": []}',
         '{"url": "http://example.com/tags", "title": "", "tags": ["a", "b"]}',
     ]
+
+
+def test_get(bm_file, fake_save_manager, qtbot):
+    bm = urlmarks.BookmarkManager()
+
+    bm.add(QUrl('http://example.com'), 'Example Site', ['a', 'b'])
+
+    assert bm.get('http://example.com') == urlmarks.Bookmark(
+        url='http://example.com',
+        title='Example Site',
+        tags=['a', 'b'],
+    )
+
+    assert bm.get('http://example.com/nope') is None
+
+
+def test_update(bm_file, fake_save_manager, qtbot):
+    bm = urlmarks.BookmarkManager()
+
+    bm.add(QUrl('http://example.com'), 'Example Site', ['a', 'b'])
+
+    newmark = urlmarks.Bookmark(
+        url='http://example.com',
+        title='New Title',
+        tags=['one', 'two'],
+    )
+
+    with qtbot.wait_signal(bm.changed):
+        bm.update(newmark)
+
+    assert bm.get('http://example.com') == newmark

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -39,6 +39,7 @@ def test_init(bm_file, fake_save_manager):
     bm_file.write('\n'.join([
         '{"url": "http://example.com", "title": "Example Site"}',
         '{"url": "http://example.com/foo", "tags": ["one", "two"]}',
+        '',
         '{"url": "http://example.com/bar", "title": "Bar", "tags": ["three"]}',
         '{"url": "http://example.com/notitle"}',
         '{"url": "http://example.com/foo", "tags": ["three", "four"]}',
@@ -58,6 +59,12 @@ def test_init(bm_file, fake_save_manager):
         urlmarks.Bookmark('http://example.com/bar', 'Bar', ['three']),
         urlmarks.Bookmark('http://example.com/notitle', '', []),
     ]
+
+
+def test_init_empty(config_tmpdir, fake_save_manager):
+    bm = urlmarks.BookmarkManager()
+    path = config_tmpdir / 'bookmarks' / 'urls'
+    path.ensure()
 
 
 def test_add(bm_file, fake_save_manager, qtbot):
@@ -83,6 +90,9 @@ def test_add(bm_file, fake_save_manager, qtbot):
         urlmarks.Bookmark('http://example.com/notitle', '', []),
         urlmarks.Bookmark('http://example.com', 'Example Site', []),
     ]
+
+    with pytest.raises(urlmarks.InvalidUrlError):
+        bm.add(QUrl('ht tp://example.com'), '', [])
 
 
 def test_add_toggle(bm_file, fake_save_manager, qtbot):

--- a/tests/unit/browser/urlmarks.py
+++ b/tests/unit/browser/urlmarks.py
@@ -128,11 +128,14 @@ def test_delete(bm_file, fake_save_manager, qtbot):
     bm.save()
 
     with qtbot.wait_signal(bm.changed):
-        bm.delete('http://example.com/bar')
+        bm.delete(QUrl('http://example.com/bar'))
     assert list(bm) == [
         urlmarks.Bookmark('http://example.com/baz', 'Baz', []),
         urlmarks.Bookmark('http://example.com/foo', 'Foo', []),
     ]
+
+    with pytest.raises(urlmarks.DoesNotExistError):
+        bm.delete(QUrl('http://example.com/nope'))
 
 
 def test_save(bm_file, fake_save_manager):
@@ -221,3 +224,17 @@ def test_untag(bm_file, fake_save_manager, qtbot, old, remove, new):
         bm.untag(url, remove)
 
     assert bm.get(url).tags == new
+
+
+def test_invalid_url(bm_file, fake_save_manager):
+    bm = urlmarks.BookmarkManager()
+    url = QUrl('ht tp://example.com')
+
+    with pytest.raises(urlmarks.InvalidUrlError):
+        bm.add(url, 'title', [])
+    with pytest.raises(urlmarks.InvalidUrlError):
+        bm.tag(url, ['one', 'two'])
+    with pytest.raises(urlmarks.InvalidUrlError):
+        bm.untag(url, ['one', 'two'])
+    with pytest.raises(urlmarks.InvalidUrlError):
+        bm.delete(url)

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -129,12 +129,20 @@ def cmdutils_patch(monkeypatch, stubs, miscmodels_patch):
         """docstring."""
         pass
 
+    @cmdutils.argument('option', completion=miscmodels_patch.option)
+    @cmdutils.argument('values', completion=miscmodels_patch.value)
+    def config_cycle(option, *values):
+        """For testing varargs."""
+        pass
+
     cmd_utils = stubs.FakeCmdUtils({
         'set': command.Command(name='set', handler=set_command),
         'help': command.Command(name='help', handler=show_help),
         'open': command.Command(name='open', handler=openurl, maxsplit=0),
         'bind': command.Command(name='bind', handler=bind),
         'tab-detach': command.Command(name='tab-detach', handler=tab_detach),
+        'config-cycle': command.Command(name='config-cycle',
+                                        handler=config_cycle),
     })
     monkeypatch.setattr(completer, 'cmdutils', cmd_utils)
 
@@ -191,6 +199,10 @@ def _set_cmd_prompt(cmd, txt):
     ('/:help|', None, '', []),
     ('::bind|', 'command', ':bind', []),
     (':-w open |', None, '', []),
+    # varargs
+    (':config-cycle option |', 'value', '', ['option']),
+    (':config-cycle option one |', 'value', '', ['option', 'one']),
+    (':config-cycle option one two |', 'value', '', ['option', 'one', 'two']),
 ])
 def test_update_completion(txt, kind, pattern, pos_args, status_command_stub,
                            completer_obj, completion_widget_stub, config_stub,

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -153,7 +153,7 @@ def bookmarks(bookmark_manager_mock):
         urlmarks.Bookmark('https://python.org', 'Welcome to Python.org', []),
         urlmarks.Bookmark('http://qutebrowser.org', 'qutebrowser', ['baz']),
     ]))
-    bookmark_manager_mock.all_tags.return_value = set(['foo', 'bar', 'baz'])
+    bookmark_manager_mock.all_tags.return_value = {['foo', 'bar', 'baz']}
     return bookmark_manager_mock
 
 

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -149,10 +149,11 @@ def configdata_stub(config_stub, monkeypatch, configdata_init):
 def bookmarks(bookmark_manager_mock):
     """Pre-populate the bookmark-manager stub with some bookmarks."""
     bookmark_manager_mock.__iter__ = mock.Mock(return_value=iter([
-        urlmarks.Bookmark('https://github.com', 'GitHub', []),
+        urlmarks.Bookmark('https://github.com', 'GitHub', ['foo', 'bar']),
         urlmarks.Bookmark('https://python.org', 'Welcome to Python.org', []),
-        urlmarks.Bookmark('http://qutebrowser.org', 'qutebrowser', []),
+        urlmarks.Bookmark('http://qutebrowser.org', 'qutebrowser', ['baz']),
     ]))
+    bookmark_manager_mock.all_tags.return_value = set(['foo', 'bar', 'baz'])
     return bookmark_manager_mock
 
 
@@ -261,9 +262,9 @@ def test_bookmark_completion(qtmodeltester, bookmarks):
 
     _check_completions(model, {
         "Bookmarks": [
-            ('https://github.com', 'GitHub', '[]'),
+            ('https://github.com', 'GitHub', "['foo', 'bar']"),
             ('https://python.org', 'Welcome to Python.org', '[]'),
-            ('http://qutebrowser.org', 'qutebrowser', '[]'),
+            ('http://qutebrowser.org', 'qutebrowser', "['baz']"),
         ]
     })
 
@@ -287,6 +288,22 @@ def test_bookmark_completion_delete(qtmodeltester, bookmarks, row, removed):
     assert bookmarks.delete.called_once_with(removed)
 
 
+def test_bookmark_tag_completion(qtmodeltester, bookmarks):
+    """Test the results of bookmark completion."""
+    model = miscmodels.bookmark_tag()
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        "Tags": [
+            ('bar', '', None),
+            ('baz', '', None),
+            ('foo', '', None),
+        ]
+    })
+
+
 @pytest.fixture(autouse=True)
 def url_args(fake_args):
     """Prepare arguments needed to test the URL completion."""
@@ -308,9 +325,9 @@ def test_url_completion(qtmodeltester, web_history_populated, bookmarks, info):
 
     _check_completions(model, {
         "Bookmarks": [
-            ('https://github.com', 'GitHub', '[]'),
-            ('https://python.org', 'Welcome to Python.org', '[]'),
-            ('http://qutebrowser.org', 'qutebrowser', '[]'),
+            ('https://github.com', 'GitHub', "['foo', 'bar']"),
+            ('https://python.org', 'Welcome to Python.org', "[]"),
+            ('http://qutebrowser.org', 'qutebrowser', "['baz']"),
         ],
         "History": [
             ('https://github.com', 'https://github.com', '2016-05-01'),

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -255,7 +255,7 @@ def test_help_completion(qtmodeltester, cmdutils_stub, key_config_stub,
 
 def test_bookmark_completion(qtmodeltester, bookmarks):
     """Test the results of bookmark completion."""
-    model = miscmodels.bookmark()
+    model = urlmodel.bookmark()
     model.set_pattern('')
     qtmodeltester.data_display_may_return_none = True
     qtmodeltester.check(model)
@@ -276,7 +276,7 @@ def test_bookmark_completion(qtmodeltester, bookmarks):
 ])
 def test_bookmark_completion_delete(qtmodeltester, bookmarks, row, removed):
     """Test deleting a bookmark from the bookmark completion model."""
-    model = miscmodels.bookmark()
+    model = urlmodel.bookmark()
     model.set_pattern('')
     qtmodeltester.data_display_may_return_none = True
     qtmodeltester.check(model)
@@ -290,7 +290,7 @@ def test_bookmark_completion_delete(qtmodeltester, bookmarks, row, removed):
 
 def test_bookmark_tag_completion(qtmodeltester, bookmarks):
     """Test the results of bookmark completion."""
-    model = miscmodels.bookmark_tag()
+    model = urlmodel.bookmark_tag()
     model.set_pattern('')
     qtmodeltester.data_display_may_return_none = True
     qtmodeltester.check(model)

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -262,9 +262,9 @@ def test_bookmark_completion(qtmodeltester, bookmarks):
 
     _check_completions(model, {
         "Bookmarks": [
-            ('https://github.com', 'GitHub', "['foo', 'bar']"),
-            ('https://python.org', 'Welcome to Python.org', '[]'),
-            ('http://qutebrowser.org', 'qutebrowser', "['baz']"),
+            ('https://github.com', 'GitHub', 'foo bar'),
+            ('https://python.org', 'Welcome to Python.org', ''),
+            ('http://qutebrowser.org', 'qutebrowser', 'baz'),
         ]
     })
 
@@ -325,9 +325,9 @@ def test_url_completion(qtmodeltester, web_history_populated, bookmarks, info):
 
     _check_completions(model, {
         "Bookmarks": [
-            ('https://github.com', 'GitHub', "['foo', 'bar']"),
-            ('https://python.org', 'Welcome to Python.org', "[]"),
-            ('http://qutebrowser.org', 'qutebrowser', "['baz']"),
+            ('https://github.com', 'GitHub', 'foo bar'),
+            ('https://python.org', 'Welcome to Python.org', ''),
+            ('http://qutebrowser.org', 'qutebrowser', 'baz'),
         ],
         "History": [
             ('https://github.com', 'https://github.com', '2016-05-01'),

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -716,6 +716,44 @@ def test_setting_value_completion_invalid(info):
     assert configmodel.value(optname='foobarbaz', info=info) is None
 
 
+@pytest.mark.parametrize('args, expected', [
+    ([], {
+        "Current/Default": [
+            ('true', 'Current value', None),
+            ('true', 'Default value', None),
+        ],
+        "Completions": [
+            ('false', '', None),
+            ('true', '', None),
+        ],
+    }),
+    (['false'], {
+        "Current/Default": [
+            ('true', 'Current value', None),
+            ('true', 'Default value', None),
+        ],
+        "Completions": [
+            ('true', '', None),
+        ],
+    }),
+    (['true'], {
+        "Completions": [
+            ('false', '', None),
+        ],
+    }),
+    (['false', 'true'], {}),
+])
+def test_setting_value_cycle(qtmodeltester, config_stub, configdata_stub,
+                             info, args, expected):
+    opt = 'content.javascript.enabled'
+
+    model = configmodel.value(opt, *args, info=info)
+    model.set_pattern('')
+    qtmodeltester.data_display_may_return_none = True
+    qtmodeltester.check(model)
+    _check_completions(model, expected)
+
+
 def test_bind_completion(qtmodeltester, cmdutils_stub, config_stub,
                          key_config_stub, configdata_stub, info):
     """Test the results of keybinding command completion.

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -407,15 +407,12 @@ class TestMoveWindowsAndMacOS:
     def test_move_macos(self, files):
         """Test moving configs on macOS."""
         (files.auto_config_dir / 'autoconfig.yml').ensure()
-        (files.auto_config_dir / 'quickmarks').ensure()
         files.config_dir.ensure(dir=True)
 
         standarddir._move_macos()
 
         assert (files.auto_config_dir / 'autoconfig.yml').exists()
         assert not (files.config_dir / 'autoconfig.yml').exists()
-        assert not (files.auto_config_dir / 'quickmarks').exists()
-        assert (files.config_dir / 'quickmarks').exists()
 
     def test_move_windows(self, files):
         """Test moving configs on Windows."""


### PR DESCRIPTION
Resolves #882 by merging quickmarks and bookmarks together and implementing bookmark tags.


Some open questions:

1. I'm not quite sure I got url input processing "right". 
   I want to avoid inconsistent url formatting issues like we've had with the SQL history.
   There are a few options I see:

   - The old way used `fuzzy_url` on the input, which had some weird behavior (`bookmark-add foo` would add a bookmark "https://duckduckgo.com/?q=foo&ia=web")
   - My approach: convert all inputs to `QUrl`, let the `BookmarkManager` use a consistent format.
   - Don't do any formatting on the way in, but use `QUrl` or `fuzzy_url` on the way out
   - Don't do any formatting whatsoever

2. `m` is now mapped to `set-cmd-text -s :bookmark-tag {url}` because I thought that would be a more common use case. 
   Should it instead be `set-cmd-text -s :bookmark-tag -u {url}` to have closer functionality to the original quickmarks?

3. Should the new bookmarks be stored in `${configdir}/bookmarks` and `${configdir}/bookmarks/urls` be moved to `${configdir}/bookmarks.bak`? 

4. Should there be a builtin migration for old book/quickmarks? Or just instructions on how to do it yourself?
