### PR TITLE
add proper multiline support for qute-pass

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -169,7 +169,7 @@ def main(arguments):
 
     # Match username
     target = selection if arguments.username_target == 'path' else secret
-    match = re.match(arguments.username_pattern, target)
+    match = re.search(arguments.username_pattern, target, re.MULTILINE)
     if not match:
         stderr('Failed to match username pattern on {}!'.format(arguments.username_target))
         return ExitCodes.COULD_NOT_MATCH_USERNAME


### PR DESCRIPTION
when using the 'username-taget secret' option, the supplied
regex 'username-pattern' will only scan the first line of the
secret file.

you could specify a username-pattern with '\n', but this will
break if the position of the username is not consistent.

this change will implement re.search and the re.MULTILINE
option to search every line in a secrect file.

example:

--secret file
my_secret_password
username: my_username
--secret file

spawn --userscript qute-pass --username-target secret --username-pattern "^username: (.*)"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4207)
<!-- Reviewable:end -->
