### PR TITLE
[qute-pass] Follow symlinks when finding pass candidates

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -96,7 +96,7 @@ def qute_command(command):
 
 def find_pass_candidates(domain, password_store_path):
     candidates = []
-    for path, directories, file_names in os.walk(password_store_path):
+    for path, directories, file_names in os.walk(password_store_path, followlinks=True):
         if directories or domain not in path.split(os.path.sep):
             continue
 


### PR DESCRIPTION
This allows the aliasing of a domain using symbolic links. For example:

```
user@host ~ $ pass ls | grep -A 1 steam
├── steamcommunity.com -> steampowered.com
│   └── cryzed
├── steampowered.com
│   └── cryzed
```

Where `steamcommunity.com` is a symbolic link to `steampowered.com`. `pass` supports this by default, but `qute-pass` didn't.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4080)
<!-- Reviewable:end -->
