### PR TITLE
Process all events before issuing an alert

### DIFF
--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -24,7 +24,8 @@ import base64
 import itertools
 import functools
 
-from PyQt5.QtCore import pyqtSlot, QRect, QPoint, QTimer, Qt
+from PyQt5.QtCore import (pyqtSlot, QRect, QPoint, QTimer, Qt,
+                          QCoreApplication, QEventLoop)
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QApplication, QSizePolicy
 
 from qutebrowser.commands import runners, cmdutils
@@ -98,6 +99,8 @@ def raise_window(window, alert=True):
     window.setWindowState(window.windowState() & ~Qt.WindowMinimized)
     window.setWindowState(window.windowState() | Qt.WindowActive)
     window.raise_()
+    QCoreApplication.processEvents(
+        QEventLoop.ExcludeUserInputEvents | QEventLoop.ExcludeSocketNotifiers)
     window.activateWindow()
 
     if alert:


### PR DESCRIPTION
Fixes #2603

The call to processEvents fixes an apparent race condition with some window
managers, e.g. i3. QT seems to be thinking, that the window is not marked as
urgent and toggles it twice, so synchronizing before issuing the alert makes QT
behave correctly.

This change should not change the behaviour on other systems only correct the
fault reported in #2603.

This is only tested on Arch with the i3 window manager.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4072)
<!-- Reviewable:end -->
