### PR TITLE
Allow customizing tab audio indicators

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -268,6 +268,8 @@
 |<<tabs.show_switching_delay,tabs.show_switching_delay>>|Duration (in milliseconds) to show the tab bar before hiding it when tabs.show is set to 'switching'.
 |<<tabs.tabs_are_windows,tabs.tabs_are_windows>>|Open a new window for every tab.
 |<<tabs.title.alignment,tabs.title.alignment>>|Alignment of the text inside of tabs.
+|<<tabs.title.audio_indicator,tabs.title.audio_indicator>>|Value of the `{audio}` title format placeholder when the tab has been recently audible.
+|<<tabs.title.audio_mute_indicator,tabs.title.audio_mute_indicator>>|Value of the `{audio}` title format placeholder when the tab is muted.
 |<<tabs.title.format,tabs.title.format>>|Format to use for the tab title.
 |<<tabs.title.format_pinned,tabs.title.format_pinned>>|Format to use for the tab title for pinned tabs. The same placeholders like for `tabs.title.format` are defined.
 |<<tabs.width,tabs.width>>|Width (in pixels or as percentage of the window) of the tab bar if it's vertical.
@@ -417,7 +419,7 @@ Default:
 * +pass:[L]+: +pass:[scroll right]+
 * +pass:[Y]+: +pass:[yank selection -s]+
 * +pass:[[]+: +pass:[move-to-start-of-prev-block]+
-* +pass:[]]+: +pass:[move-to-start-of-next-block]+
+* +pass:[\]]+: +pass:[move-to-start-of-next-block]+
 * +pass:[b]+: +pass:[move-to-prev-word]+
 * +pass:[c]+: +pass:[enter-mode normal]+
 * +pass:[e]+: +pass:[move-to-end-of-word]+
