### PR TITLE
Add support for muting tabs

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -278,7 +278,8 @@ Set all settings back to their default.
 
 [[config-cycle]]
 === config-cycle
-Syntax: +:config-cycle [*--pattern* 'pattern'] [*--temp*] [*--print*] 'option' ['values' ['values' ...]]+
+Syntax: +:config-cycle [*--pattern* 'pattern'] [*--temp*] [*--print*]
+             'option' ['values' ['values' ...]]+
 
 Cycle an option between multiple values.
 
@@ -530,7 +531,8 @@ Show help about a command or setting.
 
 [[hint]]
 === hint
-Syntax: +:hint [*--mode* 'mode'] [*--add-history*] [*--rapid*] [*--first*] ['group'] ['target'] ['args' ['args' ...]]+
+Syntax: +:hint [*--mode* 'mode'] [*--add-history*] [*--rapid*] [*--first*]
+     ['group'] ['target'] ['args' ['args' ...]]+
 
 Start hinting.
 
@@ -781,7 +783,8 @@ Do nothing.
 
 [[open]]
 === open
-Syntax: +:open [*--related*] [*--bg*] [*--tab*] [*--window*] [*--secure*] [*--private*] ['url']+
+Syntax: +:open [*--related*] [*--bg*] [*--tab*] [*--window*] [*--secure*] [*--private*]
+     ['url']+
 
 Open a URL in the current/[count]th tab.
 
@@ -1110,7 +1113,9 @@ Load a session.
 
 [[session-save]]
 === session-save
-Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*] [*--with-private*] ['name']+
+Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*]
+             [*--with-private*]
+             ['name']+
 
 Save a session.
 

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -111,6 +111,7 @@ It is possible to run or bind multiple commands by separating them with `;;`.
 |<<tab-focus,tab-focus>>|Select the tab given as argument/[count].
 |<<tab-give,tab-give>>|Give the current tab to a new or existing window if win_id given.
 |<<tab-move,tab-move>>|Move the current tab according to the argument and [count].
+|<<tab-mute,tab-mute>>|Mute/Unmute the current/[count]th tab.
 |<<tab-next,tab-next>>|Switch to the next tab, or switch [count] tabs forward.
 |<<tab-only,tab-only>>|Close all tabs except for the current one.
 |<<tab-pin,tab-pin>>|Pin/Unpin the current/[count]th tab.
@@ -277,8 +278,7 @@ Set all settings back to their default.
 
 [[config-cycle]]
 === config-cycle
-Syntax: +:config-cycle [*--pattern* 'pattern'] [*--temp*] [*--print*]
-             'option' ['values' ['values' ...]]+
+Syntax: +:config-cycle [*--pattern* 'pattern'] [*--temp*] [*--print*] 'option' ['values' ['values' ...]]+
 
 Cycle an option between multiple values.
 
@@ -530,8 +530,7 @@ Show help about a command or setting.
 
 [[hint]]
 === hint
-Syntax: +:hint [*--mode* 'mode'] [*--add-history*] [*--rapid*] [*--first*]
-     ['group'] ['target'] ['args' ['args' ...]]+
+Syntax: +:hint [*--mode* 'mode'] [*--add-history*] [*--rapid*] [*--first*] ['group'] ['target'] ['args' ['args' ...]]+
 
 Start hinting.
 
@@ -782,8 +781,7 @@ Do nothing.
 
 [[open]]
 === open
-Syntax: +:open [*--related*] [*--bg*] [*--tab*] [*--window*] [*--secure*] [*--private*]
-     ['url']+
+Syntax: +:open [*--related*] [*--bg*] [*--tab*] [*--window*] [*--secure*] [*--private*] ['url']+
 
 Open a URL in the current/[count]th tab.
 
@@ -1112,9 +1110,7 @@ Load a session.
 
 [[session-save]]
 === session-save
-Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*]
-             [*--with-private*]
-             ['name']+
+Syntax: +:session-save [*--current*] [*--quiet*] [*--force*] [*--only-active-window*] [*--with-private*] ['name']+
 
 Save a session.
 
