### PR TITLE
Cache hot config accesses for hints

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -101,7 +101,7 @@ class HintLabel(QLabel):
             matched: The part of the text which was typed.
             unmatched: The part of the text which was not typed yet.
         """
-        if (config.val.hints.uppercase and
+        if (config.cache['hints.uppercase'] and
                 self._context.hint_mode in ['letter', 'word']):
             matched = html.escape(matched.upper())
             unmatched = html.escape(unmatched.upper())
@@ -109,7 +109,7 @@ class HintLabel(QLabel):
             matched = html.escape(matched)
             unmatched = html.escape(unmatched)
 
-        match_color = html.escape(config.val.colors.hints.match.fg)
+        match_color = html.escape(config.cache['colors.hints.match.fg'])
         if matched:
             self.setText('<font color="{}">{}</font>{}'.format(
                 match_color, matched, unmatched))
@@ -125,7 +125,7 @@ class HintLabel(QLabel):
             log.hints.debug("Frame for {!r} vanished!".format(self))
             self.hide()
             return
-        no_js = config.val.hints.find_implementation != 'javascript'
+        no_js = config.cache['hints.find_implementation'] != 'javascript'
         rect = self.elem.rect_on_view(no_js=no_js)
         self.move(rect.x(), rect.y())
 


### PR DESCRIPTION
Before:
```
------------------------------------- benchmark: 2 tests ------------------------------------
Name (time in ms)                       Min                 Max              Median          
---------------------------------------------------------------------------------------------
test_show_benchmark[webkit]        218.9720 (1.0)      243.3722 (1.0)      229.8361 (1.0)    
test_show_benchmark[webengine]     229.7689 (1.05)     245.4788 (1.01)     237.2474 (1.03)   
---------------------------------------------------------------------------------------------
```
After:
```
------------------------------------- benchmark: 2 tests ------------------------------------
Name (time in ms)                       Min                 Max              Median          
---------------------------------------------------------------------------------------------
test_show_benchmark[webkit]        175.3396 (1.0)      182.8130 (1.0)      178.7441 (1.0)    
test_show_benchmark[webengine]     190.2506 (1.09)     225.1895 (1.23)     194.2149 (1.09)   
---------------------------------------------------------------------------------------------
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4361)
<!-- Reviewable:end -->
