### PR TITLE
Cache hot config accesses in completion

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -166,11 +166,11 @@ class CompletionItemDelegate(QStyledItemDelegate):
         self._painter.save()
 
         if self._opt.state & QStyle.State_Selected:
-            color = config.val.colors.completion.item.selected.fg
+            color = config.cache['colors.completion.item.selected.fg']
         elif not self._opt.state & QStyle.State_Enabled:
-            color = config.val.colors.completion.category.fg
+            color = config.cache['colors.completion.category.fg']
         else:
-            colors = config.val.colors.completion.fg
+            colors = config.cache['colors.completion.fg']
             # if multiple colors are set, use different colors per column
             color = colors[col % len(colors)]
         self._painter.setPen(color)


### PR DESCRIPTION
I did a little profiling of the completion and while scrolling through entries these config accesses are about ~10% of cpu while scrolling down through the completion (holding `tab`)

The rest seems to mostly be in `_get_textdoc` (but not much from the functions it calls), `draw` and `documentLayout` (which are qt builtins).

This is a pretty trivial change though, so I thought I'd just submit it :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4332)
<!-- Reviewable:end -->
