### PR TITLE
Sort history completion results by frecency score.

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -72,7 +72,7 @@ from qutebrowser.keyinput import macros
 from qutebrowser.mainwindow import mainwindow, prompt
 from qutebrowser.misc import (readline, ipc, savemanager, sessions,
                               crashsignal, earlyinit, sql, cmdhistory,
-                              backendproblem, objects)
+                              backendproblem, objects, executor)
 from qutebrowser.utils import (log, version, message, utils, urlutils, objreg,
                                usertypes, standarddir, error, qtutils)
 # pylint: disable=unused-import
@@ -421,6 +421,9 @@ def _init_modules(args, crash_handler):
         args: The argparse namespace.
         crash_handler: The CrashHandler instance.
     """
+    log.init.debug("Initializing task executor...")
+    executor.init()
+
     log.init.debug("Initializing save manager...")
     save_manager = savemanager.SaveManager(qApp)
     objreg.register('save-manager', save_manager)
@@ -443,9 +446,6 @@ def _init_modules(args, crash_handler):
     objreg.register('readline-bridge', readline_bridge)
 
     try:
-        log.init.debug("Initializing sql...")
-        sql.init(os.path.join(standarddir.data(), 'history.sqlite'))
-
         log.init.debug("Initializing web history...")
         history.init(qApp)
     except sql.SqlEnvironmentError as e:

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -244,6 +244,7 @@ class WebHistory(sql.SqlTable):
 
         if old_ver or rebuild:
             CompletionHistory.drop()
+            self._metainfo['force_rebuild'] = False
         self.completion = CompletionHistory(self)
         if not self.completion:
             self.completion.init(self._grouped())

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -21,6 +21,7 @@
 
 import os
 import time
+import datetime
 import contextlib
 
 from PyQt5.QtCore import pyqtSlot, QUrl, pyqtSignal
@@ -33,7 +34,7 @@ from qutebrowser.misc import objects, sql
 
 
 # increment to indicate that HistoryCompletion must be regenerated
-_USER_VERSION = 2
+_USER_VERSION = 3
 
 
 class HistoryProgress:
@@ -109,15 +110,110 @@ class CompletionMetaInfo(sql.SqlTable):
 
 class CompletionHistory(sql.SqlTable):
 
-    """History which only has the newest entry for each URL."""
+    """History which only has the newest entry for each URL.
+
+    Attributes:
+        _progress: A HistoryProgress instance.
+
+    Class attributes:
+        _PROGRESS_THRESHOLD: When to start showing progress dialogs.
+        _NAME: Table name.
+    """
+
+    _PROGRESS_THRESHOLD = 1000
+    _NAME = 'CompletionHistory'
 
     def __init__(self, parent=None):
-        super().__init__("CompletionHistory", ['url', 'title', 'last_atime'],
-                         constraints={'url': 'PRIMARY KEY',
-                                      'title': 'NOT NULL',
-                                      'last_atime': 'NOT NULL'},
+        super().__init__(self._NAME, ['url', 'title', 'first_atime',
+                                      'last_atime', 'last_atime_ts',
+                                      'visits', 'frecency'],
+                         constraints={'url': 'TEXT PRIMARY KEY',
+                                      'title': 'TEXT NOT NULL',
+                                      'visits': 'INTEGER NOT NULL',
+                                      'first_atime': 'INTEGER NOT NULL',
+                                      'last_atime': 'INTEGER NOT NULL',
+                                      'last_atime_ts': 'INTEGER NOT NULL',
+                                      'frecency': 'INTEGER NOT NULL'},
                          parent=parent)
-        self.create_index('CompletionHistoryAtimeIndex', 'last_atime')
+        self.create_index(self._NAME + 'FrecencyIndex', 'frecency')
+        self._progress = HistoryProgress()
+        self._update_frecency()
+
+    def init(self, items):
+        if len(items) > self._PROGRESS_THRESHOLD:
+            self._progress.start("Rebuilding completion...", len(items))
+
+        data = {'url': [], 'title': [], 'visits': [], 'first_atime': [],
+                'last_atime': [], 'last_atime_ts': [], 'frecency': []}
+        for item in items:
+            self._progress.tick()
+            url = QUrl(item.url)
+            if self._is_excluded(url):
+                continue
+
+            data['url'].append(self._format_completion_url(url))
+            data['title'].append(item.title)
+            data['visits'].append(item.visits)
+            data['first_atime'].append(self._days(item.first_atime))
+            data['last_atime'].append(self._days(item.last_atime))
+            data['last_atime_ts'].append(item.last_atime)
+            # Frecency will be calculated with _update_frecency() call below.
+            data['frecency'].append(0)
+
+        self._progress.finish()
+        self.insert_batch(data, replace=True)
+        self._update_frecency()
+
+    def add_url(self, url):
+        if self._is_excluded(url):
+            return
+
+        u = {'url': self._format_completion_url(url['url']),
+             'title': url['title'],
+             'visits': 1,
+             'first_atime': self._days(url['atime']),
+             'last_atime': self._days(url['atime']),
+             'last_atime_ts': url['atime'],
+             'frecency': 1}
+        update = {'visits': 'visits + 1',
+                  'frecency': 'frecency + 1',
+                  'last_atime': u['last_atime'],
+                  'last_atime_ts': u['last_atime_ts']}
+
+        self.upsert(u, 'url', update, False)
+
+    def delete_url(self, url):
+        self.delete('url', self._format_completion_url(url))
+
+    def _update_frecency(self):
+        start = time.time()
+        today = self._days(int(time.time()))
+
+        u = ('visits * MAX(last_atime - first_atime, 1) '
+             '/ (MAX({today} - last_atime, 1) * MAX({today} - last_atime, 1))')
+        self.update({'frecency': u.format(today=today)},
+                    {}, False)
+        log.misc.info('Completion frecency recalculation took {:.3f} seconds.'
+                      .format(time.time() - start))
+
+    def _format_completion_url(self, url):
+        return url.toString(QUrl.RemovePassword)
+
+    def _is_excluded(self, url):
+        """Check if the given URL is excluded from the completion."""
+        patterns = config.cache['completion.web_history.exclude']
+
+        return any(pattern.matches(url) for pattern in patterns)
+
+    def _days(self, ts):
+        d = datetime.date.fromtimestamp(ts) - datetime.date.fromtimestamp(0)
+
+        return d.days
+
+    @staticmethod
+    def drop():
+        q = sql.Query("DROP TABLE IF EXISTS {}".format(CompletionHistory._NAME))
+        q.run()
 
 
 class WebHistory(sql.SqlTable):
@@ -126,11 +222,7 @@ class WebHistory(sql.SqlTable):
 
     Attributes:
         completion: A CompletionHistory instance.
-        metainfo: A CompletionMetaInfo instance.
-        _progress: A HistoryProgress instance.
-
-    Class attributes:
-        _PROGRESS_THRESHOLD: When to start showing progress dialogs.
+        _metainfo: A CompletionMetaInfo instance.
     """
 
     # All web history cleared
