### PR TITLE
Save _autosave session on an interval

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -1078,9 +1078,6 @@ class AbstractTab(QWidget):
             # https://github.com/qutebrowser/qutebrowser/issues/3498
             return
 
-        if sessions.session_manager is not None:
-            sessions.session_manager.save_autosave()
-
         self.load_finished.emit(ok)
 
         if not self.title():

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -244,9 +244,6 @@ class TabbedBrowser(QWidget):
         config.instance.changed.connect(self._on_config_changed)
         quitter.instance.shutting_down.connect(self.shutdown)
         self.save_manager = objreg.get('save-manager')
-        self.save_manager.add_saveable(
-            'session._autosave', sess_manager.save_autosave,
-            self.cur_load_finished)
 
     def _update_stack_size(self):
         newsize = config.instance.get('tabs.undo_stack_size')
@@ -387,6 +384,9 @@ class TabbedBrowser(QWidget):
         idx = self.widget.currentIndex()
         return self.widget.tab_url(idx)
 
+    def _mark_dirty(self):
+        self.save_manager.mark_dirty('session._autosave')
+
     def shutdown(self):
         """Try to shut down all tabs cleanly."""
         self.is_shutting_down = True
@@ -441,7 +441,7 @@ class TabbedBrowser(QWidget):
                 self.load_url(config.val.url.default_page, newtab=True)
 
         if not self.shutting_down:
-            self.save_manager.mark_dirty('session._autosave')
+            self._mark_dirty()
 
     def _remove_tab(self, tab, *, add_undo=True, new_undo=True, crashed=False):
         """Remove a tab from the tab list and delete it properly.
@@ -916,7 +916,7 @@ class TabbedBrowser(QWidget):
         self.widget.set_tab_indicator_color(idx, color)
         if idx == self.widget.currentIndex():
             tab.private_api.handle_auto_insert_mode(ok)
-        self.save_manager.mark_dirty('session._autosave')
+        self._mark_dirty()
 
     @pyqtSlot()
     def _on_scroll_pos_changed(self):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -243,8 +243,8 @@ class TabbedBrowser(QWidget):
         self.tab_deque = TabDeque()
         config.instance.changed.connect(self._on_config_changed)
         quitter.instance.shutting_down.connect(self.shutdown)
-        sess_manager = sessions.session_manager
-        objreg.get('save-manager').add_saveable(
+        self.save_manager = objreg.get('save-manager')
+        self.save_manager.add_saveable(
             'session._autosave', sess_manager.save_autosave,
             self.cur_load_finished)
 
@@ -441,8 +441,7 @@ class TabbedBrowser(QWidget):
                 self.load_url(config.val.url.default_page, newtab=True)
 
         if not self.shutting_down:
-            save_manager = objreg.get('save-manager')
-            save_manager.saveables['session._autosave'].mark_dirty()
+            self.save_manager.mark_dirty('session._autosave')
 
     def _remove_tab(self, tab, *, add_undo=True, new_undo=True, crashed=False):
         """Remove a tab from the tab list and delete it properly.
@@ -917,7 +916,7 @@ class TabbedBrowser(QWidget):
         self.widget.set_tab_indicator_color(idx, color)
         if idx == self.widget.currentIndex():
             tab.private_api.handle_auto_insert_mode(ok)
-        objreg.get('save-manager').saveables['session._autosave'].mark_dirty()
+        self.save_manager.mark_dirty('session._autosave')
 
     @pyqtSlot()
     def _on_scroll_pos_changed(self):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -244,8 +244,9 @@ class TabbedBrowser(QWidget):
         config.instance.changed.connect(self._on_config_changed)
         quitter.instance.shutting_down.connect(self.shutdown)
         sess_manager = sessions.session_manager
-        objreg.get('save-manager').add_saveable('session._autosave',
-                                                sess_manager.save_autosave)
+        objreg.get('save-manager').add_saveable(
+            'session._autosave', sess_manager.save_autosave,
+            self.cur_load_finished)
 
     def _update_stack_size(self):
         newsize = config.instance.get('tabs.undo_stack_size')

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -440,9 +440,6 @@ class TabbedBrowser(QWidget):
             elif last_close == 'default-page':
                 self.load_url(config.val.url.default_page, newtab=True)
 
-        if not self.shutting_down:
-            self._mark_dirty()
-
     def _remove_tab(self, tab, *, add_undo=True, new_undo=True, crashed=False):
         """Remove a tab from the tab list and delete it properly.
 
@@ -502,6 +499,9 @@ class TabbedBrowser(QWidget):
                 tab.layout().unwrap()
 
             tab.deleteLater()
+
+        if not quitter.instance.shutting_down:
+            self._mark_dirty()
 
     def undo(self, depth=1):
         """Undo removing of a tab or tabs."""

--- a/qutebrowser/misc/quitter.py
+++ b/qutebrowser/misc/quitter.py
@@ -55,7 +55,7 @@ class Quitter(QObject):
 
     Attributes:
         quit_status: The current quitting status.
-        _is_shutting_down: Whether we're currently shutting down.
+        is_shutting_down: Whether we're currently shutting down.
         _args: The argparse namespace.
     """
 
@@ -70,7 +70,7 @@ class Quitter(QObject):
             'tabs': False,
             'main': False,
         }
-        self._is_shutting_down = False
+        self.is_shutting_down = False
         self._args = args
 
     def on_last_window_closed(self) -> None:
