### PR TITLE
Clear visited links when running :history-clear or Ctrl-d on webengine

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -23,7 +23,7 @@ import os
 import time
 import contextlib
 
-from PyQt5.QtCore import pyqtSlot, QUrl, QTimer
+from PyQt5.QtCore import pyqtSlot, QUrl, QTimer, pyqtSignal
 
 from qutebrowser.commands import cmdutils, cmdexc
 from qutebrowser.utils import (utils, objreg, log, usertypes, message,
@@ -51,6 +51,8 @@ class CompletionHistory(sql.SqlTable):
 class WebHistory(sql.SqlTable):
 
     """The global history of visited pages."""
+
+    history_cleared = pyqtSignal()
 
     def __init__(self, parent=None):
         super().__init__("History", ['url', 'title', 'atime', 'redirect'],
@@ -157,6 +159,7 @@ class WebHistory(sql.SqlTable):
         with self._handle_sql_errors():
             self.delete_all()
             self.completion.delete_all()
+        self.history_cleared.emit()
 
     def delete_url(self, url):
         """Remove all history entries with the given url.

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -52,7 +52,10 @@ class WebHistory(sql.SqlTable):
 
     """The global history of visited pages."""
 
+    # All web history cleared
     history_cleared = pyqtSignal()
+    # one url cleared
+    url_cleared = pyqtSignal(QUrl)
 
     def __init__(self, parent=None):
         super().__init__("History", ['url', 'title', 'atime', 'redirect'],
@@ -171,6 +174,7 @@ class WebHistory(sql.SqlTable):
         qtutils.ensure_valid(qurl)
         self.delete('url', self._format_url(qurl))
         self.completion.delete('url', self._format_completion_url(qurl))
+        self.url_cleared.emit(qurl)
 
     @pyqtSlot(QUrl, QUrl, str)
     def add_from_tab(self, url, requested_url, title):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -73,6 +73,13 @@ def init():
     download_manager.install(webenginesettings.private_profile)
     objreg.register('webengine-download-manager', download_manager)
 
+    # Clear visited links on web history clear
+    hist = objreg.get('web-history')
+    hist.history_cleared.connect(
+        webenginesettings.default_profile.clearAllVisitedLinks)
+    hist.history_cleared.connect(
+        webenginesettings.private_profile.clearAllVisitedLinks)
+
 
 # Mapping worlds from usertypes.JsWorld to QWebEngineScript world IDs.
 _JS_WORLD_MAP = {

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -79,6 +79,10 @@ def init():
         webenginesettings.default_profile.clearAllVisitedLinks)
     hist.history_cleared.connect(
         webenginesettings.private_profile.clearAllVisitedLinks)
+    hist.url_cleared.connect(
+        lambda url: webenginesettings.default_profile.clearVisitedLinks([url]))
+    hist.url_cleared.connect(
+        lambda url: webenginesettings.private_profile.clearVisitedLinks([url]))
 
 
 # Mapping worlds from usertypes.JsWorld to QWebEngineScript world IDs.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -75,14 +75,11 @@ def init():
 
     # Clear visited links on web history clear
     hist = objreg.get('web-history')
-    hist.history_cleared.connect(
-        webenginesettings.default_profile.clearAllVisitedLinks)
-    hist.history_cleared.connect(
-        webenginesettings.private_profile.clearAllVisitedLinks)
-    hist.url_cleared.connect(
-        lambda url: webenginesettings.default_profile.clearVisitedLinks([url]))
-    hist.url_cleared.connect(
-        lambda url: webenginesettings.private_profile.clearVisitedLinks([url]))
+    for p in [webenginesettings.default_profile,
+              webenginesettings.private_profile]:
+        hist.history_cleared.connect(p.clearAllVisitedLinks)
+        hist.url_cleared.connect(lambda url, profile=p:
+                                 profile.clearVisitedLinks([url]))
 
 
 # Mapping worlds from usertypes.JsWorld to QWebEngineScript world IDs.


### PR DESCRIPTION
This creates a new slot that is emitted when clearing history, and connects the `clearAllVisitedLinks` function to that slot. I'm not sure if this is the best way to implement this still, so feedback would be appreciated!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3899)
<!-- Reviewable:end -->
