### PR TITLE
Fix _partial_timer connection in modeparsers

### DIFF
--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -71,6 +71,7 @@ class NormalKeyParser(CommandKeyParser):
         self._read_config('normal')
         self._partial_timer = usertypes.Timer(self, 'partial-match')
         self._partial_timer.setSingleShot(True)
+        self._partial_timer.timeout.connect(self._clear_partial_match)
         self._inhibited = False
         self._inhibited_timer = usertypes.Timer(self, 'normal-inhibited')
         self._inhibited_timer.setSingleShot(True)
@@ -101,7 +102,6 @@ class NormalKeyParser(CommandKeyParser):
             timeout = config.val.input.partial_timeout
             if timeout != 0:
                 self._partial_timer.setInterval(timeout)
-                self._partial_timer.timeout.connect(self._clear_partial_match)
                 self._partial_timer.start()
         return match
 
@@ -133,11 +133,7 @@ class NormalKeyParser(CommandKeyParser):
     def _stop_timers(self):
         super()._stop_timers()
         self._partial_timer.stop()
-        try:
-            self._partial_timer.timeout.disconnect(self._clear_partial_match)
-        except TypeError:
-            # no connections
-            pass
+        self._partial_timer.timeout.disconnect(self._clear_partial_match)
         self._inhibited_timer.stop()
         try:
             self._inhibited_timer.timeout.disconnect(self._clear_inhibited)


### PR DESCRIPTION
The old behavior clears the partial keystring multiple times (once for each connection made)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4363)
<!-- Reviewable:end -->
