### PR TITLE
Tests for ipv6 support in urlmatch

### DIFF
--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -56,7 +56,7 @@ class Option:
 @attr.s
 class Migrations:
 
-    """Nigrated options in configdata.yml.
+    """Migrated options in configdata.yml.
 
     Attributes:
         renamed: A dict mapping old option names to new names.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1622,6 +1622,14 @@ url.yank_ignored_parameters:
     - utm_content
   desc: URL parameters to strip with `:yank url`.
 
+url.yank_remove_password:
+  type: Bool
+  default: true
+  desc: |
+    Remove the password with `:yank url`.
+
+    E.g. 
+
 ## window
 
 window.hide_wayland_decoration:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1622,14 +1622,6 @@ url.yank_ignored_parameters:
     - utm_content
   desc: URL parameters to strip with `:yank url`.
 
-url.yank_remove_password:
-  type: Bool
-  default: true
-  desc: |
-    Remove the password with `:yank url`.
-
-    E.g. 
-
 ## window
 
 window.hide_wayland_decoration:

--- a/qutebrowser/utils/urlmatch.py
+++ b/qutebrowser/utils/urlmatch.py
@@ -183,8 +183,8 @@ class UrlPattern:
             # Using QUrl parsing to minimize ipv6 addresses
             url = QUrl()
             url.setHost("[" + parsed.hostname + "]")
-            if url.host() == "":
-                raise ParseError("Invalid IPv6 URL"+parsed.hostname)
+            if not url.isValid():
+                raise ParseError(url.errorString())
             self._host = url.host()
             return
 

--- a/qutebrowser/utils/urlmatch.py
+++ b/qutebrowser/utils/urlmatch.py
@@ -30,6 +30,7 @@ import fnmatch
 import urllib.parse
 
 from qutebrowser.utils import utils, qtutils
+from PyQt5.QtCore import QUrl
 
 
 class ParseError(Exception):
@@ -175,6 +176,13 @@ class UrlPattern:
             if self._scheme not in self._SCHEMES_WITHOUT_HOST:
                 raise ParseError("Pattern without host")
             assert self._host is None
+            return
+
+        if not utils.raises(ValueError, ipaddress.IPv6Address, parsed.netloc[1:-1]):
+            # Using QUrl parsing to minimize ipv6 addresses
+            url = QUrl()
+            url.setHost(parsed.hostname)
+            self._host = url.host()
             return
 
         # FIXME what about multiple dots?

--- a/qutebrowser/utils/urlmatch.py
+++ b/qutebrowser/utils/urlmatch.py
@@ -29,8 +29,9 @@ import ipaddress
 import fnmatch
 import urllib.parse
 
-from qutebrowser.utils import utils, qtutils
 from PyQt5.QtCore import QUrl
+
+from qutebrowser.utils import utils, qtutils
 
 
 class ParseError(Exception):
@@ -178,10 +179,12 @@ class UrlPattern:
             assert self._host is None
             return
 
-        if not utils.raises(ValueError, ipaddress.IPv6Address, parsed.netloc[1:-1]):
+        if parsed.netloc.startswith('['):
             # Using QUrl parsing to minimize ipv6 addresses
             url = QUrl()
-            url.setHost(parsed.hostname)
+            url.setHost("[" + parsed.hostname + "]")
+            if url.host() == "":
+                raise ParseError("Invalid IPv6 URL"+parsed.hostname)
             self._host = url.host()
             return
 

--- a/qutebrowser/utils/urlmatch.py
+++ b/qutebrowser/utils/urlmatch.py
@@ -182,7 +182,7 @@ class UrlPattern:
         if parsed.netloc.startswith('['):
             # Using QUrl parsing to minimize ipv6 addresses
             url = QUrl()
-            url.setHost("[" + parsed.hostname + "]")
+            url.setHost(parsed.hostname)
             if not url.isValid():
                 raise ParseError(url.errorString())
             self._host = url.host()

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -85,17 +85,16 @@ from qutebrowser.utils import urlmatch
     # Additional tests
     ("http://[", "Invalid IPv6 URL"),
     ("http://[fc2e:bb88::edac]:", "Invalid port: Port is empty"),
