### PR TITLE
Replace `[bot]` indicator with `[btm]`

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -49,6 +49,7 @@ Changed
   adblocker can be disabled on a given page.
 - Elements with a `tabindex` attribute now also get hints by default.
 - Various small performance improvements for hints and the completion.
+- The `[bot]` bottom indicator was replaced by `[btm]` for clarity.
 
 Fixed
 ~~~~~

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -208,7 +208,7 @@ class TabWidget(QTabWidget):
         elif y <= 0:
             scroll_pos = 'top'
         elif y >= 100:
-            scroll_pos = 'bot'
+            scroll_pos = 'btm'
         else:
             scroll_pos = '{:2}%'.format(y)
 


### PR DESCRIPTION
* `[bot]` could be mistaken for '*bot*' instead of '*bottom*'
* fixes #4350

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4351)
<!-- Reviewable:end -->