@@ -138,29 +230,24 @@ class WebHistory(sql.SqlTable):
     # one url cleared
     url_cleared = pyqtSignal(QUrl)
 
-    _PROGRESS_THRESHOLD = 1000
-
-    def __init__(self, progress, parent=None):
+    def __init__(self, parent=None):
         super().__init__("History", ['url', 'title', 'atime', 'redirect'],
                          constraints={'url': 'NOT NULL',
                                       'title': 'NOT NULL',
                                       'atime': 'NOT NULL',
                                       'redirect': 'NOT NULL'},
                          parent=parent)
-        self._progress = progress
+        self._metainfo = CompletionMetaInfo(parent=self)
 
-        self.completion = CompletionHistory(parent=self)
-        self.metainfo = CompletionMetaInfo(parent=self)
+        old_ver = self._get_version() < _USER_VERSION
+        rebuild = self._metainfo['force_rebuild']
 
-        if sql.Query('pragma user_version').run().value() < _USER_VERSION:
-            self.completion.delete_all()
-        if self.metainfo['force_rebuild']:
-            self.completion.delete_all()
-            self.metainfo['force_rebuild'] = False
-
+        if old_ver or rebuild:
+            CompletionHistory.drop()
+        self.completion = CompletionHistory(self)
         if not self.completion:
