### PR TITLE
Have :repeat be able to use [count]

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -919,7 +919,7 @@ Repeat a given command.
 * +'command'+: The command to run, with optional args.
 
 ==== count
-Multiplies with 'times' when given
+Multiplies with 'times' when given.
 
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -910,7 +910,7 @@ The tab index to reload.
 
 [[repeat]]
 === repeat
-Syntax: +:repeat [*--mulcount*] 'times' 'command'+
+Syntax: +:repeat 'times' 'command'+
 
 Repeat a given command.
 
@@ -918,8 +918,8 @@ Repeat a given command.
 * +'times'+: How many times to repeat.
 * +'command'+: The command to run, with optional args.
 
-==== optional arguments
-* +*-c*+, +*--mulcount*+: When given, 'times' will be multiplied with [count].
+==== count
+Multiplies with 'times' when given
 
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -910,13 +910,16 @@ The tab index to reload.
 
 [[repeat]]
 === repeat
-Syntax: +:repeat 'times' 'command'+
+Syntax: +:repeat [*--mulcount*] 'times' 'command'+
 
 Repeat a given command.
 
 ==== positional arguments
 * +'times'+: How many times to repeat.
 * +'command'+: The command to run, with optional args.
+
+==== optional arguments
+* +*-c*+, +*--mulcount*+: When given, 'times' will be multiplied with [count].
 
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -74,13 +74,20 @@ def later(ms: int, command, win_id):
 
 @cmdutils.register(maxsplit=1, no_cmd_split=True, no_replace_variables=True)
 @cmdutils.argument('win_id', win_id=True)
-def repeat(times: int, command, win_id):
+@cmdutils.argument('count', count=True)
+@cmdutils.argument('mulcount', flag='c')
+def repeat(times: int, command, win_id, count=None, mulcount=False):
     """Repeat a given command.
 
     Args:
         times: How many times to repeat.
         command: The command to run, with optional args.
+        mulcount: Multiply 'times' with [count].
     """
+
+    if mulcount and count is not None:
+        times *= count
+
     if times < 0:
         raise cmdexc.CommandError("A negative count doesn't make sense.")
     commandrunner = runners.CommandRunner(win_id)

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -81,8 +81,8 @@ def repeat(times: int, command, win_id, count=None):
     Args:
         times: How many times to repeat.
         command: The command to run, with optional args.
+        count: Multiplies with 'times' when given.
     """
-
     if count is not None:
         times *= count
 

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -75,17 +75,15 @@ def later(ms: int, command, win_id):
 @cmdutils.register(maxsplit=1, no_cmd_split=True, no_replace_variables=True)
 @cmdutils.argument('win_id', win_id=True)
 @cmdutils.argument('count', count=True)
-@cmdutils.argument('mulcount', flag='c')
-def repeat(times: int, command, win_id, count=None, mulcount=False):
+def repeat(times: int, command, win_id, count=None):
     """Repeat a given command.
 
     Args:
         times: How many times to repeat.
         command: The command to run, with optional args.
-        mulcount: Multiply 'times' with [count].
     """
 
-    if mulcount and count is not None:
+    if count is not None:
         times *= count
 
     if times < 0:

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -41,6 +41,15 @@ Feature: Miscellaneous utility commands exposed to the user.
         # If we have an error, the test will fail
         Then no crash should happen
 
+    Scenario: :repeat with count
+        When I run :run-with-count 2 repeat 3 message-info "repeat-test 3"
+        Then the message "repeat-test 3" should be shown
+        And the message "repeat-test 3" should be shown
+        And the message "repeat-test 3" should be shown
+        And the message "repeat-test 3" should be shown
+        And the message "repeat-test 3" should be shown
+        And the message "repeat-test 3" should be shown
+
     ## :run-with-count
 
     Scenario: :run-with-count

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -42,7 +42,7 @@ Feature: Miscellaneous utility commands exposed to the user.
         Then no crash should happen
 
     Scenario: :repeat with count
-        When I run :run-with-count 2 repeat 3 message-info "repeat-test 3"
+        When I run :repeat 3 message-info "repeat-test 3" with count 2
         Then the message "repeat-test 3" should be shown
         And the message "repeat-test 3" should be shown
         And the message "repeat-test 3" should be shown


### PR DESCRIPTION
This would make it possible to repeatedly run commands like :tab-close and :undo without having to add flags for each and every one of them.

See https://www.reddit.com/r/qutebrowser/comments/96gmlc/using_count_to_literally_repeat_commands/

TODO:

 - (X) Core functionality
 - (X) Update documentation
 - (X) Tests? (Should work, although i'm not that familiar with tox. I suggest taking a look at it.)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4126)
<!-- Reviewable:end -->
