### PR TITLE
Don't complete url and title from same search word.

### DIFF
--- a/qutebrowser/completion/models/histcategory.py
+++ b/qutebrowser/completion/models/histcategory.py
@@ -74,7 +74,8 @@ class HistoryCategory(QSqlQueryModel):
 
         # build a where clause to match all of the words in any order
         # given the search term "a b", the WHERE clause would be:
-        # ((url || title) LIKE '%a%') AND ((url || title) LIKE '%b%')
+        # ((url || ' ' || title) LIKE '%a%') AND
+        # ((url || ' ' || title) LIKE '%b%')
         where_clause = ' AND '.join(
             "(url || ' ' || title) LIKE :{} escape '\\'".format(i)
             for i in range(len(words)))

--- a/qutebrowser/completion/models/histcategory.py
+++ b/qutebrowser/completion/models/histcategory.py
@@ -76,7 +76,7 @@ class HistoryCategory(QSqlQueryModel):
         # given the search term "a b", the WHERE clause would be:
         # ((url || title) LIKE '%a%') AND ((url || title) LIKE '%b%')
         where_clause = ' AND '.join(
-            "(url || title) LIKE :{} escape '\\'".format(i)
+            "(url || ' ' || title) LIKE :{} escape '\\'".format(i)
             for i in range(len(words)))
 
         # replace ' in timestamp-format to avoid breaking the query

--- a/tests/unit/completion/test_histcategory.py
+++ b/tests/unit/completion/test_histcategory.py
@@ -82,6 +82,14 @@ def hist(init_sql, config_stub):
     ("ample itle",
      [('example.com', 'title'), ('example.com', 'nope')],
      [('example.com', 'title')]),
+
+    # https://github.com/qutebrowser/qutebrowser/issues/4411
+    ("mlfreq",
+     [('https://qutebrowser.org/FAQ.html', 'Frequently Asked Questions')],
+     []),
+    ("ml freq",
+     [('https://qutebrowser.org/FAQ.html', 'Frequently Asked Questions')],
+     [('https://qutebrowser.org/FAQ.html', 'Frequently Asked Questions')]),
 ])
 def test_set_pattern(pattern, before, after, model_validator, hist):
     """Validate the filtering and sorting results of set_pattern."""


### PR DESCRIPTION
Resolves #4411:

> When opening a webpage, the suggested results will include those whose
> URL ends with the beginning of the string you've typed and whose title
> begins with the rest of the string.

By joining the url and title with a space, we ensure that the last word
of the url and the first word of the title are treated as separate
words.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4412)
<!-- Reviewable:end -->
