### PR TITLE
Optimize configcache for critical path

### DIFF
--- a/qutebrowser/config/configcache.py
+++ b/qutebrowser/config/configcache.py
@@ -46,7 +46,9 @@ class ConfigCache:
             self._cache[attr] = config.instance.get(attr)
 
     def __getitem__(self, attr: str) -> typing.Any:
-        if attr not in self._cache:
+        try:
+            return self._cache[attr]
+        except KeyError:
             assert not config.instance.get_opt(attr).supports_pattern
             self._cache[attr] = config.instance.get(attr)
-        return self._cache[attr]
+            return self._cache[attr]

--- a/tests/unit/config/test_configcache.py
+++ b/tests/unit/config/test_configcache.py
@@ -50,3 +50,17 @@ def test_configcache_get_after_set(config_stub):
     assert not config.cache['auto_save.session']
     config_stub.val.auto_save.session = True
     assert config.cache['auto_save.session']
+
+
+def test_configcache_naive_benchmark(config_stub, benchmark):
+    def _run_bench():
+        for _i in range(10000):
+            # pylint: disable=pointless-statement
+            config.cache['tabs.padding']
+            config.cache['tabs.indicator.width']
+            config.cache['tabs.indicator.padding']
+            config.cache['tabs.min_width']
+            config.cache['tabs.max_width']
+            config.cache['tabs.pinned.shrink']
+            # pylint: enable=pointless-statement
+    benchmark(_run_bench)


### PR DESCRIPTION
Since we are using configcache more and more (and I've started to barely see it in some profiles), I took another look at the control flow and I think we can optimize the most common case to avoid a lookup. I bumped up the iterations in the test case for this, but:

Before:
```
--------------------- benchmark: 1 tests ---------------------
Name (time in ms)                        Min      Max   Median
--------------------------------------------------------------
test_configcache_naive_benchmark     76.9207  78.5182  77.5965
--------------------------------------------------------------
```
After:
```
--------------------- benchmark: 1 tests ---------------------
Name (time in ms)                        Min      Max   Median
--------------------------------------------------------------
test_configcache_naive_benchmark     58.3996  58.7792  58.5754
--------------------------------------------------------------
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4518)
<!-- Reviewable:end -->
