### PR TITLE
Lazier load

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -766,6 +766,7 @@ class AbstractTab(QWidget):
         self._mouse_event_filter = mouse.MouseEventFilter(
             self, parent=self)
         self.backend = None
+        self.load_on_focus = False
         self.loaded = True
 
         # FIXME:qtwebengine  Should this be public api via self.hints?
@@ -936,13 +937,47 @@ class AbstractTab(QWidget):
         return self._load_status
 
     def load(self):
-        raise NotImplementedError
+        if self.loaded:
+            return
+
+        self.history.load_items(self.history._to_load)
+        self.history._to_load = []
+        self.loaded = True
+        self.load_on_focus = False
 
     def unload(self):
-        raise NotImplementedError
+        if not self.loaded:
+            return
 
-    def load_history_entries(self, entries):
-        raise NotImplementedError
+        self.loaded = False
+        self.load_on_focus = True
+
+        _to_load = []
+        for idx, item in enumerate(self.history):
+            qtutils.ensure_valid(item)
+            item = TabHistoryItem(
+                item.url(),
+                item.title(),
+                original_url=item.originalUrl(),
+                active=idx == self.history.current_idx(),
+                user_data=None)
+            _to_load.append(item)
+        self.history._to_load =_to_load
+
+        _title = self._widget.title()
+        self._widget.setHtml('', self._widget.url())
+        self.title_changed.emit(_title)
+
+    def setFocus(self):
+        super().setFocus()
+        if self.load_on_focus:
+            self.load()
+
+    def load_history_items(self, entries):
+        if self.loaded:
+            self.history.load_items(entries)
+        else:
+            self.history._to_load.extend(entries)
 
     def _openurl_prepare(self, url, *, predict=True):
         qtutils.ensure_valid(url)

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -566,7 +566,10 @@ class AbstractHistory:
         return len(self._history)
 
     def __iter__(self):
-        return iter(self._to_load or self._history.items())
+        if self._history is not None:
+            return iter(self._history.items())
+        else:
+            return iter(self._to_load)
 
     def current_idx(self):
         raise NotImplementedError
@@ -763,7 +766,7 @@ class AbstractTab(QWidget):
         self._mouse_event_filter = mouse.MouseEventFilter(
             self, parent=self)
         self.backend = None
-        self.loaded = False
+        self.loaded = True
 
         # FIXME:qtwebengine  Should this be public api via self.hints?
         #                    Also, should we get it out of objreg?

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -524,6 +524,34 @@ class AbstractScroller(QObject):
     def at_bottom(self):
         raise NotImplementedError
 
+class TabHistoryItem:
+
+    """A single item in the tab history.
+
+    Attributes:
+        url: The QUrl of this item.
+        original_url: The QUrl of this item which was originally requested.
+        title: The title as string of this item.
+        active: Whether this item is the item currently navigated to.
+        user_data: The user data for this item.
+    """
+
+    def __init__(self, url, title, *, original_url=None, active=False,
+                 user_data=None):
+        self.url = url
+        if original_url is None:
+            self.original_url = url
+        else:
+            self.original_url = original_url
+        self.title = title
+        self.active = active
+        self.user_data = user_data
+
+    def __repr__(self):
+        return utils.get_repr(self, constructor=True, url=self.url,
+                              original_url=self.original_url, title=self.title,
+                              active=self.active, user_data=self.user_data)
+
 
 class AbstractHistory:
 
@@ -905,6 +933,9 @@ class AbstractTab(QWidget):
         return self._load_status
 
     def load(self):
+        raise NotImplementedError
+
+    def unload(self):
         raise NotImplementedError
 
     def load_history_entries(self, entries):

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -566,10 +566,10 @@ class AbstractHistory:
         return len(self._history)
 
     def __iter__(self):
-        if self._history is not None:
-            return iter(self._history.items())
-        else:
+        if self._to_load:
             return iter(self._to_load)
+        else:
+            return iter(self._history.items())
 
     def current_idx(self):
         raise NotImplementedError

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -532,12 +532,13 @@ class AbstractHistory:
     def __init__(self, tab):
         self._tab = tab
         self._history = None
+        self._to_load = []
 
     def __len__(self):
         return len(self._history)
 
     def __iter__(self):
-        return iter(self._history.items())
+        return iter(self._to_load or self._history.items())
 
     def current_idx(self):
         raise NotImplementedError
