### PR TITLE
NSIS: Remove installation dir if it exists

### DIFF
--- a/misc/qutebrowser.nsi
+++ b/misc/qutebrowser.nsi
@@ -40,6 +40,8 @@ Section "Install"
   ; Uninstall old versions
   ExecWait 'MsiExec.exe /quiet /qn /norestart /X{633F41F9-FE9B-42D1-9CC4-718CBD01EE11}'
   ExecWait 'MsiExec.exe /quiet /qn /norestart /X{9331D947-AC86-4542-A755-A833429C6E69}'
+  RMDir /r "$INSTDIR\*.*"
+  CreateDirectory "$INSTDIR"
 
   SetOutPath "$INSTDIR"
   


### PR DESCRIPTION
If we don't do this, when a newer version is installed on top of an older one,
old files which have been deleted persist. In the case of v1.3.3 -> v1.4.0,
this means qutebrowser won't start because of a leftover sip installation which
confuses PyQt 5.11.

This is still potentially dangerous as the user could use e.g. C:\ as
installation path, but we have that issue when uninstalling anyways.
See http://nsis.sourceforge.net/Uninstall_only_installed_files

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4054)
<!-- Reviewable:end -->
