### PR TITLE
Add basic_str_validation cache

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -204,6 +204,12 @@ class BaseType:
         assert isinstance(value, str), value
         if not value and not self.none_ok:
             raise configexc.ValidationError(value, "may not be empty!")
+        BaseType._basic_str_validation_cache(value)
+
+    @staticmethod
+    @functools.lru_cache(maxsize=2**9)
+    def _basic_str_validation_cache(value: str) -> None:
+        """Cache validation result to prevent looping over strings."""
         if any(ord(c) < 32 or ord(c) == 0x7f for c in value):
             raise configexc.ValidationError(
                 value, "may not contain unprintable chars!")

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -31,7 +31,7 @@ from qutebrowser.browser import qutescheme
 from qutebrowser.utils import log, objreg, usertypes, message, debug, utils
 from qutebrowser.commands import runners
 from qutebrowser.api import cmdutils
-from qutebrowser.config import config, configdata
+from qutebrowser.config import config, configdata, configtypes
 from qutebrowser.misc import consolewidget
 from qutebrowser.utils.version import pastebin_version
 from qutebrowser.qt import sip
@@ -140,12 +140,16 @@ def debug_cache_stats():
     # pylint: disable=protected-access
     tab_bar = tabbed_browser.widget.tabBar()
     tabbed_browser_info = tab_bar._minimum_tab_size_hint_helper.cache_info()
+
+    str_validation_info = (configtypes.BaseType.
+                           _basic_str_validation_cache.cache_info())
     # pylint: enable=protected-access
 
     log.misc.info('is_valid_prefix: {}'.format(prefix_info))
     log.misc.info('_render_stylesheet: {}'.format(render_stylesheet_info))
     log.misc.info('history: {}'.format(history_info))
     log.misc.info('tab width cache: {}'.format(tabbed_browser_info))
+    log.misc.info('str validation cache: {}'.format(str_validation_info))
 
 
 @cmdutils.register(debug=True)

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -712,6 +712,9 @@ class TestConfig:
         conf.set_obj('content.headers.user_agent', strings[case])
         benchmark(functools.partial(conf.get, 'content.headers.user_agent'))
 
+    def test_get_dict_benchmark(self, conf, qtbot, benchmark):
+        benchmark(functools.partial(conf.get, 'bindings.default'))
+
 
 class TestContainer:
 

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -20,6 +20,7 @@
 
 import types
 import unittest.mock
+import functools
 
 import pytest
 from PyQt5.QtCore import QObject, QUrl
@@ -700,6 +701,16 @@ class TestConfig:
 
     def test_dump_userconfig_default(self, conf):
         assert conf.dump_userconfig() == '<Default configuration>'
+
+    @pytest.mark.parametrize('case', range(3))
+    def test_get_str_benchmark(self, conf, qtbot, benchmark, case):
+        strings = ['true',
+                   ('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML'
+                    ', like Gecko) QtWebEngine/5.7.1 Chrome/49.0.2623.111 '
+                    'Safari/537.36'),
+                   "a" * 10000]
+        conf.set_obj('content.headers.user_agent', strings[case])
+        benchmark(functools.partial(conf.get, 'content.headers.user_agent'))
 
 
 class TestContainer:


### PR DESCRIPTION
Currently, this is the most expensive part of string validation, especially on longer strings. Unfortunately, this method is called quite frequently (eg: user agent), during intercept request, and needs to be cheap.

The 'proper' fix for this would be to subclass String (and all other immutable types), add a flag to set when fully validated, and use that flag instead. Ideally, we could do this for dicts too, so we wouldn't need to do the traversal which is extremely costly, and gets even worse if people have bound a lot of keys.

If you'd like, I could try to solve this a different way. This shouldn't take up much more memory because these strings are sitting in the config system anyway, but I really don't like sticking caches on everything instead of the proper fix.

I also made a profile for looking up default bindings :cry: .

Before:
```
-------------------------------------- benchmark: 4 tests -------------------------------------
Name (time in us)                    Min                    Max                Median          
-----------------------------------------------------------------------------------------------
test_get_str_benchmark[0]         3.6000 (1.0)          12.8400 (1.0)          3.7600 (1.0)    
test_get_str_benchmark[1]        12.8600 (3.57)         31.0200 (2.42)        13.1100 (3.49)   
test_get_str_benchmark[2]       762.0310 (211.68)      982.2980 (76.50)      791.0010 (210.37) 
test_get_dict_benchmark       5,548.5810 (>1000.0)  25,766.7170 (>1000.0)  5,615.2400 (>1000.0)
-----------------------------------------------------------------------------------------------
```
After
```
-------------------------------------- benchmark: 4 tests -------------------------------------
Name (time in us)                    Min                    Max                Median          
-----------------------------------------------------------------------------------------------
test_get_str_benchmark[2]         2.8500 (1.0)          25.3700 (2.08)         3.0200 (1.0)    
test_get_str_benchmark[1]         2.9090 (1.02)         23.0900 (1.89)         3.0500 (1.01)   
test_get_str_benchmark[0]         3.0100 (1.06)         12.2000 (1.0)          3.1600 (1.05)   
test_get_dict_benchmark       4,865.0920 (>1000.0)  25,787.3310 (>1000.0)  4,934.3300 (>1000.0)
-----------------------------------------------------------------------------------------------
```
It's weird that the dict benchmark improved from the string cache, but idk...

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4555)
<!-- Reviewable:end -->