@@ -1283,6 +1279,13 @@ If neither is given, move it to the first position.
 If moving relatively: Offset. If moving absolutely: New position (default: 0). This
  overrides the index argument, if given.
 
+
+[[tab-mute]]
+=== tab-mute
+Mute/Unmute the current/[count]th tab.
+
+==== count
+The tab index to pin or unpin
 
 [[tab-next]]
 === tab-next

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -3045,6 +3045,7 @@ The following placeholders are defined:
 * `{private}`: Indicates when private mode is enabled.
 * `{current_url}`: URL of the current web page.
 * `{protocol}`: Protocol (http/https/...) of the current web page.
+* `{muted}`: Icon if the tab is muted
 
 
 Type: <<types,FormatString>>

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -649,6 +649,7 @@ class AbstractTab(QWidget):
     fullscreen_requested = pyqtSignal(bool)
     renderer_process_terminated = pyqtSignal(TerminationStatus, int)
     predicted_navigation = pyqtSignal(QUrl)
+    audio_muted_changed = pyqtSignal(bool)
 
     def __init__(self, *, win_id, mode_manager, private, parent=None):
         self.private = private
@@ -923,3 +924,11 @@ class AbstractTab(QWidget):
 
     def is_deleted(self):
         return sip.isdeleted(self._widget)
+
+    def set_muted(self, muted: bool):
+        """Set this tab as muted or not."""
+        raise NotImplementedError
+
+    def is_muted(self):
+        """Whether this tab is muted."""
+        raise NotImplementedError

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -650,6 +650,7 @@ class AbstractTab(QWidget):
     renderer_process_terminated = pyqtSignal(TerminationStatus, int)
     predicted_navigation = pyqtSignal(QUrl)
     audio_muted_changed = pyqtSignal(bool)
+    recently_audible_changed = pyqtSignal(bool)
 
     def __init__(self, *, win_id, mode_manager, private, parent=None):
         self.private = private
@@ -931,4 +932,8 @@ class AbstractTab(QWidget):
 
     def is_muted(self):
         """Whether this tab is muted."""
+        raise NotImplementedError
+
+    def is_recently_audible(self):
+        """Whether this tab has had audio playing recently."""
         raise NotImplementedError

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2230,3 +2230,20 @@ class CommandDispatcher:
 
         window = self._tabbed_browser.widget.window()
         window.setWindowState(window.windowState() ^ Qt.WindowFullScreen)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window',
+                       name='tab-mute')
+    @cmdutils.argument('count', count=True)
+    def tab_mute(self, count=None):
+        """Mute/Unmute the current/[count]th tab.
+
+        Args:
+            count: The tab index to pin or unpin, or None
+        """
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+        try:
+            tab.set_muted(not tab.is_muted())
+        except browsertab.WebTabError as e:
+            raise cmdexc.CommandError(e)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2238,7 +2238,7 @@ class CommandDispatcher:
         """Mute/Unmute the current/[count]th tab.
 
         Args:
-            count: The tab index to pin or unpin, or None
+            count: The tab index to mute or unmute, or None
         """
         tab = self._cntwidget(count)
         if tab is None:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1092,6 +1092,7 @@ class WebEngineTab(browsertab.AbstractTab):
         page.fullScreenRequested.connect(self._on_fullscreen_requested)
         page.contentsSizeChanged.connect(self.contents_size_changed)
         page.navigation_request.connect(self._on_navigation_request)
+        page.audioMutedChanged.connect(self.audio_muted_changed)
 
         view.titleChanged.connect(self.title_changed)
         view.urlChanged.connect(self._on_url_changed)
@@ -1116,3 +1117,11 @@ class WebEngineTab(browsertab.AbstractTab):
 
     def event_target(self):
         return self._widget.focusProxy()
+
+    def set_muted(self, muted: bool):
+        page = self._widget.page()
+        page.setAudioMuted(muted)
+
+    def is_muted(self):
+        page = self._widget.page()
+        return page.isAudioMuted()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1093,6 +1093,7 @@ class WebEngineTab(browsertab.AbstractTab):
         page.contentsSizeChanged.connect(self.contents_size_changed)
         page.navigation_request.connect(self._on_navigation_request)
         page.audioMutedChanged.connect(self.audio_muted_changed)
