### PR TITLE
Implement pinned.tab.frozen setting (issue #4400)

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -943,6 +943,10 @@ class AbstractTab(QWidget):
         evt.posted = True
         QApplication.postEvent(recipient, evt)
 
+    def navigation_blocked(self) -> bool:
+        """Test if navigation is allowed on the current tab."""
+        return self.data.pinned and config.val.pinned.tab.frozen
+
     @pyqtSlot(QUrl)
     def _on_before_load_started(self, url: QUrl) -> None:
         """Adjust the title if we are going to visit a URL soon."""

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -945,7 +945,7 @@ class AbstractTab(QWidget):
 
     def navigation_blocked(self) -> bool:
         """Test if navigation is allowed on the current tab."""
-        return self.data.pinned and config.val.pinned.tab.frozen
+        return self.data.pinned and config.val.tabs.pinned.frozen
 
     @pyqtSlot(QUrl)
     def _on_before_load_started(self, url: QUrl) -> None:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -316,10 +316,11 @@ class CommandDispatcher:
                     else:
                         # Explicit count with a tab that doesn't exist.
                         return
-                elif curtab.data.pinned:
-                    message.info("Tab is pinned!")
                 else:
-                    curtab.load_url(cur_url)
+                    if curtab.navigation_blocked():
+                        message.info("Tab is pinned!")
+                    else:
+                        curtab.load_url(cur_url)
 
     def _parse_url(self, url, *, force_search=False):
         """Parse a URL or quickmark or search query.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -316,11 +316,10 @@ class CommandDispatcher:
                     else:
                         # Explicit count with a tab that doesn't exist.
                         return
+                elif curtab.navigation_blocked():
+                    message.info("Tab is pinned!")
                 else:
-                    if curtab.navigation_blocked():
-                        message.info("Tab is pinned!")
-                    else:
-                        curtab.load_url(cur_url)
+                    curtab.load_url(cur_url)
 
     def _parse_url(self, url, *, force_search=False):
         """Parse a URL or quickmark or search query.

--- a/qutebrowser/components/misccommands.py
+++ b/qutebrowser/components/misccommands.py
@@ -118,7 +118,7 @@ def printpage(tab: apitypes.Tab,
 @cmdutils.argument('tab', value=cmdutils.Value.cur_tab)
 def home(tab: apitypes.Tab) -> None:
     """Open main startpage in current tab."""
-    if tab.data.pinned:
+    if tab.navigation_blocked():
         message.info("Tab is pinned!")
     else:
         tab.load_url(config.val.url.start_pages[0])

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1768,6 +1768,11 @@ tabs.pinned.shrink:
   type: Bool
   desc: Shrink pinned tabs down to their contents.
 
+tabs.pinned.frozen:
+    type: Bool
+    default: True
+    desc: If true, then pinned tabs cannot have their URL changed.
+
 tabs.wrap:
   default: true
   type: Bool
@@ -2917,8 +2922,3 @@ bindings.commands:
 
     * register: Entered when qutebrowser is waiting for a register name/key for
       commands like `:set-mark`.
-
-pinned.tab.frozen:
-    type: Bool
-    default: True
-    desc: If true, then pinned tabs cannot have their URL changed.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2917,3 +2917,8 @@ bindings.commands:
 
     * register: Entered when qutebrowser is waiting for a register name/key for
       commands like `:set-mark`.
+
+pinned.tab.frozen:
+    type: Bool
+    default: True
+    desc: If true, then pinned tabs cannot have their URL changed.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1771,7 +1771,7 @@ tabs.pinned.shrink:
 tabs.pinned.frozen:
     type: Bool
     default: True
-    desc: If true, then pinned tabs cannot have their URL changed.
+    desc: Force pinned tabs to stay at fixed URL.
 
 tabs.wrap:
   default: true

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1289,6 +1289,14 @@ Feature: Tab management
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
 
+    Scenario: :tab-pin open url with pinned.tab.frozen = false
+        When I set pinned.tab.frozen to false
+        And I open data/numbers/1.txt
+        And I run :tab-pin
+        And I open data/numbers/2.txt
+        Then the following tabs should be open:
+            - data/numbers/2.txt (active) (pinned)
+
     Scenario: :home on a pinned tab
         When I open data/numbers/1.txt
         And I run :tab-pin
@@ -1296,6 +1304,16 @@ Feature: Tab management
         Then the message "Tab is pinned!" should be shown
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
+
+    Scenario: :home on a pinned tab with pinned.tab.frozen = false
+        When I set url.start_pages to ["http://localhost:(port)/data/numbers/2.txt"]
+        And I set pinned.tab.frozen to false
+        And I open data/numbers/1.txt
+        And I run :tab-pin
+        And I run :home
+        Then data/numbers/2.txt should be loaded
+        And the following tabs should be open:
+            - data/numbers/2.txt (active) (pinned)
 
     Scenario: Cloning a pinned tab
         When I open data/numbers/1.txt

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1289,8 +1289,8 @@ Feature: Tab management
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
 
-    Scenario: :tab-pin open url with pinned.tab.frozen = false
-        When I set pinned.tab.frozen to false
+    Scenario: :tab-pin open url with tabs.pinned.frozen = false
+        When I set tabs.pinned.frozen to false
         And I open data/numbers/1.txt
         And I run :tab-pin
         And I open data/numbers/2.txt
@@ -1305,9 +1305,9 @@ Feature: Tab management
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
 
-    Scenario: :home on a pinned tab with pinned.tab.frozen = false
+    Scenario: :home on a pinned tab with tabs.pinned.frozen = false
         When I set url.start_pages to ["http://localhost:(port)/data/numbers/2.txt"]
-        And I set pinned.tab.frozen to false
+        And I set tabs.pinned.frozen to false
         And I open data/numbers/1.txt
         And I run :tab-pin
         And I run :home


### PR DESCRIPTION
Implement a new setting, `pinned.tab.frozen` (boolean), which when false
allows a user to navigate to new URLs in a pinned tab (default behavior
is to have `pinned.tab.frozen = true`, in which no navigation is allowed).

closes #4400

Changes to be committed:
      modified:   qutebrowser/browser/browsertab.py
        Add `navigation_blocked` method to AbstractTab, which returns
        true if navigation is allowed on a tab.
      modified:   qutebrowser/browser/commands.py
        Change `openurl` to use `navigation_blocked` method of a tab to
        determine behavior while navigating a pinned tab.
      modified:   qutebrowser/components/misccommands.py
        Change `home` to use `navigation_blocked` method of a tab to
        determine behavior while navigating a pinned tab.
      modified:   qutebrowser/config/configdata.yml
        Add `pinned.tab.frozen` config.
      modified:   tests/end2end/features/tabs.feature
        Add tests for :open and :home on pinned tabs with
        `pinned.tab.frozen` set to false

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4508)
<!-- Reviewable:end -->
