### PR TITLE
Prevent closing :report dialog when pressing <escape>

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2179,6 +2179,13 @@ fonts.web.size.minimum_logical:
     maxval: maxint
   desc: Minimum logical font size (in pixels) that is applied when zooming out.
 
+## reporter
+
+reporter.escape_quits:
+  type: Bool
+  default: True
+  desc: Allow escape to quit the crash reporter.
+
 ## keybindings
 
 bindings.key_mappings:

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -158,6 +158,11 @@ class _CrashDialog(QDialog):
         self._init_info_text()
         self._init_buttons()
 
+    # Prevent closing :report dialogs when pressing <escape>
+    def keyPressEvent(self, e):
+        if e.key() != Qt.Key_Escape:
+            super().keyPressEvent(e)
+
     def __repr__(self):
         return utils.get_repr(self)
 

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -160,7 +160,7 @@ class _CrashDialog(QDialog):
 
     # Prevent closing :report dialogs when pressing <escape>
     def keyPressEvent(self, e):
-        if e.key() != Qt.Key_Escape:
+        if config.val.reporter.escape_quits or e.key() != Qt.Key_Escape:
             super().keyPressEvent(e)
 
     def __repr__(self):


### PR DESCRIPTION
I've accidentally closed quite a few `:report`s (which is really bad when a crash happened), so I decided to unbind `<escape>` for `_CrashDialog`. By default `QDialog` calls [reject when escape is pressed](https://doc.qt.io/qt-5/qdialog.html#escape-key), and all this does is filter out the `<escape>` key.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3944)
<!-- Reviewable:end -->
