### PR TITLE
(QtWebEngine) Unhide scrollbar on search result

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -274,7 +274,7 @@ def get_tab(win_id, target):
     return tabbed_browser.tabopen(url=None, background=bg_tab)
 
 
-def get_user_stylesheet():
+def get_user_stylesheet(searching=False):
     """Get the combined user-stylesheet."""
     css = ''
     stylesheets = config.val.content.user_stylesheets
@@ -283,7 +283,7 @@ def get_user_stylesheet():
         with open(filename, 'r', encoding='utf-8') as f:
             css += f.read()
 
-    if not config.val.scrolling.bar:
+    if not (config.val.scrolling.bar == 'always' or config.val.scrolling.bar == 'when_searching' and searching):
         css += '\nhtml > ::-webkit-scrollbar { width: 0px; height: 0px; }'
 
     return css

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1191,9 +1191,14 @@ prompt.radius:
 ## scrolling
 
 scrolling.bar:
-  type: Bool
-  default: false
-  desc: Show a scrollbar.
+  type:
+    name: String
+    valid_values:
+      - always: Always show the scrollbar.
+      - never: Never show the scrollbar.
+      - when_searching: Show the scrollbar when searching for text in the webpage.
+  default: when_searching
+  desc: When to show the scrollbar.
 
 scrolling.smooth:
   type: Bool

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -277,6 +277,7 @@ class YamlConfig(QObject):
             self._mark_changed()
 
         self._migrate_bool(settings, 'tabs.favicons.show', 'always', 'never')
+        self._migrate_bool(settings, 'scrolling.bar', 'when_searching', 'never')
         self._migrate_bool(settings, 'qt.force_software_rendering',
                            'software-opengl', 'none')
 


### PR DESCRIPTION
See #4183 

This is my first contribution, so if there's a better way to do this (most likely), please give me feedback and I'll make the changes.

Should there be a config option for this, something like "scrolling.search_unhide" or "search.unhide_scrollbar"?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4186)
<!-- Reviewable:end -->