+        page.recentlyAudibleChanged.connect(self.recently_audible_changed)
 
         view.titleChanged.connect(self.title_changed)
         view.urlChanged.connect(self._on_url_changed)
@@ -1125,3 +1126,7 @@ class WebEngineTab(browsertab.AbstractTab):
     def is_muted(self):
         page = self._widget.page()
         return page.isAudioMuted()
+
+    def is_recently_audible(self):
+        page = self._widget.page()
+        return page.recentlyAudible()

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -828,3 +828,10 @@ class WebKitTab(browsertab.AbstractTab):
 
     def event_target(self):
         return self._widget
+
+    def set_muted(self, muted: bool):
+        raise browsertab.WebTabError('Muting is not supported on QtWebKit!')
+
+    def is_muted(self):
+        # Dummy value for things that read muted status
+        return False

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -835,3 +835,7 @@ class WebKitTab(browsertab.AbstractTab):
     def is_muted(self):
         # Dummy value for things that read muted status
         return False
+
+    def is_recently_audible(self):
+        # Dummy value for things that read audible status
+        return False

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1344,7 +1344,7 @@ tabs.title.alignment:
   desc: Alignment of the text inside of tabs.
 
 tabs.title.format:
-  default: '{index}: {title}'
+  default: '{audio}{index}: {title}'
   type:
     name: FormatString
     fields:
@@ -1359,7 +1359,7 @@ tabs.title.format:
       - private
       - current_url
       - protocol
-      - muted
+      - audio
     none_ok: true
   desc: |
     Format to use for the tab title.
@@ -1377,7 +1377,7 @@ tabs.title.format:
     * `{private}`: Indicates when private mode is enabled.
     * `{current_url}`: URL of the current web page.
     * `{protocol}`: Protocol (http/https/...) of the current web page.
-    * `{muted}`: Icon if the tab is muted
+    * `{audio}`: Cookie for audio/mute status
 
 tabs.title.format_pinned:
   default: '{index}'
@@ -1395,7 +1395,7 @@ tabs.title.format_pinned:
       - private
       - current_url
       - protocol
-      - muted
+      - audio
     none_ok: true
   desc: Format to use for the tab title for pinned tabs. The same placeholders
     like for `tabs.title.format` are defined.
@@ -1563,7 +1563,7 @@ window.title_format:
       - private
       - current_url
       - protocol
-      - muted
+      - audio
   default: '{perc}{title}{title_sep}qutebrowser'
   desc: |
     Format to use for the window title. The same placeholders like for
@@ -2366,6 +2366,7 @@ bindings.default:
       <Ctrl-Return>: follow-selected -t
       .: repeat-command
       <Ctrl-p>: tab-pin
+      <Alt-m>: tab-mute
       q: record-macro
       "@": run-macro
       tsh: config-cycle -p -t -u *://{url:host}/* content.javascript.enabled ;; reload

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1377,7 +1377,7 @@ tabs.title.format:
     * `{private}`: Indicates when private mode is enabled.
     * `{current_url}`: URL of the current web page.
     * `{protocol}`: Protocol (http/https/...) of the current web page.
-    * `{audio}`: Cookie for audio/mute status
+    * `{audio}`: Indicator for audio/mute status
 
 tabs.title.format_pinned:
   default: '{index}'

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1359,6 +1359,7 @@ tabs.title.format:
       - private
       - current_url
       - protocol
+      - muted
     none_ok: true
   desc: |
     Format to use for the tab title.
@@ -1376,6 +1377,7 @@ tabs.title.format:
     * `{private}`: Indicates when private mode is enabled.
     * `{current_url}`: URL of the current web page.
     * `{protocol}`: Protocol (http/https/...) of the current web page.
+    * `{muted}`: Icon if the tab is muted
 
 tabs.title.format_pinned:
   default: '{index}'
