### PR TITLE
Add catch and error handling for errors in follow_selected click

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -33,7 +33,7 @@ from PyQt5.QtWidgets import QApplication
 from PyQt5.QtWebEngineWidgets import QWebEnginePage, QWebEngineScript
 
 from qutebrowser.config import configdata, config
-from qutebrowser.browser import browsertab, mouse, shared
+from qutebrowser.browser import browsertab, mouse, shared, webelem
 from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            interceptor, webenginequtescheme,
                                            cookies, webenginedownloads,
@@ -360,7 +360,11 @@ class WebEngineCaret(browsertab.AbstractCaret):
         if elem.is_link():
             log.webview.debug("Found link in selection, clicking. ClickTarget "
                               "{}, elem {}".format(click_type, elem))
-            elem.click(click_type)
+            try:
+                elem.click(click_type)
+            except webelem.Error as e:
+                message.error(str(e))
+                return
 
     def follow_selected(self, *, tab=False):
         if self._tab.search.search_displayed:


### PR DESCRIPTION
Closes  #4073

Adds the [same check](https://github.com/qutebrowser/qutebrowser/blob/master/qutebrowser/browser/commands.py#L1705) as the one in `:click-element` to `:follow-selected` as well.

I was hoping the `if elem.is_link()` would have solved this, but it dosen't for `qute://` urls due to a workaround (I think).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4090)
<!-- Reviewable:end -->