@@ -734,6 +735,7 @@ class AbstractTab(QWidget):
         self._mouse_event_filter = mouse.MouseEventFilter(
             self, parent=self)
         self.backend = None
+        self.loaded = False
 
         # FIXME:qtwebengine  Should this be public api via self.hints?
         #                    Also, should we get it out of objreg?
@@ -901,6 +903,12 @@ class AbstractTab(QWidget):
 
     def load_status(self):
         return self._load_status
+
+    def load(self):
+        raise NotImplementedError
+
+    def load_history_entries(self, entries):
+        raise NotImplementedError
 
     def _openurl_prepare(self, url, *, predict=True):
         qtutils.ensure_valid(url)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2253,6 +2253,9 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def tab_load(self, prev=False, next_=False, opposite=False,
                   force=False, count=None):
+        """
+        load the current tab
+        """
 
         # tabbar = self._tabbed_browser.widget.tabBar()
         tab = self._current_widget()
@@ -2261,6 +2264,9 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def tab_unload(self, prev=False, next_=False, opposite=False,
                   force=False, count=None):
+        """
+        unload the current tab
+        """
         tab = self._current_widget()
         tab.unload()
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1114,6 +1114,8 @@ class CommandDispatcher:
         window.activateWindow()
         window.raise_()
         tabbed_browser.widget.setCurrentWidget(tab)
+        if not tab.loaded:
+            tab.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('index', choices=['last'])

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -2249,3 +2249,18 @@ class CommandDispatcher:
             tab.audio.toggle_muted()
         except browsertab.WebTabError as e:
             raise cmdexc.CommandError(e)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def tab_load(self, prev=False, next_=False, opposite=False,
+                  force=False, count=None):
+
+        # tabbar = self._tabbed_browser.widget.tabBar()
+        tab = self._current_widget()
+        tab.load()
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def tab_unload(self, prev=False, next_=False, opposite=False,
+                  force=False, count=None):
+        tab = self._current_widget()
+        tab.unload()
+

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1114,8 +1114,6 @@ class CommandDispatcher:
         window.activateWindow()
         window.raise_()
         tabbed_browser.widget.setCurrentWidget(tab)
-        if not tab.loaded:
-            tab.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('index', choices=['last'])
@@ -2251,22 +2249,28 @@ class CommandDispatcher:
             raise cmdexc.CommandError(e)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def tab_load(self, prev=False, next_=False, opposite=False,
-                  force=False, count=None):
+    @cmdutils.argument('count', count=True)
+    def tab_load(self, index=None, count=None):
         """
         load the current tab
         """
 
-        # tabbar = self._tabbed_browser.widget.tabBar()
-        tab = self._current_widget()
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+
         tab.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def tab_unload(self, prev=False, next_=False, opposite=False,
-                  force=False, count=None):
+    @cmdutils.argument('count', count=True)
+    def tab_unload(self, index=None, count=None):
         """
         unload the current tab
         """
-        tab = self._current_widget()
+
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+
         tab.unload()
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -482,7 +482,7 @@ def qute_back(url):
     """
     src = jinja.render(
         'back.html',
-        title='Suspended: ' + urllib.parse.unquote(url.fragment()))
+        title='~: ' + urllib.parse.unquote(url.fragment()))
     return 'text/html', src
 
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -474,18 +474,6 @@ def qute_bindings(_url):
     return 'text/html', src
 
 
-@add_handler('back')
-def qute_back(url):
-    """Handler for qute://back.
-
-    Simple page to free ram / lazy load a site, goes back on focusing the tab.
-    """
-    src = jinja.render(
-        'back.html',
-        title='~: ' + urllib.parse.unquote(url.fragment()))
-    return 'text/html', src
-
-
 @add_handler('configdiff')
 def qute_configdiff(url):
     """Handler for qute://configdiff."""

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -96,6 +96,7 @@ _JS_WORLD_MAP = {
 }
 
 
+
 class WebEngineAction(browsertab.AbstractAction):
 
     """QtWebEngine implementations related to web actions."""
@@ -1018,6 +1019,26 @@ class WebEngineTab(browsertab.AbstractTab):
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
 
