### PR TITLE
Add No-Script-like JavaScript blocking to FAQ

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -105,6 +105,15 @@ Is there an adblocker?::
     https://blog.mozilla.org/nnethercote/2014/05/14/adblock-pluss-effect-on-firefoxs-memory-usage/[RAM
     usage], so implementing support for AdBlockPlus-like lists is currently not
     a priority.
+    
+How can I get No-Script-like behaviour?::
+    You can toggle JavaScript blocking for the current domain with `tsh` by default.
+    To disable JavaScript by default:
++
+----
+:set content.javascript.enabled false
+----
++
 
 How do I play Youtube videos with mpv?::
     You can easily add a key binding to play youtube videos inside a real video

--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -117,7 +117,7 @@ The basic command for enabling JavaScript for the current host is `tsh`.
 This will allow JavaScript execution for the current session.
 Use `S` instead of `s` to make the exception permanent.
 With `H` instead of `h`, subdomains are included.
-Use S instead of s to make the exception permanent. With H instead of h, subdomains are included. With u instead of h, only the current URL is whitelisted (not the whole host).With `u` instead of `h`, only the current URL is whitelisted (not the whole host).
+With `u` instead of `h`, only the current URL is whitelisted (not the whole host).
 
 How do I play Youtube videos with mpv?::
     You can easily add a key binding to play youtube videos inside a real video

--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -106,14 +106,18 @@ Is there an adblocker?::
     usage], so implementing support for AdBlockPlus-like lists is currently not
     a priority.
     
-How can I get No-Script-like behaviour?::
-    You can toggle JavaScript blocking for the current domain with `tsh` by default.
+How can I get No-Script-like behavior?::
     To disable JavaScript by default:
 +
 ----
 :set content.javascript.enabled false
 ----
 +
+The basic command for enabling JavaScript for the current host is `tsh`.
+This will allow JavaScript execution for the current session.
+Use `S` instead of `s` to make the exception permanent.
+With `H` instead of `h`, subdomains are included.
+Use S instead of s to make the exception permanent. With H instead of h, subdomains are included. With u instead of h, only the current URL is whitelisted (not the whole host).With `u` instead of `h`, only the current URL is whitelisted (not the whole host).
 
 How do I play Youtube videos with mpv?::
     You can easily add a key binding to play youtube videos inside a real video


### PR DESCRIPTION
The main reason I didn't use Qutebrowser all the time was that it didn't support JavaScript blocking on a per-domain basis. But now #27 has been resolved, which makes this very easy. I added an entry to the FAQ which explains the basics of how to use it similar to No-Script.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4103)
<!-- Reviewable:end -->
