### PR TITLE
[WIP] Implement URL patters for content.cookies.store in webkit

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -348,6 +348,7 @@ content.cookies.accept:
 content.cookies.store:
   default: true
   type: Bool
+  supports_pattern: true
   desc: >-
     Store cookies.
 


### PR DESCRIPTION
This PR is a sub-task of issue #3636

TODO: tests

This is kind of hacky because the URL pattern will have a scheme, but we don't know the scheme of the request that set the cookie at the time of saving them to disk. So we check if the pattern matches against `https://url` **or** `http://url`. It would break if you have something like:
```python
config.set('content.cookies.store', True)
config.set('content.cookies.store', False, 'http://*.github.com/*')
```
because you would imagine that the most specific setting would apply, but I guess it doesn't really make sense to filter cookies based on the scheme. What the user wants in this case is probably:
```python
config.set('content.cookies.store', True)
config.set('content.cookies.store', False, '*://*.github.com/*')
```
Let me know what you guys think.

I haven't found an easy way of doing this with QtWebEngine, still looking...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4396)
<!-- Reviewable:end -->
