### PR TITLE
Sanitize download filenames

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1224,8 +1224,7 @@ class TempDownloadManager:
             A tempfile.NamedTemporaryFile that should be used to save the file.
         """
         tmpdir = self._get_tmpdir()
-        encoding = sys.getfilesystemencoding()
-        suggested_name = utils.force_encoding(suggested_name, encoding)
+        suggested_name = utils.sanitize_filename(suggested_name)
         # Make sure that the filename is not too long
         suggested_name = utils.elide_filename(suggested_name, 50)
         fobj = tempfile.NamedTemporaryFile(dir=tmpdir.name, delete=False,

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -135,11 +135,11 @@ def create_full_filename(basename, filename):
         The full absolute path, or None if filename creation was not possible.
     """
     basename = utils.sanitize_filename(basename)
+    # Filename can be a full path so don't use sanitize_filename on it.
     # Remove chars which can't be encoded in the filename encoding.
     # See https://github.com/qutebrowser/qutebrowser/issues/427
     encoding = sys.getfilesystemencoding()
     filename = utils.force_encoding(filename, encoding)
-    basename = utils.force_encoding(basename, encoding)
     if os.path.isabs(filename) and (os.path.isdir(filename) or
                                     filename.endswith(os.sep)):
         # We got an absolute directory from the user, so we save it under
@@ -161,8 +161,6 @@ def get_filename_question(*, suggested_filename, url, parent=None):
         parent: The parent of the question (a QObject).
     """
     suggested_filename = utils.sanitize_filename(suggested_filename)
-    encoding = sys.getfilesystemencoding()
-    suggested_filename = utils.force_encoding(suggested_filename, encoding)
 
     q = usertypes.Question(parent)
     q.title = "Save file to:"

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -134,6 +134,7 @@ def create_full_filename(basename, filename):
     Return:
         The full absolute path, or None if filename creation was not possible.
     """
+    basename = utils.sanitize_filename(basename)
     # Remove chars which can't be encoded in the filename encoding.
     # See https://github.com/qutebrowser/qutebrowser/issues/427
     encoding = sys.getfilesystemencoding()
@@ -159,6 +160,7 @@ def get_filename_question(*, suggested_filename, url, parent=None):
         url: The URL the download originated from.
         parent: The parent of the question (a QObject).
     """
+    suggested_filename = utils.sanitize_filename(suggested_filename)
     encoding = sys.getfilesystemencoding()
     suggested_filename = utils.force_encoding(suggested_filename, encoding)
 

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -499,6 +499,12 @@ def sanitize_filename(name, replacement='_'):
     """
     if replacement is None:
         replacement = ''
+
+    # Remove chars which can't be encoded in the filename encoding.
+    # See https://github.com/qutebrowser/qutebrowser/issues/427
+    encoding = sys.getfilesystemencoding()
+    name = force_encoding(name, encoding)
+
     # Bad characters taken from Windows, there are even fewer on Linux
     # See also
     # https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -505,10 +505,16 @@ def sanitize_filename(name, replacement='_'):
     encoding = sys.getfilesystemencoding()
     name = force_encoding(name, encoding)
 
-    # Bad characters taken from Windows, there are even fewer on Linux
     # See also
     # https://en.wikipedia.org/wiki/Filename#Reserved_characters_and_words
-    bad_chars = '\\/:*?"<>|'
+    if is_windows:
+        bad_chars = '\\/:*?"<>|'
+    elif is_mac:
+        # Colons can be confusing in finder https://superuser.com/a/326627
+        bad_chars = '/:'
+    else:
+        bad_chars = '/'
+
     for bad_char in bad_chars:
         name = name.replace(bad_char, replacement)
     return name

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -459,16 +459,35 @@ def mode_manager(win_registry, config_stub, qapp):
     objreg.delete('mode-manager', scope='window', window=0)
 
 
+def standarddir_tmpdir(folder, monkeypatch, tmpdir):
+    """Set tmpdir/config as the configdir.
+
+    Use this to avoid creating a 'real' config dir (~/.config/qute_test).
+    """
+    confdir = tmpdir / folder
+    confdir.ensure(dir=True)
+    if hasattr(standarddir, folder):
+        monkeypatch.setattr(standarddir, folder,
+                            lambda **_kwargs: str(confdir))
+    return confdir
+
+
+@pytest.fixture
+def download_tmpdir(monkeypatch, tmpdir):
+    """Set tmpdir/download as the downloaddir.
+
+    Use this to avoid creating a 'real' download dir (~/.config/qute_test).
+    """
+    return standarddir_tmpdir('download', monkeypatch, tmpdir)
+
+
 @pytest.fixture
 def config_tmpdir(monkeypatch, tmpdir):
     """Set tmpdir/config as the configdir.
 
     Use this to avoid creating a 'real' config dir (~/.config/qute_test).
     """