@@ -1393,6 +1395,7 @@ tabs.title.format_pinned:
       - private
       - current_url
       - protocol
+      - muted
     none_ok: true
   desc: Format to use for the tab title for pinned tabs. The same placeholders
     like for `tabs.title.format` are defined.
@@ -1560,6 +1563,7 @@ window.title_format:
       - private
       - current_url
       - protocol
+      - muted
   default: '{perc}{title}{title_sep}qutebrowser'
   desc: |
     Format to use for the window title. The same placeholders like for

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -239,7 +239,9 @@ class TabbedBrowser(QWidget):
         tab.renderer_process_terminated.connect(
             functools.partial(self._on_renderer_process_terminated, tab))
         tab.audio_muted_changed.connect(
-            functools.partial(self.on_mute_changed, tab))
+            functools.partial(self.on_audio_changed, tab))
+        tab.recently_audible_changed.connect(
+            functools.partial(self.on_audio_changed, tab))
         tab.new_tab_requested.connect(self.tabopen)
         if not self.private:
             web_history = objreg.get('web-history')
@@ -736,16 +738,16 @@ class TabbedBrowser(QWidget):
         self.widget.update_tab_title(idx, 'scroll_pos')
 
     @pyqtSlot()
-    def on_mute_changed(self, tab, muted):
-        """Update tab and window title when scroll position changed."""
+    def on_audio_changed(self, tab, muted):
+        """Update audio cookie in tab when mute or recentlyAudible changed."""
         try:
             idx = self._tab_index(tab)
         except TabDeletedError:
             # We can get signals for tabs we already deleted...
             return
-        self.widget.update_tab_title(idx, 'muted')
+        self.widget.update_tab_title(idx, 'audio')
         if idx == self.widget.currentIndex():
-            self._update_window_title('muted')
+            self._update_window_title('audio')
 
     def _on_renderer_process_terminated(self, tab, status, code):
         """Show an error when a renderer process terminated."""

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -239,9 +239,9 @@ class TabbedBrowser(QWidget):
         tab.renderer_process_terminated.connect(
             functools.partial(self._on_renderer_process_terminated, tab))
         tab.audio_muted_changed.connect(
-            functools.partial(self.on_audio_changed, tab))
+            functools.partial(self._on_audio_changed, tab))
         tab.recently_audible_changed.connect(
-            functools.partial(self.on_audio_changed, tab))
+            functools.partial(self._on_audio_changed, tab))
         tab.new_tab_requested.connect(self.tabopen)
         if not self.private:
             web_history = objreg.get('web-history')
@@ -737,8 +737,7 @@ class TabbedBrowser(QWidget):
         self._update_window_title('scroll_pos')
         self.widget.update_tab_title(idx, 'scroll_pos')
 
-    @pyqtSlot()
-    def on_audio_changed(self, tab, _muted):
+    def _on_audio_changed(self, tab, _muted):
         """Update audio field in tab when mute or recentlyAudible changed."""
         try:
             idx = self._tab_index(tab)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -238,6 +238,8 @@ class TabbedBrowser(QWidget):
             functools.partial(self.on_window_close_requested, tab))
         tab.renderer_process_terminated.connect(
             functools.partial(self._on_renderer_process_terminated, tab))
+        tab.audio_muted_changed.connect(
+            functools.partial(self.on_mute_changed, tab))
         tab.new_tab_requested.connect(self.tabopen)
         if not self.private:
             web_history = objreg.get('web-history')
@@ -732,6 +734,18 @@ class TabbedBrowser(QWidget):
             return
         self._update_window_title('scroll_pos')
         self.widget.update_tab_title(idx, 'scroll_pos')
+
+    @pyqtSlot()
+    def on_mute_changed(self, tab, muted):
+        """Update tab and window title when scroll position changed."""
+        try:
+            idx = self._tab_index(tab)
+        except TabDeletedError:
+            # We can get signals for tabs we already deleted...
+            return
+        self.widget.update_tab_title(idx, 'muted')
+        if idx == self.widget.currentIndex():
+            self._update_window_title('muted')
 
     def _on_renderer_process_terminated(self, tab, status, code):
         """Show an error when a renderer process terminated."""

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -738,8 +738,8 @@ class TabbedBrowser(QWidget):
         self.widget.update_tab_title(idx, 'scroll_pos')
 
     @pyqtSlot()
