### PR TITLE
Add restart to content.private_browsing

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -1976,6 +1976,7 @@ On QtWebEngine, this setting requires Qt 5.8 or newer.
 [[content.private_browsing]]
 === content.private_browsing
 Open new windows in private browsing mode which does not record visited pages.
+This setting requires a restart.
 
 Type: <<types,Bool>>
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -675,6 +675,7 @@ content.print_element_backgrounds:
 content.private_browsing:
   type: Bool
   default: false
+  restart: true
   desc: Open new windows in private browsing mode which does not record visited
     pages.
 


### PR DESCRIPTION
We should probably print a message when these things are `:set`, is there an issue for that?
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4173)
<!-- Reviewable:end -->
