### PR TITLE
Encode slashes in search terms for searchengines

### DIFF
--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -116,7 +116,8 @@ def _get_search_url(txt):
     if engine is None:
         engine = 'DEFAULT'
     template = config.val.url.searchengines[engine]
-    url = qurl_from_user_input(template.format(urllib.parse.quote(term, safe='')))
+    quoted_term = urllib.parse.quote(term, safe='')
+    url = qurl_from_user_input(template.format(quoted_term))
 
     if config.val.url.open_base_url and term in config.val.url.searchengines:
         url = qurl_from_user_input(config.val.url.searchengines[term])

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -116,7 +116,7 @@ def _get_search_url(txt):
     if engine is None:
         engine = 'DEFAULT'
     template = config.val.url.searchengines[engine]
-    url = qurl_from_user_input(template.format(urllib.parse.quote(term)))
+    url = qurl_from_user_input(template.format(urllib.parse.quote(term, safe='')))
 
     if config.val.url.open_base_url and term in config.val.url.searchengines:
         url = qurl_from_user_input(config.val.url.searchengines[term])

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -187,10 +187,10 @@ Feature: Yanking and pasting.
             http://qutebrowser.org
             should not open
         And I run :open -t {clipboard}
-        And I wait until data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open is loaded
+        And I wait until data/hello.txt?q=this%20url%3A%0Ahttp%3A%2F%2Fqutebrowser.org%0Ashould%20not%20open is loaded
         Then the following tabs should be open:
             - about:blank
-            - data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open (active)
+            - data/hello.txt?q=this%20url%3A%0Ahttp%3A%2F%2Fqutebrowser.org%0Ashould%20not%20open (active)
 
     Scenario: Pasting multiline whose first line looks like a URI
         When I set url.auto_search to naive


### PR DESCRIPTION
If a search term contains a slash, this should be encoded. While this
makes no differences for search engines of the form

    http://example.org?q={}

it does for engines like these:

    http://example.org/search/{}

For a real world example, try:

    https://www.doi2bib.org/bib/{}

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4434)
<!-- Reviewable:end -->