@@ -215,9 +215,9 @@ class Quitter(QObject):
                             closing.
             is_restart: If we're planning to restart.
         """
-        if self._is_shutting_down:
+        if self.is_shutting_down:
             return
-        self._is_shutting_down = True
+        self.is_shutting_down = True
         log.destroy.debug("Shutting down with status {}, session {}...".format(
             status, session))
 

--- a/qutebrowser/misc/savemanager.py
+++ b/qutebrowser/misc/savemanager.py
@@ -70,6 +70,8 @@ class Saveable:
 
     def mark_dirty(self):
         """Mark this saveable as dirty (having changes)."""
+        if self._dirty:
+            return
         log.save.debug("Marking {} as dirty.".format(self._name))
         self._dirty = True
 

--- a/qutebrowser/misc/savemanager.py
+++ b/qutebrowser/misc/savemanager.py
@@ -46,7 +46,7 @@ class Saveable:
     """
 
     def __init__(self, name, save_handler, changed=None, config_opt=None,
-                 filename=None):
+                 filename=None, save_on_exit=None):
         self._name = name
         self._dirty = False
         self._save_handler = save_handler
@@ -56,6 +56,8 @@ class Saveable:
             self._save_on_exit = False
         else:
             self._save_on_exit = True
+        if save_on_exit is not None:
+            self._save_on_exit = save_on_exit
         self._filename = filename
         if filename is not None and not os.path.exists(filename):
             self._dirty = True
@@ -135,7 +137,7 @@ class SaveManager(QObject):
             self._save_timer.start()
 
     def add_saveable(self, name, save, changed=None, config_opt=None,
-                     filename=None, dirty=False):
+                     filename=None, dirty=False, save_on_exit=None):
         """Add a new saveable.
 
         Args:
@@ -146,10 +148,13 @@ class SaveManager(QObject):
             filename: The filename of the underlying file, so we can force
                       saving if it doesn't exist.
             dirty: Whether the saveable is already dirty.
+            save_on_exit: Whether to also save on shutdown. The default
+                          is to do so if no `changed` signal is provided.
         """
         if name in self.saveables:
             raise ValueError("Saveable {} already registered!".format(name))
-        saveable = Saveable(name, save, changed, config_opt, filename)
+        saveable = Saveable(name, save, changed, config_opt, filename,
+                            save_on_exit)
         self.saveables[name] = saveable
         if dirty:
             saveable.mark_dirty()

--- a/qutebrowser/misc/savemanager.py
+++ b/qutebrowser/misc/savemanager.py
@@ -218,3 +218,13 @@ class SaveManager(QObject):
                     e, "Error while saving!",
                     pre_text="Error while saving {}".format(key),
                     no_err_windows=objects.args.no_err_windows)
+
+    def mark_dirty(self, name):
+        """Mark a saveable as dirty.
+
+        Args:
+            name: The name of the saveable.
+        """
+        if name not in self.saveables:
+            raise ValueError("Saveable {} not registered!".format(name))
+        self.saveables[name].mark_dirty()

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -157,6 +157,10 @@ class SessionManager(QObject):
         self._base_path = base_path
         self._last_window_session = None
         self.did_load = False
+        save_manager = objreg.get('save-manager')
+        save_manager.add_saveable(
+            'session._autosave', self.save_autosave,
+            save_on_exit=False)
 
     def _get_session_path(self, name, check_exists=False):
         """Get the session path based on a session name or absolute path.

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -42,6 +42,7 @@ from PyQt5.QtWidgets import QWidget, QHBoxLayout, QVBoxLayout
 from PyQt5.QtNetwork import QNetworkCookieJar
 
 import helpers.stubs as stubsmod
+from qutebrowser import app
 from qutebrowser.config import (config, configdata, configtypes, configexc,
                                 configfiles, configcache, stylesheet)
 from qutebrowser.api import config as configapi
@@ -520,6 +521,16 @@ def fake_save_manager():
     objreg.register('save-manager', fake_save_manager)
     yield fake_save_manager
     objreg.delete('save-manager')
+
+
+@pytest.fixture
+def fake_quitter():
+    """Create a mock of quitter and register it into objreg."""
+    fake_quitter = unittest.mock.Mock(spec=app.Quitter)
+    fake_quitter.shutting_down = False
+    objreg.register('quitter', fake_quitter)
+    yield fake_quitter
+    objreg.delete('quitter')
 
 
 @pytest.fixture

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -32,7 +32,11 @@ from qutebrowser.utils import objreg, qtutils
 from qutebrowser.browser.webkit import tabhistory
 
 
-pytestmark = pytest.mark.qt_log_ignore('QIODevice::read.*: device not open')
+@pytest.fixture(autouse=True)
+@pytest.mark.qt_log_ignore('QIODevice::read.*: device not open')
+def autouse(fake_save_manager):
+    yield
+
 
 webengine_refactoring_xfail = pytest.mark.xfail(
     True, reason='Broke during QtWebEngine refactoring, will be fixed after '


### PR DESCRIPTION
Move the `_autosave` session to a timed saveable instead of having saved immediately.

Previously the `_autosave` session (see #2081) was being saved immediately whenever a tab finished a page load. This was a blocking action and was most noticeable when loading a saved session with many tabs on a slow hard drive. It has been mentioned in issues such as #3651 and #3519.

With this change the `_autosave` recovery session will be saved periodically, governed by the `auto_save.interval` setting, instead of immediately. This setting currently defaults to 15 seconds so there is the chance of missing out on 15 seconds worth of browsing state.

Normally when registering a saveable one would pass through a signal which would set the dirty flag when emitted. Since there is currently no signal that fires when any tab finishes loading or is deleted I added a new `mark_dirty(name)` method so `SaveManager`.

[edit by @jgkamat]: Closes https://github.com/qutebrowser/qutebrowser/issues/4535

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4087)
<!-- Reviewable:end -->
