### PR TITLE
Allow password_fill to work without final newline

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -269,7 +269,7 @@ pass_backend() {
                     break
                 fi
             fi
-        done < <($GPG "${GPG_OPTS[@]}" -d "$path" )
+        done < <($GPG "${GPG_OPTS[@]}" -d "$path" | awk 1 )
     }
 }
 # =======================================================


### PR DESCRIPTION
Currently, if the gpg file doesn't have a newline at the end, it's not recognized by the userscript. This fixes it using the simplest answer from [here](https://stackoverflow.com/questions/10082204/add-a-newline-only-if-it-doesnt-exist).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4420)
<!-- Reviewable:end -->
