### PR TITLE
Simplify logic in HintKeyParser.handle

### DIFF
--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -259,9 +259,8 @@ class HintKeyParser(CommandKeyParser):
         Returns:
             True if the match has been handled, False otherwise.
         """
-        dry_run_match = super().handle(e, dry_run=True)
         if dry_run:
-            return dry_run_match
+            return super().handle(e, dry_run=True)
 
         if keyutils.is_special(e.key(), e.modifiers()):
             log.keyboard.debug("Got special key, clearing keychain")


### PR DESCRIPTION
`dry_run_match` is not used in non-dry_run branch since commit ebb373ccad587522f80b2d6f3966dbfc87e8f905, there is no need to evaluate it.

Actually, the performance benefit is negligible, but the code is simpler. Besides, it reduces number of logging lines in debug mode.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4362)
<!-- Reviewable:end -->
