### PR TITLE
Change :q to close current window, add :qa (quit --all) to perform previous behavior

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -679,18 +679,13 @@ class Quitter:
 
     @cmdutils.register(instance='quitter', name='quit')
     @cmdutils.argument('session', completion=miscmodels.session)
-    def quit(self, all=False, save=False, session=None):
+    def quit(self, save=False, session=None):
         """Quit qutebrowser.
         Args:
-            all: When given, closes all windows and kills the current instance
             save: When given, save the open windows even if auto_save.session
                   is turned off.
             session: The name of the session to save.
         """
-        if  not all:
-            window = QApplication.activeWindow()
-            window.close()
-            return
         if session is not None and not save:
             raise cmdexc.CommandError("Session name given without --save!")
         if save:

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -679,14 +679,18 @@ class Quitter:
 
     @cmdutils.register(instance='quitter', name='quit')
     @cmdutils.argument('session', completion=miscmodels.session)
-    def quit(self, save=False, session=None):
+    def quit(self, all=False, save=False, session=None):
         """Quit qutebrowser.
-
         Args:
+            all: When given, closes all windows and kills the current instance
             save: When given, save the open windows even if auto_save.session
                   is turned off.
             session: The name of the session to save.
         """
+        if  not all:
+            window = QApplication.activeWindow()
+            window.close()
+            return
         if session is not None and not save:
             raise cmdexc.CommandError("Session name given without --save!")
         if save:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -4,7 +4,8 @@ aliases:
   default:
     w: session-save
     q: quit
-    wq: quit --save
+    qa: quit --all
+    wqa: quit --all --save
   type:
     name: Dict
     keytype:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3,9 +3,9 @@
 aliases:
   default:
     w: session-save
-    q: quit
-    qa: quit --all
-    wqa: quit --all --save
+    q: close
+    qa: quit
+    wqa: quit --save
   type:
     name: Dict
     keytype:


### PR DESCRIPTION
These changes introduce the --all option to quit, which quits the instance, and changes quit to by default only close the current window. 

Also changed is :wq, which is replaced by :wqa instead. 

This fixes #1089

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4061)
<!-- Reviewable:end -->
