### PR TITLE
Add instructions to link against OpenSSL 1.0 on Ubuntu

### DIFF
--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -443,6 +443,14 @@ caveats:
   (`export LD_LIBRARY_PATH=/usr/lib/openssl-1.0` on Archlinux) before starting
   qutebrowser if you want SSL to work in certain downloads (e.g. for
   `:adblock-update` or `:download`).
+  * On Ubuntu (tested on 18.04), you will need to install the `libssl1.0.0`
+    package (`apt install libssl1.0.0`). Then, in the qutebrowser git
+    repository, create a directory named `libssl` (`mkdir libssl`), and link
+    `libcrypto.so.1.0.0` and `libssl.so.1.0.0` into it without the versioning
+    part in their names (`ln -s /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
+    libssl/libcrypto.so` and `ln -s /usr/lib/x86_64-linux-gnu/libssl.so.1.0.0
+    libssl/libssl.so`). Now you can start qutebrowser issuing `export
+    LD_LIBRARY_PATH=$(pwd)/libssl` beforehand.
 - It comes with a QtWebEngine compiled without proprietary codec support (such
   as h.264).
 


### PR DESCRIPTION
When installing qutebrowser via tox on Ubuntu 18.04, the notes on linking
OpenSSL 1.0 instead of OpenSSL 1.1 to make QtNetwork SSL working are a bit
confusing, due to some path differences between Ubuntu and ArchLinux. The
addition of an item addressing this specific issue should help newcomers.

Ubuntu being widely used, it seems reasonable to add some help for this use case. Plus, some details on the procedure may help users of other distributions get their head around the issue.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4156)
<!-- Reviewable:end -->
