### PR TITLE
Fix crash on key-event-based input of characters in the Supplemental Planes (e.g. emoji 😬)

### DIFF
--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -52,13 +52,13 @@ def _is_printable(key):
     _assert_plain_key(key)
     return key <= 0xff and key not in [Qt.Key_Space, 0x0]
 
-def _is_extended_unicode(key):
+def _is_surrogate(key):
     """Check for Unicode characters such as emoji and extended CJK characters
     Necessary to work around poor handling of higher codepoints by QKeyEvent
     This checks for unicode codepoints above ASCII range. The highest unicode
     is below Qt::Key modifiers and "special" keys, which start at 0x1000000
     """
-    return 0xff < key < 0x10ffff
+    return 0xd800 <= key <= 0xdfff
 
 def is_special(key, modifiers):
     """Check whether this key requires special key syntax."""
@@ -79,11 +79,11 @@ def is_modifier_key(key):
     return key in _MODIFIER_MAP
 
 def _remap_unicode(key, text):
-    """Work around Qt having bad values for higher Unicode characters
+    """Work around Qt having bad values for UTF-16 surrogates
     Qt events have the upper half of the UTF-16 representation as key()
     instead of the unicode codepoint. We re-parse these from text()
     """
-    if _is_extended_unicode(key):
+    if _is_surrogate(key):
         if len(text) != 1:
             raise KeyParseError(text, "Key had too many characters!")
         else:

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -308,7 +308,7 @@ class KeyInfo:
 
     key = attr.ib()
     modifiers = attr.ib()
-    key_text = attr.ib()
+    key_text = attr.ib(default="")
 
     @classmethod
     def from_event(cls, e):
@@ -324,9 +324,9 @@ class KeyInfo:
         # These are Unicode characters (such as emoji)
         if _is_extended_unicode(self.key):
             _check_valid_utf8(self.key_text, self.key)
-            key_string = self.key_text
-        else:
-            key_string = _key_to_string(self.key)
+            return self.key_text
+
+        key_string = _key_to_string(self.key)
 
         modifiers = int(self.modifiers)
 
@@ -426,7 +426,7 @@ class KeySequence:
             key = int(key_and_modifiers) & ~Qt.KeyboardModifierMask
             modifiers = Qt.KeyboardModifiers(int(key_and_modifiers) &
                                              Qt.KeyboardModifierMask)
-            yield KeyInfo(key=key, modifiers=modifiers, key_text="")
+            yield KeyInfo(key=key, modifiers=modifiers)
 
     def __repr__(self):
         return utils.get_repr(self, keys=str(self))

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -52,6 +52,8 @@ def _is_printable(key):
     _assert_plain_key(key)
     return key <= 0xff and key not in [Qt.Key_Space, 0x0]
 
+def _is_extended_unicode(key):
+    return key > 0xff and key < 0x010000000
 
 def is_special(key, modifiers):
     """Check whether this key requires special key syntax."""
@@ -317,11 +319,12 @@ class KeyInfo:
         """
 
         # These are Unicode characters (such as emoji)
-        if self.key > 0xff and self.key < 0x01000000:
+        if _is_extended_unicode(self.key):
             _check_valid_utf8(self.key_text, self.key)
-            return self.key_text
+            key_string = self.key_text
+        else:
+            key_string = _key_to_string(self.key)
 
-        key_string = _key_to_string(self.key)
         modifiers = int(self.modifiers)
 
         if self.key in _MODIFIER_MAP:

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -52,10 +52,12 @@ def _is_printable(key):
     _assert_plain_key(key)
     return key <= 0xff and key not in [Qt.Key_Space, 0x0]
 
-# Unicode characters such as emoji and extended CJK characters land here
-# This checks for unicode codepoints above ASCII range. The highest unicode
-# is below Qt::Key modifiers and "special" keys, which start at 0x1000000
 def _is_extended_unicode(key):
+    """Check for Unicode characters such as emoji and extended CJK characters
+    Necessary to work around poor handling of higher codepoints by QKeyEvent
+    This checks for unicode codepoints above ASCII range. The highest unicode
+    is below Qt::Key modifiers and "special" keys, which start at 0x1000000
+    """
     return 0xff < key < 0x10ffff
 
 def is_special(key, modifiers):
@@ -77,12 +79,13 @@ def is_modifier_key(key):
     return key in _MODIFIER_MAP
 
 def _remap_unicode(key, text):
-    # Work around Qt having bad values for higher Unicode characters
-    # Qt events have the upper half of the UTF-16 representation as key()
-    # instead of the unicode codepoint. We re-parse these from text()
+    """Work around Qt having bad values for higher Unicode characters
+    Qt events have the upper half of the UTF-16 representation as key()
+    instead of the unicode codepoint. We re-parse these from text()
+    """
     if _is_extended_unicode(key):
         if len(text) != 1:
-            raise KeyParseError(text[0], "Key had too many characters!")
+            raise KeyParseError(text, "Key had too many characters!")
         else:
             return ord(text[0])
     else:
@@ -314,7 +317,6 @@ class KeyInfo:
     Attributes:
         key: A Qt::Key member.
         modifiers: A Qt::KeyboardModifiers enum value.
