### PR TITLE
Feature/containerized installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM ubuntu:18.04
+
+RUN apt update
+
+RUN apt install -y qutebrowser
+
+CMD ["qutebrowser"]

--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -8,6 +8,15 @@ means those instructions might be out of date in some places.
 https://github.com/qutebrowser/qutebrowser/blob/master/doc/contributing.asciidoc[Please help]
 updating them if you notice something being broken!
 
+Containerized Installation on any Linux platform (with Docker)
+--------------------------------------------------------------
+
+Run the following command and enjoy qutebrowser:
+
+----
+# docker run --net=host --env="DISPLAY" --volume="$HOME/.Xauthority:/root/.Xauthority:rw" omervexler/qutebrowser
+----
+
 On Debian / Ubuntu
 ------------------
 

--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -9,11 +9,11 @@ https://github.com/qutebrowser/qutebrowser/blob/master/doc/contributing.asciidoc
 updating them if you notice something being broken!
 
 Containerized Installation on Linux platform (with Docker)
---------------------------------------------------------------
+----------------------------------------------------------
 
 This installation method was tested against Ubuntu 18.04.1 LTS.
 
-Run the following command as a user that can access the docker engine:
+Run the following command:
 
 ----
 # docker run -it --env="DISPLAY" -v /tmp/.X11-unix:/tmp/.X11-unix omervexler/qutebrowser:latest

--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -8,8 +8,10 @@ means those instructions might be out of date in some places.
 https://github.com/qutebrowser/qutebrowser/blob/master/doc/contributing.asciidoc[Please help]
 updating them if you notice something being broken!
 
-Containerized Installation on any Linux platform (with Docker)
+Containerized Installation on Linux platform (with Docker)
 --------------------------------------------------------------
+
+This installation method was tested against Ubuntu 18.04.1 LTS.
 
 Run the following command as a user that can access the docker engine:
 

--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -11,10 +11,10 @@ updating them if you notice something being broken!
 Containerized Installation on any Linux platform (with Docker)
 --------------------------------------------------------------
 
-Run the following command and enjoy qutebrowser:
+Run the following command as a user that can access the docker engine:
 
 ----
-# docker run --net=host --env="DISPLAY" --volume="$HOME/.Xauthority:/root/.Xauthority:rw" omervexler/qutebrowser
+# docker run -it --env="DISPLAY" -v /tmp/.X11-unix:/tmp/.X11-unix omervexler/qutebrowser:latest
 ----
 
 On Debian / Ubuntu


### PR DESCRIPTION
Hi, just added a new installation method- install qutebrowser from a docker image.

The image is at omervexler/qutebrowser in the dockerhub, but I really think it should live inside qutebrowser/qutebrowser. 
There is already a qutebrowser namespace in the dockerhub, so this is why the image is located in my personal project. 

I added the Dockerfile itself to the root of the project, if you have a suggestion to a better place I would be glad to change the file's location. I also updated the docs accordingly.

Also, it was tested only against my Ubuntu 18.04.1 LTS.

cheers :smile:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4219)
<!-- Reviewable:end -->