+    def unload(self):
+        if not self.loaded:
+            return
+
+        self.loaded = False
+        self.history._to_load = []
+        for idx, item in enumerate(self.history):
+            qtutils.ensure_valid(item)
+            item = browsertab.TabHistoryItem(
+                item.url(),
+                item.title(),
+                original_url=item.originalUrl(),
+                active=idx == self.history.current_idx(),
+                user_data=None)
+            self.history._to_load.append(item)
+
+        _title = self._widget.title()
+        self._widget.setHtml('', self._widget.url())
+        self.title_changed.emit(_title)
+
     def load(self):
         self.history.load_items(self.history._to_load)
         self.history._to_load = []
@@ -1028,7 +1049,6 @@ class WebEngineTab(browsertab.AbstractTab):
             self.history.load_items(entries)
         else:
             self.history._to_load.extend(entries)
-            # self.entries_to_load.extend(entries)
 
     def openurl(self, url, *, predict=True):
         """Open the given URL in this tab.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1026,37 +1026,6 @@ class WebEngineTab(browsertab.AbstractTab):
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
 
-    def unload(self):
-        if not self.loaded:
-            return
-
-        self.loaded = False
-        _to_load = []
-        for idx, item in enumerate(self.history):
-            qtutils.ensure_valid(item)
-            item = browsertab.TabHistoryItem(
-                item.url(),
-                item.title(),
-                original_url=item.originalUrl(),
-                active=idx == self.history.current_idx(),
-                user_data=None)
-            _to_load.append(item)
-        self.history._to_load =_to_load
-
-        _title = self._widget.title()
-        self._widget.setHtml('', self._widget.url())
-        self.title_changed.emit(_title)
-
-    def load(self):
-        self.history.load_items(self.history._to_load)
-        self.history._to_load = []
-        self.loaded = True
-
-    def load_history_items(self, entries):
-        if self.loaded:
-            self.history.load_items(entries)
-        else:
-            self.history._to_load.extend(entries)
 
     def openurl(self, url, *, predict=True):
         """Open the given URL in this tab.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -503,6 +503,13 @@ class WebEngineHistory(browsertab.AbstractHistory):
     """QtWebEngine implementations related to page history."""
 
     def current_idx(self):
+        if self._to_load:
+            idx = next(
+                (i for i, item in enumerate(self._to_load) if item.active),
+                None)
+            if idx is None:
+                idx = len(self._to_load)-1
+            return idx
         return self._history.currentItemIndex()
 
     def can_go_back(self):
@@ -1024,7 +1031,7 @@ class WebEngineTab(browsertab.AbstractTab):
             return
 
         self.loaded = False
-        self.history._to_load = []
+        _to_load = []
         for idx, item in enumerate(self.history):
             qtutils.ensure_valid(item)
             item = browsertab.TabHistoryItem(
@@ -1033,7 +1040,8 @@ class WebEngineTab(browsertab.AbstractTab):
                 original_url=item.originalUrl(),
                 active=idx == self.history.current_idx(),
                 user_data=None)
-            self.history._to_load.append(item)
+            _to_load.append(item)
+        self.history._to_load =_to_load
 
         _title = self._widget.title()
         self._widget.setHtml('', self._widget.url())

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -991,6 +991,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self._saved_zoom = None
         self._reload_url = None
         self._scripts.init()
+        # self.entries_to_load = []
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access
@@ -1016,6 +1017,18 @@ class WebEngineTab(browsertab.AbstractTab):
             return
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
+
+    def load(self):
+        self.history.load_items(self.history._to_load)
+        self.history._to_load = []
+        self.loaded = True
+
+    def load_history_items(self, entries):
+        if self.loaded:
+            self.history.load_items(entries)
+        else:
+            self.history._to_load.extend(entries)
+            # self.entries_to_load.extend(entries)
 
     def openurl(self, url, *, predict=True):
         """Open the given URL in this tab.
@@ -1063,6 +1076,10 @@ class WebEngineTab(browsertab.AbstractTab):
         self._widget.shutdown()
 
     def reload(self, *, force=False):
+        if not self.loaded:
+            self.load()
+            return
+
         if force:
             action = QWebEnginePage.ReloadAndBypassCache
         else:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -96,7 +96,6 @@ _JS_WORLD_MAP = {
 }
 
 
-
 class WebEngineAction(browsertab.AbstractAction):
 
     """QtWebEngine implementations related to web actions."""
@@ -999,7 +998,6 @@ class WebEngineTab(browsertab.AbstractTab):
         self._saved_zoom = None
         self._reload_url = None
         self._scripts.init()
-        # self.entries_to_load = []
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access
@@ -1025,7 +1023,6 @@ class WebEngineTab(browsertab.AbstractTab):
             return
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
-
 
     def openurl(self, url, *, predict=True):
         """Open the given URL in this tab.

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -58,6 +58,10 @@ class WebEngineView(QWebEngineView):
             sip.delete(self.layout())
             self._layout = miscwidgets.PseudoLayout(self)
 
