### PR TITLE
Fix #3981 Cursor is not visible in private mode command mode

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2191,7 +2191,7 @@ colors.statusbar.private.fg:
   desc: Foreground color of the statusbar in private browsing mode.
 
 colors.statusbar.private.bg:
-  default: '#666666'
+  default: darkslategray
   type: QssColor
   desc: Background color of the statusbar in private browsing mode.
 
@@ -2211,7 +2211,7 @@ colors.statusbar.command.private.fg:
   desc: Foreground color of the statusbar in private browsing + command mode.
 
 colors.statusbar.command.private.bg:
-  default: grey
+  default: darkslategray
   type: QssColor
   desc: Background color of the statusbar in private browsing + command mode.
 


### PR DESCRIPTION
Fixes #3981 by using a different default color for private mode status bar background

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4415)
<!-- Reviewable:end -->