-            # either the table is out-of-date or the user wiped it manually
-            self._rebuild_completion()
+            self.completion.init(self._grouped())
+            self._set_version(_USER_VERSION)
 
         self.create_index('HistoryIndex', 'url')
         self.create_index('HistoryAtimeIndex', 'atime')
@@ -189,7 +276,7 @@ class WebHistory(sql.SqlTable):
 
     @config.change_filter('completion.web_history.exclude')
     def _on_config_changed(self):
-        self.metainfo['force_rebuild'] = True
+        self._metainfo['force_rebuild'] = True
 
     @contextlib.contextmanager
     def _handle_sql_errors(self):
@@ -198,36 +285,18 @@ class WebHistory(sql.SqlTable):
         except sql.SqlEnvironmentError as e:
             message.error("Failed to write history: {}".format(e.text()))
 
-    def _is_excluded(self, url):
-        """Check if the given URL is excluded from the completion."""
-        patterns = config.cache['completion.web_history.exclude']
-        return any(pattern.matches(url) for pattern in patterns)
+    def _grouped(self):
+        q = sql.Query("SELECT "
+                      "    url, "
+                      "    title, "
+                      "    COUNT(*) AS visits, "
+                      "    MIN(atime) AS first_atime, "
+                      "    MAX(atime) AS last_atime "
+                      "FROM History "
+                      "WHERE NOT redirect AND url NOT LIKE 'qute://back%' "
+                      "GROUP BY url ORDER BY atime asc")
 
-    def _rebuild_completion(self):
-        data = {'url': [], 'title': [], 'last_atime': []}
-        # select the latest entry for each url
-        q = sql.Query('SELECT url, title, max(atime) AS atime FROM History '
-                      'WHERE NOT redirect and url NOT LIKE "qute://back%" '
-                      'GROUP BY url ORDER BY atime asc')
-        entries = list(q.run())
-
-        if len(entries) > self._PROGRESS_THRESHOLD:
-            self._progress.start("Rebuilding completion...", len(entries))
-
-        for entry in entries:
-            self._progress.tick()
-
-            url = QUrl(entry.url)
-            if self._is_excluded(url):
-                continue
-            data['url'].append(self._format_completion_url(url))
-            data['title'].append(entry.title)
-            data['last_atime'].append(entry.atime)
-
-        self._progress.finish()
-
-        self.completion.insert_batch(data, replace=True)
-        sql.Query('pragma user_version = {}'.format(_USER_VERSION)).run()
+        return list(q.run())
 
     def get_recent(self):
         """Get the most recent history entries."""
@@ -286,7 +355,7 @@ class WebHistory(sql.SqlTable):
         qurl = QUrl(url)
         qtutils.ensure_valid(qurl)
         self.delete('url', self._format_url(qurl))
-        self.completion.delete('url', self._format_completion_url(qurl))
+        self.completion.delete_url(qurl)
         self.url_cleared.emit(qurl)
 
     @pyqtSlot(QUrl, QUrl, str)
@@ -332,20 +401,12 @@ class WebHistory(sql.SqlTable):
                          'atime': atime,
                          'redirect': redirect})
 
-            if redirect or self._is_excluded(url):
-                return
-
-            self.completion.insert({
-                'url': self._format_completion_url(url),
-                'title': title,
-                'last_atime': atime
-            }, replace=True)
+            if not redirect:
+                self.completion.add_url({'url': url, 'title': title,
+                                         'atime': atime})
 
     def _format_url(self, url):
         return url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
-
-    def _format_completion_url(self, url):
-        return url.toString(QUrl.RemovePassword)
 
     @cmdutils.register(instance='web-history', debug=True)
     def debug_dump_history(self, dest):
@@ -367,6 +428,13 @@ class WebHistory(sql.SqlTable):
         except OSError as e:
             raise cmdexc.CommandError('Could not write history: {}'.format(e))
 
+    def _get_version(self):
+        return sql.Query('pragma user_version').run().value()
+
+    def _set_version(self, ver):
+        sql.Query('pragma user_version = {}'.format(ver)).run()
+
+
 
 def init(parent=None):
     """Initialize the web history.
@@ -374,8 +442,7 @@ def init(parent=None):
     Args:
         parent: The parent to use for WebHistory.
     """
