### PR TITLE
Sort settings page by name

### DIFF
--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -34,7 +34,7 @@ input { width: 98%; }
         <th>Setting</th>
         <th>Value</th>
     </tr>
-  {% for option in configdata.DATA.values() if not option.no_autoconfig %}
+  {% for option in configdata.DATA.values()|sort(attribute='name') if not option.no_autoconfig %}
     <tr>
       <!-- FIXME: convert to string properly -->
       <td class="setting">{{ option.name }} (Current: {{ confget(option.name) | string |truncate(100) }})


### PR DESCRIPTION
Hello,

this is a really small change in order to sort the settings page so that related settings are grouped together.

Tests done: open the settings page with qutebrowser check that the list is sorted, make a change and see it applied.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4263)
<!-- Reviewable:end -->
