### PR TITLE
add {link_hovered} to the command variables

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -17,6 +17,7 @@ For command arguments, there are also some variables you can use:
 - `{url:host}` expands to the host part of the URL
 - `{clipboard}` expands to the clipboard contents
 - `{primary}` expands to the primary selection contents
+- `{link_hovered}` expands to the URL of the last hovered link  
 
 It is possible to run or bind multiple commands by separating them with `;;`.
 

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -699,6 +699,7 @@ class AbstractTab(QWidget):
 
         _load_status: loading status of this page
                       Accessible via load_status() method.
+        _last_hovered_link: The URL of the last hovered link as String
         _has_ssl_errors: Whether SSL errors happened.
                          Needs to be set by subclasses.
 
@@ -759,6 +760,7 @@ class AbstractTab(QWidget):
         self._mouse_event_filter = mouse.MouseEventFilter(
             self, parent=self)
         self.backend = None
+        self._last_hovered_link = None
 
         # FIXME:qtwebengine  Should this be public api via self.hints?
         #                    Also, should we get it out of objreg?
@@ -767,6 +769,7 @@ class AbstractTab(QWidget):
                         window=self.win_id, tab=self.tab_id)
 
         self.predicted_navigation.connect(self._on_predicted_navigation)
+        self.link_hovered.connect(self.on_link_hovered_change)
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access
@@ -861,6 +864,10 @@ class AbstractTab(QWidget):
             message.error(msg)
             self.data.open_target = usertypes.ClickTarget.normal
             navigation.accepted = False
+
+    @pyqtSlot(str)
+    def on_link_hovered_change(self, link_hovered):
+        self._last_hovered_link = link_hovered
 
     def handle_auto_insert_mode(self, ok):
         """Handle `input.insert_mode.auto_load` after loading finished."""

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -867,7 +867,8 @@ class AbstractTab(QWidget):
 
     @pyqtSlot(str)
     def on_link_hovered_change(self, link_hovered):
-        self._last_hovered_link = link_hovered
+        if link_hovered:
+            self._last_hovered_link = link_hovered
 
     def handle_auto_insert_mode(self, ok):
         """Handle `input.insert_mode.auto_load` after loading finished."""

--- a/qutebrowser/commands/__init__.py
+++ b/qutebrowser/commands/__init__.py
@@ -29,6 +29,7 @@ For command arguments, there are also some variables you can use:
 - `{url:host}` expands to the host part of the URL
 - `{clipboard}` expands to the clipboard contents
 - `{primary}` expands to the primary selection contents
+- `{link_hovered}` expands to the URL of the last hovered link  
 
 It is possible to run or bind multiple commands by separating them with `;;`.
 """

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -66,7 +66,7 @@ def replace_variables(win_id, arglist):
         'url:host': lambda: _current_url(tabbed_browser).host(),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
-        'link_hovered': lambda: tabbed_browser._last_hovered_link,
+        'link_hovered': lambda: tabbed_browser._now_focused._last_hovered_link,
     }
     for key in list(variables):
         modified_key = '{' + key + '}'

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -66,6 +66,7 @@ def replace_variables(win_id, arglist):
         'url:host': lambda: _current_url(tabbed_browser).host(),
         'clipboard': utils.get_clipboard,
         'primary': lambda: utils.get_clipboard(selection=True),
+        'link_hovered': lambda: tabbed_browser._last_hovered_link,
     }
     for key in list(variables):
         modified_key = '{' + key + '}'

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -68,6 +68,7 @@ class TabbedBrowser(QWidget):
         _win_id: The window ID this tabbedbrowser is associated with.
         _filter: A SignalFilter instance.
         _now_focused: The tab which is focused now.
+        _last_hovered_link:The URL of the last hovered link as String
         _tab_insert_idx_left: Where to insert a new tab with
                               tabs.new_tab_position set to 'prev'.
         _tab_insert_idx_right: Same as above, for 'next'.
@@ -126,6 +127,7 @@ class TabbedBrowser(QWidget):
         self._undo_stack = []
         self._filter = signalfilter.SignalFilter(win_id, self)
         self._now_focused = None
+        self._last_hovered_link = None
         self.search_text = None
         self.search_options = {}
         self._local_marks = {}
@@ -204,6 +206,7 @@ class TabbedBrowser(QWidget):
         # filtered signals
         tab.link_hovered.connect(
             self._filter.create(self.cur_link_hovered, tab))
+        tab.link_hovered.connect(self.on_link_hovered_change)
         tab.load_progress.connect(
             self._filter.create(self.cur_progress, tab))
         tab.load_finished.connect(
@@ -407,6 +410,10 @@ class TabbedBrowser(QWidget):
             self.tabopen(url, background=False)
         else:
             self.widget.currentWidget().openurl(url)
+
+    @pyqtSlot(str)
+    def on_link_hovered_change(self, link_hovered):
+        self._last_hovered_link = link_hovered
 
     @pyqtSlot(int)
     def on_tab_close_requested(self, idx):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -68,7 +68,6 @@ class TabbedBrowser(QWidget):
         _win_id: The window ID this tabbedbrowser is associated with.
         _filter: A SignalFilter instance.
         _now_focused: The tab which is focused now.
-        _last_hovered_link:The URL of the last hovered link as String
         _tab_insert_idx_left: Where to insert a new tab with
                               tabs.new_tab_position set to 'prev'.
         _tab_insert_idx_right: Same as above, for 'next'.
@@ -127,7 +126,6 @@ class TabbedBrowser(QWidget):
         self._undo_stack = []
         self._filter = signalfilter.SignalFilter(win_id, self)
         self._now_focused = None
-        self._last_hovered_link = None
         self.search_text = None
         self.search_options = {}
         self._local_marks = {}
@@ -206,7 +204,6 @@ class TabbedBrowser(QWidget):
         # filtered signals
         tab.link_hovered.connect(
             self._filter.create(self.cur_link_hovered, tab))
-        tab.link_hovered.connect(self.on_link_hovered_change)
         tab.load_progress.connect(
             self._filter.create(self.cur_progress, tab))
         tab.load_finished.connect(
@@ -410,10 +407,6 @@ class TabbedBrowser(QWidget):
             self.tabopen(url, background=False)
         else:
             self.widget.currentWidget().openurl(url)
-
-    @pyqtSlot(str)
-    def on_link_hovered_change(self, link_hovered):
-        self._last_hovered_link = link_hovered
 
     @pyqtSlot(int)
     def on_tab_close_requested(self, idx):


### PR DESCRIPTION
{link_hovered} expands to the URL of the last hovered link.
The usecases are similar to "Custom context/right-click menu" (see https://github.com/qutebrowser/qutebrowser/issues/349).

example usecase:
open youtube videos without entering hinting mode:
in config.py:
`config.bind('3', 'spawn mpv {link_hovered}')`
Then hover over a link and press 3

This and another pull request are my first code contributions on Github, so please tell me if I did anything wrong or if something is odd.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4082)
<!-- Reviewable:end -->
