### PR TITLE
Strip fragment and query only for `:navigate up`

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -65,6 +65,7 @@ Fixed
   `content.cookies.accept = no-3rdparty` from working properly on some pages
   like GMail. However, the default for `content.cookies.accept` is still `all`
   to be in line with what other browsers do.
+- `:navigate` not incrementing in anchors or queries or anchors.
 
 v1.5.2
 ------

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -653,7 +653,7 @@ class CommandDispatcher:
                 handler(browsertab=widget, win_id=self._win_id, baseurl=url,
                         tab=tab, background=bg, window=window)
             elif where in ['up', 'increment', 'decrement']:
-                if where is 'up':
+                if where == 'up':
                     url = url.adjusted(QUrl.RemoveFragment | QUrl.RemoveQuery)
                 new_url = handlers[where](url, count)
                 self._open(new_url, tab, bg, window, related=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -636,7 +636,6 @@ class CommandDispatcher:
         cmdutils.check_exclusive((tab, bg, window), 'tbw')
         widget = self._current_widget()
         url = self._current_url()
-        url = url.adjusted(QUrl.RemoveFragment | QUrl.RemoveQuery)
 
         handlers = {
             'prev': functools.partial(navigate.prevnext, prev=True),
@@ -654,6 +653,8 @@ class CommandDispatcher:
                 handler(browsertab=widget, win_id=self._win_id, baseurl=url,
                         tab=tab, background=bg, window=window)
             elif where in ['up', 'increment', 'decrement']:
+                if where is 'up':
+                    url = url.adjusted(QUrl.RemoveFragment | QUrl.RemoveQuery)
                 new_url = handlers[where](url, count)
                 self._open(new_url, tab, bg, window, related=True)
             else:  # pragma: no cover

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -125,6 +125,12 @@ Feature: Using :navigate
         And I run :navigate increment
         Then the error "No number found in URL!" should be shown
 
+    Scenario: Incrementing query
+        When I set url.incdec_segments to ["query"]
+        And I open data/numbers/1.txt?value=2
+        And I run :navigate increment
+        Then data/numbers/1.txt?value=3 should be loaded
+
     @qtwebengine_todo: Doesn't find any elements
     Scenario: Navigating multiline links
         When I open data/navigate/multilinelinks.html


### PR DESCRIPTION
Resolves #4402 after introducing it in with #4282.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4408)
<!-- Reviewable:end -->