-    def on_audio_changed(self, tab, muted):
-        """Update audio cookie in tab when mute or recentlyAudible changed."""
+    def on_audio_changed(self, tab, _muted):
+        """Update audio field in tab when mute or recentlyAudible changed."""
         try:
             idx = self._tab_index(tab)
         except TabDeletedError:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -172,6 +172,7 @@ class TabWidget(QTabWidget):
         fields['perc_raw'] = tab.progress()
         fields['backend'] = objects.backend.name
         fields['private'] = ' [Private Mode] ' if tab.private else ''
+        fields['muted'] = '[M] ' if tab.is_muted() else ''
 
         if tab.load_status() == usertypes.LoadStatus.loading:
             fields['perc'] = '[{}%] '.format(tab.progress())

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -33,6 +33,7 @@ from PyQt5.QtGui import QIcon, QPalette, QColor
 from qutebrowser.utils import qtutils, objreg, utils, usertypes, log
 from qutebrowser.config import config
 from qutebrowser.misc import objects
+from qutebrowser.browser import browsertab
 
 
 PixelMetrics = enum.IntEnum('PixelMetrics', ['icon_padding'],
@@ -172,8 +173,12 @@ class TabWidget(QTabWidget):
         fields['perc_raw'] = tab.progress()
         fields['backend'] = objects.backend.name
         fields['private'] = ' [Private Mode] ' if tab.private else ''
-        fields['audio'] = '[M] ' if tab.is_muted() else (
-            '[A] ' if tab.is_recently_audible() else '')
+        try:
+            fields['audio'] = '[M] ' if tab.is_muted() else (
+                '[A] ' if tab.is_recently_audible() else '')
+        except (NotImplementedError, browsertab.WebTabError):
+            # one of the functions was not implemented or had an error, abort
+            fields['audio'] = ''
 
         if tab.load_status() == usertypes.LoadStatus.loading:
             fields['perc'] = '[{}%] '.format(tab.progress())

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -172,7 +172,8 @@ class TabWidget(QTabWidget):
         fields['perc_raw'] = tab.progress()
         fields['backend'] = objects.backend.name
         fields['private'] = ' [Private Mode] ' if tab.private else ''
-        fields['muted'] = '[M] ' if tab.is_muted() else ''
+        fields['audio'] = '[M] ' if tab.is_muted() else (
+            '[A] ' if tab.is_recently_audible() else '')
 
         if tab.load_status() == usertypes.LoadStatus.loading:
             fields['perc'] = '[{}%] '.format(tab.progress())

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -174,10 +174,14 @@ class TabWidget(QTabWidget):
         fields['backend'] = objects.backend.name
         fields['private'] = ' [Private Mode] ' if tab.private else ''
         try:
-            fields['audio'] = '[M] ' if tab.is_muted() else (
-                '[A] ' if tab.is_recently_audible() else '')
-        except (NotImplementedError, browsertab.WebTabError):
-            # one of the functions was not implemented or had an error, abort
+            if tab.is_muted():
+                fields['audio'] = '[M] '
+            elif tab.is_recently_audible():
+                fields['audio'] = '[A] '
+            else:
+                fields['audio'] = ''
+        except browsertab.WebTabError:
+            # Muting is only implemented with QtWebEngine
             fields['audio'] = ''
 
         if tab.load_status() == usertypes.LoadStatus.loading:


### PR DESCRIPTION
Closes #2331 

Muting was added in 5.7 so we shouldn't see version issues.

Pretty simple, but I'm not sure if I structured the API in a good way.

![peek 2018-05-09 19-01](https://user-images.githubusercontent.com/4349709/39848360-0b845b72-53f6-11e8-993e-08865d49c17a.gif)


<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3908)
<!-- Reviewable:end -->
