### PR TITLE
Don't rely on tabData for pinned tabs

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -108,10 +108,7 @@ class TabWidget(QTabWidget):
             tab: The tab to pin
             pinned: Pinned tab state to set.
         """
-        bar = self.tabBar()
         idx = self.indexOf(tab)
-
-        bar.set_tab_data(idx, 'pinned', pinned)
         tab.data.pinned = pinned
         self.update_tab_favicon(tab)
         self.update_tab_title(idx)
@@ -570,10 +567,10 @@ class TabBar(QTabBar):
 
     def _tab_pinned(self, index: int) -> bool:
         """Return True if tab is pinned."""
-        try:
-            return self.tab_data(index, 'pinned')
-        except KeyError:
-            return False
+        if not 0 <= index < self.count():
+            raise IndexError("Tab index ({}) out of range ({})!".format(
+                index, self.count()))
+        return self.parent().widget(index).data.pinned
 
     def tabSizeHint(self, index: int):
         """Override tabSizeHint to customize qb's tab size.

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -20,6 +20,7 @@
 """Tests for the custom TabWidget/TabBar."""
 
 import pytest
+import functools
 
 from PyQt5.QtGui import QIcon, QPixmap
 
@@ -141,3 +142,9 @@ class TestTabWidget:
             browser.shutdown()
 
         benchmark(_run_bench)
+
+    def test_tab_pinned_benchmark(self, benchmark, widget, fake_web_tab):
+        """Benchmark for _tab_pinned."""
+        widget.addTab(fake_web_tab(), 'foobar')
+        tab_bar = widget.tabBar()
+        benchmark(functools.partial(tab_bar._tab_pinned, 0))


### PR DESCRIPTION
Because figuring out if a tab is pinned is done very often, it's important for it to be fairly fast, but it shows up to be a large chunk of the profile. I added a benchmark and decided to use `tab.data` instead of `tabData`, as `tabData` seems to rely on catching exceptions for every tab that's never been pinned, [which can be slow](https://docs.python.org/3/faq/design.html#how-fast-are-exceptions), and because `tabData` seems to be really slow to return its value either way (maybe it's something in pyqt with the return type being converted or something).

Without Patch:

```
Name (time in us)                               Min                    Max                Median          
----------------------------------------------------------------------------------------------------------
test_tab_pinned_benchmark                    2.4760 (1.0)          35.4580 (1.0)          2.6720 (1.0)    
```

With Patch (note this went from `us` to `ns`):
```
Name (time in ns)                                   Min                        Max                    Median          
----------------------------------------------------------------------------------------------------------------------
test_tab_pinned_benchmark                      807.8350 (1.0)           5,869.0008 (1.0)            874.1724 (1.0)    
```

While this is only 2x as fast, this makes a noticable difference when the `minimumTabSizeHint` cache is blown (when deleting the first tab of ~100 tabs all in a row)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4245)
<!-- Reviewable:end -->
