### PR TITLE
Add yank --quiet option support.

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1397,7 +1397,7 @@ Close all windows except for the current one.
 
 [[yank]]
 === yank
-Syntax: +:yank [*--sel*] [*--keep*] ['what']+
+Syntax: +:yank [*--sel*] [*--keep*] [*--quiet*] ['what']+
 
 Yank something to the clipboard or primary selection.
 
@@ -1416,6 +1416,7 @@ Yank something to the clipboard or primary selection.
 ==== optional arguments
 * +*-s*+, +*--sel*+: Use the primary selection instead of the clipboard.
 * +*-k*+, +*--keep*+: Stay in visual mode after yanking the selection.
+* +*-q*+, +*--quiet*+: Don't show information message.
 
 [[zoom]]
 === zoom

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -817,7 +817,7 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('what', choices=['selection', 'url', 'pretty-url',
                                         'title', 'domain'])
-    def yank(self, what='url', sel=False, keep=False):
+    def yank(self, what='url', sel=False, keep=False, quiet=False):
         """Yank something to the clipboard or primary selection.
 
         Args:
@@ -831,6 +831,7 @@ class CommandDispatcher:
 
             sel: Use the primary selection instead of the clipboard.
             keep: Stay in visual mode after yanking the selection.
+            quiet: Don't show information message.
         """
         if what == 'title':
             s = self._tabbed_browser.widget.page_title(self._current_index())
@@ -844,10 +845,10 @@ class CommandDispatcher:
             what = 'URL'  # For printing
         elif what == 'selection':
             def _selection_callback(s):
-                if not s:
+                if not s and not quiet:
                     message.info("Nothing to yank")
                     return
-                self._yank_to_target(s, sel, what, keep)
+                self._yank_to_target(s, sel, what, keep, quiet)
 
             caret = self._current_widget().caret
             caret.selection(callback=_selection_callback)
@@ -855,9 +856,9 @@ class CommandDispatcher:
         else:  # pragma: no cover
             raise ValueError("Invalid value {!r} for `what'.".format(what))
 
-        self._yank_to_target(s, sel, what, keep)
+        self._yank_to_target(s, sel, what, keep, quiet)
 
-    def _yank_to_target(self, s, sel, what, keep):
+    def _yank_to_target(self, s, sel, what, keep, quiet):
         if sel and utils.supports_selection():
             target = "primary selection"
         else:
@@ -866,10 +867,12 @@ class CommandDispatcher:
 
         utils.set_clipboard(s, selection=sel)
         if what != 'selection':
-            message.info("Yanked {} to {}: {}".format(what, target, s))
+            if not quiet:
+                message.info("Yanked {} to {}: {}".format(what, target, s))
         else:
-            message.info("{} {} yanked to {}".format(
-                len(s), "char" if len(s) == 1 else "chars", target))
+            if not quiet:
+                message.info("{} {} yanked to {}".format(
+                    len(s), "char" if len(s) == 1 else "chars", target))
             if not keep:
                 modeman.leave(self._win_id, KeyMode.caret, "yank selected",
                               maybe=True)


### PR DESCRIPTION
Continue to making QB more quiet. :)

Motivation.
Some of my applications use selections, some clipboard. To make things simpler I made next mapping `config.bind('yy', 'yank ;; yank -s')` which generates two information messages, which is is double annoying. New --quiet option adds more flexibility.