### PR TITLE
Display value when calling :set without a value

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1139,7 +1139,7 @@ Syntax: +:set [*--temp*] [*--print*] [*--pattern* 'pattern'] ['option'] ['value'
 
 Set an option.
 
-If the option name ends with '?', the value of the option is shown instead. Using :set without any arguments opens a page where settings can be changed interactively.
+If the option name ends with '?' or no value is provided, the value of the option is shown instead. Using :set without any arguments opens a page where settings can be changed interactively.
 
 ==== positional arguments
 * +'option'+: The name of the option.

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -85,8 +85,8 @@ class ConfigCommands:
             *, pattern=None):
         """Set an option.
 
-        If the option name ends with '?', the value of the option is shown
-        instead.
+        If the option name ends with '?' or no value is provided, the
+        value of the option is shown instead.
 
         Using :set without any arguments opens a page where settings can be
         changed interactively.
@@ -97,6 +97,7 @@ class ConfigCommands:
             pattern: The URL pattern to use.
             temp: Set value temporarily until qutebrowser is closed.
             print_: Print the value after setting.
+
         """
         if option is None:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
@@ -116,8 +117,7 @@ class ConfigCommands:
 
         with self._handle_config_error():
             if value is None:
-                raise cmdexc.CommandError("set: The following arguments "
-                                          "are required: value")
+                self._print_value(option, pattern=pattern)
             else:
                 self._config.set_str(option, value, pattern=pattern,
                                      save_yaml=not temp)

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -61,13 +61,14 @@ class TestSet:
         commands.set(win_id=0)
         assert tabbed_browser_stubs[0].opened_url == QUrl('qute://settings')
 
-    def test_get(self, config_stub, commands, message_mock):
-        """Run ':set url.auto_search?'.
+    @pytest.mark.parametrize('option', ['url.auto_search?', 'url.auto_search'])
+    def test_get(self, config_stub, commands, message_mock, option):
+        """Run ':set url.auto_search?' / ':set url.auto_search?'.
 
         Should show the value.
         """
         config_stub.val.url.auto_search = 'never'
-        commands.set(win_id=0, option='url.auto_search?')
+        commands.set(win_id=0, option=option)
         msg = message_mock.getmsg(usertypes.MessageLevel.info)
         assert msg.text == 'url.auto_search = never'
 
@@ -183,17 +184,13 @@ class TestSet:
                            "not available with the QtWebEngine backend!"):
             commands.set(0, 'hints.find_implementation', 'javascript')
 
-    @pytest.mark.parametrize('option', ['?', 'url.auto_search'])
-    def test_empty(self, commands, option):
-        """Run ':set ?' / ':set url.auto_search'.
-
-        Should show an error.
+    def test_empty(self, commands):
+        """Run ':set ?'.
+         Should show an error.
         See https://github.com/qutebrowser/qutebrowser/issues/1109
         """
-        with pytest.raises(cmdexc.CommandError,
-                           match="The following arguments are required: "
-                                 "value"):
-            commands.set(win_id=0, option=option)
+        with pytest.raises(cmdexc.CommandError, match="No option '?'"):
+            commands.set(win_id=0, option='?')
 
     def test_toggle(self, commands):
         """Try toggling a value.


### PR DESCRIPTION
This change brings Qutebrowser closer to Vim's behavior of `:set foo?` *and* `:set foo` displaying the current value of `foo`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4178)
<!-- Reviewable:end -->
