### PR TITLE
tabbedbrowser.py: Change Suspended tab's indicator color

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -739,7 +739,14 @@ class TabbedBrowser(QWidget):
             start = config.val.colors.tabs.indicator.start
             stop = config.val.colors.tabs.indicator.stop
             system = config.val.colors.tabs.indicator.system
-            color = utils.interpolate_color(start, stop, 100, system)
+            try:
+                url_str=self.widget.tab_url(idx).toString()
+                if url_str.find("qute://back") != -1 :
+                    color = config.val.colors.tabs.indicator.suspended
+                else :
+                    color = utils.interpolate_color(start, stop, 100, system)
+            except :
+                color = config.val.colors.tabs.indicator.error
         else:
             color = config.val.colors.tabs.indicator.error
         self.widget.set_tab_indicator_color(idx, color)


### PR DESCRIPTION
If the url starts with "qute://back",then the indicator
color is changed to colors.tab.indicator.suspended
(on_load_finished function) .

Closes https://github.com/qutebrowser/qutebrowser/issues/3600