### PR TITLE
Set desktop file name

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -104,6 +104,7 @@ def run(args):
     qApp = Application(args)
     qApp.setOrganizationName("qutebrowser")
     qApp.setApplicationName("qutebrowser")
+    qApp.setDesktopFileName("qutebrowser")
     qApp.setApplicationVersion(qutebrowser.__version__)
     qApp.lastWindowClosed.connect(quitter.on_last_window_closed)
 


### PR DESCRIPTION
When using the QT Wayland backend, setting the desktop file name controls the `app_id` used for the xdg_shell protocol. This is similar to `WM_CLASS` in X11, and can be used to select and configure windows in compositors like `sway`. When the desktop file name is unset, it defaults to the executable name, which in qutebrowser's case is the much less useful `python3`.

I'm not sure if this is actually documented, but it's explained in the comment [here](https://github.com/qt/qtwayland/blob/5.12/src/client/qwaylandwindow.cpp#L147).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4153)
<!-- Reviewable:end -->
