### PR TITLE
Use netrc for proxy authentication

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -307,8 +307,12 @@ def netrc_authentication(url, authenticator):
         return False
     user, password = None, None
     try:
+        host = url.host()
+    except AttributeError:
+        host = url
+    try:
         net = netrc.netrc(config.val.content.netrc_file)
-        authenticators = net.authenticators(url.host())
+        authenticators = net.authenticators(host)
         if authenticators is not None:
             (user, _account, password) = authenticators
     except FileNotFoundError:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1151,7 +1151,12 @@ class WebEngineTab(browsertab.AbstractTab):
         netrc_success = False
         if not self.data.netrc_used:
             self.data.netrc_used = True
-            netrc_success = shared.netrc_authentication(url, authenticator)
+            urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
+            netrc_success = shared.netrc_authentication(html_utils.escape(proxy_host),
+                                                        authenticator)
+
+            print("netrc_success we: " + str(netrc_success))
+            print(type(shared.netrc_authentication))
         if not netrc_success:
             msg = "<b>{}</b> requires a username and password.".format(
                 html_utils.escape(proxy_host))

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1154,9 +1154,6 @@ class WebEngineTab(browsertab.AbstractTab):
             urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
             netrc_success = shared.netrc_authentication(html_utils.escape(proxy_host),
                                                         authenticator)
-
-            print("netrc_success we: " + str(netrc_success))
-            print(type(shared.netrc_authentication))
         if not netrc_success:
             msg = "<b>{}</b> requires a username and password.".format(
                 html_utils.escape(proxy_host))

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1148,23 +1148,28 @@ class WebEngineTab(browsertab.AbstractTab):
     def _on_proxy_authentication_required(self, url, authenticator,
                                           proxy_host):
         """Called when a proxy needs authentication."""
-        msg = "<b>{}</b> requires a username and password.".format(
-            html_utils.escape(proxy_host))
-        urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
-        answer = message.ask(
-            title="Proxy authentication required", text=msg,
-            mode=usertypes.PromptMode.user_pwd,
-            abort_on=[self.shutting_down, self.load_started], url=urlstr)
-        if answer is not None:
-            authenticator.setUser(answer.user)
-            authenticator.setPassword(answer.password)
-        else:
-            try:
-                # pylint: disable=no-member, useless-suppression
-                sip.assign(authenticator, QAuthenticator())
-                # pylint: enable=no-member, useless-suppression
-            except AttributeError:
-                self._show_error_page(url, "Proxy authentication required")
+        netrc_success = False
+        if not self.data.netrc_used:
+            self.data.netrc_used = True
+            netrc_success = shared.netrc_authentication(url, authenticator)
+        if not netrc_success:
+            msg = "<b>{}</b> requires a username and password.".format(
+                html_utils.escape(proxy_host))
+            urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
+            answer = message.ask(
+                title="Proxy authentication required", text=msg,
+                mode=usertypes.PromptMode.user_pwd,
+                abort_on=[self.shutting_down, self.load_started], url=urlstr)
+            if answer is not None:
+                authenticator.setUser(answer.user)
+                authenticator.setPassword(answer.password)
+            else:
+                try:
+                    # pylint: disable=no-member, useless-suppression
+                    sip.assign(authenticator, QAuthenticator())
+                    # pylint: enable=no-member, useless-suppression
+                except AttributeError:
+                    self._show_error_page(url, "Proxy authentication required")
 
     @pyqtSlot(QUrl, 'QAuthenticator*')
     def _on_authentication_required(self, url, authenticator):

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -300,8 +300,6 @@ class NetworkManager(QNetworkAccessManager):
                 urlstr = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
                 netrc_success = shared.netrc_authentication(html_utils.escape(proxy_host),
                                                             authenticator)
-
-                print("netrc_success nm: " + str(netrc_success))
             if not netrc_success:
                 msg = '<b>{}</b> says:<br/>{}'.format(
                     html.escape(proxy.hostName()),


### PR DESCRIPTION
This adds support for proxy authentication using usernames/passwords in ~/.netrc. If the credentials are wrong either an access denied or SSL error occurs, depending on the protocol.

The change that I made in shared.py is probably not great, but it served to test with:

    try:
        host = url.host()
    except AttributeError:
        host = url

There's probably a better/more secure way to do this, like casting proxy_host to a Qurl before sending it, but that's a bit beyond my knowledge.

I didn't do any documentation for this. I wanted to just fly the general idea past you first.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4151)
<!-- Reviewable:end -->
