### PR TITLE
Use POSIX shell instead of bash on scripts/open_url_in_instance.sh

### DIFF
--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 # initial idea: Florian Bruhin (The-Compiler)
 # author: Thore Bödecker (foxxx0)
 


### PR DESCRIPTION
There are other scripts in scripts/dev/ that can use /bin/sh too, some of them without modifications... but I can't test them right now, so I'm fixing only this script that I use everyday :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4460)
<!-- Reviewable:end -->
