### PR TITLE
Add completion for :back/:forward

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -143,9 +143,12 @@ This updates `~/.local/share/qutebrowser/blocked-hosts` with downloaded host lis
 
 [[back]]
 === back
-Syntax: +:back [*--tab*] [*--bg*] [*--window*]+
+Syntax: +:back [*--tab*] [*--bg*] [*--window*] ['index']+
 
 Go back in the history of the current tab.
+
+==== positional arguments
+* +'index'+: Which page to go back to, count takes precedence.
 
 ==== optional arguments
 * +*-t*+, +*--tab*+: Go back in a new tab.
@@ -542,9 +545,12 @@ Follow the selected text.
 
 [[forward]]
 === forward
-Syntax: +:forward [*--tab*] [*--bg*] [*--window*]+
+Syntax: +:forward [*--tab*] [*--bg*] [*--window*] ['index']+
 
 Go forward in the history of the current tab.
+
+==== positional arguments
+* +'index'+: Which page to go forward to, count takes precedence.
 
 ==== optional arguments
 * +*-t*+, +*--tab*+: Go forward in a new tab.

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -676,6 +676,12 @@ class AbstractHistory:
     def _go_to_item(self, item: typing.Any) -> None:
         raise NotImplementedError
 
+    def back_items(self) -> typing.List[typing.Any]:
+        raise NotImplementedError
+
+    def forward_items(self) -> typing.List[typing.Any]:
+        raise NotImplementedError
+
 
 class AbstractElements:
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -492,7 +492,7 @@ class CommandDispatcher:
             self._tabbed_browser.close_tab(self._current_widget(),
                                            add_undo=False)
 
-    def _back_forward(self, tab, bg, window, count, forward):
+    def _back_forward(self, tab, bg, window, count, forward, index=None):
         """Helper function for :back/:forward."""
         history = self._current_widget().history
         # Catch common cases before e.g. cloning tab
@@ -506,6 +506,12 @@ class CommandDispatcher:
         else:
             widget = self._current_widget()
 
+        if count is None:
+            if index is None:
+                count = 1
+            else:
+                count = abs(history.current_idx() - index)
+
         try:
             if forward:
                 widget.history.forward(count)
@@ -516,7 +522,9 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def back(self, tab=False, bg=False, window=False, count=1):
+    @cmdutils.argument('index', completion=miscmodels.back)
+    def back(self, tab=False, bg=False, window=False,
+             count=None, index: int = None):
         """Go back in the history of the current tab.
 
         Args:
@@ -524,12 +532,15 @@ class CommandDispatcher:
             bg: Go back in a background tab.
             window: Go back in a new window.
             count: How many pages to go back.
+            index: Which page to go back to, count takes precedence.
         """
-        self._back_forward(tab, bg, window, count, forward=False)
+        self._back_forward(tab, bg, window, count, forward=False, index=index)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def forward(self, tab=False, bg=False, window=False, count=1):
+    @cmdutils.argument('index', completion=miscmodels.forward)
+    def forward(self, tab=False, bg=False, window=False,
+                count=None, index: int = None):
         """Go forward in the history of the current tab.
 
         Args:
@@ -537,8 +548,9 @@ class CommandDispatcher:
             bg: Go forward in a background tab.
             window: Go forward in a new window.
             count: How many pages to go forward.
+            index: Which page to go forward to, count takes precedence.
         """
