### PR TITLE
Use outsuffix for relative links in asciidoc files

### DIFF
--- a/doc/contributing.asciidoc
+++ b/doc/contributing.asciidoc
@@ -88,7 +88,7 @@ git format-patch origin/master <1>
 Running qutebrowser
 -------------------
 
-After link:install.html#tox[installing qutebrowser via tox], you can run
+After link:install{outfilesuffix}#tox[installing qutebrowser via tox], you can run
 `.venv/bin/qutebrowser --debug --temp-basedir` to test your changes with debug
 logging enabled and without affecting existing running instances.
 

--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -315,5 +315,5 @@ My issue is not listed.::
     https://github.com/qutebrowser/qutebrowser/issues[the issue tracker] or
     using the `:report` command.
     If you are reporting a segfault, make sure you read the
-    link:doc/stacktrace.html[guide] on how to report them with all needed
+    link:stacktrace{outfilesuffix}[guide] on how to report them with all needed
     information.

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -758,11 +758,11 @@ This tries to automatically click on typical _Previous Page_ or _Next Page_ link
  - `up`: Go up a level in the current URL.
  - `increment`: Increment the last number in the URL.
  Uses the
- link:settings{outfilesuffix}#url.incdec_segments[url.incdec_segments]
+ link:settings{outsuffix}#url.incdec_segments[url.incdec_segments]
  config option.
  - `decrement`: Decrement the last number in the URL.
  Uses the
- link:settings{outfilesuffix}#url.incdec_segments[url.incdec_segments]
+ link:settings{outsuffix}#url.incdec_segments[url.incdec_segments]
  config option.
  
 

--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -758,11 +758,11 @@ This tries to automatically click on typical _Previous Page_ or _Next Page_ link
  - `up`: Go up a level in the current URL.
  - `increment`: Increment the last number in the URL.
  Uses the
- link:settings.html#url.incdec_segments[url.incdec_segments]
+ link:settings{outfilesuffix}#url.incdec_segments[url.incdec_segments]
  config option.
  - `decrement`: Decrement the last number in the URL.
  Uses the
- link:settings.html#url.incdec_segments[url.incdec_segments]
+ link:settings{outfilesuffix}#url.incdec_segments[url.incdec_segments]
  config option.
  
 

--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -44,7 +44,7 @@ If you want to customize many settings, you can open the link:qute://settings[]
 page by running `:set` without any arguments, where all settings are listed and
 customizable.
 
-Using the link:commands.html#set[`:set`] command and command completion, you
+Using the link:commands{outfilesuffix}#set[`:set`] command and command completion, you
 can quickly set settings interactively, for example `:set tabs.position left`.
 
 Some settings are also customizable for a given
@@ -53,8 +53,8 @@ https://developer.chrome.com/apps/match_patterns[URL pattern] by doing e.g.
 
 To get more help about a setting, use e.g. `:help tabs.position`.
 
-To bind and unbind keys, you can use the link:commands.html#bind[`:bind`] and
-link:commands.html#unbind[`:unbind`] commands:
+To bind and unbind keys, you can use the link:commands{outfilesuffix}#bind[`:bind`] and
+link:commands{outfilesuffix}#unbind[`:unbind`] commands:
 
 - Binding the key chain `,v` to the `:spawn mpv {url}` command:
   `:bind ,v spawn mpv {url}`
@@ -67,9 +67,9 @@ See the help pages linked above (or `:help :bind`, `:help :unbind`) for more
 information.
 
 Other useful commands for config manipulation are
-link:commands.html#config-unset[`:config-unset`] to reset a value to its default,
-link:commands.html#config-clear[`:config-clear`] to reset the entire configuration,
-and link:commands.html#config-cycle[`:config-cycle`] to cycle a setting between
+link:commands{outfilesuffix}#config-unset[`:config-unset`] to reset a value to its default,
+link:commands{outfilesuffix}#config-clear[`:config-clear`] to reset the entire configuration,
+and link:commands{outfilesuffix}#config-cycle[`:config-cycle`] to cycle a setting between
 different values.
 
 [[configpy]]
@@ -111,7 +111,7 @@ Note that qutebrowser does some Python magic so it's able to warn you about
 mistyped config settings. As an example, if you do `c.tabs.possition = "left"`,
 you'll get an error when starting.
 
-See the link:settings.html[settings help page] for all available settings. The
+See the link:settings{outfilesuffix}[settings help page] for all available settings. The
 accepted values depend on the type of the option. Commonly used are:
 
 - Strings: `c.tabs.position = "left"`
@@ -187,7 +187,7 @@ preferred to use the `config.bind` command. Doing so ensures the commands are
 valid and normalizes different expressions which map to the same key.
 
 For details on how to specify keys and the available modes, see the
-link:settings.html#bindings.commands[documentation] for the `bindings.commands`
+link:settings{outfilesuffix}#bindings.commands[documentation] for the `bindings.commands`
 setting.
 
 To bind a key:

--- a/doc/help/index.asciidoc
+++ b/doc/help/index.asciidoc
@@ -6,14 +6,14 @@ Documentation
 
 The following help pages are currently available:
 
-* link:../quickstart.html[Quick start guide]
-* link:../faq.html[Frequently asked questions]
-* link:../changelog.html[Change Log]
-* link:commands.html[Documentation of commands]
-* link:configuring.html[Configuring qutebrowser]
-* link:settings.html[Documentation of settings]
-* link:../userscripts.html[How to write userscripts]
-* link:../contributing.html[Contributing to qutebrowser]
+* link:../quickstart{outfilesuffix}[Quick start guide]
+* link:../faq{outfilesuffix}[Frequently asked questions]
+* link:../changelog{outfilesuffix}[Change Log]
+* link:commands{outfilesuffix}[Documentation of commands]
+* link:configuring{outfilesuffix}[Configuring qutebrowser]
+* link:settings{outfilesuffix}[Documentation of settings]
+* link:../userscripts{outfilesuffix}[How to write userscripts]
+* link:../contributing{outfilesuffix}[Contributing to qutebrowser]
 
 Getting help
 ------------

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -606,11 +606,11 @@ class CommandDispatcher:
                 - `up`: Go up a level in the current URL.
                 - `increment`: Increment the last number in the URL.
                   Uses the
-                  link:settings.html#url.incdec_segments[url.incdec_segments]
+                  link:settings{outsuffix}#url.incdec_segments[url.incdec_segments]
                   config option.
                 - `decrement`: Decrement the last number in the URL.
                   Uses the
-                  link:settings.html#url.incdec_segments[url.incdec_segments]
+                  link:settings{outsuffix}#url.incdec_segments[url.incdec_segments]
                   config option.
 
             tab: Open in a new tab.


### PR DESCRIPTION
Based on issue #3457, this is a simple PR to fix some relative links when viewing docs on github.

I followed recommendation [here](https://asciidoctor.org/docs/user-manual/#navigating-between-source-files) for how to render correctly on github without affecting the publish HTML versions. 

I have *not* tested that this still works when asciidoctor converts to HTML. I'm not sure how to actually run that conversion, but will give it a shot if there's instruction somewhere. This is my first PR :)

I also fixed a relative link that was pointed to doc/stacktrace instead of stacktrace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4202)
<!-- Reviewable:end -->
