### PR TITLE
Sort tab completion properly with more than 9 tabs.

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -122,8 +122,8 @@ def _buffer(skip_win_id=None):
             tabs.append(("{}/{}".format(win_id, idx + 1),
                          tab.url().toDisplayString(),
                          tabbed_browser.widget.page_title(idx)))
-        cat = listcategory.ListCategory("{}".format(win_id), tabs,
-                                        delete_func=delete_buffer)
+        cat = listcategory.ListCategory(
+            str(win_id), tabs, delete_func=delete_buffer, sort=False)
         model.add_category(cat)
 
     return model


### PR DESCRIPTION
Don't alphabetically sort tab completion.

`ListCategory` was changed to sort completions (on the first column) by default in #3237, most callers that didn't want to be sorted were addressed but the tab completion missed out. This change address that and adds a test to ensure the completion stays in insertion order.

The test tests the case of where you have 11 tabs and if the model was sorted the tabs with index 10 and 11 would be sorted before the one with index 2.

The `random.choices` bit for the tab url and title is to also make sure the model isn't being sorted on those columns, whithout haveng to write and all ten lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4140)
<!-- Reviewable:end -->