-        text: A QString with the value of QKeyEvent::text()
     """
 
     key = attr.ib()
@@ -330,9 +332,7 @@ class KeyInfo:
         Return:
             A name of the key (combination) as a string.
         """
-
         key_string = _key_to_string(self.key)
-
         modifiers = int(self.modifiers)
 
         if self.key in _MODIFIER_MAP:

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -298,14 +298,16 @@ class KeyInfo:
     Attributes:
         key: A Qt::Key member.
         modifiers: A Qt::KeyboardModifiers enum value.
+        text: A QString with the value of QKeyEvent::text()
     """
 
     key = attr.ib()
     modifiers = attr.ib()
+    key_text = attr.ib()
 
     @classmethod
     def from_event(cls, e):
-        return cls(e.key(), e.modifiers())
+        return cls(e.key(), e.modifiers(), e.text())
 
     def __str__(self):
         """Convert this KeyInfo to a meaningful name.
@@ -313,6 +315,12 @@ class KeyInfo:
         Return:
             A name of the key (combination) as a string.
         """
+
+        # These are Unicode characters (such as emoji)
+        if self.key > 0xff and self.key < 0x01000000:
+            _check_valid_utf8(self.key_text, self.key)
+            return self.key_text
+
         key_string = _key_to_string(self.key)
         modifiers = int(self.modifiers)
 
@@ -412,7 +420,7 @@ class KeySequence:
             key = int(key_and_modifiers) & ~Qt.KeyboardModifierMask
             modifiers = Qt.KeyboardModifiers(int(key_and_modifiers) &
                                              Qt.KeyboardModifierMask)
-            yield KeyInfo(key=key, modifiers=modifiers)
+            yield KeyInfo(key=key, modifiers=modifiers, key_text="")
 
     def __repr__(self):
         return utils.get_repr(self, keys=str(self))

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -53,10 +53,10 @@ def _is_printable(key):
     return key <= 0xff and key not in [Qt.Key_Space, 0x0]
 
 # Unicode characters such as emoji and extended CJK characters land here
-# These get key codes that are above ASCII range but aren't Qt::Key enum members
-# Qt::Key_Escape is the first "special" Qt::Key
+# These get key codes above ASCII range, but not as high as the special
+# Qt::Key enum members. Qt::Key_Escape is the first special Qt::Key.
 def _is_extended_unicode(key):
-    return key > 0xff and key < Qt.Key_Escape
+    return 0xff < key < Qt.Key_Escape
 
 def is_special(key, modifiers):
     """Check whether this key requires special key syntax."""

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -52,8 +52,11 @@ def _is_printable(key):
     _assert_plain_key(key)
     return key <= 0xff and key not in [Qt.Key_Space, 0x0]
 
+# Unicode characters such as emoji and extended CJK characters land here
+# These get key codes that are above ASCII range but aren't Qt::Key enum members
+# Qt::Key_Escape is the first "special" Qt::Key
 def _is_extended_unicode(key):
-    return key > 0xff and key < 0x010000000
+    return key > 0xff and key < Qt.Key_Escape
 
 def is_special(key, modifiers):
     """Check whether this key requires special key syntax."""

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -171,7 +171,7 @@ def test_key_info_str(key, modifiers, expected):
     (0xd867, Qt.NoModifier, '𩷶', '<𩷶>'),
     (0xd867, Qt.ShiftModifier, '𩷶', '<Shift+𩷶>'),
 ])
-def test_extended_unicode(key, modifiers, text, expected):
+def test_surrogates(key, modifiers, text, expected):
     evt = QKeyEvent(QKeyEvent.KeyPress, key, modifiers, text)
     assert str(keyutils.KeyInfo.from_event(evt)) == expected
 
@@ -182,13 +182,14 @@ def test_extended_unicode(key, modifiers, text, expected):
     ([Qt.Key_Shift, 0x29df6], '<Shift><𩷶>'),
     ([0x1f468, 0x200d, 0x1f468, 0x200d, 0x1f466], '<👨><‍><👨><‍><👦>'),
 ])
-def test_extended_unicode_sequences(keys, expected):
+def test_surrogate_sequences(keys, expected):
     seq = keyutils.KeySequence(*keys)
     assert str(seq) == expected
 
+
 # This shouldn't happen, but if it does we should handle it well
-def test_extended_unicode_error():
-    evt = QKeyEvent(QKeyEvent.KeyPress, 0x26d1, Qt.NoModifier, '⛑🏻')
+def test_surrogate_error():
+    evt = QKeyEvent(QKeyEvent.KeyPress, 0xd83e, Qt.NoModifier, '🤞🏻')
     with pytest.raises(keyutils.KeyParseError):
         keyutils.KeyInfo.from_event(evt)
 

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -165,9 +165,30 @@ class TestKeyToString:
 def test_key_info_str(key, modifiers, expected):
     assert str(keyutils.KeyInfo(key, modifiers)) == expected
 
-def test_extended_unicode():
-    assert str(keyutils.KeyInfo(0xd83c, Qt.NoModifier, "🏻")) == "🏻"
-    assert str(keyutils.KeyInfo(0xd867, Qt.NoModifier, "𩷶")) == "𩷶"
+@pytest.mark.parametrize('key, modifiers, text, expected', [
+    (0xd83c, Qt.NoModifier, '🏻', '<🏻>'),
+    (0xd867, Qt.NoModifier, '𩷶', '<𩷶>'),
+    (0xd867, Qt.ShiftModifier, '𩷶', '<Shift+𩷶>'),
+])
+def test_extended_unicode(key, modifiers, text, expected):
+    evt = QKeyEvent(QKeyEvent.KeyPress, key, modifiers, text)
+    assert str(keyutils.KeyInfo.from_event(evt)) == expected
+
+@pytest.mark.parametrize('keys, expected', [
+    ([0x1f3fb], '<🏻>'),
+    ([0x29df6], '<𩷶>'),
+    ([Qt.Key_Shift, 0x29df6], '<Shift><𩷶>'),
+    ([0x1f468,0x200d,0x1f468,0x200d,0x1f466], '<👨><‍><👨><‍><👦>'),
+])
+def test_extended_unicode_sequences(keys, expected):
+    seq = keyutils.KeySequence(*keys)
+    assert str(seq) == expected
+
+# This shouldn't happen, but if it does we should handle it well
+def test_extended_unicode_error():
+    with pytest.raises(keyutils.KeyParseError):
+        evt = QKeyEvent(QKeyEvent.KeyPress, 0x26d1, Qt.NoModifier, '⛑🏻')
+        keyutils.KeyInfo.from_event(evt)
 
 @pytest.mark.parametrize('keystr, expected', [
     ('foo', "Could not parse 'foo': error"),

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -165,6 +165,9 @@ class TestKeyToString:
 def test_key_info_str(key, modifiers, expected):
     assert str(keyutils.KeyInfo(key, modifiers)) == expected
 
+def test_extended_unicode():
+    assert str(keyutils.KeyInfo(0xd83c, Qt.NoModifier, "🏻")) == "🏻"
+    assert str(keyutils.KeyInfo(0xd83c, Qt.NoModifier, "𩷶")) == "𩷶"
 
 @pytest.mark.parametrize('keystr, expected', [
     ('foo', "Could not parse 'foo': error"),

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -167,7 +167,7 @@ def test_key_info_str(key, modifiers, expected):
 
 def test_extended_unicode():
     assert str(keyutils.KeyInfo(0xd83c, Qt.NoModifier, "🏻")) == "🏻"
-    assert str(keyutils.KeyInfo(0xd83c, Qt.NoModifier, "𩷶")) == "𩷶"
+    assert str(keyutils.KeyInfo(0xd867, Qt.NoModifier, "𩷶")) == "𩷶"
 
 @pytest.mark.parametrize('keystr, expected', [
     ('foo', "Could not parse 'foo': error"),

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -165,6 +165,7 @@ class TestKeyToString:
 def test_key_info_str(key, modifiers, expected):
     assert str(keyutils.KeyInfo(key, modifiers)) == expected
 
+
 @pytest.mark.parametrize('key, modifiers, text, expected', [
     (0xd83c, Qt.NoModifier, '🏻', '<🏻>'),
     (0xd867, Qt.NoModifier, '𩷶', '<𩷶>'),
@@ -174,11 +175,12 @@ def test_extended_unicode(key, modifiers, text, expected):
     evt = QKeyEvent(QKeyEvent.KeyPress, key, modifiers, text)
     assert str(keyutils.KeyInfo.from_event(evt)) == expected
 
+
 @pytest.mark.parametrize('keys, expected', [
     ([0x1f3fb], '<🏻>'),
     ([0x29df6], '<𩷶>'),
     ([Qt.Key_Shift, 0x29df6], '<Shift><𩷶>'),
-    ([0x1f468,0x200d,0x1f468,0x200d,0x1f466], '<👨><‍><👨><‍><👦>'),
+    ([0x1f468, 0x200d, 0x1f468, 0x200d, 0x1f466], '<👨><‍><👨><‍><👦>'),
 ])
 def test_extended_unicode_sequences(keys, expected):
     seq = keyutils.KeySequence(*keys)
@@ -186,9 +188,10 @@ def test_extended_unicode_sequences(keys, expected):
 
 # This shouldn't happen, but if it does we should handle it well
 def test_extended_unicode_error():
+    evt = QKeyEvent(QKeyEvent.KeyPress, 0x26d1, Qt.NoModifier, '⛑🏻')
     with pytest.raises(keyutils.KeyParseError):
-        evt = QKeyEvent(QKeyEvent.KeyPress, 0x26d1, Qt.NoModifier, '⛑🏻')
         keyutils.KeyInfo.from_event(evt)
+
 
 @pytest.mark.parametrize('keystr, expected', [
     ('foo', "Could not parse 'foo': error"),


### PR DESCRIPTION
I'm not sure if this is the best way to fix this, it should perhaps be checked somewhere else, but this is the basic idea. And this does allow me to type emoji into qutebrowser. This is my attempt at fixing #4439.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4492)
<!-- Reviewable:end -->