-        self._back_forward(tab, bg, window, count, forward=True)
+        self._back_forward(tab, bg, window, count, forward=True, index=index)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('where', choices=['prev', 'next', 'up', 'increment',

--- a/qutebrowser/browser/webengine/tabhistory.py
+++ b/qutebrowser/browser/webengine/tabhistory.py
@@ -60,7 +60,14 @@ def _serialize_item(item, stream):
     ## entry->GetIsOverridingUserAgent();
     stream.writeBool(False)
     ## static_cast<qint64>(entry->GetTimestamp().ToInternalValue());
-    stream.writeInt64(int(time.time()))
+    if item.last_visited is None:
+        unix_msecs = 0
+    else:
+        unix_msecs = item.last_visited.toMSecsSinceEpoch()
+    # 11644516800000 is the number of milliseconds from
+    # 1601-01-01T00:00 (Windows NT Epoch) to 1970-01-01T00:00 (UNIX Epoch)
+    nt_usecs = (unix_msecs + 11644516800000) * 1000
+    stream.writeInt64(nt_usecs)
     ## entry->GetHttpStatusCode();
     stream.writeInt(200)
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -608,6 +608,12 @@ class WebEngineHistory(browsertab.AbstractHistory):
         self._tab.before_load_started.emit(item.url())
         self._history.goToItem(item)
 
+    def back_items(self):
+        return self._history.backItems(self._history.count())
+
+    def forward_items(self):
+        return self._history.forwardItems(self._history.count())
+
 
 class WebEngineZoom(browsertab.AbstractZoom):
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -575,6 +575,12 @@ class WebKitHistory(browsertab.AbstractHistory):
         self._tab.before_load_started.emit(item.url())
         self._history.goToItem(item)
 
+    def back_items(self):
+        return self._history.backItems(self._history.count())
+
+    def forward_items(self):
+        return self._history.forwardItems(self._history.count())
+
 
 class WebKitElements(browsertab.AbstractElements):
 

--- a/qutebrowser/completion/models/completionmodel.py
+++ b/qutebrowser/completion/models/completionmodel.py
@@ -154,7 +154,7 @@ class CompletionModel(QAbstractItemModel):
     def columnCount(self, parent=QModelIndex()):
         """Override QAbstractItemModel::columnCount."""
         # pylint: disable=unused-argument
-        return 3
+        return len(self.column_widths)
 
     def canFetchMore(self, parent):
         """Override to forward the call to the categories."""

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -187,10 +187,15 @@ def _back_forward(info, go_forward):
     current_idx = history.current_idx()
 
     model = completionmodel.CompletionModel(column_widths=(6, 40, 54))
+    if go_forward:
+        start = current_idx + 1
+        items = history.forward_items()
+    else:
+        start = 0
+        items = history.back_items()
     entries = [
         (str(idx), entry.url().toDisplayString(), entry.title())
-        for idx, entry in enumerate(history)
-        if (idx > current_idx) == go_forward and idx != current_idx
+        for idx, entry in enumerate(items, start)
     ]
     if not go_forward:
         # make sure the most recent is at the top for :back

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -179,3 +179,38 @@ def window(*, info):
     model.add_category(listcategory.ListCategory("Windows", windows))
 
     return model
+
+
+def _back_forward(info, go_forward):
+    tab = objreg.get('tab', scope='tab', window=info.win_id, tab='current')
+    history = tab.history
+    current_idx = history.current_idx()
+
+    model = completionmodel.CompletionModel(column_widths=(6, 40, 54))
+    entries = [
+        (str(idx), entry.url().toDisplayString(), entry.title())
+        for idx, entry in enumerate(history)
+        if (idx > current_idx) == go_forward and idx != current_idx
+    ]
+    if not go_forward:
+        # make sure the most recent is at the top for :back
+        entries = reversed(entries)
+    cat = listcategory.ListCategory("History", entries, sort=False)
+    model.add_category(cat)
+    return model
+
+
+def forward(*, info):
+    """A model to complete on history of the current tab.
+
+    Used for the :forward command.
+    """
+    return _back_forward(info, go_forward=True)
+
+
+def back(*, info):
+    """A model to complete on history of the current tab.
+
+    Used for the :back command.
+    """
+    return _back_forward(info, go_forward=False)

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -19,6 +19,7 @@
 
 """Functions that return miscellaneous completion models."""
 
+import datetime
 import typing
 
 from qutebrowser.config import config, configdata
@@ -180,13 +181,16 @@ def window(*, info):
 
     return model
 
+def _qdatetime_to_completion_format(qdate):
+    pydate = datetime.datetime.fromtimestamp(qdate.toSecsSinceEpoch())
+    return pydate.strftime(config.val.completion.timestamp_format)
 
 def _back_forward(info, go_forward):
     tab = objreg.get('tab', scope='tab', window=info.win_id, tab='current')
     history = tab.history
     current_idx = history.current_idx()
 
-    model = completionmodel.CompletionModel(column_widths=(6, 40, 54))
+    model = completionmodel.CompletionModel(column_widths=(5, 36, 50, 9))
     if go_forward:
         start = current_idx + 1
         items = history.forward_items()
@@ -194,7 +198,8 @@ def _back_forward(info, go_forward):
         start = 0
         items = history.back_items()
     entries = [
-        (str(idx), entry.url().toDisplayString(), entry.title())
+        (str(idx), entry.url().toDisplayString(), entry.title(),
+         _qdatetime_to_completion_format(entry.lastVisited()))
         for idx, entry in enumerate(items, start)
     ]
     if not go_forward:

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -182,7 +182,13 @@ def window(*, info):
     return model
 
 def _qdatetime_to_completion_format(qdate):
-    pydate = datetime.datetime.fromtimestamp(qdate.toSecsSinceEpoch())
+    if not qdate.isValid():
+        ts = 0
+    else:
+        ts = qdate.toSecsSinceEpoch()
+        if ts < 0:
+            ts = 0
+    pydate = datetime.datetime.fromtimestamp(ts)
     return pydate.strftime(config.val.completion.timestamp_format)
 
 def _back_forward(info, go_forward):
@@ -198,8 +204,12 @@ def _back_forward(info, go_forward):
         start = 0
         items = history.back_items()
     entries = [
-        (str(idx), entry.url().toDisplayString(), entry.title(),
-         _qdatetime_to_completion_format(entry.lastVisited()))
+        (
+            str(idx),
+            entry.url().toDisplayString(),
+            entry.title(),
+            _qdatetime_to_completion_format(entry.lastVisited())
+        )
         for idx, entry in enumerate(items, start)
     ]
     if not go_forward:

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -25,7 +25,8 @@ import itertools
 import urllib
 import typing
 
-from PyQt5.QtCore import QUrl, QObject, QPoint, QTimer, pyqtSlot
+from PyQt5.QtCore import (Qt, QUrl, QObject, QPoint, QTimer, QDateTime,
+                          pyqtSlot)
 from PyQt5.QtWidgets import QApplication
 import yaml
 
@@ -96,7 +97,7 @@ class TabHistoryItem:
     """
 
     def __init__(self, url, title, *, original_url=None, active=False,
-                 user_data=None):
+                 user_data=None, last_visited=None):
         self.url = url
         if original_url is None:
             self.original_url = url
@@ -105,11 +106,13 @@ class TabHistoryItem:
         self.title = title
         self.active = active
         self.user_data = user_data
+        self.last_visited = last_visited
 
     def __repr__(self):
         return utils.get_repr(self, constructor=True, url=self.url,
                               original_url=self.original_url, title=self.title,
-                              active=self.active, user_data=self.user_data)
+                              active=self.active, user_data=self.user_data,
+                              last_visited=self.last_visited)
 
 
 class SessionManager(QObject):
@@ -194,6 +197,8 @@ class SessionManager(QObject):
         except AttributeError:
             # QtWebEngine
             user_data = None
+
+        data['last_visited'] = item.lastVisited().toString(Qt.ISODate)
 
         if tab.history.current_idx() == idx:
             pos = tab.scroller.pos_px()
@@ -403,9 +408,17 @@ class SessionManager(QObject):
                     histentry['original-url'].encode('ascii'))
             else:
                 orig_url = url
+            if histentry.get("last_visited"):
+                last_visited = QDateTime.fromString(
+                    histentry.get("last_visited"),
+                    Qt.ISODate,
+                )
+            else:
+                last_visited = None
             entry = TabHistoryItem(url=url, original_url=orig_url,
                                    title=histentry['title'], active=active,
-                                   user_data=user_data)
+                                   user_data=user_data,
+                                   last_visited=last_visited)
             entries.append(entry)
             if active:
                 new_tab.title_changed.emit(histentry['title'])

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -66,7 +66,6 @@ def _check_completions(model, expected):
             actual[catname].append((name, desc, misc))
     assert actual == expected
     # sanity-check the column_widths
-    assert len(model.column_widths) == 3
     assert sum(model.column_widths) == 100
 
 

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -23,9 +23,16 @@ import collections
 import random
 import string
 from datetime import datetime
+from unittest import mock
 
 import pytest
 from PyQt5.QtCore import QUrl
+try:
+    from PyQt5.QtWebEngineWidgets import (
+        QWebEngineHistory, QWebEngineHistoryItem
+    )
+except ImportError:
+    pass
 
 from qutebrowser.misc import objects
 from qutebrowser.completion import completer
@@ -1144,3 +1151,59 @@ def test_url_completion_benchmark(benchmark, info,
         model.set_pattern('ex 123')
 
     benchmark(bench)
+
+
+@pytest.fixture
+def tab_with_history(fake_web_tab, tabbed_browser_stubs, info, monkeypatch):
+    """Returns a fake tab with some fake history items."""
+    pytest.importorskip('PyQt5.QtWebEngineWidgets')
+    tab = fake_web_tab(QUrl('https://github.com'), 'GitHub', 0)
+
+    history = []
+    for url, title in [
+            ("http://example.com/index", "list of things"),
+            ("http://example.com/thing1", "thing1 detail"),
+            ("http://example.com/thing2", "thing2 detail"),
+            ("http://example.com/thing3", "thing3 detail"),
+            ("http://example.com/thing4", "thing4 detail"),
+    ]:
+        entry = mock.Mock(spec=QWebEngineHistoryItem)
+        entry.url.return_value = QUrl(url)
+        entry.title.return_value = title
+        history.append(entry)
+    tab.history._history = mock.Mock(spec=QWebEngineHistory)
+    tab.history._history.items.return_value = history
+
+    monkeypatch.setattr(
+        tab.history, 'current_idx',
+        lambda: 2,
+    )
+    tabbed_browser_stubs[0].widget.tabs = [tab]
+    tabbed_browser_stubs[0].widget.current_index = 0
+    return tab
+
+
+def test_back_completion(tab_with_history, info):
+    """Test back tab history completion."""
+    model = miscmodels.back(info=info)
+    model.set_pattern('')
+
+    _check_completions(model, {
+        "History": [
+            ("1", "http://example.com/thing1", "thing1 detail"),
+            ("0", "http://example.com/index", "list of things"),
+        ],
+    })
+
+
+def test_forward_completion(tab_with_history, info):
+    """Test forward tab history completion."""
+    model = miscmodels.forward(info=info)
+    model.set_pattern('')
+
+    _check_completions(model, {
+        "History": [
+            ("3", "http://example.com/thing3", "thing3 detail"),
+            ("4", "http://example.com/thing4", "thing4 detail"),
+        ],
+    })

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -22,11 +22,12 @@
 import collections
 import random
 import string
+import time
 from datetime import datetime
 from unittest import mock
 
 import pytest
-from PyQt5.QtCore import QUrl
+from PyQt5.QtCore import QUrl, QDateTime
 try:
     from PyQt5.QtWebEngineWidgets import (
         QWebEngineHistory, QWebEngineHistoryItem
@@ -1164,16 +1165,18 @@ def tab_with_history(fake_web_tab, tabbed_browser_stubs, info, monkeypatch):
     )
 
     history = []
-    for url, title in [
-            ("http://example.com/index", "list of things"),
-            ("http://example.com/thing1", "thing1 detail"),
-            ("http://example.com/thing2", "thing2 detail"),
-            ("http://example.com/thing3", "thing3 detail"),
-            ("http://example.com/thing4", "thing4 detail"),
+    now = time.time()
+    for url, title, ts in [
+            ("http://example.com/index", "list of things", now),
+            ("http://example.com/thing1", "thing1 detail", now+5),
+            ("http://example.com/thing2", "thing2 detail", now+10),
+            ("http://example.com/thing3", "thing3 detail", now+15),
+            ("http://example.com/thing4", "thing4 detail", now+20),
     ]:
         entry = mock.Mock(spec=QWebEngineHistoryItem)
         entry.url.return_value = QUrl(url)
         entry.title.return_value = title
+        entry.lastVisited.return_value = QDateTime.fromSecsSinceEpoch(ts)
         history.append(entry)
     tab.history._history = mock.Mock(spec=QWebEngineHistory)
     tab.history._history.items.return_value = history

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -35,7 +35,7 @@ from qutebrowser.utils import usertypes
 
 
 def _check_completions(model, expected):
-    """Check that a model contains the expected items in any order.
+    """Check that a model contains the expected items in order.
 
     Args:
         expected: A dict of form


### PR DESCRIPTION
Adds a completion for :back and :forward based on the history API for
the current tab in the current window. The column widths are copied from
the buffer completion. The first column is just the index in history.

I imagine that people may be interested in the `item.lastVisited()`
value which appears to be supported by both backends but we don't save
it out to the session file and it isn't used anywhere else in the
codebase so I held off on that.

Both backend's history classes also have `backItems()` and
`forwardItems()` but they aren't exposed in qutebrowsers history API,
hence the conditional in the list comprehension.

I haven't added a delete function, although I'm sure people will want
it, because:

* since there is no API for it it would involve serializing, editing,
  and deserealizing the history which would cause the tab to be reloaded at
  which point you may as well just have opened a new one and closed the
  tab with the unwanted history item
* it would only remove from the tab history, not the global history
  which may be surprising behavior

I had to pass `index=index` in the command methods because `forward`
isn't defined as a keyword argument in `_back_forward` but it is called
as one.

Passing negative values for index will do slightly weird things (for
back it go all the way back, for forward it'll go 1 forward) but I don't
care enough to add an extra check in there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4180)
<!-- Reviewable:end -->
