### PR TITLE
Fix selection clearing when using <shift-home>

### DIFF
--- a/qutebrowser/misc/miscwidgets.py
+++ b/qutebrowser/misc/miscwidgets.py
@@ -105,13 +105,6 @@ class CommandLineEdit(QLineEdit):
         self._validator.prompt = text
         self._promptlen = len(text)
 
-    def home(self, mark):
-        """Override home so it works properly with our cursor restriction."""
-        oldpos = self.cursorPosition()
-        self.setCursorPosition(self._promptlen)
-        if mark:
-            self.setSelection(self._promptlen, oldpos - self._promptlen)
-
 
 class _CommandValidator(QValidator):
 

--- a/qutebrowser/misc/miscwidgets.py
+++ b/qutebrowser/misc/miscwidgets.py
@@ -94,7 +94,7 @@ class CommandLineEdit(QLineEdit):
         We use __ here to avoid accidentally overriding it in subclasses.
         """
         if new < self._promptlen:
-            self.setCursorPosition(self._promptlen)
+            self.cursorForward(self.hasSelectedText(), self._promptlen - new)
 
     def set_prompt(self, text):
         """Set the current prompt to text.

--- a/tests/unit/misc/test_miscwidgets.py
+++ b/tests/unit/misc/test_miscwidgets.py
@@ -59,8 +59,8 @@ class TestCommandLineEdit:
         assert cmd_edit.text() == ':hello'
         assert cmd_edit.cursorPosition() == len(':hello')
 
-        cmd_edit.home(mark=True)
-        assert cmd_edit.cursorPosition() == len(':hello')
+        cmd_edit.home(True)
+        assert cmd_edit.cursorPosition() == len(':')
         qtbot.keyClick(cmd_edit, Qt.Key_Delete)
         assert cmd_edit.text() == ':'
         qtbot.keyClick(cmd_edit, Qt.Key_Backspace)
@@ -73,6 +73,25 @@ class TestCommandLineEdit:
         """Test preventing of an invalid prompt being entered."""
         qtbot.keyClicks(cmd_edit, '$hello')
         assert cmd_edit.text() == ''
+
+    def test_selection_home(self, qtbot, cmd_edit):
+        """Test selection persisting when pressing home."""
+        qtbot.keyClicks(cmd_edit, ':hello')
+        assert cmd_edit.text() == ':hello'
+        assert cmd_edit.cursorPosition() == len(':hello')
+        cmd_edit.home(True)
+        assert cmd_edit.cursorPosition() == len(':')
+        assert cmd_edit.selectionStart() == len(':')
+
+    def test_selection_backspace(self, qtbot, cmd_edit):
+        """Test selection persisting when backspacing to the first char."""
+        qtbot.keyClicks(cmd_edit, ':hello')
+        assert cmd_edit.text() == ':hello'
+        assert cmd_edit.cursorPosition() == len(':hello')
+        for _ in range(len(':hello')):
+            qtbot.keyClick(cmd_edit, Qt.Key_Left, modifier=Qt.ShiftModifier)
+        assert cmd_edit.cursorPosition() == len(':')
+        assert cmd_edit.selectionStart() == len(':')
 
 
 class WrappedWidget(QWidget):


### PR DESCRIPTION
See #4377 for an alternative solution which also adjusts the selection on triple click. If on 5.10+, we might want to consider using that as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4382)
<!-- Reviewable:end -->
