### PR TITLE
Fix tabs appearing when updating all tab titles

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -225,8 +225,8 @@ class TabWidget(QTabWidget):
         non-visible. To avoid flickering, disable repaint updates whlie we
         work.
         """
-        toggle = self.count() > 10
         bar = self.tabBar()
+        toggle = self.count() > 10 and bar.isVisible()
         if toggle:
             bar.setUpdatesEnabled(False)
             bar.setVisible(False)

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -134,6 +134,14 @@ class TestTabWidget:
         config_stub.val.tabs.max_width = max_size
         assert widget.tabBar().tabRect(0).width() == max_size
 
+    def test_tab_stays_hidden(self, widget, fake_web_tab, config_stub):
+        assert widget.tabBar().isVisible()
+        config_stub.val.tabs.show = "never"
+        assert not widget.tabBar().isVisible()
+        for i in range(12):
+            widget.addTab(fake_web_tab(), 'foobar' + str(i))
+        assert not widget.tabBar().isVisible()
+
     @pytest.mark.parametrize("num_tabs", [4, 100])
     @pytest.mark.parametrize("rev", [True, False])
     def test_add_remove_tab_benchmark(self, benchmark, widget,


### PR DESCRIPTION
Added a test, and works fine in testing.

If we continue to see issues, we might just want to disable this in 1.5.1, but we'll see.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4296)
<!-- Reviewable:end -->