+    def focusInEvent(self, event):
+        super().focusInEvent(event)
+        print('focusIn', self)
+
     def render_widget(self):
         """Get the RenderWidgetHostViewQt for this view.
 

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -58,7 +58,6 @@ class WebEngineView(QWebEngineView):
             sip.delete(self.layout())
             self._layout = miscwidgets.PseudoLayout(self)
 
-
     def render_widget(self):
         """Get the RenderWidgetHostViewQt for this view.
 

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -58,9 +58,6 @@ class WebEngineView(QWebEngineView):
             sip.delete(self.layout())
             self._layout = miscwidgets.PseudoLayout(self)
 
-    def focusInEvent(self, event):
-        super().focusInEvent(event)
-        print('focusIn', self)
 
     def render_widget(self):
         """Get the RenderWidgetHostViewQt for this view.

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -675,6 +675,18 @@ class WebKitTab(browsertab.AbstractTab):
         settings = widget.settings()
         settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, True)
 
+    def load(self):
+        if not self.loaded:
+            self.history.load_items(self.history._to_load)
+            self.history._to_load = []
+            self.loaded = True
+
+    def load_history_items(self, entries):
+        if self.loaded:
+            self.history.load_items(entries)
+        else:
+            self.history._to_load.extend(entries)
+
     def openurl(self, url, *, predict=True):
         self._openurl_prepare(url, predict=predict)
         self._widget.openurl(url)

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -675,18 +675,6 @@ class WebKitTab(browsertab.AbstractTab):
         settings = widget.settings()
         settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, True)
 
-    def load(self):
-        if not self.loaded:
-            self.history.load_items(self.history._to_load)
-            self.history._to_load = []
-            self.loaded = True
-
-    def load_history_items(self, entries):
-        if self.loaded:
-            self.history.load_items(entries)
-        else:
-            self.history._to_load.extend(entries)
-
     def openurl(self, url, *, predict=True):
         self._openurl_prepare(url, predict=predict)
         self._widget.openurl(url)
@@ -720,6 +708,10 @@ class WebKitTab(browsertab.AbstractTab):
         self._widget.shutdown()
 
     def reload(self, *, force=False):
+        if not self.loaded:
+            self.load()
+            return
+
         if force:
             action = QWebPage.ReloadAndBypassCache
         else:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -378,7 +378,6 @@ class TabBar(QTabBar):
     def setCurrentIndex(self, idx):
         super().setCurrentIndex(idx)
 
-        print('tabBar setIndex', idx)
         tab = self.widget(idx)
         if not tab.loaded:
             tab.load()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -72,6 +72,20 @@ class TabWidget(QTabWidget):
         self._init_config()
         config.instance.changed.connect(self._init_config)
 
+    def setCurrentIndex(self, idx):
+        super().setCurrentIndex(idx)
+        self.load_tab_at_index(idx)
+
+    # def setCurrentWidget(self, tabWidget):
+    #     super().setCurrentWidget(tabWidget)
+    #     if not tabWidget.loaded:
+    #         tabWidget.load()
+
+    def load_tab_at_index(self, idx):
+        tab = self.widget(idx)
+        if not tab.loaded:
+            tab.load()
+
     @config.change_filter('tabs')
     def _init_config(self):
         """Initialize attributes based on the config."""
@@ -361,6 +375,14 @@ class TabBar(QTabBar):
         self._set_colors()
         QTimer.singleShot(0, self.maybe_hide)
 
+    def setCurrentIndex(self, idx):
+        super().setCurrentIndex(idx)
+
+        print('tabBar setIndex', idx)
+        tab = self.widget(idx)
+        if not tab.loaded:
+            tab.load()
+
     def __repr__(self):
         return utils.get_repr(self, count=self.count())
 
@@ -500,7 +522,11 @@ class TabBar(QTabBar):
                     idx = self.count() - 1
             self.tabCloseRequested.emit(idx)
             return
+
+        prevIdx = self.currentIndex()
         super().mousePressEvent(e)
+        if prevIdx != self.currentIndex():
+            self.parent().load_tab_at_index(self.currentIndex())
 
     def minimumTabSizeHint(self, index, ellipsis: bool = True) -> QSize:
         """Set the minimum tab size to indicator/icon/... text.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -74,16 +74,8 @@ class TabWidget(QTabWidget):
 
     def setCurrentIndex(self, idx):
         super().setCurrentIndex(idx)
