### PR TITLE
Change URL to www.qt.io in README.

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -97,7 +97,7 @@ Requirements
 The following software and libraries are required to run qutebrowser:
 
 * http://www.python.org/[Python] 3.5 or newer (3.6 recommended)
-* http://qt.io/[Qt] 5.7.1 or newer (5.11.1 recommended) with the following modules:
+* http://www.qt.io/[Qt] 5.7.1 or newer (5.11.1 recommended) with the following modules:
   - QtCore / qtbase
   - QtQuick (part of qtbase in some distributions)
   - QtSQL (part of qtbase in some distributions)


### PR DESCRIPTION
The old qt.io URL responds with Domain Not Found error today.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4164)
<!-- Reviewable:end -->
