### PR TITLE
Add messages.level configuration property support.

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1241,6 +1241,16 @@ keyhint.delay:
 
 ## messages
 
+messages.level:
+  type:
+    name: String
+    valid_values:
+      - info: Display info, warning and error messages
+      - warning: Display warnings and errors
+      - error: Display errors only
+  default: info
+  desc: Minimum level of messages to display in message view window.
+
 messages.timeout:
   type:
     name: Int

--- a/qutebrowser/mainwindow/messageview.py
+++ b/qutebrowser/mainwindow/messageview.py
@@ -118,6 +118,9 @@ class MessageView(QWidget):
     @pyqtSlot(usertypes.MessageLevel, str, bool)
     def show_message(self, level, text, replace=False):
         """Show the given message with the given MessageLevel."""
+        if level < usertypes.MessageLevel[config.val.messages.level]:
+            return
+
         if text == self._last_text:
             return
 

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -245,7 +245,7 @@ JsWorld = enum.Enum('JsWorld', ['main', 'application', 'user', 'jseval'])
 JsLogLevel = enum.Enum('JsLogLevel', ['unknown', 'info', 'warning', 'error'])
 
 
-MessageLevel = enum.Enum('MessageLevel', ['error', 'warning', 'info'])
+MessageLevel = enum.IntEnum('MessageLevel', ['info', 'warning', 'error'])
 
 
 class Question(QObject):

--- a/tests/unit/mainwindow/test_messageview.py
+++ b/tests/unit/mainwindow/test_messageview.py
@@ -17,6 +17,7 @@
 # You should have received a copy of the GNU General Public License
 # along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
 
+import random
 import pytest
 from PyQt5.QtCore import Qt
 
@@ -27,6 +28,7 @@ from qutebrowser.utils import usertypes
 @pytest.fixture
 def view(qtbot, config_stub):
     config_stub.val.messages.timeout = 100
+    config_stub.val.messages.level = 'info'
     mv = messageview.MessageView()
     qtbot.add_widget(mv)
     return mv
@@ -39,6 +41,30 @@ def test_single_message(qtbot, view, level):
     with qtbot.waitExposed(view):
         view.show_message(level, 'test')
     assert view._messages[0].isVisible()
+
+
+def test_messages_level(qtbot, view, config_stub):
+    def assert_visible(level, visible):
+        n = len(view._messages)
+        with qtbot.waitExposed(view):
+            view.show_message(level, str(random.random()))
+        if visible:
+            assert n == len(view._messages) - 1
+        else:
+            assert n == len(view._messages)
+
+    config_stub.val.messages.level = 'info'
+    assert_visible(usertypes.MessageLevel.info, True)
+    assert_visible(usertypes.MessageLevel.warning, True)
+    assert_visible(usertypes.MessageLevel.error, True)
+    config_stub.val.messages.level = 'warning'
+    assert_visible(usertypes.MessageLevel.info, False)
+    assert_visible(usertypes.MessageLevel.warning, True)
+    assert_visible(usertypes.MessageLevel.error, True)
+    config_stub.val.messages.level = 'error'
+    assert_visible(usertypes.MessageLevel.info, False)
+    assert_visible(usertypes.MessageLevel.warning, False)
+    assert_visible(usertypes.MessageLevel.error, True)
 
 
 def test_message_hiding(qtbot, view):


### PR DESCRIPTION
I find it annoying to see info messages every time I change zoom level. Proposed new `messages.level` option allows to suppress info-level messages. It is also backward compatible.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4255)
<!-- Reviewable:end -->