-    ("http://[fc2e::bb88::edac]", """Invalid IPv6 address (character ':' not permitted); source was "[fc2e::bb88::edac]"; host = """""),
-    ("http://[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]"; host = ""'),
-    ("http://[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]"; host = ""'),
-    ("http://[127.0.0.1:fc2e::bb88:edac]", """Invalid IPv6 address (character '1' not permitted); source was "[127.0.0.1:fc2e::bb88:edac]"; host = """""),
+    ("http://[fc2e::bb88::edac]", 'Invalid IPv6 address; source was "fc2e::bb88::edac"; host = ""'),
+    ("http://[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]", 'Invalid IPv6 address; source was "fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac"; host = ""'),
+    ("http://[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]", 'Invalid IPv6 address; source was "fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac"; host = ""'),
+    ("http://[127.0.0.1:fc2e::bb88:edac]", 'Invalid IPv6 address; source was "127.0.0.1:fc2e::bb88:edac'),
     ("http://[]:20", "Pattern without host"),
     ("http://[fc2e::bb88", "Invalid IPv6 URL"),
-    ("http://[[fc2e::bb88:edac]", """Invalid IPv6 address (character '[' not permitted); source was "[[fc2e::bb88:edac]"; host = """""),
-        pytest.param("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL", marks=pytest.mark.xfail(
-    reason="https://bugs.python.org/issue34360")),
-    ("http://[fc2e:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:bb88:edac]"; host = ""'),
-    ("http://[fc2e:bb88:edac::z]", """Invalid IPv6 address (character 'z' not permitted); source was "[fc2e:bb88:edac::z]"; host = """""),
+    ("http://[[fc2e::bb88:edac]", """Expected ']' to match '[' in hostname; source was "[fc2e::bb88:edac"; host = """""),
+    pytest.param("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL", marks=pytest.mark.xfail(reason="https://bugs.python.org/issue34360")),
+    ("http://[fc2e:bb88:edac]", 'Invalid IPv6 address; source was "fc2e:bb88:edac"; host = ""'),
+    ("http://[fc2e:bb88:edac::z]", 'Invalid IPv6 address; source was "fc2e:bb88:edac::z"; host = ""'),
     ("http://[fc2e:bb88:edac::2]:2a2", "Invalid port: invalid literal for int() with base 10: '2a2'"),
 
 ])

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -84,6 +84,18 @@ from qutebrowser.utils import urlmatch
 
     # Additional tests
     ("http://[", "Invalid IPv6 URL"),
+    ("http://[fc2e::bb88::edac]:", "Invalid port: Port is empty"),
+    ("http://[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]", "Invalid IPv6 URL"),
+    ("http://[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]", "Invalid IPv6 URL"),
+    ("http://[127.0.0.1:fc2e::bb88:edac]", "Invalid IPv6 URL"),
+    ("http://[]:20", "Pattern without host"),
+    ("http://[fc2e::bb88", "Invalid IPv6 URL"),
+    ("http://[[fc2e::bb88:edac]", "Invalid IPv6 URL"),
+    ("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL"),
+    ("http://[fc2e:bb88:edac]", "Invalid IPv6 URL"),
+    ("http://[fc2e:bb88:edac::z]", "Invalid IPv6 URL"),
+    ("http://[fc2e:bb88:edac::2]:2a2", "Invalid port: invalid literal for int() with base 10: '2a2'"),
+
 ])
 def test_invalid_patterns(pattern, error):
     with pytest.raises(urlmatch.ParseError, match=re.escape(error)):
@@ -161,6 +173,8 @@ class TestMatchAllPagesForGivenScheme:
         ("https://google.com", False),
         ("http://74.125.127.100/search", True),
         ("http://[fc2e:0e35:bb88::edac]", True),
+        ("http://[fc2e:e35:bb88::edac]", True),
+        ("http://[fc2e:e35:bb88::127.0.0.1]", True),
         ("http://[::1]/bar", True),
     ])
     def test_urls(self, up, url, expected):
@@ -260,7 +274,7 @@ class TestMatchIpAddresses:
     def test_urls(self, pattern, expected):
         up = urlmatch.UrlPattern(pattern)
         assert up.matches(QUrl("http://127.0.0.1")) == expected
-    
+
 
 class TestMatchChromeUrls:
 

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -85,16 +85,17 @@ from qutebrowser.utils import urlmatch
     # Additional tests
     ("http://[", "Invalid IPv6 URL"),
     ("http://[fc2e:bb88::edac]:", "Invalid port: Port is empty"),
