### PR TITLE
Move audible strings into class variables

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -54,6 +54,10 @@ class TabWidget(QTabWidget):
     tab_index_changed = pyqtSignal(int, int)
     new_tab_requested = pyqtSignal('QUrl', bool, bool)
 
+    # Strings for controlling the mute/audible text
+    MUTE_STRING = '[M] '
+    AUDIBLE_STRING = '[A] '
+
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
         bar = TabBar(win_id, self)
@@ -175,9 +179,9 @@ class TabWidget(QTabWidget):
         fields['private'] = ' [Private Mode] ' if tab.private else ''
         try:
             if tab.audio.is_muted():
-                fields['audio'] = '[M] '
+                fields['audio'] = TabWidget.MUTE_STRING
             elif tab.audio.is_recently_audible():
-                fields['audio'] = '[A] '
+                fields['audio'] = TabWidget.AUDIBLE_STRING
             else:
                 fields['audio'] = ''
         except browsertab.WebTabError:


### PR DESCRIPTION
This PR is a tiny refactor to make it easier to change the audible strings.

With this PR, you can hackily (READ: NOT SUPPORTED) change the audible strings using:

```python
from qutebrowser.mainwindow import tabwidget
tabwidget.TabWidget.MUTE_STRING = "I AM NOT LOUD: "
tabwidget.TabWidget.AUDIBLE_STRING = "I AM VERY LOUD: "
```

![2018-07-21-125329_998x77_scrot](https://user-images.githubusercontent.com/4349709/43039607-4729ad04-8d20-11e8-836e-9b535f0f0547.png)


#4088, cc @nemanjan00

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4089)
<!-- Reviewable:end -->
