### PR TITLE
Add support for triggering change handlers when using :open-editor

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1653,7 +1653,7 @@ class CommandDispatcher:
         try:
             elem.set_value(text)
             # Kick off js handlers to trick them into thinking there was input.
-            elem.dispatch_event("input")
+            elem.dispatch_event("input", bubbles=True)
         except webelem.OrphanedError:
             message.error('Edited element vanished')
             ed.backup()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1652,6 +1652,8 @@ class CommandDispatcher:
         """
         try:
             elem.set_value(text)
+            # Kick off js handlers to trick them into thinking there was input.
+            elem.dispatch_event("input")
         except webelem.OrphanedError:
             message.error('Edited element vanished')
             ed.backup()

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -139,6 +139,10 @@ class AbstractWebElement(collections.abc.MutableMapping):
         """Set the element value."""
         raise NotImplementedError
 
+    def dispatch_event(self, event):
+        """Set the element value."""
+        raise NotImplementedError
+
     def insert_text(self, text):
         """Insert the given text into the element."""
         raise NotImplementedError

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -139,8 +139,16 @@ class AbstractWebElement(collections.abc.MutableMapping):
         """Set the element value."""
         raise NotImplementedError
 
-    def dispatch_event(self, event):
-        """Set the element value."""
+    def dispatch_event(self, event, bubbles=False,
+                       cancelable=False, composed=False):
+        """Dispatch an event to the element.
+
+        Args:
+            bubbles: Whether this event should bubble.
+            cancelable: Whether this event can be cancelled.
+            composed: Whether the event will trigger listeners outside of a
+                      shadow root
+        """
         raise NotImplementedError
 
     def insert_text(self, text):

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -135,8 +135,10 @@ class WebEngineElement(webelem.AbstractWebElement):
     def set_value(self, value):
         self._js_call('set_value', value)
 
-    def dispatch_event(self, event):
-        self._js_call('dispatch_event', event)
+
+    def dispatch_event(self, event, bubbles=False,
+                       cancelable=False, composed=False):
+        self._js_call('dispatch_event', event, bubbles, cancelable, composed)
 
     def caret_position(self):
         """Get the text caret position for the current element.

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -135,6 +135,9 @@ class WebEngineElement(webelem.AbstractWebElement):
     def set_value(self, value):
         self._js_call('set_value', value)
 
