### PR TITLE
Add last-ditch attempt to focus the webview on 5.11

### DIFF
--- a/qutebrowser/keyinput/modeman.py
+++ b/qutebrowser/keyinput/modeman.py
@@ -114,6 +114,12 @@ def leave(win_id, mode, reason=None, *, maybe=False):
     instance(win_id).leave(mode, reason, maybe=maybe)
 
 
+# A list of modes where key presses should be transferred to the webview
+PASSTHROUGH_MODES = [usertypes.KeyMode.insert,
+                     usertypes.KeyMode.passthrough,
+                     usertypes.KeyMode.caret]
+
+
 class ModeManager(QObject):
 
     """Manager for keyboard modes.

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -493,6 +493,7 @@ class MainWindow(QWidget):
 
         # command input / completion
         mode_manager.left.connect(self.tabbed_browser.on_mode_left)
+        mode_manager.entered.connect(self.tabbed_browser.on_mode_entered)
         cmd.clear_completion_selection.connect(
             completion_obj.on_clear_completion_selection)
         cmd.hide_completion.connect(completion_obj.hide)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -640,6 +640,21 @@ class TabbedBrowser(QWidget):
                 return
             widget.setFocus()
 
+    @pyqtSlot(usertypes.KeyMode)
+    def on_mode_entered(self, mode):
+        """Focus webview when entering insert modes."""
+        if mode in modeman.PASSTHROUGH_MODES:
+            # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-58698
+            # The previous fixes don't seem to work across domains, this is a
+            # last-ditch effort. Does not fix forward_unbound_keys.
+            widget = self.widget.currentWidget()
+            if widget is None:
+                return
+            widget.setFocus()
+            log.modes.debug(
+                "Entered a passthrough mode, ensuring focus of {}".format(
+                    widget))
+
     @pyqtSlot(int)
     def on_current_changed(self, idx):
         """Set last-focused-tab and leave hinting mode when focus changed."""


### PR DESCRIPTION
Steals from #3834, migitates focus issues in #3661. Migitation for [QTBUG-68076](https://bugreports.qt.io/browse/QTBUG-68076)

Despite the previous fixes, we still didn't have focus when switching between domains, for example:

1. `:open ddg.gg`
2. `:open google.com`
3. `i` (enter insert mode)
4. Type

Didn't seem to work for me.

This adds a last-ditch effort to focus the webview on entering insert mode. However, `forward_unbound_keys` will still be broken in this state.


This should probably target 1.3.1 if we want it at all.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3921)
<!-- Reviewable:end -->
