### PR TITLE
Default to white background

### DIFF
--- a/www/qute.css
+++ b/www/qute.css
@@ -7,6 +7,7 @@ body {
 	font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, sans-serif;
 	-webkit-text-size-adjust: none;
 	color: #333333;
+	background-color: #ffffff;
     overflow-y: scroll;
 }
 


### PR DESCRIPTION
If the user has customized their background color, the text color will
not stay as the default but the background will, leading to unreadable
text.

Should be pretty harmless either way though :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4515)
<!-- Reviewable:end -->

*edit by @The-Compiler: fixes #4510*