-    confdir = tmpdir / 'config'
-    confdir.ensure(dir=True)
-    monkeypatch.setattr(standarddir, 'config', lambda auto=False: str(confdir))
-    return confdir
+    return standarddir_tmpdir('config', monkeypatch, tmpdir)
 
 
 @pytest.fixture
@@ -477,10 +496,7 @@ def data_tmpdir(monkeypatch, tmpdir):
 
     Use this to avoid creating a 'real' data dir (~/.local/share/qute_test).
     """
-    datadir = tmpdir / 'data'
-    datadir.ensure(dir=True)
-    monkeypatch.setattr(standarddir, 'data', lambda system=False: str(datadir))
-    return datadir
+    return standarddir_tmpdir('data', monkeypatch, tmpdir)
 
 
 @pytest.fixture
@@ -489,10 +505,7 @@ def runtime_tmpdir(monkeypatch, tmpdir):
 
     Use this to avoid creating a 'real' runtime dir.
     """
-    runtimedir = tmpdir / 'runtime'
-    runtimedir.ensure(dir=True)
-    monkeypatch.setattr(standarddir, 'runtime', lambda: str(runtimedir))
-    return runtimedir
+    return standarddir_tmpdir('runtime', monkeypatch, tmpdir)
 
 
 @pytest.fixture
@@ -501,10 +514,7 @@ def cache_tmpdir(monkeypatch, tmpdir):
 
     Use this to avoid creating a 'real' cache dir (~/.cache/qute_test).
     """
-    cachedir = tmpdir / 'cache'
-    cachedir.ensure(dir=True)
-    monkeypatch.setattr(standarddir, 'cache', lambda: str(cachedir))
-    return cachedir
+    return standarddir_tmpdir('cache', monkeypatch, tmpdir)
 
 
 @pytest.fixture

--- a/tests/unit/browser/webkit/test_downloads.py
+++ b/tests/unit/browser/webkit/test_downloads.py
@@ -96,3 +96,24 @@ class TestDownloadTarget:
     ])
     def test_class_hierarchy(self, obj):
         assert isinstance(obj, downloads._DownloadTarget)
+
+
+@pytest.mark.parametrize('raw, expected', [
+    ('http://foo/bar', 'bar'),
+    ('A *|<>\\: bear!', 'A ______ bear!')
+])
+def test_sanitized_filenames(raw, expected, config_stub, download_tmpdir):
+    manager = downloads.AbstractDownloadManager()
+    target = downloads.FileDownloadTarget(download_tmpdir)
+    item = downloads.AbstractDownloadItem()
+
+    # Don't try to start a timer outside of a QThread
+    manager._update_timer.isActive = lambda: True
+
+    # Abstract methods
+    item._ensure_can_set_filename = lambda *args: True
+    item._after_set_filename = lambda *args: True
+
+    manager._init_item(item, True, raw)
+    item.set_target(target)
+    assert item._filename.endswith(expected)

--- a/tests/unit/browser/webkit/test_downloads.py
+++ b/tests/unit/browser/webkit/test_downloads.py
@@ -104,7 +104,7 @@ class TestDownloadTarget:
 ])
 def test_sanitized_filenames(raw, expected, config_stub, download_tmpdir):
     manager = downloads.AbstractDownloadManager()
-    target = downloads.FileDownloadTarget(download_tmpdir)
+    target = downloads.FileDownloadTarget(str(download_tmpdir))
     item = downloads.AbstractDownloadItem()
 
     # Don't try to start a timer outside of a QThread


### PR DESCRIPTION
As per #3922, downloading files with illegal characters fails on windows at file creation. This change uses `utils.sanitize_filename()` in two places, once where we finalize guessing a filename based on URL or Content-Disposition and once in get_filename_question where we prompt the user for a filename.

Filenames input at the download location prompt are not modified so a user can still input asterisks and such in there if they like.

Maybe this should be platform dependant, I have a slight preference for having the saved filename closer to the URL.

I wasn't sure about all the possible paths into and through the downloading code so I modified all the end2end tests because they seem to have good coverage.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3950)
<!-- Reviewable:end -->
