### PR TITLE
Fix crash when tab is closed after a per-domain forced reload

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -979,6 +979,9 @@ class WebEngineTab(browsertab.AbstractTab):
             url: The QUrl to open.
             predict: If set to False, predicted_navigation is not emitted.
         """
+        if sip.isdeleted(self._widget):
+            # https://github.com/qutebrowser/qutebrowser/issues/3896
+            return
         self._saved_zoom = self.zoom.factor()
         self._openurl_prepare(url, predict=predict)
         self._widget.load(url)


### PR DESCRIPTION
I think this might work towards https://github.com/qutebrowser/qutebrowser/issues/3896, but I'm not 100% sure yet. See 7162f15 and https://github.com/qutebrowser/qutebrowser/issues/3498 as well.

After 7162f15, I still got crashes, but they were slightly different:

```
00:11:41 DEBUG    config     webenginetab:_on_load_finished:1214 Loading https://github.com/ again because of config change
00:11:41 DEBUG    modes      modeman:_handle_keypress:172 got keypress in mode KeyMode.normal - delegating to <qutebrowser.keyinput.modeparsers.NormalKeyParser>
00:11:41 DEBUG    keyboard   basekeyparser:_debug_log:91 Got key: 0x58 / modifiers: 0x0 / text: 'x' / dry_run True
00:11:41 DEBUG    modes      modeman:_handle_keypress:199 match: 2, forward_unbound_keys: auto, passthrough: False, is_non_alnum: False, dry_run: True --> filter: True (focused: None)
00:11:41 DEBUG    modes      modeman:_handle_keypress:172 got keypress in mode KeyMode.normal - delegating to <qutebrowser.keyinput.modeparsers.NormalKeyParser>
00:11:41 DEBUG    keyboard   basekeyparser:_debug_log:91 Got key: 0x58 / modifiers: 0x0 / text: 'x' / dry_run False
00:11:41 DEBUG    keyboard   basekeyparser:_debug_log:91 Definitive match for 'x'.
00:11:41 DEBUG    keyboard   basekeyparser:_debug_log:91 Clearing keystring (was: x).
00:11:41 DEBUG    commands   command:run:491 command called: tab-close
00:11:41 DEBUG    commands   command:run:506 Calling qutebrowser.browser.commands.CommandDispatcher.tab_close(<qutebrowser.browser.commands.CommandDispatcher>, False, False, False, False, None)
00:11:41 DEBUG    modes      tabbedbrowser:on_current_changed:683 Current tab changed, focusing <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=66 url='http://ergoemacs.org/emacs/elisp_find-file_vs_with-temp-buffer.html'>
00:11:41 DEBUG    misc       app:on_focus_object_changed:840 Focus object changed: <PyQt5.QtWidgets.QWidget object at 0x7f1bcfb689d8>
00:11:41 DEBUG    modes      tabbedbrowser:on_current_changed:691 Mode before tab change: normal (mode_on_change = persist)
00:11:41 DEBUG    modes      modeman:leave:307 Ignoring leave request for KeyMode.hint (reason tab changed) as we're in mode KeyMode.normal
00:11:41 DEBUG    modes      modeman:leave:307 Ignoring leave request for KeyMode.caret (reason tab changed) as we're in mode KeyMode.normal
00:11:41 DEBUG    modes      tabbedbrowser:on_current_changed:703 Mode after tab change: normal (mode_on_change = persist)
00:11:41 DEBUG    modes      modeman:_handle_keypress:199 match: 2, forward_unbound_keys: auto, passthrough: False, is_non_alnum: False, dry_run: False --> filter: True (focused: <PyQt5.QtWidgets.QWidget object at 0x7f1bcf4359d8>)
00:11:41 DEBUG    modes      modeman:_handle_keyrelease:219 filter: True
00:11:41 DEBUG    webview    tabbedbrowser:_tab_index:160 Got invalid tab (index is -1)!
00:11:41 DEBUG    webview    tabbedbrowser:_tab_index:160 Got invalid tab (index is -1)!
00:11:41 DEBUG    mouse      mouse:eventFilter:79 <PyQt5.QtWebEngineWidgets.QWebEngineView object at 0x7f1bcfb68558>: removed child <PyQt5.QtWidgets.QWidget object at 0x7f1bcf4359d8>
00:11:41 DEBUG    mouse      mouse:eventFilter:79 <PyQt5.QtWidgets.QWidget object at 0x7f1bcfb68558>: removed child <PyQt5.QtCore.QObject object at 0x7f1bcf4359d8>
00:11:41 DEBUG    misc       app:on_focus_object_changed:840 Focus object changed: <PyQt5.QtWidgets.QWidget object at 0x7f1bcfb67f78>
00:11:41 DEBUG    destroy    objreg:on_destroyed:121 schedule removal: 73
00:11:41 DEBUG    destroy    objreg:on_destroyed:121 schedule removal: tab
00:11:41 DEBUG    destroy    objreg:on_destroyed:121 schedule removal: hintmanager
00:11:41 ERROR    misc       crashsignal:exception_hook:214 Uncaught exception
Traceback (most recent call last):
  File "/usr/lib64/python3.5/site-packages/qutebrowser/browser/webengine/webenginetab.py", line 984, in openurl
    self._widget.load(url)
RuntimeError: wrapped C/C++ object of type WebEngineView has been deleted
...
```

To reproduce this more reliably, add a print before [this line](https://github.com/qutebrowser/qutebrowser/blob/749056ff906435cf990f993d39af251276232478/qutebrowser/browser/webengine/webenginetab.py#L1029) and increase the singleShot timer from 100ms to 2000ms, and close the tab while the timer is running.

I think this is the simplest way to fix this, but let me know if you think of a better solution.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4019)
<!-- Reviewable:end -->
