### PR TITLE
Add setting for DnsPrefetchEnabled

### DIFF
--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -25,6 +25,7 @@ Module attributes:
 """
 
 import os
+import operator
 
 from PyQt5.QtGui import QFont
 from PyQt5.QtWebEngineWidgets import (QWebEngineSettings, QWebEngineProfile,
@@ -165,7 +166,11 @@ class WebEngineSettings(websettings.AbstractSettings):
                 ('PrintElementBackgrounds', None),
             # Qt 5.11
             'content.autoplay':
-                ('PlaybackRequiresUserGesture', lambda val: not val),
+                ('PlaybackRequiresUserGesture', operator.not_),
+
+            # Qt 5.12
+            'content.dns_prefetch':
+                ('DnsPrefetchEnabled', None),
         }
         for name, (attribute, converter) in new_attributes.items():
             try:

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -164,6 +164,7 @@ def _parse_yaml_backends_dict(
         'Qt 5.9.2': qtutils.version_check('5.9.2'),
         'Qt 5.10': qtutils.version_check('5.10'),
         'Qt 5.11': qtutils.version_check('5.11'),
+        'Qt 5.12': qtutils.version_check('5.12'),
     }
     for key in sorted(node.keys()):
         if conditionals[node[key]]:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -379,7 +379,9 @@ content.developer_extras:
 content.dns_prefetch:
   default: true
   type: Bool
-  backend: QtWebKit
+  backend:
+    QtWebKit: true
+    QtWebEngine: Qt 5.12
   supports_pattern: true
   desc: Try to pre-fetch DNS entries to speed up browsing.
 


### PR DESCRIPTION
Red Flag - DnsPrefetch is enabled by default (as that is how it was on qtwebkit), but it is disabled by default in qtwebengine.

See https://github.com/qutebrowser/qutebrowser/issues/3992

I'm not sure how to actually test if this is getting enabled, but it seems to be following the right code-paths to me.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4567)
<!-- Reviewable:end -->
