### PR TITLE
greasemonkey: enable running in isolated js worlds

### DIFF
--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -58,6 +58,7 @@ class GreasemonkeyScript:
         self.run_at = None
         self.script_meta = None
         self.runs_on_sub_frames = True
+        self.jsworld = "main"
         for name, value in properties:
             if name == 'name':
                 self.name = value
@@ -77,6 +78,8 @@ class GreasemonkeyScript:
                 self.runs_on_sub_frames = False
             elif name == 'require':
                 self.requires.append(value)
+            elif name == 'qute-js-world':
+                self.jsworld = value
 
     HEADER_REGEX = r'// ==UserScript==|\n+// ==/UserScript==\n'
     PROPS_REGEX = r'// @(?P<prop>[^\s]+)\s*(?P<val>.*)'

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -908,6 +908,9 @@ class _WebEngineScripts(QObject):
             remove_first: Whether to remove all previously injected
                           scripts before adding these ones.
         """
+        if sip.isdeleted(self._widget):
+            return
+
         # Since we are inserting scripts into a per-tab collection,
         # rather than just injecting scripts on page load, we need to
         # make sure we replace existing scripts, not just add new ones.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -874,18 +874,18 @@ class _WebEngineScripts(QObject):
         self._inject_early_js('stylesheet', js_code, subframes=True)
 
     def _inject_userscripts(self):
-        """Register user JavaScript files with the global profiles."""
+        """Register user JavaScript files with the current tab."""
         # The Greasemonkey metadata block support in QtWebEngine only starts at
         # Qt 5.8. With 5.7.1, we need to inject the scripts ourselves in
         # response to urlChanged.
         if not qtutils.version_check('5.8'):
             return
 
-        # Since we are inserting scripts into profile.scripts they won't
-        # just get replaced by new gm scripts like if we were injecting them
-        # ourselves so we need to remove all gm scripts, while not removing
-        # any other stuff that might have been added. Like the one for
-        # stylesheets.
+        # Since we are inserting scripts into a per-tab collection,
+        # rather than just injecting scripts on page load, we need to
+        # make sure we replace existing scripts, not just add new ones.
+        # While, taking care not to remove any other scripts that might
+        # have been added elsewhere, like the one for stylesheets.
         greasemonkey = objreg.get('greasemonkey')
         scripts = self._widget.page().scripts()
         for script in scripts.toList():

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -859,11 +859,12 @@ class _WebEngineScripts(QObject):
         # response to urlChanged.
         if not qtutils.version_check('5.8'):
             self._widget.page().urlChanged.connect(
-                self._inject_userscripts_for_url)
+                self._inject_greasemonkey_scripts_for_url)
         else:
             greasemonkey = objreg.get('greasemonkey')
-            greasemonkey.scripts_reloaded.connect(self._inject_all_userscripts)
-            self._inject_all_userscripts()
+            greasemonkey.scripts_reloaded.connect(
+                self._inject_all_greasemonkey_scripts)
+            self._inject_all_greasemonkey_scripts()
 
     def _init_stylesheet(self):
         """Initialize custom stylesheets.
@@ -880,23 +881,23 @@ class _WebEngineScripts(QObject):
         )
         self._inject_early_js('stylesheet', js_code, subframes=True)
 
-    def _inject_userscripts_for_url(self, url):
+    def _inject_greasemonkey_scripts_for_url(self, url):
         greasemonkey = objreg.get('greasemonkey')
         matching_scripts = greasemonkey.scripts_for(url)
