### PR TITLE
Make HTTPClient follow redirects by default.

### DIFF
--- a/qutebrowser/misc/autoupdate.py
+++ b/qutebrowser/misc/autoupdate.py
@@ -45,7 +45,7 @@ class PyPIVersionClient(QObject):
                arg: The error message, as string.
     """
 
-    API_URL = 'https://pypi.python.org/pypi/{}/json'
+    API_URL = 'https://pypi.org/pypi/{}/json'
     success = pyqtSignal(str)
     error = pyqtSignal(str)
 

--- a/qutebrowser/misc/httpclient.py
+++ b/qutebrowser/misc/httpclient.py
@@ -28,6 +28,21 @@ from PyQt5.QtNetwork import (QNetworkAccessManager, QNetworkRequest,
                              QNetworkReply)
 
 
+class HTTPRequest(QNetworkRequest):
+    """A QNetworkRquest that follows (secure) redirects by default."""
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        try:
+            self.setAttribute(QNetworkRequest.RedirectPolicyAttribute,
+                              QNetworkRequest.NoLessSafeRedirectPolicy)
+        except AttributeError:
+            # RedirectPolicyAttribute was introduced in 5.9 to replace
+            # FollowRedirectsAttribute.
+            self.setAttribute(QNetworkRequest.FollowRedirectsAttribute,
+                              True)
+
+
 class HTTPClient(QObject):
 
     """An HTTP client based on QNetworkAccessManager.
@@ -63,7 +78,7 @@ class HTTPClient(QObject):
         if data is None:
             data = {}
         encoded_data = urllib.parse.urlencode(data).encode('utf-8')
-        request = QNetworkRequest(url)
+        request = HTTPRequest(url)
         request.setHeader(QNetworkRequest.ContentTypeHeader,
                           'application/x-www-form-urlencoded;charset=utf-8')
         reply = self._nam.post(request, encoded_data)
@@ -77,7 +92,7 @@ class HTTPClient(QObject):
         Args:
             url: The URL to access, as QUrl.
         """
-        request = QNetworkRequest(url)
+        request = HTTPRequest(url)
         reply = self._nam.get(request)
         self._handle_reply(reply)
 

--- a/tests/unit/misc/test_autoupdate.py
+++ b/tests/unit/misc/test_autoupdate.py
@@ -67,7 +67,7 @@ def test_get_version_success(qtbot):
         with qtbot.waitSignal(client.success):
             client.get_version('test')
 
-    assert http_stub.url == QUrl('https://pypi.python.org/pypi/test/json')
+    assert http_stub.url == QUrl(client.API_URL.format('test'))
 
 
 def test_get_version_error(qtbot):


### PR DESCRIPTION
Closes #3875

The autoupdator, which uses `qutebrowser.misc.httpclient`, has been failing recently because the URL that it hits to check version information is now serving a 301 moved permanently. By default QNetworkRequest doesn't follow redirects so it was getting back a (non-json, despite the request) body pointing to the new location, instead of version information. This PR fixes that by changing HTTPClient to use a QNetworkRequest subclass which follows redirects by default.

It lookes like HTTPClient is currently only used in autoupdate.py, version.py, and crashdialog.py so I don't expect any breakage.

5.6-5.8 Only had a boolean setting available which allows redirects, but not from the https scheme to http, 5.9 introduces a more nuanced setting. I have tested locally on 5.7.1 and 5.10.

Both those attributes are near the bottom of this table: http://doc.qt.io/qt-5/qnetworkrequest.html#Attribute-enum

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3884)
<!-- Reviewable:end -->