-    ("http://[fc2e::bb88::edac]", "Invalid IPv6 URL"),
-    ("http://[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]", "Invalid IPv6 URL"),
-    ("http://[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]", "Invalid IPv6 URL"),
-    ("http://[127.0.0.1:fc2e::bb88:edac]", "Invalid IPv6 URL"),
+    ("http://[fc2e::bb88::edac]", """Invalid IPv6 address (character ':' not permitted); source was "[fc2e::bb88::edac]"; host = """""),
+    ("http://[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]"; host = ""'),
+    ("http://[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]"; host = ""'),
+    ("http://[127.0.0.1:fc2e::bb88:edac]", """Invalid IPv6 address (character '1' not permitted); source was "[127.0.0.1:fc2e::bb88:edac]"; host = """""),
     ("http://[]:20", "Pattern without host"),
     ("http://[fc2e::bb88", "Invalid IPv6 URL"),
-    ("http://[[fc2e::bb88:edac]", "Invalid IPv6 URL"),
-    ("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL"),
-    ("http://[fc2e:bb88:edac]", "Invalid IPv6 URL"),
-    ("http://[fc2e:bb88:edac::z]", "Invalid IPv6 URL"),
+    ("http://[[fc2e::bb88:edac]", """Invalid IPv6 address (character '[' not permitted); source was "[[fc2e::bb88:edac]"; host = """""),
+    pytest.param("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL", marks=pytest.mark.xfail(
+    reason="https://bugs.python.org/issue34360")),
+    ("http://[fc2e:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:bb88:edac]"; host = ""'),
+    ("http://[fc2e:bb88:edac::z]", """Invalid IPv6 address (character 'z' not permitted); source was "[fc2e:bb88:edac::z]"; host = """""),
     ("http://[fc2e:bb88:edac::2]:2a2", "Invalid port: invalid literal for int() with base 10: '2a2'"),
 
 ])

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -257,6 +257,9 @@ class TestMatchIpAddresses:
         ("http://127.0.0.1/*", "127.0.0.1", False),
         ("http://*.0.0.1/*", "0.0.1", True),
         ("http://[::1]/*", "::1", False),
+        ("http://[0::1]/*", "::1", False),
+        ("http://[::01]/*", "::1", False),
+        ("http://[0:0:0:0:20::1]/*", "::20:0:0:1", False),
     ])
     def test_attrs(self, pattern, host, match_subdomains):
         up = urlmatch.UrlPattern(pattern)

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -154,10 +154,14 @@ class TestMatchAllPagesForGivenScheme:
 
     @pytest.mark.parametrize('url, expected', [
         ("http://google.com", True),
+        ("http://google.com:80", True),
+        ("http://google.com.", True),
         ("http://yahoo.com", True),
         ("http://google.com/foo", True),
         ("https://google.com", False),
         ("http://74.125.127.100/search", True),
+        ("http://[fc2e:0e35:bb88::edac]", True),
+        ("http://[::1]/bar", True),
     ])
     def test_urls(self, up, url, expected):
         assert up.matches(QUrl(url)) == expected
@@ -238,6 +242,7 @@ class TestMatchIpAddresses:
     @pytest.mark.parametrize('pattern, host, match_subdomains', [
         ("http://127.0.0.1/*", "127.0.0.1", False),
         ("http://*.0.0.1/*", "0.0.1", True),
+        ("http://[::1]/*", "::1", False),
     ])
     def test_attrs(self, pattern, host, match_subdomains):
         up = urlmatch.UrlPattern(pattern)
@@ -255,7 +260,7 @@ class TestMatchIpAddresses:
     def test_urls(self, pattern, expected):
         up = urlmatch.UrlPattern(pattern)
         assert up.matches(QUrl("http://127.0.0.1")) == expected
-
+    
 
 class TestMatchChromeUrls:
 

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -84,7 +84,8 @@ from qutebrowser.utils import urlmatch
 
     # Additional tests
     ("http://[", "Invalid IPv6 URL"),
-    ("http://[fc2e::bb88::edac]:", "Invalid port: Port is empty"),
+    ("http://[fc2e:bb88::edac]:", "Invalid port: Port is empty"),
+    ("http://[fc2e::bb88::edac]", "Invalid IPv6 URL"),
     ("http://[fc2e:0e35:bb88::edac:fc2e:0e35:bb88:edac]", "Invalid IPv6 URL"),
     ("http://[fc2e:0e35:bb88:af:edac:fc2e:0e35:bb88:edac]", "Invalid IPv6 URL"),
     ("http://[127.0.0.1:fc2e::bb88:edac]", "Invalid IPv6 URL"),

--- a/tests/unit/utils/test_urlmatch.py
+++ b/tests/unit/utils/test_urlmatch.py
@@ -92,7 +92,7 @@ from qutebrowser.utils import urlmatch
     ("http://[]:20", "Pattern without host"),
     ("http://[fc2e::bb88", "Invalid IPv6 URL"),
     ("http://[[fc2e::bb88:edac]", """Invalid IPv6 address (character '[' not permitted); source was "[[fc2e::bb88:edac]"; host = """""),
-    pytest.param("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL", marks=pytest.mark.xfail(
+        pytest.param("http://[fc2e::bb88:edac]]", "Invalid IPv6 URL", marks=pytest.mark.xfail(
     reason="https://bugs.python.org/issue34360")),
     ("http://[fc2e:bb88:edac]", 'Invalid IPv6 address; source was "[fc2e:bb88:edac]"; host = ""'),
     ("http://[fc2e:bb88:edac::z]", """Invalid IPv6 address (character 'z' not permitted); source was "[fc2e:bb88:edac::z]"; host = """""),


### PR DESCRIPTION
https://github.com/qutebrowser/qutebrowser/issues/4006 seems to be working mostly, except a few edge cases. A few of those are tested here. Ideas were taken here:
- https://chromium.googlesource.com/chromium/src.git/+/c008bf657dbc01fadc4ff1ea3df21f9cf237569a%5E%21/
- https://en.wikipedia.org/wiki/IPv6_address
(I fucked up in one of the commit messages, dunno how to change it after the fact)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4118)
<!-- Reviewable:end -->