-        self.load_tab_at_index(idx)
-
-    # def setCurrentWidget(self, tabWidget):
-    #     super().setCurrentWidget(tabWidget)
-    #     if not tabWidget.loaded:
-    #         tabWidget.load()
-
-    def load_tab_at_index(self, idx):
         tab = self.widget(idx)
-        if not tab.loaded:
+        if tab.load_on_focus:
             tab.load()
 
     @config.change_filter('tabs')
@@ -522,10 +514,7 @@ class TabBar(QTabBar):
             self.tabCloseRequested.emit(idx)
             return
 
-        prevIdx = self.currentIndex()
         super().mousePressEvent(e)
-        if prevIdx != self.currentIndex():
-            self.parent().load_tab_at_index(self.currentIndex())
 
     def minimumTabSizeHint(self, index, ellipsis: bool = True) -> QSize:
         """Set the minimum tab size to indicator/icon/... text.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -513,7 +513,6 @@ class TabBar(QTabBar):
                     idx = self.count() - 1
             self.tabCloseRequested.emit(idx)
             return
-
         super().mousePressEvent(e)
 
     def minimumTabSizeHint(self, index, ellipsis: bool = True) -> QSize:

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -226,6 +226,7 @@ class SessionManager(QObject):
 
         # check active
         if data['history'] and not any(i.get('active') for i in data['history']):
+            log.session.warning('no active item for', tab)
             data['history'][-1]['active'] = True
 
         return data

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -35,6 +35,7 @@ from qutebrowser.config import config, configfiles
 from qutebrowser.completion.models import miscmodels
 from qutebrowser.mainwindow import mainwindow
 from qutebrowser.qt import sip
+from qutebrowser.browser import browsertab
 
 
 default = object()  # Sentinel value
@@ -66,33 +67,33 @@ class SessionNotFoundError(SessionError):
     """Exception raised when a session to be loaded was not found."""
 
 
-class TabHistoryItem:
+# class TabHistoryItem:
 
-    """A single item in the tab history.
+#     """A single item in the tab history.
 
-    Attributes:
-        url: The QUrl of this item.
-        original_url: The QUrl of this item which was originally requested.
-        title: The title as string of this item.
-        active: Whether this item is the item currently navigated to.
-        user_data: The user data for this item.
-    """
+#     Attributes:
+#         url: The QUrl of this item.
+#         original_url: The QUrl of this item which was originally requested.
+#         title: The title as string of this item.
+#         active: Whether this item is the item currently navigated to.
+#         user_data: The user data for this item.
+#     """
 
-    def __init__(self, url, title, *, original_url=None, active=False,
-                 user_data=None):
-        self.url = url
-        if original_url is None:
-            self.original_url = url
-        else:
-            self.original_url = original_url
-        self.title = title
-        self.active = active
-        self.user_data = user_data
+#     def __init__(self, url, title, *, original_url=None, active=False,
+#                  user_data=None):
+#         self.url = url
+#         if original_url is None:
+#             self.original_url = url
+#         else:
+#             self.original_url = original_url
+#         self.title = title
+#         self.active = active
+#         self.user_data = user_data
 
-    def __repr__(self):
-        return utils.get_repr(self, constructor=True, url=self.url,
-                              original_url=self.original_url, title=self.title,
-                              active=self.active, user_data=self.user_data)
+#     def __repr__(self):
+#         return utils.get_repr(self, constructor=True, url=self.url,
+#                               original_url=self.original_url, title=self.title,
+#                               active=self.active, user_data=self.user_data)
 
 
 class SessionManager(QObject):
@@ -205,9 +206,9 @@ class SessionManager(QObject):
         if active:
             data['active'] = True
         for idx, item in enumerate(tab.history):
-            if not isinstance(item, TabHistoryItem):
+            if not isinstance(item, browsertab.TabHistoryItem):
                 qtutils.ensure_valid(item)
