### PR TITLE
Change caret style

### DIFF
--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -863,7 +863,7 @@ window._qutebrowser.caret = (function() {
             "  min-width: 0.6em;" +
             "  mix-blend-mode: difference;" +
             "  --inherited-color: inherit;" +
-            "  background-color: var(--inherited-color, #fff);" +
+            "  background-color: var(--inherited-color, #000);" +
             "  color: var(--inherited-color, #000);" +
             "  filter: invert(50%);" +
             "  animation: blink 1s step-end infinite;" +
@@ -874,6 +874,7 @@ window._qutebrowser.caret = (function() {
         const node = document.createElement("style");
         node.innerHTML = style;
         document.body.appendChild(node);
+
         const node2 = document.createElement("style");
         node2.innerHTML = blink;
         document.body.appendChild(node2);
@@ -944,7 +945,7 @@ window._qutebrowser.caret = (function() {
      */
     CaretBrowsing.setCaretElementNormalStyle = function() {
         const element = CaretBrowsing.caretElement;
-        element.className = "CaretBrowsing_Caret";
+        element.ClassName = "CaretBrowsing_Caret";
         if (CaretBrowsing.isSelectionCollapsed) {
             element.style.opacity = "1.0";
         } else {
@@ -1170,6 +1171,8 @@ window._qutebrowser.caret = (function() {
                 CaretBrowsing.updateCaretOrSelection(true);
             }, 0);
         }
+
+        CaretBrowsing.stopAnimation();
     };
 
     CaretBrowsing.moveToBlock = function(paragraph, boundary) {
@@ -1188,6 +1191,8 @@ window._qutebrowser.caret = (function() {
         window.setTimeout(() => {
             CaretBrowsing.updateCaretOrSelection(true);
         }, 0);
+
+        CaretBrowsing.stopAnimation();
     };
 
     CaretBrowsing.toggle = function(value) {
@@ -1252,6 +1257,17 @@ window._qutebrowser.caret = (function() {
     CaretBrowsing.onWindowBlur = function() {
         CaretBrowsing.isWindowFocused = false;
         CaretBrowsing.updateIsCaretVisible();
+    };
+
+    CaretBrowsing.startAnimation = function() {
+        CaretBrowsing.caretElement.style.animationIterationCount = 'infinite';
+    };
+
+    CaretBrowsing.stopAnimation = function() {
+        CaretBrowsing.caretElement.style.animationIterationCount = 0;
+        window.setTimeout(() => {
+            CaretBrowsing.startAnimation();
+        }, 1000);
     };
 
     CaretBrowsing.init = function() {

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -862,6 +862,9 @@ window._qutebrowser.caret = (function() {
             "  min-height: 10px;" +
             "  min-width: 0.6em;" +
             "  mix-blend-mode: difference;" +
+            "  --inherited-color: inherit;" +
+            "  background-color: var(--inherited-color, #fff);" +
+            "  color: var(--inherited-color, #000);" +
             "  filter: invert(50%);" +
             "  animation: blink 1s step-end infinite;" +
             "}";

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -867,17 +867,13 @@ window._qutebrowser.caret = (function() {
             "  mix-blend-mode: difference;" +
             "  filter: invert(85%);" +
             "  animation: blink 1s step-end infinite;" +
-            "}";
-        const blink = "@keyframes blink {" +
+            "}" +
+            "@keyframes blink {" +
             "50% { visibility: hidden; }" +
             "}";
         const node = document.createElement("style");
         node.innerHTML = style;
         document.body.appendChild(node);
-
-        const node2 = document.createElement("style");
-        node2.innerHTML = blink;
-        document.body.appendChild(node2);
     };
 
     /**

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -860,11 +860,22 @@ window._qutebrowser.caret = (function() {
             "  position: absolute;" +
             "  z-index: 2147483647;" +
             "  min-height: 10px;" +
-            "  background-color: #000;" +
+            "  min-width: 0.6em;" +
+            "  background: inherit;" +
+            "  color: inherit;" +
+            "  mix-blend-mode: difference;" +
+            "  filter: invert(50%);" +
+            "  animation: blink 1s step-end infinite;" +
+            "}";
+        const blink = "@keyframes blink {" +
+            "50% { visibility: hidden; }" +
             "}";
         const node = document.createElement("style");
         node.innerHTML = style;
         document.body.appendChild(node);
+        const node2 = document.createElement("style");
+        node2.innerHTML = blink;
+        document.body.appendChild(node2);
     };
 
     /**

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -861,15 +861,11 @@ window._qutebrowser.caret = (function() {
             "  z-index: 2147483647;" +
             "  min-height: 1em;" +
             "  min-width: 0.2em;" +
-            "  --inherited-color: inherit;" +
-            "  background-color: var(--inherited-color, #000);" +
-            "  color: var(--inherited-color, #000);" +
-            "  mix-blend-mode: difference;" +
-            "  filter: invert(85%);" +
+            "  background-color: #000;" +
             "  animation: blink 1s step-end infinite;" +
             "}" +
             "@keyframes blink {" +
-            "50% { visibility: hidden; }" +
+            "  50% { visibility: hidden; }" +
             "}";
         const node = document.createElement("style");
         node.innerHTML = style;

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -860,9 +860,9 @@ window._qutebrowser.caret = (function() {
             "  position: absolute;" +
             "  z-index: 2147483647;" +
             "  min-height: 1em;" +
-            "  min-width: 0.6em;" +
+            "  min-width: 0.2em;" +
             "  --inherited-color: inherit;" +
-            "  background-color: var(--inherited-color, #AAA);" +
+            "  background-color: var(--inherited-color, #FFF);" +
             "  color: var(--inherited-color, #000);" +
             "  mix-blend-mode: difference;" +
             "  filter: invert(45%);" +

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -862,7 +862,7 @@ window._qutebrowser.caret = (function() {
             "  min-height: 1em;" +
             "  min-width: 0.2em;" +
             "  --inherited-color: inherit;" +
-            "  background-color: var(--inherited-color, #FFF);" +
+            "  background-color: var(--inherited-color, #000);" +
             "  color: var(--inherited-color, #000);" +
             "  mix-blend-mode: difference;" +
             "  filter: invert(85%);" +

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -865,7 +865,7 @@ window._qutebrowser.caret = (function() {
             "  background-color: var(--inherited-color, #FFF);" +
             "  color: var(--inherited-color, #000);" +
             "  mix-blend-mode: difference;" +
-            "  filter: invert(45%);" +
+            "  filter: invert(85%);" +
             "  animation: blink 1s step-end infinite;" +
             "}";
         const blink = "@keyframes blink {" +

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -861,8 +861,6 @@ window._qutebrowser.caret = (function() {
             "  z-index: 2147483647;" +
             "  min-height: 10px;" +
             "  min-width: 0.6em;" +
-            "  background: inherit;" +
-            "  color: inherit;" +
             "  mix-blend-mode: difference;" +
             "  filter: invert(50%);" +
             "  animation: blink 1s step-end infinite;" +

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -945,7 +945,7 @@ window._qutebrowser.caret = (function() {
      */
     CaretBrowsing.setCaretElementNormalStyle = function() {
         const element = CaretBrowsing.caretElement;
-        element.ClassName = "CaretBrowsing_Caret";
+        element.className = "CaretBrowsing_Caret";
         if (CaretBrowsing.isSelectionCollapsed) {
             element.style.opacity = "1.0";
         } else {
@@ -1260,7 +1260,7 @@ window._qutebrowser.caret = (function() {
     };
 
     CaretBrowsing.startAnimation = function() {
-        CaretBrowsing.caretElement.style.animationIterationCount = 'infinite';
+        CaretBrowsing.caretElement.style.animationIterationCount = "infinite";
     };
 
     CaretBrowsing.stopAnimation = function() {

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -859,13 +859,13 @@ window._qutebrowser.caret = (function() {
         const style = ".CaretBrowsing_Caret {" +
             "  position: absolute;" +
             "  z-index: 2147483647;" +
-            "  min-height: 10px;" +
+            "  min-height: 1em;" +
             "  min-width: 0.6em;" +
-            "  mix-blend-mode: difference;" +
             "  --inherited-color: inherit;" +
-            "  background-color: var(--inherited-color, #000);" +
+            "  background-color: var(--inherited-color, #AAA);" +
             "  color: var(--inherited-color, #000);" +
-            "  filter: invert(50%);" +
+            "  mix-blend-mode: difference;" +
+            "  filter: invert(45%);" +
             "  animation: blink 1s step-end infinite;" +
             "}";
         const blink = "@keyframes blink {" +


### PR DESCRIPTION
This changes some of the style of the caret:

Use inherit rather than set colours so whatever is in the parent element is used.
min-width of 0.6em uses roughtly the whole character width, and it resizes in proportion with zoom and/or min-font-size. To use a vertical line it could be changed to 0.2em perhaps (untested).
mix-blend-mode inverts the text colour.
blink helps to make it stand out more
background could be background-color. Not sure yet what difference it makes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3940)
<!-- Reviewable:end -->

*edit by @The-Compiler to link issues: Fixes #3936*