### PR TITLE
Add tabs.max_width setting

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1602,6 +1602,23 @@ tabs.min_width:
 
     This setting does not apply to pinned tabs, unless `tabs.pinned.shrink` is False.
 
+tabs.max_width:
+  default: -1
+  type:
+    name: Int
+    minval: -1
+    maxval: maxint
+  desc: >-
+    Maximum width (in pixels) of tabs (-1 for no maximum).
+
+    This setting only applies when tabs are horizontal.
+
+    This setting does not apply to pinned tabs, unless `tabs.pinned.shrink` is
+    False.
+
+    This setting may not apply properly if max_width is smaller than the
+    minimum size of tab contents, or smaller than tabs.min_width.
+
 tabs.width.indicator:
   renamed: tabs.indicator.width
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -610,6 +610,9 @@ class TabBar(QTabBar):
                 # Request as much space as possible so we fill the tabbar, let
                 # Qt shrink us down
                 width = self.width()
+                max_width = config.cache['tabs.max_width']
+                if max_width > 0:
+                    width = min(max_width, width)
 
             # If we don't have enough space, we return the minimum size
             width = max(width, minimum_size.width())

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -613,15 +613,12 @@ class TabBar(QTabBar):
                 width = self.minimumTabSizeHint(index, ellipsis=False).width()
             else:
                 # Request as much space as possible so we fill the tabbar, let
-                # Qt shrink us down
-                width = self.width()
+                # Qt shrink us down. If for some reason (tests, bugs)
+                # self.width() gives 0, use a sane min of 10 px
+                width = max(self.width(), 10)
                 max_width = config.cache['tabs.max_width']
                 if max_width > 0:
                     width = min(max_width, width)
-
-                # If for some reason (tests, bugs) self.width() gives 0, use a
-                # sane min of 10 px
-                width = max(width, 10)
             size = QSize(width, height)
         qtutils.ensure_valid(size)
         return size

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -38,7 +38,8 @@ class TestTabWidget:
         qtbot.addWidget(w)
         monkeypatch.setattr(tabwidget.objects, 'backend',
                             usertypes.Backend.QtWebKit)
-        monkeypatch.setattr(w.tabBar(), 'width', w.width)
+        w.show()
+        # monkeypatch.setattr(w.tabBar(), 'width', w.width)
         return w
 
     @pytest.fixture
@@ -130,20 +131,16 @@ class TestTabWidget:
         benchmark(widget.update_tab_titles)
 
     def test_tab_min_width(self, widget, fake_web_tab, config_stub):
-        """Ensure by default, all tab sizes are the same."""
         widget.addTab(fake_web_tab(), 'foobar')
-        normal_size = widget.tabBar().minimumTabSizeHint(0).width()
-        normal_size += 100
+        normal_size = widget.tabBar().tabRect(0).width() + 100
         config_stub.val.tabs.min_width = normal_size
-        assert widget.tabBar().minimumTabSizeHint(0).width() == normal_size
+        assert widget.tabBar().tabRect(0).width() == normal_size
 
     def test_tab_max_width(self, widget, fake_web_tab, config_stub):
-        """Ensure by default, all tab sizes are the same."""
         widget.addTab(fake_web_tab(), 'foobar')
-        normal_size = widget.tabBar().tabSizeHint(0).width()
-        normal_size -= 10
+        normal_size = widget.tabBar().tabRect(0).width() - 10
         config_stub.val.tabs.max_width = normal_size
-        assert widget.tabBar().tabSizeHint(0).width() == normal_size
+        assert widget.tabBar().tabRect(0).width() == normal_size
 
     @pytest.mark.parametrize("num_tabs", [4, 10])
     def test_add_remove_tab_benchmark(self, benchmark, browser,

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -38,6 +38,7 @@ class TestTabWidget:
         qtbot.addWidget(w)
         monkeypatch.setattr(tabwidget.objects, 'backend',
                             usertypes.Backend.QtWebKit)
+        monkeypatch.setattr(w.tabBar(), 'width', w.width)
         return w
 
     @pytest.fixture
@@ -108,7 +109,7 @@ class TestTabWidget:
 
         for i in range(num_tabs):
             if i in pinned_num and shrink_pinned and not vertical:
-                assert (first_size.width() <
+                assert (first_size.width() >
                         widget.tabBar().tabSizeHint(i).width())
                 assert (first_size_min.width() <
                         widget.tabBar().minimumTabSizeHint(i).width())
@@ -127,6 +128,22 @@ class TestTabWidget:
             widget.show()
 
         benchmark(widget.update_tab_titles)
+
+    def test_tab_min_width(self, widget, fake_web_tab, config_stub):
+        """Ensure by default, all tab sizes are the same."""
+        widget.addTab(fake_web_tab(), 'foobar')
+        normal_size = widget.tabBar().minimumTabSizeHint(0).width()
+        normal_size += 100
+        config_stub.val.tabs.min_width = normal_size
+        assert widget.tabBar().minimumTabSizeHint(0).width() == normal_size
+
+    def test_tab_max_width(self, widget, fake_web_tab, config_stub):
+        """Ensure by default, all tab sizes are the same."""
+        widget.addTab(fake_web_tab(), 'foobar')
+        normal_size = widget.tabBar().tabSizeHint(0).width()
+        normal_size -= 10
+        config_stub.val.tabs.max_width = normal_size
+        assert widget.tabBar().tabSizeHint(0).width() == normal_size
 
     @pytest.mark.parametrize("num_tabs", [4, 10])
     def test_add_remove_tab_benchmark(self, benchmark, browser,

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -39,7 +39,6 @@ class TestTabWidget:
         monkeypatch.setattr(tabwidget.objects, 'backend',
                             usertypes.Backend.QtWebKit)
         w.show()
-        # monkeypatch.setattr(w.tabBar(), 'width', w.width)
         return w
 
     @pytest.fixture
@@ -130,17 +129,18 @@ class TestTabWidget:
 
         benchmark(widget.update_tab_titles)
 
-    def test_tab_min_width(self, widget, fake_web_tab, config_stub):
+    def test_tab_min_width(self, widget, fake_web_tab, config_stub, qtbot):
         widget.addTab(fake_web_tab(), 'foobar')
-        normal_size = widget.tabBar().tabRect(0).width() + 100
-        config_stub.val.tabs.min_width = normal_size
-        assert widget.tabBar().tabRect(0).width() == normal_size
+        widget.addTab(fake_web_tab(), 'foobar1')
+        min_size = widget.tabBar().tabRect(0).width() + 10
+        config_stub.val.tabs.min_width = min_size
+        assert widget.tabBar().tabRect(0).width() == min_size
 
-    def test_tab_max_width(self, widget, fake_web_tab, config_stub):
+    def test_tab_max_width(self, widget, fake_web_tab, config_stub, qtbot):
         widget.addTab(fake_web_tab(), 'foobar')
-        normal_size = widget.tabBar().tabRect(0).width() - 10
-        config_stub.val.tabs.max_width = normal_size
-        assert widget.tabBar().tabRect(0).width() == normal_size
+        max_size = widget.tabBar().tabRect(0).width() - 10
+        config_stub.val.tabs.max_width = max_size
+        assert widget.tabBar().tabRect(0).width() == max_size
 
     @pytest.mark.parametrize("num_tabs", [4, 10])
     def test_add_remove_tab_benchmark(self, benchmark, browser,


### PR DESCRIPTION
Pretty small commit to add a `tabs.max_width` feature, as someone asked for it on IRC.

Might trivially conflict with #4246, but that's not really a problem :P

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4261)
<!-- Reviewable:end -->
