### PR TITLE
Cache config accesses in minimumTabSizeHint

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -574,19 +574,20 @@ class TabBar(QTabBar):
             return self.fontMetrics().size(Qt.TextShowMnemonic, text).width()
         text_width = min(_text_to_width(text),
                          _text_to_width(tab_text))
-        padding = config.val.tabs.padding
-        indicator_width = config.val.tabs.indicator.width
-        indicator_padding = config.val.tabs.indicator.padding
+        padding = config.cache['tabs.padding']
+        indicator_width = config.cache['tabs.indicator.width']
+        indicator_padding = config.cache['tabs.indicator.padding']
         padding_h = padding.left + padding.right
+
         # Only add padding if indicator exists
         if indicator_width != 0:
             padding_h += indicator_padding.left + indicator_padding.right
         height = self._minimum_tab_height()
         width = (text_width + icon_width +
                  padding_h + indicator_width)
-        min_width = config.val.tabs.min_width
+        min_width = config.cache['tabs.min_width']
         if (not self.vertical and min_width > 0 and
-                not pinned or not config.val.tabs.pinned.shrink):
+                not pinned or not config.cache['tabs.pinned.shrink']):
             width = max(min_width, width)
         return QSize(width, height)
 


### PR DESCRIPTION
Using ce4ad878aa6a4a487a820a4f70bed29d0da8729f, the tab stress test is bottlenecked by the minTabSizeHint config calls. This is probably because the test is constantly changing the tab titles, and blowing it's cache.

Maybe if we get this method optimized enough we could remove the cache completely :)

Of course, this only helps the worst-case performance, so in practice it's probably not going to impact people too much, but it's pretty safe :)

Before:
```
[33m-------------------------------------------------------- benchmark: 9 tests --------------------------------------------------------
Name (time in ns)                                          Min                           Max                        Median          
------------------------------------------------------------------------------------------------------------------------------------
test_tab_pinned_benchmark                             930.6629 (1.0)             34,212.4986 (1.0)                949.0032 (1.0)    
test_update_tab_titles_benchmark[4]                53,085.9979 (57.04)          294,722.9950 (8.61)            54,675.9984 (57.61)  
test_update_tab_titles_benchmark[10]              124,112.9939 (133.36)         395,880.9830 (11.57)          127,341.0162 (134.18) 
test_update_tab_titles_benchmark[50]              620,006.9911 (666.20)       1,419,697.0151 (41.50)          675,517.0180 (711.82) 
test_update_tab_titles_benchmark[100]           1,177,044.9928 (>1000.0)      2,771,118.9759 (81.00)        1,307,740.5019 (>1000.0)
test_add_remove_tab_benchmark[True-4]           2,033,964.0032 (>1000.0)      3,640,068.0256 (106.40)       2,426,774.9977 (>1000.0)
test_add_remove_tab_benchmark[False-4]          4,708,866.0067 (>1000.0)      6,430,787.9948 (187.97)       5,430,313.9914 (>1000.0)
test_add_remove_tab_benchmark[True-70]        212,838,314.0080 (>1000.0)    219,596,740.9934 (>1000.0)    216,739,830.9975 (>1000.0)
test_add_remove_tab_benchmark[False-70]     1,704,711,862.9853 (>1000.0)  2,546,135,418.9902 (>1000.0)  2,367,125,128.9779 (>1000.0)
------------------------------------------------------------------------------------------------------------------------------------
```

After:

```
[33m----------------------------------------------------- benchmark: 9 tests -----------------------------------------------------
Name (time in ns)                                        Min                         Max                      Median          
------------------------------------------------------------------------------------------------------------------------------
test_tab_pinned_benchmark                           931.6670 (1.0)           10,550.8322 (1.0)              971.3306 (1.0)    
test_update_tab_titles_benchmark[4]              52,218.0053 (56.05)        229,928.0022 (21.79)         53,738.0110 (55.32)  
test_update_tab_titles_benchmark[10]            126,541.0101 (135.82)       417,353.0033 (39.56)        129,199.9943 (133.01) 
test_update_tab_titles_benchmark[50]            614,791.0026 (659.88)     1,166,394.9990 (110.55)       636,672.9940 (655.46) 
test_update_tab_titles_benchmark[100]         1,225,019.0193 (>1000.0)    4,353,155.0036 (412.59)     1,626,139.5067 (>1000.0)
test_add_remove_tab_benchmark[True-4]         2,352,651.9944 (>1000.0)    4,881,404.9806 (462.66)     2,642,380.0155 (>1000.0)
test_add_remove_tab_benchmark[False-4]        3,829,632.0126 (>1000.0)    5,017,816.0018 (475.58)     4,791,479.9943 (>1000.0)
test_add_remove_tab_benchmark[True-70]      215,680,697.0015 (>1000.0)  283,324,522.9849 (>1000.0)  229,691,443.9939 (>1000.0)
test_add_remove_tab_benchmark[False-70]     542,433,075.0247 (>1000.0)  834,412,117.9834 (>1000.0)  802,473,477.9901 (>1000.0)
------------------------------------------------------------------------------------------------------------------------------
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4306)
<!-- Reviewable:end -->