@@ -561,7 +563,7 @@ Default:
 * +pass:[ZQ]+: +pass:[quit]+
 * +pass:[ZZ]+: +pass:[quit --save]+
 * +pass:[[[]+: +pass:[navigate prev]+
-* +pass:[]]]+: +pass:[navigate next]+
+* +pass:[\]\]]+: +pass:[navigate next]+
 * +pass:[`]+: +pass:[enter-mode set_mark]+
 * +pass:[ad]+: +pass:[download-cancel]+
 * +pass:[b]+: +pass:[set-cmd-text -s :quickmark-load]+
@@ -2550,7 +2552,7 @@ Default:
 - +pass:[\bnext\b]+
 - +pass:[\bmore\b]+
 - +pass:[\bnewer\b]+
-- +pass:[\b[&gt;→≫]\b]+
+- +pass:[\b[&gt;→≫\]\b]+
 - +pass:[\b(&gt;&gt;|»)\b]+
 - +pass:[\bcontinue\b]+
 
@@ -2565,7 +2567,7 @@ Default:
 - +pass:[\bprev(ious)?\b]+
 - +pass:[\bback\b]+
 - +pass:[\bolder\b]+
-- +pass:[\b[&lt;←≪]\b]+
+- +pass:[\b[&lt;←≪\]\b]+
 - +pass:[\b(&lt;&lt;|«)\b]+
 
 [[hints.scatter]]
@@ -2595,48 +2597,48 @@ Default:
 * +pass:[area]+
 * +pass:[textarea]+
 * +pass:[select]+
-* +pass:[input:not([type=&quot;hidden&quot;])]+
+* +pass:[input:not([type=&quot;hidden&quot;\])]+
 * +pass:[button]+
 * +pass:[frame]+
 * +pass:[iframe]+
 * +pass:[img]+
 * +pass:[link]+
 * +pass:[summary]+
-* +pass:[[onclick]]+
-* +pass:[[onmousedown]]+
-* +pass:[[role=&quot;link&quot;]]+
-* +pass:[[role=&quot;option&quot;]]+
-* +pass:[[role=&quot;button&quot;]]+
-* +pass:[[ng-click]]+
-* +pass:[[ngClick]]+
-* +pass:[[data-ng-click]]+
-* +pass:[[x-ng-click]]+
-* +pass:[[tabindex]]+
+* +pass:[[onclick\]]+
+* +pass:[[onmousedown\]]+
+* +pass:[[role=&quot;link&quot;\]]+
+* +pass:[[role=&quot;option&quot;\]]+
+* +pass:[[role=&quot;button&quot;\]]+
+* +pass:[[ng-click\]]+
+* +pass:[[ngClick\]]+
+* +pass:[[data-ng-click\]]+
+* +pass:[[x-ng-click\]]+
+* +pass:[[tabindex\]]+
 - +pass:[images]+:
 
 * +pass:[img]+
 - +pass:[inputs]+:
 
-* +pass:[input[type=&quot;text&quot;]]+
-* +pass:[input[type=&quot;date&quot;]]+
-* +pass:[input[type=&quot;datetime-local&quot;]]+
-* +pass:[input[type=&quot;email&quot;]]+
-* +pass:[input[type=&quot;month&quot;]]+
-* +pass:[input[type=&quot;number&quot;]]+
-* +pass:[input[type=&quot;password&quot;]]+
-* +pass:[input[type=&quot;search&quot;]]+
-* +pass:[input[type=&quot;tel&quot;]]+
-* +pass:[input[type=&quot;time&quot;]]+
-* +pass:[input[type=&quot;url&quot;]]+
-* +pass:[input[type=&quot;week&quot;]]+
-* +pass:[input:not([type])]+
+* +pass:[input[type=&quot;text&quot;\]]+
+* +pass:[input[type=&quot;date&quot;\]]+
+* +pass:[input[type=&quot;datetime-local&quot;\]]+
+* +pass:[input[type=&quot;email&quot;\]]+
+* +pass:[input[type=&quot;month&quot;\]]+
+* +pass:[input[type=&quot;number&quot;\]]+
+* +pass:[input[type=&quot;password&quot;\]]+
+* +pass:[input[type=&quot;search&quot;\]]+
+* +pass:[input[type=&quot;tel&quot;\]]+
+* +pass:[input[type=&quot;time&quot;\]]+
+* +pass:[input[type=&quot;url&quot;\]]+
+* +pass:[input[type=&quot;week&quot;\]]+
+* +pass:[input:not([type\])]+
 * +pass:[textarea]+
 - +pass:[links]+:
 
-* +pass:[a[href]]+
-* +pass:[area[href]]+
-* +pass:[link[href]]+
-* +pass:[[role=&quot;link&quot;][href]]+
+* +pass:[a[href\]]+
+* +pass:[area[href\]]+
+* +pass:[link[href\]]+
+* +pass:[[role=&quot;link&quot;\][href\]]+
 - +pass:[media]+:
 
 * +pass:[audio]+
@@ -2644,8 +2646,8 @@ Default:
 * +pass:[video]+
 - +pass:[url]+:
 
-* +pass:[[src]]+
-* +pass:[[href]]+
+* +pass:[[src\]]+
+* +pass:[[href\]]+
 
 [[hints.uppercase]]
 === hints.uppercase
@@ -3388,6 +3390,22 @@ Valid values:
  * +center+
 
 Default: +pass:[left]+
+
+[[tabs.title.audio_indicator]]
+=== tabs.title.audio_indicator
+Value of the `{audio}` title format placeholder when the tab has been recently audible.
+
+Type: <<types,String>>
+
+Default: +pass:[[A\] ]+
+
+[[tabs.title.audio_mute_indicator]]
+=== tabs.title.audio_mute_indicator
+Value of the `{audio}` title format placeholder when the tab is muted.
+
+Type: <<types,String>>
+
+Default: +pass:[[M\] ]+
 
 [[tabs.title.format]]
 === tabs.title.format

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1638,6 +1638,17 @@ tabs.title.alignment:
   type: TextAlignment
   desc: Alignment of the text inside of tabs.
 
+tabs.title.audio_indicator:
+  default: '[A] '
+  type: String
+  desc: Value of the `{audio}` title format placeholder when the tab has been
+    recently audible.
+
+tabs.title.audio_mute_indicator:
+  default: '[M] '
+  type: String
+  desc: Value of the `{audio}` title format placeholder when the tab is muted.
+
 tabs.title.format:
   default: '{audio}{index}: {title}'
   type:

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -291,7 +291,7 @@ class BaseType:
         str_value = self.to_str(value)
         if not str_value:
             return 'empty'
-        return '+pass:[{}]+'.format(html.escape(str_value))
+        return '+pass:[{}]+'.format(html.escape(str_value).replace(']', r'\]'))
 
     def complete(self) -> _Completions:
         """Return a list of possible values for completion.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -58,10 +58,6 @@ class TabWidget(QTabWidget):
     tab_index_changed = pyqtSignal(int, int)
     new_tab_requested = pyqtSignal('QUrl', bool, bool)
 
-    # Strings for controlling the mute/audible text
-    MUTE_STRING = '[M] '
-    AUDIBLE_STRING = '[A] '
-
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
         bar = TabBar(win_id, self)
@@ -180,9 +176,10 @@ class TabWidget(QTabWidget):
         fields['private'] = ' [Private Mode] ' if tab.is_private else ''
         try:
             if tab.audio.is_muted():
-                fields['audio'] = TabWidget.MUTE_STRING
+                fields['audio'] = (
+                    config.cache['tabs.title.audio_mute_indicator'])
             elif tab.audio.is_recently_audible():
-                fields['audio'] = TabWidget.AUDIBLE_STRING
+                fields['audio'] = config.cache['tabs.title.audio_indicator']
             else:
                 fields['audio'] = ''
         except browsertab.WebTabError:


### PR DESCRIPTION
This adds two settings, `tabs.title.audio_indicator` and `tabs.title.audio_mute_indicator`, to customize the appearance of the `{audio}` title format placeholder. Their default values match the current hardcoded values. 

I also fixed the generation of asciidoc default values when the value contains a closing square bracket, which [must be escaped within a macro](https://asciidoc.org/chunked/ch21.html). This fixes a few existing doc formatting issues, such as the fourth default value of `hints.next_regexes`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4499)
<!-- Reviewable:end -->
