### PR TITLE
Short options for basedir, temp-basedir, debug, and debug-flags

### DIFF
--- a/doc/qutebrowser.1.asciidoc
+++ b/doc/qutebrowser.1.asciidoc
@@ -38,7 +38,7 @@ show it.
 *-h*, *--help*::
     show this help message and exit
 
-*--basedir* 'BASEDIR'::
+*-B*, *--basedir* 'BASEDIR'::
     Base directory for all storage.
 
 *-V*, *--version*::
@@ -87,7 +87,7 @@ show it.
 *--nowindow*::
     Don't show the main window.
 
-*--temp-basedir*::
+*-T*, *--temp-basedir*::
     Use a temporary basedir.
 
 *--no-err-windows*::

--- a/doc/qutebrowser.1.asciidoc
+++ b/doc/qutebrowser.1.asciidoc
@@ -72,7 +72,7 @@ show it.
 *--loglines* 'LOGLINES'::
     How many lines of the debug log to keep in RAM (-1: unlimited).
 
-*--debug*::
+*-d*, *--debug*::
     Turn on debugging options.
 
 *--json-logging*::
@@ -99,7 +99,7 @@ show it.
 *--qt-flag* 'QT_FLAG'::
     Pass an argument to Qt as flag.
 
-*--debug-flag* 'DEBUG_FLAGS'::
+*-D*, *--debug-flag* 'DEBUG_FLAGS'::
     Pass name of debugging feature to be turned on.
 // QUTE_OPTIONS_END
 

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -103,7 +103,7 @@ def get_argparser():
                        help="How many lines of the debug log to keep in RAM "
                        "(-1: unlimited).",
                        default=2000, type=int)
-    debug.add_argument('--debug', help="Turn on debugging options.",
+    debug.add_argument('-d', '--debug', help="Turn on debugging options.",
                        action='store_true')
     debug.add_argument('--json-logging', action='store_true', help="Output log"
                        " lines in JSON format (one object per line).")
@@ -124,9 +124,9 @@ def get_argparser():
                        action='append')
     debug.add_argument('--qt-flag', help="Pass an argument to Qt as flag.",
                        nargs=1, action='append')
-    debug.add_argument('--debug-flag', type=debug_flag_error, default=[],
-                       help="Pass name of debugging feature to be turned on.",
-                       action='append', dest='debug_flags')
+    debug.add_argument('-D', '--debug-flag', type=debug_flag_error,
+                       default=[], help="Pass name of debugging feature to be"
+                       " turned on.", action='append', dest='debug_flags')
     parser.add_argument('command', nargs='*', help="Commands to execute on "
                         "startup.", metavar=':command')
     # URLs will actually be in command

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -61,7 +61,8 @@ def get_argparser():
     """Get the argparse parser."""
     parser = argparse.ArgumentParser(prog='qutebrowser',
                                      description=qutebrowser.__description__)
-    parser.add_argument('--basedir', help="Base directory for all storage.")
+    parser.add_argument('-B', '--basedir', help="Base directory for all "
+                        "storage.")
     parser.add_argument('-V', '--version', help="Show version and quit.",
                         action='store_true')
     parser.add_argument('-s', '--set', help="Set a temporary setting for "
@@ -112,8 +113,8 @@ def get_argparser():
                        action='store_true')
     debug.add_argument('--nowindow', action='store_true', help="Don't show "
                        "the main window.")
-    debug.add_argument('--temp-basedir', action='store_true', help="Use a "
-                       "temporary basedir.")
+    debug.add_argument('-T', '--temp-basedir', action='store_true', help="Use "
+                       "a temporary basedir.")
     debug.add_argument('--no-err-windows', action='store_true', help="Don't "
                        "show any error windows (used for tests/smoke.py).")
     debug.add_argument('--qt-arg', help="Pass an argument with a value to Qt. "


### PR DESCRIPTION
As discussed in IRC:

Assigns -B for basedir, -T for temp-basedir.

Assigns -d for debug, -D for debug-flags.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3900)
<!-- Reviewable:end -->
