### PR TITLE
Add bindings to toggle content.images

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2559,6 +2559,12 @@ bindings.default:
       tPH: config-cycle -p -u *://*.{url:host}/* content.plugins ;; reload
       tpu: config-cycle -p -t -u {url} content.plugins ;; reload
       tPu: config-cycle -p -u {url} content.plugins ;; reload
+      tih: config-cycle -p -t -u *://{url:host}/* content.images ;; reload
+      tIh: config-cycle -p -u *://{url:host}/* content.images ;; reload
+      tiH: config-cycle -p -t -u *://*.{url:host}/* content.images ;; reload
+      tIH: config-cycle -p -u *://*.{url:host}/* content.images ;; reload
+      tiu: config-cycle -p -t -u {url} content.images ;; reload
+      tIu: config-cycle -p -u {url} content.images ;; reload
     insert:
       <Ctrl-E>: open-editor
       <Shift-Ins>: insert-text {primary}


### PR DESCRIPTION
I've recently turned off `content.images` by default, and while it's nice, some pages just don't work without the images shown, so I've added these bindings in my config.py, but I figured others may like these as well. The bindings are structured similar to the `tsh`/`tph` family of bindings to toggle JavaScript/plugins, using `i` instead of `s`/`p`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4231)
<!-- Reviewable:end -->
