### PR TITLE
Add support for following tab selected elements to :follow-selected

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -337,8 +337,10 @@ class WebEngineCaret(browsertab.AbstractCaret):
             return
         if js_elem == "focused":
             # we had a focused element, not a selected one. Just send <enter>
-            self._tab.key_press(Qt.Key_Enter)
-            return
+            if tab:
+                self._tab.key_press(Qt.Key_Enter, modifier=Qt.ControlModifier)
+            else:
+                self._tab.key_press(Qt.Key_Enter)
 
         assert isinstance(js_elem, dict), js_elem
         elem = webengineelem.WebEngineElement(js_elem, tab=self._tab)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -335,6 +335,11 @@ class WebEngineCaret(browsertab.AbstractCaret):
         """
         if js_elem is None:
             return
+        if js_elem == "focused":
+            # we had a focused element, not a selected one. Just send <enter>
+            self._tab.key_press(Qt.Key_Enter)
+            return
+
         assert isinstance(js_elem, dict), js_elem
         elem = webengineelem.WebEngineElement(js_elem, tab=self._tab)
         if tab:
@@ -364,7 +369,8 @@ class WebEngineCaret(browsertab.AbstractCaret):
 
         else:
             # click an existing blue selection
-            js_code = javascript.assemble('webelem', 'find_selected_focused_link')
+            js_code = javascript.assemble('webelem',
+                                          'find_selected_focused_link')
             self._tab.run_js_async(js_code, lambda jsret:
                                    self._follow_selected_cb(jsret, tab))
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -364,7 +364,7 @@ class WebEngineCaret(browsertab.AbstractCaret):
 
         else:
             # click an existing blue selection
-            js_code = javascript.assemble('webelem', 'find_selected_link')
+            js_code = javascript.assemble('webelem', 'find_selected_focused_link')
             self._tab.run_js_async(js_code, lambda jsret:
                                    self._follow_selected_cb(jsret, tab))
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -388,6 +388,11 @@ class WebKitCaret(browsertab.AbstractCaret):
         else:
             selection = self._widget.selectedHtml()
             if not selection:
+                # Getting here may mean we crashed, but we can't do anything
+                # about that:
+                # https://github.com/annulen/webkit/commit/0e75f3272d149bc64899c161f150eb341a2417af
+                # TODO find a way to check if something is focused
+                self._tab.key_press(Qt.Key_Enter)
                 return
             try:
                 selected_element = xml.etree.ElementTree.fromstring(

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -377,8 +377,14 @@ class WebKitCaret(browsertab.AbstractCaret):
                 QWebSettings.JavascriptEnabled):
             if tab:
                 self._tab.data.override_target = usertypes.ClickTarget.tab
-            self._tab.run_js_async(
-                'window.getSelection().anchorNode.parentNode.click()')
+            self._tab.run_js_async("""
+                const aElm = document.activeElement;
+                if (window.getSelection().anchorNode) {
+                    window.getSelection().anchorNode.parentNode.click();
+                } else if (aElm && aElm !== document.body) {
+                    aElm.click();
+                }
+            """)
         else:
             selection = self._widget.selectedHtml()
             if not selection:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -389,10 +389,14 @@ class WebKitCaret(browsertab.AbstractCaret):
             selection = self._widget.selectedHtml()
             if not selection:
                 # Getting here may mean we crashed, but we can't do anything
-                # about that:
+                # about that until this commit is released:
                 # https://github.com/annulen/webkit/commit/0e75f3272d149bc64899c161f150eb341a2417af
                 # TODO find a way to check if something is focused
-                self._tab.key_press(Qt.Key_Enter)
+                if tab:
+                    self._tab.key_press(Qt.Key_Enter,
+                                        modifier=Qt.ControlModifier)
+                else:
+                    self._tab.key_press(Qt.Key_Enter)
                 return
             try:
                 selected_element = xml.etree.ElementTree.fromstring(

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -243,6 +243,7 @@ window._qutebrowser.webelem = (function() {
     };
 
     // Runs a function in a frame until the result is not null, then return
+    // If no frame succeds, return null
     function run_frames(func) {
         for (let i = 0; i < window.frames.length; ++i) {
             const frame = window.frames[i];
@@ -329,7 +330,8 @@ window._qutebrowser.webelem = (function() {
     };
 
     // Function for returning a selection to python (so we can click it)
-    funcs.find_selected_link = () => {
+    // If there is no selection, get the currently focused element.
+    funcs.find_selected_focused_link = () => {
         const elem = window.getSelection().baseNode;
         if (elem) {
             return serialize_elem(elem.parentNode);
@@ -342,7 +344,12 @@ window._qutebrowser.webelem = (function() {
             }
             return null;
         });
-        return serialized_frame_elem;
+
+        if (serialized_frame_elem) {
+            return serialized_frame_elem;
+        }
+        // No selected element, return focused element
+        return funcs.find_focused();
     };
 
     funcs.set_value = (id, value) => {

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -329,8 +329,9 @@ window._qutebrowser.webelem = (function() {
         return serialize_elem(elem);
     };
 
-    // Function for returning a selection to python (so we can click it)
-    // If there is no selection, get the currently focused element.
+    // Function for returning a selection or focus to python (so we can click
+    // it). If nothing is selected but there is something focused, returns
+    // "focused"
     funcs.find_selected_focused_link = () => {
         const elem = window.getSelection().baseNode;
         if (elem) {
@@ -348,8 +349,7 @@ window._qutebrowser.webelem = (function() {
         if (serialized_frame_elem) {
             return serialized_frame_elem;
         }
-        // No selected element, return focused element
-        return funcs.find_focused();
+        return funcs.find_focused() && "focused";
     };
 
     funcs.set_value = (id, value) => {

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -321,6 +321,32 @@ Feature: Caret mode
             - data/caret.html
             - data/hello.txt (active)
 
+    @qtwebkit_skip: getting focused element not possible without js
+    Scenario: :follow-selected with link tabbing (without JS)
+        When I set content.javascript.enabled to false
+        And I run :fake-key <tab>
+        And I run :follow-selected
+        Then data/hello.txt should be loaded
+
+    Scenario: :follow-selected with link tabbing (with JS)
+        When I set content.javascript.enabled to true
+        And I run :fake-key <tab>
+        And I run :follow-selected
+        Then data/hello.txt should be loaded
+
+    @qtwebkit_skip: getting focused element not possible without js
+    Scenario: :follow-selected with link tabbing in a tab (without JS)
+        When I set content.javascript.enabled to false
+        And I run :fake-key <tab>
+        And I run :follow-selected --tab
+        Then data/hello.txt should be loaded
+
+    Scenario: :follow-selected with link tabbing in a tab (with JS)
+        When I set content.javascript.enabled to true
+        And I run :fake-key <tab>
+        And I run :follow-selected --tab
+        Then data/hello.txt should be loaded
+
     # Search + caret mode
 
     # https://bugreports.qt.io/browse/QTBUG-60673

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -321,28 +321,34 @@ Feature: Caret mode
             - data/caret.html
             - data/hello.txt (active)
 
-    @qtwebkit_skip: getting focused element not possible without js
     Scenario: :follow-selected with link tabbing (without JS)
         When I set content.javascript.enabled to false
+        And I run :leave-mode
+        And I run :jseval document.activeElement.blur();
         And I run :fake-key <tab>
         And I run :follow-selected
         Then data/hello.txt should be loaded
 
     Scenario: :follow-selected with link tabbing (with JS)
         When I set content.javascript.enabled to true
+        And I run :leave-mode
+        And I run :jseval document.activeElement.blur();
         And I run :fake-key <tab>
         And I run :follow-selected
         Then data/hello.txt should be loaded
 
-    @qtwebkit_skip: getting focused element not possible without js
     Scenario: :follow-selected with link tabbing in a tab (without JS)
         When I set content.javascript.enabled to false
+        And I run :leave-mode
+        And I run :jseval document.activeElement.blur();
         And I run :fake-key <tab>
         And I run :follow-selected --tab
         Then data/hello.txt should be loaded
 
     Scenario: :follow-selected with link tabbing in a tab (with JS)
         When I set content.javascript.enabled to true
+        And I run :leave-mode
+        And I run :jseval document.activeElement.blur();
         And I run :fake-key <tab>
         And I run :follow-selected --tab
         Then data/hello.txt should be loaded


### PR DESCRIPTION
For qtwebkit, I couldn't find a way to do this without js, so I'm only supporting it there if js is enabled.

Closes #3935

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3947)
<!-- Reviewable:end -->
