### PR TITLE
FAQ: Add MacOS PATH info to Troubleshooting

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -310,6 +310,15 @@ Lastly, set your `qt.args` to point to that directory and restart qutebrowser:
 :restart
 ----
 
+Unable to use `spawn` on MacOS.::
+When running qutebrowser from the prebuilt binary (`qutebrowser.app`) it *will
+not* read any files that would alter your `$PATH` (e.g. `.profile`, `.bashrc`,
+etc). This is not a bug, just that `.profile` is not propogated to GUI
+applications in MacOS.
++
+See https://github.com/qutebrowser/qutebrowser/issues/4273[Issue #4273] for
+details and potential workarounds.
+
 My issue is not listed.::
     If you experience any segfaults or crashes, you can report the issue in
     https://github.com/qutebrowser/qutebrowser/issues[the issue tracker] or


### PR DESCRIPTION
For issue https://github.com/qutebrowser/qutebrowser/issues/4273

Hopefully clears up some of the issues with the PATH for MacOS users. Includes some basic info about why and links to the issue above for details and potential workarounds.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4274)
<!-- Reviewable:end -->