-    progress = HistoryProgress()
-    history = WebHistory(progress=progress, parent=parent)
+    history = WebHistory(parent=parent)
     objreg.register('web-history', history)
 
     if objects.backend == usertypes.Backend.QtWebKit:  # pragma: no cover

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -161,7 +161,7 @@ class CompletionHistory(sql.SqlTable):
         self._progress.finish()
         self.insert_batch(data, replace=True)
 
-    def add_url(self, url):
+    def add(self, url):
         if self._is_excluded(url):
             return
 
@@ -175,9 +175,9 @@ class CompletionHistory(sql.SqlTable):
                   'frecency': 'frecency + 1',
                   'last_atime': u['last_atime']}
 
-        self.upsert(u, 'url', update, False)
+        self.upsert(u, 'url', update, escape=False)
 
-    def delete_url(self, url):
+    def delete(self, url):
         self.delete('url', self._format_completion_url(url))
 
     def update_frecency(self):
@@ -375,7 +375,7 @@ class WebHistory(sql.SqlTable):
         qurl = QUrl(url)
         qtutils.ensure_valid(qurl)
         self.delete('url', self._format_url(qurl))
-        self.completion.delete_url(qurl)
+        self.completion.delete(qurl)
         self.url_cleared.emit(qurl)
 
     @pyqtSlot(QUrl, QUrl, str)
@@ -422,8 +422,8 @@ class WebHistory(sql.SqlTable):
                          'redirect': redirect})
 
             if not redirect:
-                self.completion.add_url({'url': url, 'title': title,
-                                         'atime': atime})
+                self.completion.add({'url': url, 'title': title,
+                                     'atime': atime})
 
     def _format_url(self, url):
         return url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)

--- a/qutebrowser/completion/models/histcategory.py
+++ b/qutebrowser/completion/models/histcategory.py
@@ -63,7 +63,7 @@ class HistoryCategory(QSqlQueryModel):
         if not self._query or len(words) != len(self._query.bound_values()):
             # replace ' in timestamp-format to avoid breaking the query
             timestamp_format = config.val.completion.timestamp_format or ''
