### PR TITLE
Expose $QUTE_COUNT to userscripts

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1200,6 +1200,9 @@ Spawn a command in a shell.
 * +*-o*+, +*--output*+: Whether the output should be shown in a new tab.
 * +*-d*+, +*--detach*+: Whether the command should be detached from qutebrowser.
 
+==== count
+Given to userscripts as $QUTE_COUNT.
+
 ==== note
 * This command does not split arguments after the last argument and handles quotes literally.
 


### PR DESCRIPTION
This will allow userscripts to use a count when binded to a hotkey, which makes it more practical to have userscripts that do basic functionality outside of qutebrowser. An example of this would be having :tab-close use count to delete count tabs instead of the counth tab. (This is currently possible, see #4126)

By the way, how should no count be handled? For the moment the str(count) takes a None literally, meaning that $QUTE_COUNT becomes "None" when no count is given.

TODO:
 - (X) Functionality and docs
 - ( ) Tests