### PR TITLE
Improve open in existing instance speed

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -86,19 +86,8 @@ from qutebrowser.misc import utilcmds
 qApp = None
 
 
-def run(args):
+def run(socketname, args):
     """Initialize everything and run the application."""
-    if args.temp_basedir:
-        args.basedir = tempfile.mkdtemp(prefix='qutebrowser-basedir-')
-
-    log.init.debug("Initializing directories...")
-    standarddir.init(args)
-    utils.preload_resources()
-
-    if not args.version:
-        socketname = ipc.get_socketname(args.basedir)
-        ipc.send_to_running_instance(socketname, args)
-
     quitter = Quitter(args)
     objreg.register('quitter', quitter)
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -130,15 +130,9 @@ def run(args):
         # We didn't really initialize much so far, so we just quit hard.
         sys.exit(usertypes.Exit.err_ipc)
 
-    if server is None:
-        if args.backend is not None:
-            log.init.warning(
-                "Backend from the running instance will be used")
-        sys.exit(usertypes.Exit.ok)
-    else:
-        server.got_args.connect(lambda args, target_arg, cwd:
-                                process_pos_args(args, cwd=cwd, via_ipc=True,
-                                                 target_arg=target_arg))
+    server.got_args.connect(lambda args, target_arg, cwd:
+                            process_pos_args(args, cwd=cwd, via_ipc=True,
+                                             target_arg=target_arg))
 
     init(args, crash_handler)
     ret = qt_mainloop()

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -124,9 +124,11 @@ def run(args):
     objreg.register('signal-handler', signal_handler)
 
     try:
-        server = ipc.send_or_listen(args)
+        socketname = ipc.get_socketname(args.basedir)
+        ipc.send_to_running_instance(socketname, args)
+        server = ipc.listen_or_send(socketname, args)
     except ipc.Error:
-        # ipc.send_or_listen already displays the error message for us.
+        # ipc.listen_or_send already displays the error message for us.
         # We didn't really initialize much so far, so we just quit hard.
         sys.exit(usertypes.Exit.err_ipc)
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -91,12 +91,16 @@ def run(args):
     if args.temp_basedir:
         args.basedir = tempfile.mkdtemp(prefix='qutebrowser-basedir-')
 
-    quitter = Quitter(args)
-    objreg.register('quitter', quitter)
-
     log.init.debug("Initializing directories...")
     standarddir.init(args)
     utils.preload_resources()
+
+    if not args.version:
+        socketname = ipc.get_socketname(args.basedir)
+        ipc.send_to_running_instance(socketname, args)
+
+    quitter = Quitter(args)
+    objreg.register('quitter', quitter)
 
     log.init.debug("Initializing config...")
     configinit.early_init(args)
@@ -124,8 +128,6 @@ def run(args):
     objreg.register('signal-handler', signal_handler)
 
     try:
-        socketname = ipc.get_socketname(args.basedir)
-        ipc.send_to_running_instance(socketname, args)
         server = ipc.listen_or_send(socketname, args)
     except ipc.Error:
         # ipc.listen_or_send already displays the error message for us.

--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -289,8 +289,6 @@ def early_init(args):
     # Here we check if QtCore is available, and if not, print a message to the
     # console or via Tk.
     check_pyqt_core()
-    # Init logging as early as possible
-    init_log(args)
     # Now we can be sure QtCore is available, so we can print dialogs on
     # errors, so people only using the GUI notice them as well.
     check_libraries()

--- a/qutebrowser/misc/ipc.py
+++ b/qutebrowser/misc/ipc.py
@@ -54,7 +54,7 @@ def _get_socketname_windows(basedir):
     return '-'.join(parts)
 
 
-def _get_socketname(basedir):
+def get_socketname(basedir):
     """Get a socketname to use."""
     if utils.is_windows:  # pragma: no cover
         return _get_socketname_windows(basedir)
@@ -476,10 +476,12 @@ def display_error(exc, args):
         post_text="Maybe another instance is running but frozen?")
 
 
-def send_or_listen(args):
-    """Send the args to a running instance or start a new IPCServer.
+def listen_or_send(socketname, args):
+    """Start a new IPCServer. If fails due to AddressInUseError, try sending the
+    args to a running instance.
 
     Args:
+        socketname: The socketname to use.
         args: The argparse namespace.
 
     Return:
@@ -487,10 +489,7 @@ def send_or_listen(args):
         None if an instance was running and received our request.
     """
     global server
-    socketname = _get_socketname(args.basedir)
     try:
-        send_to_running_instance(socketname, args)
-
         try:
             log.init.debug("Starting IPC server...")
             server = IPCServer(socketname)

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -188,12 +188,13 @@ def main():
         # from json.
         data = json.loads(args.json_args)
         args = argparse.Namespace(**data)
-    earlyinit.early_init(args)
 
     # We do some imports late here for various reasons:
     # - earlyinit needs to be run first (because of version checking and other
     #   early initialization)
     # - Importing Qt stuff takes rather long, so we avoid it if we can.
+    earlyinit.init_log(args)
+
     if args.temp_basedir:
         args.basedir = tempfile.mkdtemp(prefix='qutebrowser-basedir-')
 
@@ -205,5 +206,6 @@ def main():
         socketname = ipc.get_socketname(args.basedir)
         ipc.send_to_running_instance(socketname, args)
 
+    earlyinit.early_init(args)
     from qutebrowser import app
     return app.run(socketname, args)


### PR DESCRIPTION
On my machine the startup time reduces from 1.9s to 0.6s with an existing instance.

------

All optimizations move parts of functions around and rearrange initialization order.

One of the optimizations move the code for sending from app.py to qutebrowser.py, which:

* The `socketname` value has to be passed between the functions.
* It may not be the "correct" place.
* If stuff keeps being moved to qutebrowser.py, it will eventually get bloated and the import time gets slow.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4507)
<!-- Reviewable:end -->
