### PR TITLE
Fix _hint_scattered

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -454,10 +454,13 @@ class HintManager(QObject):
         # case. Usually we do not need all of these digits for every link
         # single hint, so we can show shorter hints for a few of the links.
         needed = max(min_chars, utils.ceil_log(len(elems), len(chars)))
+
         # Short hints are the number of hints we can possibly show which are
         # (needed - 1) digits in length.
         if needed > min_chars and needed > 1:
             total_space = len(chars) ** needed
+            # For each 1 short link being added, len(chars) long links are
+            # removed, therefore the space removed is len(chars) - 1.
             short_count = (total_space - len(elems)) // (len(chars) - 1)
         else:
             short_count = 0

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -21,7 +21,6 @@
 
 import collections
 import functools
-import math
 import os
 import re
 import html
@@ -454,8 +453,7 @@ class HintManager(QObject):
         # Determine how many digits the link hints will require in the worst
         # case. Usually we do not need all of these digits for every link
         # single hint, so we can show shorter hints for a few of the links.
-        needed = max(min_chars, math.ceil(
-            math.log(len(elems), len(chars))-1e-13))
+        needed = max(min_chars, utils.ceil_log(len(elems), len(chars)))
         # Short hints are the number of hints we can possibly show which are
         # (needed - 1) digits in length.
         if needed > min_chars and needed > 1:
@@ -487,7 +485,7 @@ class HintManager(QObject):
             elems: The elements to generate labels for.
         """
         strings = []
-        needed = max(min_chars, math.ceil(math.log(len(elems), len(chars))))
+        needed = max(min_chars, utils.ceil_log(len(elems), len(chars)))
         for i in range(len(elems)):
             strings.append(self._number_to_hint_str(i, chars, needed))
         return strings

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -454,21 +454,13 @@ class HintManager(QObject):
         # Determine how many digits the link hints will require in the worst
         # case. Usually we do not need all of these digits for every link
         # single hint, so we can show shorter hints for a few of the links.
-        needed = max(min_chars, math.ceil(math.log(len(elems), len(chars))))
+        needed = max(min_chars, math.ceil(
+            math.log(len(elems), len(chars))-1e-13))
         # Short hints are the number of hints we can possibly show which are
         # (needed - 1) digits in length.
-        if needed > min_chars:
+        if needed > min_chars and needed > 1:
             total_space = len(chars) ** needed
-            # Calculate short_count naively, by finding the avaiable space and
-            # dividing by the number of spots we would loose by adding a
-            # short element
-            short_count = math.floor((total_space - len(elems)) /
-                                     len(chars))
-            # Check if we double counted above to warrant another short_count
-            # https://github.com/qutebrowser/qutebrowser/issues/3242
-            if total_space - (short_count * len(chars) +
-                              (len(elems) - short_count)) >= len(chars) - 1:
-                short_count += 1
+            short_count = (total_space - len(elems)) // (len(chars) - 1)
         else:
             short_count = 0
 

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -712,3 +712,16 @@ def guess_mimetype(filename, fallback=False):
         else:
             raise ValueError("Got None mimetype for {}".format(filename))
     return mimetype
+
+
+def ceil_log(number, base):
+    """Compute max(1, ceil(log(number, base))).
+
+    Use only integer arithmetic in order to avoid numerical error.
+    """
+    result = 1
+    accum = base
+    while accum < number:
+        result += 1
+        accum *= base
+    return result

--- a/tests/unit/browser/test_hints.py
+++ b/tests/unit/browser/test_hints.py
@@ -88,4 +88,5 @@ def test_scattered_hints_count(win_registry, mode_manager, min_len,
         assert num_chars ** (longest_hint_len - 1) < num_elements
         if shortest_hint_len == longest_hint_len:
             # Check that we really couldn't use any short links
-            assert (num_chars ** longest_hint_len) - num_elements < len(chars) - 1
+            assert ((num_chars ** longest_hint_len) - num_elements <
+                    len(chars) - 1)

--- a/tests/unit/browser/test_hints.py
+++ b/tests/unit/browser/test_hints.py
@@ -19,6 +19,7 @@
 
 import string
 import functools
+import itertools
 import operator
 
 import pytest
@@ -27,8 +28,8 @@ import qutebrowser.browser.hints
 
 
 @pytest.mark.parametrize('min_len', [0, 3])
-@pytest.mark.parametrize('num_chars', [9])
-@pytest.mark.parametrize('num_elements', range(1, 26))
+@pytest.mark.parametrize('num_chars', [5, 9])
+@pytest.mark.parametrize('num_elements', itertools.chain(range(1, 26), [125]))
 def test_scattered_hints_count(win_registry, mode_manager, min_len,
                                num_chars, num_elements):
     """Test scattered hints function.
@@ -62,7 +63,9 @@ def test_scattered_hints_count(win_registry, mode_manager, min_len,
         # 'ab' and 'c' can
         assert abs(functools.reduce(operator.sub, hint_lens)) <= 1
 
-    longest_hints = [x for x in hints if len(x) == max(hint_lens)]
+    longest_hint_len = max(hint_lens)
+    shortest_hint_len = min(hint_lens)
+    longest_hints = [x for x in hints if len(x) == longest_hint_len]
 
     if min_len < max(hint_lens) - 1:
         # Check if we have any unique prefixes. For example, 'la'
@@ -72,3 +75,17 @@ def test_scattered_hints_count(win_registry, mode_manager, min_len,
             prefix = x[:-1]
             count_map[prefix] = count_map.get(prefix, 0) + 1
         assert all(e != 1 for e in count_map.values())
+
+    # Check that the longest hint length isn't too long
+    if longest_hint_len > min_len and longest_hint_len > 1:
+        assert num_chars ** (longest_hint_len - 1) < num_elements
+
+    # Check longest hint is not too short
+    assert num_chars ** longest_hint_len >= num_elements
+
+    if longest_hint_len > min_len and longest_hint_len > 1:
+        # Check that the longest hint length isn't too long
+        assert num_chars ** (longest_hint_len - 1) < num_elements
+        if shortest_hint_len == longest_hint_len:
+            # Check that we really couldn't use any short links
+            assert (num_chars ** longest_hint_len) - num_elements < len(chars) - 1


### PR DESCRIPTION
PR #3329 fixed #3242, however the code is not completely correct.

* First, the computation of `needed`. Because of some numerical error, `math.ceil(math.log(125,5))` is `4` (while it should be `3`) This can be fixed by subtracting a very small number before taking the ceil.

    I think this don't have any real consequences anyway, as (with the change below) `short_count == len(elem) and long_count == 0`.

    Alternatively, it's possible to loop multiply using only integers, that way there can't be any rounding error; however this approach already worked for all `len(elems)` up to more than a billion.

* `needed > 1`: To handle the special case of `len(elems) == 1` and `min_chars == 1`.
* `// (len(chars) - 1)`: For each `1` short link being added, `len(chars)` long links are removed, therefore number of space removed is `len(chars) - 1`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4330)
<!-- Reviewable:end -->
