### PR TITLE
Fix match highlighting on qt 5.11.3 and 5.12.1+

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -212,11 +212,11 @@ class CompletionItemDelegate(QStyledItemDelegate):
             view = self.parent()
             pattern = view.pattern
             columns_to_filter = index.model().columns_to_filter(index)
-            self._doc.setPlainText(self._opt.text)
             if index.column() in columns_to_filter and pattern:
                 pat = re.escape(pattern).replace(r'\ ', r'|')
                 _Highlighter(self._doc, pat,
                              config.val.colors.completion.match.fg)
+            self._doc.setPlainText(self._opt.text)
         else:
             self._doc.setHtml(
                 '<span style="font: {};">{}</span>'.format(


### PR DESCRIPTION
For some reason, populating the text (even if we completely overwrite
it later) before the highlighter is added results in no highlighting.
I think this has something to do with python locking/delayed
re-highlighting.

At some point, it would be nice to file this as a bug, but I can't
seem to make a small c++ example.

See https://codereview.qt-project.org/#/c/244699/4//ALL and
https://bugreports.qt.io/browse/QTBUG-71307 for more information.

(cc: @Morten242, if they want to take a closer look)

Closes #4519

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4524)
<!-- Reviewable:end -->