-                item = TabHistoryItem(
+                item = browsertab.TabHistoryItem(
                     item.url(),
                     item.title(),
                     original_url=item.originalUrl(),
@@ -401,7 +402,7 @@ class SessionManager(QObject):
                     histentry['original-url'].encode('ascii'))
             else:
                 orig_url = url
-            entry = TabHistoryItem(url=url, original_url=orig_url,
+            entry = browsertab.TabHistoryItem(url=url, original_url=orig_url,
                                    title=histentry['title'], active=active,
                                    user_data=user_data)
             entries.append(entry)
@@ -421,7 +422,6 @@ class SessionManager(QObject):
             name: The name of the session to load.
             temp: If given, don't set the current session.
         """
-        print('loading session')
         path = self._get_session_path(name, check_exists=True)
         try:
             with open(path, encoding='utf-8') as f:
@@ -454,8 +454,6 @@ class SessionManager(QObject):
             self.did_load = True
         if not name.startswith('_') and not temp:
             self._current = name
-
-        print('session loaded')
 
     def delete(self, name):
         """Delete a session."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -120,7 +120,7 @@ class SessionManager(QObject):
         Args:
             tab: The tab to save.
             idx: The index of the current history item.
-            item: TheHistoryItem.
+            item: The TabHistoryItem.
 
         Return:
             A dict with the saved data for this item.
@@ -296,7 +296,6 @@ class SessionManager(QObject):
 
     def save_autosave(self):
         """Save the autosave session."""
-        return
         try:
             self.save('_autosave')
         except SessionError as e:
@@ -418,8 +417,6 @@ class SessionManager(QObject):
 
             if win.get('active', False):
                 QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
-
-
 
         if data['windows']:
             self.did_load = True

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -148,17 +148,17 @@ class SessionManager(QObject):
         Args:
             tab: The tab to save.
             idx: The index of the current history item.
-            item: The history item.
+            item: TheHistoryItem.
 
         Return:
             A dict with the saved data for this item.
         """
         data = {
-            'url': bytes(item.url().toEncoded()).decode('ascii'),
+            'url': bytes(item.url.toEncoded()).decode('ascii'),
         }
 
-        if item.title():
-            data['title'] = item.title()
+        if item.title:
+            data['title'] = item.title
         else:
             # https://github.com/qutebrowser/qutebrowser/issues/879
             if tab.history.current_idx() == idx:
@@ -166,15 +166,15 @@ class SessionManager(QObject):
             else:
                 data['title'] = data['url']
 
-        if item.originalUrl() != item.url():
-            encoded = item.originalUrl().toEncoded()
+        if item.original_url != item.url:
+            encoded = item.original_url.toEncoded()
             data['original-url'] = bytes(encoded).decode('ascii')
 
         if tab.history.current_idx() == idx:
             data['active'] = True
 
         try:
-            user_data = item.userData()
+            user_data = item.user_data
         except AttributeError:
             # QtWebEngine
             user_data = None
@@ -205,15 +205,26 @@ class SessionManager(QObject):
         if active:
             data['active'] = True
         for idx, item in enumerate(tab.history):
-            qtutils.ensure_valid(item)
+            if not isinstance(item, TabHistoryItem):
+                qtutils.ensure_valid(item)
+                item = TabHistoryItem(
+                    item.url(),
+                    item.title(),
+                    original_url=item.originalUrl(),
+                    active=active,
+                    user_data=None)
             item_data = self._save_tab_item(tab, idx, item)
-            if item.url().scheme() == 'qute' and item.url().host() == 'back':
+            if item.url.scheme() == 'qute' and item.url.host() == 'back':
                 # don't add qute://back to the session file
                 if item_data.get('active', False) and data['history']:
                     # mark entry before qute://back as active
                     data['history'][-1]['active'] = True
             else:
                 data['history'].append(item_data)
+        # check active
+        if not any(i.get('active') for i in data['history']):
+            data['history'][-1]['active'] = True
+
         return data
 
     def _save_all(self, *, only_window=None, with_private=False):
@@ -245,6 +256,8 @@ class SessionManager(QObject):
             win_data['tabs'] = []
             if tabbed_browser.private:
                 win_data['private'] = True
+
+            # import pdb; pdb.set_trace()
             for i, tab in enumerate(tabbed_browser.widgets()):
                 active = i == tabbed_browser.widget.currentIndex()
                 win_data['tabs'].append(self._save_tab(tab, active))
@@ -308,6 +321,7 @@ class SessionManager(QObject):
 
     def save_autosave(self):
         """Save the autosave session."""
+        return
         try:
             self.save('_autosave')
         except SessionError as e:
@@ -366,19 +380,19 @@ class SessionManager(QObject):
             if 'pinned' in histentry:
                 new_tab.data.pinned = histentry['pinned']
 
-            if (config.val.session.lazy_restore and
-                    histentry.get('active', False) and
-                    not histentry['url'].startswith('qute://back')):
-                # remove "active" mark and insert back page marked as active
-                lazy_index = i + 1
-                lazy_load.append({
-                    'title': histentry['title'],
-                    'url':
-                        'qute://back#' +
-                        urllib.parse.quote(histentry['title']),
-                    'active': True
-                })
-                histentry['active'] = False
+            # if (config.val.session.lazy_restore and
+            #         histentry.get('active', False) and
+            #         not histentry['url'].startswith('qute://back')):
+            #     # remove "active" mark and insert back page marked as active
+            #     lazy_index = i + 1
+            #     lazy_load.append({
+            #         'title': histentry['title'],
+            #         'url':
+            #             'qute://back#' +
+            #             urllib.parse.quote(histentry['title']),
+            #         'active': True
+            #     })
+            #     histentry['active'] = False
 
             active = histentry.get('active', False)
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))
@@ -395,7 +409,8 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            new_tab.history.load_items(entries)
+            new_tab.load_history_items(entries)
+            # new_tab.history.load_items(entries)
         except ValueError as e:
             raise SessionError(e)
 
@@ -406,6 +421,7 @@ class SessionManager(QObject):
             name: The name of the session to load.
             temp: If given, don't set the current session.
         """
+        print('loading session')
         path = self._get_session_path(name, check_exists=True)
         try:
             with open(path, encoding='utf-8') as f:
@@ -438,6 +454,8 @@ class SessionManager(QObject):
             self.did_load = True
         if not name.startswith('_') and not temp:
             self._current = name
+
+        print('session loaded')
 
     def delete(self, name):
         """Delete a session."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -208,22 +208,24 @@ class SessionManager(QObject):
         for idx, item in enumerate(tab.history):
             if not isinstance(item, browsertab.TabHistoryItem):
                 qtutils.ensure_valid(item)
+
+                try:
+                    user_data = item.userData()
+                except AttributeError:
+                    user_data = None
+
                 item = browsertab.TabHistoryItem(
                     item.url(),
                     item.title(),
                     original_url=item.originalUrl(),
                     active=active,
-                    user_data=None)
+                    user_data=user_data)
+
             item_data = self._save_tab_item(tab, idx, item)
-            if item.url.scheme() == 'qute' and item.url.host() == 'back':
-                # don't add qute://back to the session file
-                if item_data.get('active', False) and data['history']:
-                    # mark entry before qute://back as active
-                    data['history'][-1]['active'] = True
-            else:
-                data['history'].append(item_data)
+            data['history'].append(item_data)
+
         # check active
-        if not any(i.get('active') for i in data['history']):
+        if data['history'] and not any(i.get('active') for i in data['history']):
             data['history'][-1]['active'] = True
 
         return data
@@ -258,8 +260,8 @@ class SessionManager(QObject):
             if tabbed_browser.private:
                 win_data['private'] = True
 
-            # import pdb; pdb.set_trace()
             for i, tab in enumerate(tabbed_browser.widgets()):
+                log.sessions.debug("saving tab {} with history {}...".format(tab, list(tab.history)))
                 active = i == tabbed_browser.widget.currentIndex()
                 win_data['tabs'].append(self._save_tab(tab, active))
             data['windows'].append(win_data)
@@ -410,8 +412,11 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            new_tab.load_history_items(entries)
-            # new_tab.history.load_items(entries)
+            if config.val.session.lazy_restore:
+                new_tab.loaded = False
+                new_tab.load_history_items(entries)
+            else:
+                new_tab.history.load_items(entries)
         except ValueError as e:
             raise SessionError(e)
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -67,35 +67,6 @@ class SessionNotFoundError(SessionError):
     """Exception raised when a session to be loaded was not found."""
 
 
-# class TabHistoryItem:
-
-#     """A single item in the tab history.
-
-#     Attributes:
-#         url: The QUrl of this item.
-#         original_url: The QUrl of this item which was originally requested.
-#         title: The title as string of this item.
-#         active: Whether this item is the item currently navigated to.
-#         user_data: The user data for this item.
-#     """
-
-#     def __init__(self, url, title, *, original_url=None, active=False,
-#                  user_data=None):
-#         self.url = url
-#         if original_url is None:
-#             self.original_url = url
-#         else:
-#             self.original_url = original_url
-#         self.title = title
-#         self.active = active
-#         self.user_data = user_data
-
-#     def __repr__(self):
-#         return utils.get_repr(self, constructor=True, url=self.url,
-#                               original_url=self.original_url, title=self.title,
-#                               active=self.active, user_data=self.user_data)
-
-
 class SessionManager(QObject):
 
     """Manager for sessions.
@@ -384,20 +355,6 @@ class SessionManager(QObject):
             if 'pinned' in histentry:
                 new_tab.data.pinned = histentry['pinned']
 
-            # if (config.val.session.lazy_restore and
-            #         histentry.get('active', False) and
-            #         not histentry['url'].startswith('qute://back')):
-            #     # remove "active" mark and insert back page marked as active
-            #     lazy_index = i + 1
-            #     lazy_load.append({
-            #         'title': histentry['title'],
-            #         'url':
-            #             'qute://back#' +
-            #             urllib.parse.quote(histentry['title']),
-            #         'active': True
-            #     })
-            #     histentry['active'] = False
-
             active = histentry.get('active', False)
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))
             if 'original-url' in histentry:
@@ -413,11 +370,8 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            if config.val.session.lazy_restore:
-                new_tab.loaded = False
-                new_tab.load_history_items(entries)
-            else:
-                new_tab.history.load_items(entries)
+            new_tab.loaded = False
+            new_tab.load_history_items(entries)
         except ValueError as e:
             raise SessionError(e)
 
@@ -443,18 +397,29 @@ class SessionManager(QObject):
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=window.win_id)
             tab_to_focus = None
+            new_tabs = []
             for i, tab in enumerate(win['tabs']):
                 new_tab = tabbed_browser.tabopen(background=False)
+                new_tabs.append(new_tab)
                 self._load_tab(new_tab, tab)
                 if tab.get('active', False):
                     tab_to_focus = i
                 if new_tab.data.pinned:
                     tabbed_browser.widget.set_tab_pinned(new_tab,
                                                          new_tab.data.pinned)
+
+            for tab in new_tabs:
+                tab.load_on_focus = True
+                if not config.val.session.lazy_restore:
+                    tab.load()
+
             if tab_to_focus is not None:
                 tabbed_browser.widget.setCurrentIndex(tab_to_focus)
+
             if win.get('active', False):
                 QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
+
+
 
         if data['windows']:
             self.did_load = True

--- a/tests/unit/browser/webkit/test_tabhistory.py
+++ b/tests/unit/browser/webkit/test_tabhistory.py
@@ -24,7 +24,7 @@ from PyQt5.QtCore import QUrl, QPoint
 import pytest
 
 tabhistory = pytest.importorskip('qutebrowser.browser.webkit.tabhistory')
-from qutebrowser.misc.sessions import TabHistoryItem as Item
+from qutebrowser.browser.browsertab import TabHistoryItem as Item
 from qutebrowser.utils import qtutils
 
 

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -27,7 +27,7 @@ from PyQt5.QtCore import QUrl, QPoint, QByteArray, QObject
 QWebView = pytest.importorskip('PyQt5.QtWebKitWidgets').QWebView
 
 from qutebrowser.misc import sessions
-from qutebrowser.misc.sessions import TabHistoryItem as Item
+from qutebrowser.browser.browsertab import TabHistoryItem as Item
 from qutebrowser.utils import objreg, qtutils
 from qutebrowser.browser.webkit import tabhistory
 


### PR DESCRIPTION
Hi, this is another attempt at solving #67 

The currente implementation with qute://back is a bit slow, especially when using the webengine backend. This makes it much faster by avoiding loading the history untill the tab is focused.

It would probably be possible to avoid creating the webview untill the tab is loaded, but I haven't looked into that yet.

I also added tab-unload and tab-load commands, but tab-load might not be necessary as refreshing the page does the same thing.