+    def dispatch_event(self, event):
+        self._js_call('dispatch_event', event)
+
     def caret_position(self):
         """Get the text caret position for the current element.
 

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -135,7 +135,6 @@ class WebEngineElement(webelem.AbstractWebElement):
     def set_value(self, value):
         self._js_call('set_value', value)
 
-
     def dispatch_event(self, event, bubbles=False,
                        cancelable=False, composed=False):
         self._js_call('dispatch_event', event, bubbles, cancelable, composed)

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -128,13 +128,16 @@ class WebKitElement(webelem.AbstractWebElement):
             value = javascript.string_escape(value)
             self._elem.evaluateJavaScript("this.value='{}'".format(value))
 
-    def dispatch_event(self, event):
+    def dispatch_event(self, event, bubbles=False,
+                       cancelable=False, composed=False):
         self._check_vanished()
-        if self._tab.is_deleted():
-            raise webelem.OrphanedError("Tab containing element vanished")
         log.webelem.debug("Firing event on {!r} via javascript.".format(self))
-        self._elem.evaluateJavaScript("this.dispatchEvent(new Event('{}'))"
-                                      .format(event))
+        event = javascript.string_escape(event)
+        self._elem.evaluateJavaScript(
+            "this.dispatchEvent(new Event('{}', "
+            "{{'bubbles': {}, 'cancelable': {}, 'composed': {}}}))"
+            .format(event, str(bubbles).lower(), str(cancelable).lower(),
+                    str(composed).lower()))
 
     def caret_position(self):
         """Get the text caret position for the current element."""

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -132,12 +132,13 @@ class WebKitElement(webelem.AbstractWebElement):
                        cancelable=False, composed=False):
         self._check_vanished()
         log.webelem.debug("Firing event on {!r} via javascript.".format(self))
-        event = javascript.string_escape(event)
         self._elem.evaluateJavaScript(
-            "this.dispatchEvent(new Event('{}', "
+            "this.dispatchEvent(new Event({}, "
             "{{'bubbles': {}, 'cancelable': {}, 'composed': {}}}))"
-            .format(event, str(bubbles).lower(), str(cancelable).lower(),
-                    str(composed).lower()))
+            .format(javascript.convert_js_arg(event),
+                    javascript.convert_js_arg(bubbles),
+                    javascript.convert_js_arg(cancelable),
+                    javascript.convert_js_arg(composed)))
 
     def caret_position(self):
         """Get the text caret position for the current element."""

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -128,6 +128,14 @@ class WebKitElement(webelem.AbstractWebElement):
             value = javascript.string_escape(value)
             self._elem.evaluateJavaScript("this.value='{}'".format(value))
 
+    def dispatch_event(self, event):
+        self._check_vanished()
+        if self._tab.is_deleted():
+            raise webelem.OrphanedError("Tab containing element vanished")
+        log.webelem.debug("Firing event on {!r} via javascript.".format(self))
+        self._elem.evaluateJavaScript("this.dispatchEvent(new Event('{}'))"
+                                      .format(event))
+
     def caret_position(self):
         """Get the text caret position for the current element."""
         self._check_vanished()

--- a/qutebrowser/javascript/.eslintrc.yaml
+++ b/qutebrowser/javascript/.eslintrc.yaml
@@ -59,3 +59,4 @@ rules:
      multiline-ternary: ["error", "always-multiline"]
      max-lines-per-function: "off"
      require-unicode-regexp: "off"
+     max-params: "off"

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -1,5 +1,5 @@
 /* eslint-disable max-len, max-statements, complexity,
-max-params, default-case, valid-jsdoc */
+default-case, valid-jsdoc */
 
 // Copyright 2014 The Chromium Authors. All rights reserved.
 //

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -362,7 +362,6 @@ window._qutebrowser.webelem = (function() {
         document.execCommand("insertText", false, text);
     };
 
-
     funcs.dispatch_event = (id, event, bubbles = false,
         cancelable = false, composed = false) => {
         const elem = elements[id];

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -362,6 +362,11 @@ window._qutebrowser.webelem = (function() {
         document.execCommand("insertText", false, text);
     };
 
+    funcs.dispatch_event = (id, event) => {
+        const elem = elements[id];
+        elem.dispatchEvent(new Event(event));
+    };
+
     funcs.set_attribute = (id, name, value) => {
         elements[id].setAttribute(name, value);
     };

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -362,9 +362,14 @@ window._qutebrowser.webelem = (function() {
         document.execCommand("insertText", false, text);
     };
 
-    funcs.dispatch_event = (id, event) => {
+
+    funcs.dispatch_event = (id, event, bubbles = false,
+        cancelable = false, composed = false) => {
         const elem = elements[id];
-        elem.dispatchEvent(new Event(event));
+        elem.dispatchEvent(
+            new Event(event, {"bubbles": bubbles,
+                "cancelable": cancelable,
+                "composed": composed}));
     };
 
     funcs.set_attribute = (id, name, value) => {

--- a/qutebrowser/utils/javascript.py
+++ b/qutebrowser/utils/javascript.py
@@ -49,7 +49,7 @@ def string_escape(text):
     return text
 
 
-def _convert_js_arg(arg):
+def convert_js_arg(arg):
     """Convert the given argument so it's the equivalent in JS."""
     if arg is None:
         return 'undefined'
@@ -66,7 +66,7 @@ def _convert_js_arg(arg):
 
 def assemble(module, function, *args):
     """Assemble a javascript file and a function call."""
-    js_args = ', '.join(_convert_js_arg(arg) for arg in args)
+    js_args = ', '.join(convert_js_arg(arg) for arg in args)
     if module == 'window':
         parts = ['window', function]
     else:

--- a/tests/unit/utils/test_javascript.py
+++ b/tests/unit/utils/test_javascript.py
@@ -88,9 +88,9 @@ class TestStringEscape:
 def test_convert_js_arg(arg, expected):
     if expected is TypeError:
         with pytest.raises(TypeError):
-            javascript._convert_js_arg(arg)
+            javascript.convert_js_arg(arg)
     else:
-        assert javascript._convert_js_arg(arg) == expected
+        assert javascript.convert_js_arg(arg) == expected
 
 
 @pytest.mark.parametrize('base, expected_base', [


### PR DESCRIPTION
Closes #3786

`input` was the most logical change handler to trigger when we change text, as we don't need to provide any additional information to fire it. There are a couple of other good options though (such as `paste`) but they seem less general.

I don't know of any other websites that use this behavior other than gitlab, if someone could come up with a list, I could test them out and change the signal we emit if there are differences.

I'm not sure if it would be worth it to add tests for this (it would be a little bit of extra work to set up a page that checked for handlers firing), let me know if we do want them though.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4204)
<!-- Reviewable:end -->