-        self._inject_userscripts(
+        self._inject_greasemonkey_scripts(
             matching_scripts.start, QWebEngineScript.DocumentCreation, True)
-        self._inject_userscripts(
+        self._inject_greasemonkey_scripts(
             matching_scripts.end, QWebEngineScript.DocumentReady, False)
-        self._inject_userscripts(
+        self._inject_greasemonkey_scripts(
             matching_scripts.idle, QWebEngineScript.Deferred, False)
 
-    def _inject_all_userscripts(self):
+    def _inject_all_greasemonkey_scripts(self):
         greasemonkey = objreg.get('greasemonkey')
         scripts = greasemonkey.all_scripts()
-        self._inject_userscripts(scripts)
+        self._inject_greasemonkey_scripts(scripts)
 
-    def _inject_userscripts(self, scripts=None, injection_point=None,
-                            remove_first=True):
+    def _inject_greasemonkey_scripts(self, scripts=None, injection_point=None,
+                                     remove_first=True):
         """Register user JavaScript files with the current tab.
 
         Args:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -900,7 +900,18 @@ class _WebEngineScripts(QObject):
             # @run-at (and @include/@exclude/@match) is parsed by
             # QWebEngineScript.
             new_script = QWebEngineScript()
-            new_script.setWorldId(QWebEngineScript.MainWorld)
+            try:
+                world = int(script.jsworld)
+            except ValueError:
+                try:
+                    world = _JS_WORLD_MAP[usertypes.JsWorld[
+                        script.jsworld.lower()]]
+                except KeyError:
+                    log.greasemonkey.error(
+                        "script {} has invalid value for '@qute-js-world'"
+                        ": {}".format(script.name, script.jsworld))
+                    continue
+            new_script.setWorldId(world)
             new_script.setSourceCode(script.code())
             new_script.setName("GM-{}".format(script.name))
             new_script.setRunsOnSubFrames(script.runs_on_sub_frames)

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -288,7 +288,19 @@ class WebEnginePage(QWebEnginePage):
         def _add_script(script, injection_point):
             new_script = QWebEngineScript()
             new_script.setInjectionPoint(injection_point)
-            new_script.setWorldId(QWebEngineScript.MainWorld)
+            try:
+                world = int(script.jsworld)
+            except ValueError:
+                try:
+                    from qutebrowser.browser.webengine.webenginetab import _JS_WORLD_MAP
+                    world = _JS_WORLD_MAP[usertypes.JsWorld[
+                        script.jsworld.lower()]]
+                except KeyError:
+                    log.greasemonkey.error(
+                        "script {} has invalid value for '@qute-js-world'"
+                        ": {}".format(script.name, script.jsworld))
+                    return
+            new_script.setWorldId(world)
             new_script.setSourceCode(script.code())
             new_script.setName("GM-{}".format(script.name))
             new_script.setRunsOnSubFrames(script.runs_on_sub_frames)


### PR DESCRIPTION
Allows putting greasemonkey compatible scripts in isolated JS worlds. As requested in #3238 and by @slackhead. I haven't added any tests because I think they would be bascially the same as `tests/unit/javascript/test_js_execution.py::test_simple_js_webengine()`. Although I suppose I could add tests for all the logic in `qutebrowser/browser/webengine/webenginetab.py::_inject_userscripts()`?

QtWebEngine (via chromium) has the ability to run injected scripts in
isolated "worlds". What is isolated is just the javascript environment
so variables and functions defined by the page and the script won't
clobber each other, or be able to interact (including variables saved to
the global `window` object). The DOM is still accessible from "isolated"
scripts.

This is NOT a security measure. You cannot put untrusted scripts in one
of these isolated worlds and expect it to not be able to do whatever
page js can do, it is just for namespacing convenience. See
https://stackoverflow.com/questions/9515704/insert-code-into-the-page-context-using-a-content-script
for some examples of how to inject scripts into the page scope using DOM
elements.

With this change you can specify the world ID in a `@qute-js-world` world
directive like:

```
// ==UserScript==
// @name         Do thing
// @match        *://some.site/*
// @qute-js-world 1234
// ==/UserScript==
document.body.innerHTML = "<strong>overwritten</strong>"
```

The QtWebEngine docs say worldid is a `quint32` so you can put whatever
number (positive, whole, real) you want there. I have chosen to allow
the `qutebrowser.utils.usertypes` enum as aliases for IDs that are
predefined in
`qutebrowser.browser.webengine.webenginetab._JS_WORLD_MAP`. So you can
pass main|application|user|jseval in there too. `main` (0) is the
default one and is the one that is disabled when
`content.javascript.enabled` is set to `false`. All others are still
enabled.

I'm not sure whether using any of those already-named worlds makes
sense, apart from `main`. We could stop people from using them I
suppose. Another option is to allow people to pass in `*` as a value to
have scripts put into their own little worlds, probably backed by a
counter in the GreaseMonkeyManager class.

Chrome docs: https://developer.chrome.com/extensions/content_scripts#execution-environment
Webengine docs: https://doc.qt.io/qt-5/qwebenginescript.html#details

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4017)
<!-- Reviewable:end -->
