### PR TITLE
Always show icons for pinned tabs

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -350,6 +350,15 @@ class TabWidget(QTabWidget):
             if config.val.tabs.tabs_are_windows:
                 self.window().setWindowIcon(self.window().windowIcon())
 
+    def setTabIcon(self, idx: int, icon: QIcon):
+        """Add overrides for setting tab icon sometimes when it is empty."""
+        tab = self.widget(idx)
+        if (icon.isNull() and
+                config.cache['tabs.favicons.show'] != 'never' and
+                tab is not None and tab.data.pinned):
+            icon = self.style().standardIcon(QStyle.SP_FileIcon)
+        super().setTabIcon(idx, icon)
+
 
 class TabBar(QTabBar):
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -355,6 +355,8 @@ class TabWidget(QTabWidget):
         tab = self.widget(idx)
         if (icon.isNull() and
                 config.cache['tabs.favicons.show'] != 'never' and
+                config.cache['tabs.pinned.shrink'] and
+                not self.tabBar().vertical and
                 tab is not None and tab.data.pinned):
             icon = self.style().standardIcon(QStyle.SP_FileIcon)
         super().setTabIcon(idx, icon)

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -84,7 +84,7 @@ class TestTabWidget:
             widget.addTab(fake_web_tab(), 'foobar' + str(i))
 
         # Set pinned title format longer than unpinned
-        config_stub.val.tabs.title.format_pinned = "_" * 20
+        config_stub.val.tabs.title.format_pinned = "_" * 10
         config_stub.val.tabs.title.format = "_" * 2
         config_stub.val.tabs.pinned.shrink = shrink_pinned
         if vertical:


### PR DESCRIPTION
This makes it so pinned tabs will always have an icon, if one isn't provided by the site, it will get:

![2018-10-06-230013_140x124_scrot](https://user-images.githubusercontent.com/4349709/46578777-43b6ee80-c9f6-11e8-8998-640b2eaaec68.png)

This was requested in IRC from someone who wanted to remove all paddings and only use icons in their pinned tabs which seems reasonable (since other browsers do this). This setting won't change anything if `tabs.favicons.show` is never.

Does anyone have any strong opinions about this?

This is pretty low priority, so I'm fine with keeping it in the queue until the other more important PRs are dealt with (and that gives time for others to comment too).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4309)
<!-- Reviewable:end -->
