### PR TITLE
Turn off visibility of tabs while updating titles

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -216,8 +216,17 @@ class TabWidget(QTabWidget):
 
     def update_tab_titles(self):
         """Update all texts."""
+        # Every single call to setTabText calls the size hinting functions for
+        # every single tab, which are slow. Since we know we are updating all
+        # the tab's titles, we can delay this processing by making the tab
+        # non-visible. To avoid flickering, disable repaint updates whlie we
+        # work.
+        self.setUpdatesEnabled(False)
+        self.setVisible(False)
         for idx in range(self.count()):
             self.update_tab_title(idx)
+        self.setVisible(True)
+        self.setUpdatesEnabled(True)
 
     def tabInserted(self, idx):
         """Update titles when a tab was inserted."""

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -24,7 +24,7 @@ import functools
 import pytest
 from PyQt5.QtGui import QIcon, QPixmap
 
-from qutebrowser.mainwindow import tabwidget, tabbedbrowser
+from qutebrowser.mainwindow import tabwidget
 from qutebrowser.utils import usertypes
 
 
@@ -108,7 +108,7 @@ class TestTabWidget:
                 assert first_size == widget.tabBar().tabSizeHint(i)
                 assert first_size_min == widget.tabBar().minimumTabSizeHint(i)
 
-    @pytest.mark.parametrize("num_tabs", [4, 10])
+    @pytest.mark.parametrize("num_tabs", [4, 10, 50, 100])
     def test_update_tab_titles_benchmark(self, benchmark, widget,
                                          qtbot, fake_web_tab, num_tabs):
         """Benchmark for update_tab_titles."""
@@ -120,7 +120,7 @@ class TestTabWidget:
 
         benchmark(widget.update_tab_titles)
 
-    @pytest.mark.parametrize("num_tabs", [4, 10])
+    @pytest.mark.parametrize("num_tabs", [4, 100])
     @pytest.mark.parametrize("rev", [True, False])
     def test_add_remove_tab_benchmark(self, benchmark, widget,
                                       qtbot, fake_web_tab, num_tabs, rev):

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -40,14 +40,6 @@ class TestTabWidget:
                             usertypes.Backend.QtWebKit)
         return w
 
-    @pytest.fixture
-    def browser(self, qtbot, monkeypatch, config_stub):
-        w = tabbedbrowser.TabbedBrowser(win_id=0, private=False)
-        qtbot.addWidget(w)
-        monkeypatch.setattr(tabwidget.objects, 'backend',
-                            usertypes.Backend.QtWebKit)
-        return w
-
     def test_small_icon_doesnt_crash(self, widget, qtbot, fake_web_tab):
         """Test that setting a small icon doesn't produce a crash.
 
@@ -108,7 +100,7 @@ class TestTabWidget:
 
         for i in range(num_tabs):
             if i in pinned_num and shrink_pinned and not vertical:
-                assert (first_size.width() <
+                assert (first_size.width() >
                         widget.tabBar().tabSizeHint(i).width())
                 assert (first_size_min.width() <
                         widget.tabBar().minimumTabSizeHint(i).width())
@@ -129,17 +121,22 @@ class TestTabWidget:
         benchmark(widget.update_tab_titles)
 
     @pytest.mark.parametrize("num_tabs", [4, 10])
-    def test_add_remove_tab_benchmark(self, benchmark, browser,
-                                      qtbot, fake_web_tab, num_tabs):
+    @pytest.mark.parametrize("rev", [True, False])
+    def test_add_remove_tab_benchmark(self, benchmark, widget,
+                                      qtbot, fake_web_tab, num_tabs, rev):
         """Benchmark for addTab and removeTab."""
         def _run_bench():
+            with qtbot.wait_exposed(widget):
+                widget.show()
             for i in range(num_tabs):
-                browser.widget.addTab(fake_web_tab(), 'foobar' + str(i))
+                idx = i if rev else 0
+                widget.insertTab(idx, fake_web_tab(), 'foobar' + str(i))
 
-            with qtbot.waitExposed(browser):
-                browser.show()
-
-            browser.shutdown()
+            to_del = range(num_tabs)
+            if rev:
+                to_del = reversed(to_del)
+            for i in to_del:
+                widget.removeTab(i)
 
         benchmark(_run_bench)
 


### PR DESCRIPTION
Improves performance dramatically when all titles change at once, such
as when the first tab is removed.

I don't see any flashing going on at all. The `setVisible` call after the update is hot in the profile with the tab sizing methods, which means that (I think) they should be called properly.

After all these patches I'm noticing some sort of periodic hanging when adding/removing large batches of tabs (it feels like gc pauses, but I don't think that's what it is). I think that's always been there though, and I'm just seeing it now because it's fast in-between the pauses.

As discussed in IRC, [these forced calls to tabSizeHint and minimumTabSizeHint](https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/widgets/qtabbar.cpp#n476) are what we want to avoid (as it is called for every single tab even if one tab updates its text), and the only way we can disable this (I think) is by [making the widget non-visible](https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/widgets/qtabbar.cpp#n835)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4266)
<!-- Reviewable:end -->
