### PR TITLE
Select text node in tests to imitate real selections

### DIFF
--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -333,13 +333,13 @@ window._qutebrowser.webelem = (function() {
     // it). If nothing is selected but there is something focused, returns
     // "focused"
     funcs.find_selected_focused_link = () => {
-        const elem = window.getSelection().baseNode;
+        const elem = window.getSelection().anchorNode;
         if (elem) {
             return serialize_elem(elem.parentNode);
         }
 
         const serialized_frame_elem = run_frames((frame) => {
-            const node = frame.window.getSelection().baseNode;
+            const node = frame.window.getSelection().anchorNode;
             if (node) {
                 return serialize_elem(node.parentNode, frame);
             }

--- a/tests/end2end/data/search_select.js
+++ b/tests/end2end/data/search_select.js
@@ -7,6 +7,8 @@ if(s.rangeCount > 0) s.removeAllRanges();
 
 for(var i = 0; i < toSelect.length; i++) {
     var range = document.createRange();
-    range.selectNode(toSelect[i]);
-    s.addRange(range);
+    if (toSelect[i].childNodes.length > 0) {
+        range.selectNodeContents(toSelect[i].childNodes[0]);
+        s.addRange(range);
+    }
 }


### PR DESCRIPTION
Closes #4250

I haven't actually tested this on 5.12, but I'm pretty sure this will fix the issue.

We could make `webelem.js` recurse down to the bottom most node as well, but that's probably not needed.