### PR TITLE
Properly handle the case when the cursor moves to the prompt

### DIFF
--- a/qutebrowser/misc/miscwidgets.py
+++ b/qutebrowser/misc/miscwidgets.py
@@ -94,10 +94,6 @@ class CommandLineEdit(QLineEdit):
 
         We use __ here to avoid accidentally overriding it in subclasses.
         """
-        if self.hasSelectedText():
-            # Let __on_selection_changed handle it
-            return
-
         if new < self._promptlen:
             self.setCursorPosition(self._promptlen)
 


### PR DESCRIPTION
Fixes #4376.

Also fix a bug where it's possible to select the `:` by triple-click the status bar.

However, Ctrl+A is still not fixed.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4377)
<!-- Reviewable:end -->