-            timefmt = ("strftime('{}', last_atime_ts, 'unixepoch', 'localtime')"
+            timefmt = ("strftime('{}', last_atime, 'unixepoch', 'localtime')"
                        .format(timestamp_format.replace("'", "`")))
             self._query = sql.Query(' '.join([
                 "SELECT url, title, {}".format(timefmt),

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -261,6 +261,7 @@ class TabbedBrowser(QWidget):
     def shutdown(self):
         """Try to shut down all tabs cleanly."""
         self.shutting_down = True
+        objreg.get('task-executor').shutdown()
         # Reverse tabs so we don't have to recacluate tab titles over and over
         # Removing first causes [2..-1] to be recomputed
         # Removing the last causes nothing to be recomputed

--- a/qutebrowser/misc/executor.py
+++ b/qutebrowser/misc/executor.py
@@ -1,0 +1,44 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2015-2018 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+from threading import Event
+from concurrent.futures import ThreadPoolExecutor
+
+from qutebrowser.utils import objreg
+
+
+class TaskExecutor(ThreadPoolExecutor):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._shutting_down = Event()
+
+    def submit(self, fn, *args, **kwargs):
+        super().submit(fn, self, *args, **kwargs)
+
+    def shutdown(self, wait=True):
+        self._shutting_down.set()
+        super().shutdown(wait)
+
+    def is_shutting_down(self):
+        return self._shutting_down.is_set()
+
+
+def init():
+    e = TaskExecutor(max_workers=2)
+    objreg.register('task-executor', e)

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -590,9 +590,11 @@ def short_tmpdir():
 def init_sql(data_tmpdir):
     """Initialize the SQL module, and shut it down after the test."""
     path = str(data_tmpdir / 'test.db')
-    sql.init(path)
+    db = sql.open_db(path)
     yield
-    sql.close()
+    name = db.connectionName()
+    del db
+    sql.close_db(name)
 
 
 class ModelValidator:

--- a/tests/unit/misc/test_sql.py
+++ b/tests/unit/misc/test_sql.py
@@ -150,6 +150,50 @@ def test_insert_batch_replace(qtbot):
                             'lucky': [True, True]})
 
 
+def test_update(qtbot):
+    table = sql.SqlTable('Foo', ['a', 'b', 'c'])
+    table.insert({'a': 10, 'b': 10, 'c': 10})
+    table.insert({'a': 20, 'b': 20, 'c': 20})
+
+    with qtbot.waitSignal(table.changed):
+        table.update({'a': 11, 'b': 12, 'c': 13}, {'a': 10, 'b': 10})
+    with qtbot.waitSignal(table.changed):
+        table.update({'a': 21}, {'c': 20})
+
+    assert list(table) == [(11, 12, 13), (21, 20, 20)]
+
+    with qtbot.waitSignal(table.changed):
+        table.update({'a': 'a * a', 'b': 'b + 3'}, {'a': 11, 'b': 12}, False)
+
+    assert list(table) == [(121, 15, 13), (21, 20, 20)]
+
+
+def test_upsert(qtbot):
+    table = sql.SqlTable('Foo', ['key', 'foo', 'bar'],
+                         constraints={'key': 'TEXT PRIMARY KEY'})
+    with qtbot.waitSignal(table.changed):
+        table.upsert({'key': 'one', 'foo': 1, 'bar': 1},
+                     'key', {'foo': 0})
+    with qtbot.waitSignal(table.changed):
+        table.upsert({'key': 'one', 'foo': 1, 'bar': 1},
+                     'key', {'foo': 2})
+    with qtbot.waitSignal(table.changed):
+        table.upsert({'key': 'two', 'foo': 1, 'bar': 1},
+                     'key', {'bar': 0})
+    with qtbot.waitSignal(table.changed):
+        table.upsert({'key': 'two', 'foo': 1, 'bar': 1},
+                     'key', {'bar': 2})
+    assert list(table) == [('one', 2, 1), ('two', 1, 2)]
+
+    with qtbot.waitSignal(table.changed):
+        table.upsert({'key': 'one', 'foo': 1, 'bar': 1},
+                     'key', {'foo': 'foo + 1'}, False)
+    with qtbot.waitSignal(table.changed):
+        table.upsert({'key': 'one', 'foo': 1, 'bar': 1},
+                     'key', {'foo': 'foo + 1', 'bar': 'bar + 1'}, False)
+    assert list(table) == [('one', 4, 2), ('two', 1, 2)]
+
+
 def test_iter():
     table = sql.SqlTable('Foo', ['name', 'val', 'lucky'])
     table.insert({'name': 'one', 'val': 1, 'lucky': False})


### PR DESCRIPTION
Qutebrowser users very simple URL history completion algorithm: it sorts URLs by last access time. It not very convenient for practical usage. Imagine next scenario: every day you visit http://news.com; navigate through the list of pages (page per article) on that site, like http://news.com/news-uniq1.html, http://news.com/news-uniq2.html. Next day after typing `news` QB suggests you the latest visited page (http://news.com/news-uniq2.html), most of the time it is not what you are looking for -- you want the page you visit more often (http://news.com in our case).

Firefox uses simple formula [1] [2] to calculate URL score for ranking. The idea is that the more visits URL has the higher the score, the more recent it was visited the higher the score. I took Firefox formulas as a base and modified it to feet our needs. Firefox uses background task to execute recalculation process. I have decided not to introduce background task support in this patch and found a simple solution for now -- recalculate score (frecency) every time QB starts. It takes a few tens of milliseconds to execute a recalculation query (you can find it logged), so application start time does not increased too much.

Future improvements. We may want to introduce background tasks framework, so other QB modules can run some tasks. Then frecency recalculation can use it to make it async. Another place it can be useful is blocked hosts update, it can be made with periodic background task so user does not need to care about keeping hosts list up to date.

I have not finished with tests yet. Want to make sure we are ok with the code first. 

[1] https://wiki.mozilla.org/User:Mconnor/Past/PlacesFrecency
[2] https://wiki.mozilla.org/User:Sspitzer/GlobalFrecency

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4403)
<!-- Reviewable:end -->
