### PR TITLE
Use ordered dicts to reduce complexity of pattern add

### DIFF
--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -133,6 +133,9 @@ def whitelist_generator():  # noqa
     # component hooks
     yield 'qutebrowser.components.adblock.on_config_changed'
 
+    # type hints
+    yield 'qutebrowser.config.configutils.VMAP_KEY'
+
 
 def filter_func(item):
     """Check if a missing function should be filtered or not.


### PR DESCRIPTION
Previously, adding a pattern setting was an O(n) operation, which made
large sets of pattern settings impossible.

Instead of storing pattern settings in a list, we can stored them in
an ordered map from pattern -> ScopedValue. This provides relatively
fast deletion and insertion.

With this change, the newly added benchmark of adding the existing
hosts_list measures to 1s, where it was timing out/crashing for me
when limited to 1000 entries before.

Now, the bottleneck is the initialization of UrlPattern objects.
However, if we do anything more clever for faster lookup, we will take
a penalty to init time (which is worth it).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4544)
<!-- Reviewable:end -->
