### PR TITLE
Add bash completion

### DIFF
--- a/misc/Makefile
+++ b/misc/Makefile
@@ -27,6 +27,8 @@ install: doc/qutebrowser.1.html
 			"$(DESTDIR)$(DATADIR)/icons/hicolor/$(i)x$(i)/apps/qutebrowser.png";)
 	install -Dm644 icons/qutebrowser.svg \
 		"$(DESTDIR)$(DATADIR)/icons/hicolor/scalable/apps/qutebrowser.svg"
+	install -m644 misc/bash/_qutebrowser \
+		"$(DESTDIR)$(DATADIR)/bash-completion/completions/_qutebrowser" || true
 	install -Dm755 -t "$(DESTDIR)$(DATADIR)/qutebrowser/userscripts/" \
 		$(wildcard misc/userscripts/*)
 	install -Dm755 -t "$(DESTDIR)$(DATADIR)/qutebrowser/scripts/" \

--- a/misc/bash/_qutebrowser
+++ b/misc/bash/_qutebrowser
@@ -1,0 +1,106 @@
+_qutebrowser_basedir() {
+	local i=0
+
+	for word in "${COMP_WORDS[@]}"; do
+		if [ "$word" = -B ] || [ "$word" = --basedir ]; then
+			break
+		fi
+		i=$((i + 1))
+	done
+
+	if [ "$i" -lt ${#COMP_WORDS[@]} ]; then
+		printf '%s\n' "${COMP_WORDS[i + 1]}"
+	else
+		printf '%s\n' "${XDG_DATA_HOME:-$HOME/.local/share}/qutebrowser"
+	fi
+}
+
+_qutebrowser_sessions() {
+	ls -1 "$(_qutebrowser_basedir)/sessions" 2>/dev/null |
+		grep -v '_autosave' |
+		sed 's/\.yml$//g'
+}
+
+_qutebrowser() {
+	local options='-h --help
+	               -B --basedir
+	               -V --version
+	               -s --set
+	               -r --restore
+	               -R --override-restore
+	               --target
+	               --backend
+	               --enable-webengine-inspector
+	               -l --loglevel
+	               --logfilter
+	               --loglines
+	               -d --debug
+	               --json-logging
+	               --nocolor
+	               --force-color
+	               --nowindow
+	               ---T --temp-basedir
+	               --no-err-windows
+	               --qt-arg
+	               --qt-flag
+	               -D --debug-flag'
+
+        local targets='auto
+	              tab
+	              tab-bg
+	              tab-silent
+	              tab-bg-silent
+	              window'
+
+	local backends='webkit webengine'
+
+	local log_levels='critical
+	                  error
+	                  warning
+	                  info
+	                  debug
+	                  vdebug'
+
+	COMPREPLY=()
+
+	local cur prev
+
+	cur=${COMP_WORDS[COMP_CWORD]}
+	case "$cur" in
+	-*)
+		COMPREPLY=( $(compgen -W "$options" -- "$cur") )
+		;;
+	*)
+		prev=${COMP_WORDS[COMP_CWORD - 1]}
+
+		case "$prev" in
+		-B|--basedir)
+			COMPREPLY=( $(compgen -d "$cur") )
+			return 0
+			;;
+		-r|--restore)
+			COMPREPLY=( $(compgen -W "$(_qutebrowser_sessions)" -- "$cur") )
+			return 0
+			;;
+		--target)
+			COMPREPLY=( $(compgen -W "$targets" -- "$cur") )
+			return 0
+			;;
+		--backend)
+			COMPREPLY=( $(compgen -W "$backends" -- "$cur") )
+			return 0
+			;;
+		-l|--loglevel)
+			COMPREPLY=( $(compgen -W "$log_levels" -- "$cur") )
+			return 0
+			;;
+		*)
+			COMPREPLY=()
+			;;
+		esac
+	esac
+
+	return 0
+}
+
+complete -o filenames -o noquote -F _qutebrowser qutebrowser


### PR DESCRIPTION
The script completes all options in the man page, and also completes values for the `--basedir`, `--restore`, `--target`, `--backend`, and `--loglevel` options. For `--restore` it checks the `sessions` subdirectory of the `--basedir` option if it was given, otherwise it defaults to qb's default basedir, respecting the XDG base directory specification.

There are no completions for the arguments to the `--set`, `--logfilter`, `--loglines`, `--qt-arg`, `--qt-flag`, and `--debug-flag` options, because I was too lazy to list the possible values :stuck_out_tongue:.

I also added an entry to the `Makefile`. I left off the `-D` flag to `install`, so it fails when the `bash-completion` directory doesn't exist, but I don't know if this is desirable because it can make packaging more complicated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4194)
<!-- Reviewable:end -->
