### PR TITLE
Only repaint tabs when they are needed

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -644,11 +644,15 @@ class TabBar(QTabBar):
         qtutils.ensure_valid(size)
         return size
 
-    def paintEvent(self, _e):
+    def paintEvent(self, event):
         """Override paintEvent to draw the tabs like we want to."""
         p = QStylePainter(self)
         selected = self.currentIndex()
         for idx in range(self.count()):
+            if not event.region().intersects(self.tabRect(idx)):
+                # Don't repaint if we are outside the requested region
+                continue
+
             tab = QStyleOptionTab()
             self.initStyleOption(tab, idx)
 
@@ -664,10 +668,6 @@ class TabBar(QTabBar):
 
             indicator_color = self.tab_indicator_color(idx)
             tab.palette.setColor(QPalette.Base, indicator_color)
-            if tab.rect.right() < 0 or tab.rect.left() > self.width():
-                # Don't bother drawing a tab if the entire tab is outside of
-                # the visible tab bar.
-                continue
             p.drawControl(QStyle.CE_TabBarTab, tab)
 
     def tabInserted(self, idx):


### PR DESCRIPTION
Sorry for spamming PRs but I think it's easier to merge them when they're bite size :)

After the other optimizations, `paintEvent` is one of the slowest parts. 

This PR [takes the reccomendation of the paintEvent docs](https://doc.qt.io/qt-5/qwidget.html#paintEvent) to only repaint parts that explicitly are requested, and avoids (relatively) expensive calls to drawControl and initStyleOptionTab when possible. This helps a lot when a (unpinned) tab is loading, as the size of the tab dosen't change but the indicator/text of the tab does.

This will probably also help (insane amounts) of vertical tabs too as we were always drawing every tab in that situation, even when we didn't need to, but I haven't profiled that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4234)
<!-- Reviewable:end -->
