### PR TITLE
Add note about base16-qutebrowser

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -390,6 +390,11 @@ xresources = read_xresources('*')
 c.colors.statusbar.normal.bg = xresources['*.background']
 ----
 
+Using color from base16
+^^^^^^^^^^^^^^^^^^^^^^^
+
+A collection of https://github.com/chriskempson/base16[base16]-color-schemes can be found in https://github.com/theova/base16-qutebrowser[base16-qutebrowser] and used with https://github.com/AuditeMarlow/base16-manager[base16]-manager.
+
 Avoiding flake8 errors
 ^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
I made a collection of [base16](https://github.com/chriskempson/base16)-color-schemes for qutebrowser and would like to share it. They can be found in [base16-qutebrowser](https://github.com/theova/base16-qutebrowser).

I'm not sure, if this is the right way, so I'm sorry if it isn't.

Thanks for your great work!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/3963)
<!-- Reviewable:end -->
