### PR TITLE
Use native style for downloads view on macOS

### DIFF
--- a/qutebrowser/browser/downloadview.py
+++ b/qutebrowser/browser/downloadview.py
@@ -75,7 +75,8 @@ class DownloadView(QListView):
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
-        self.setStyle(QStyleFactory.create('Fusion'))
+        if not utils.is_mac:
+            self.setStyle(QStyleFactory.create('Fusion'))
         config.set_register_stylesheet(self)
         self.setResizeMode(QListView.Adjust)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)


### PR DESCRIPTION
The native style does not have the windows-specific issues, which are the rationale for setting the style to Fusion.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4488)
<!-- Reviewable:end -->
