### PR TITLE
Correctly parse hue values from config.

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1035,7 +1035,7 @@ class QtColor(BaseType):
                 'rgb': QColor.fromRgb,
                 'hsva': QColor.fromHsv,
                 'hsv': QColor.fromHsv,
-            }
+            }  # type: typing.Dict[str, typing.Callable[..., QColor]]
 
             conv = converters.get(kind)
             if not conv:

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1001,16 +1001,16 @@ class QtColor(BaseType):
     * `hsv(h, s, v)` / `hsva(h, s, v, a)` (values 0-255, hue 0-359)
     """
 
-    def _parse_value(self, val: str) -> int:
+    def _parse_value(self, kind: str, val: str) -> int:
         try:
             return int(val)
         except ValueError:
             pass
 
-        mult = 255.0
+        mult = 359.0 if kind == 'h' else 255.0
         if val.endswith('%'):
             val = val[:-1]
-            mult = 255.0 / 100
+            mult = mult / 100
 
         try:
             return int(float(val) * mult)
@@ -1029,17 +1029,27 @@ class QtColor(BaseType):
             openparen = value.index('(')
             kind = value[:openparen]
             vals = value[openparen+1:-1].split(',')
-            int_vals = [self._parse_value(v) for v in vals]
-            if kind == 'rgba' and len(int_vals) == 4:
-                return QColor.fromRgb(*int_vals)
-            elif kind == 'rgb' and len(int_vals) == 3:
-                return QColor.fromRgb(*int_vals)
-            elif kind == 'hsva' and len(int_vals) == 4:
-                return QColor.fromHsv(*int_vals)
-            elif kind == 'hsv' and len(int_vals) == 3:
-                return QColor.fromHsv(*int_vals)
-            else:
-                raise configexc.ValidationError(value, "must be a valid color")
+
+            converters = {
+                'rgba': QColor.fromRgb,
+                'rgb': QColor.fromRgb,
+                'hsva': QColor.fromHsv,
+                'hsv': QColor.fromHsv,
+            }
+
+            conv = converters.get(kind)
+            if not conv:
+                raise configexc.ValidationError(
+                    value,
+                    '{} not in {}'.format(kind, list(converters.keys())))
+
+            if len(kind) != len(vals):
+                raise configexc.ValidationError(
+                    value,
+                    'expected {} values for {}'.format(len(kind), kind))
+
+            int_vals = [self._parse_value(p[0], p[1]) for p in zip(kind, vals)]
+            return conv(*int_vals)
 
         color = QColor(value)
         if color.isValid():

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1041,7 +1041,7 @@ class QtColor(BaseType):
             if not conv:
                 raise configexc.ValidationError(
                     value,
-                    '{} not in {}'.format(kind, list(converters.keys())))
+                    '{} not in {}'.format(kind, list(sorted(converters))))
 
             if len(kind) != len(vals):
                 raise configexc.ValidationError(

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1250,11 +1250,8 @@ class TestQtColor:
 
         ('rgba(255, 255, 255, 1.0)', QColor.fromRgb(255, 255, 255, 255)),
 
-        # this should be (36, 25, 25) as hue goes to 359
-        # however this is consistent with Qt's CSS parser
-        # https://bugreports.qt.io/browse/QTBUG-70897
-        ('hsv(10%,10%,10%)', QColor.fromHsv(25, 25, 25)),
-        ('hsva(10%,20%,30%,40%)', QColor.fromHsv(25, 51, 76, 102)),
+        ('hsv(10%,10%,10%)', QColor.fromHsv(35, 25, 25)),
+        ('hsva(10%,20%,30%,40%)', QColor.fromHsv(35, 51, 76, 102)),
     ])
     def test_valid(self, klass, val, expected):
         assert klass().to_py(val) == expected

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1262,7 +1262,7 @@ class TestQtColor:
         ('#12', 'must be a valid color'),
         ('foobar', 'must be a valid color'),
         ('42', 'must be a valid color'),
-        ('foo(1, 2, 3)', "foo not in ['rgba', 'rgb', 'hsva', 'hsv']"),
+        ('foo(1, 2, 3)', "foo not in ['hsv', 'hsva', 'rgb', 'rgba']"),
         ('rgb(1, 2, 3', 'must be a valid color'),
         ('rgb)', 'must be a valid color'),
         ('rgb(1, 2, 3))', 'must be a valid color value'),

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1256,25 +1256,26 @@ class TestQtColor:
     def test_valid(self, klass, val, expected):
         assert klass().to_py(val) == expected
 
-    @pytest.mark.parametrize('val', [
-        '#00000G',
-        '#123456789ABCD',
-        '#12',
-        'foobar',
-        '42',
-        'foo(1, 2, 3)',
-        'rgb(1, 2, 3',
-        'rgb)',
-        'rgb(1, 2, 3))',
-        'rgb((1, 2, 3)',
-        'rgb()',
-        'rgb(1, 2, 3, 4)',
-        'rgba(1, 2, 3)',
-        'rgb(10%%, 0, 0)',
+    @pytest.mark.parametrize('val,msg', [
+        ('#00000G', 'must be a valid color'),
+        ('#123456789ABCD', 'must be a valid color'),
+        ('#12', 'must be a valid color'),
+        ('foobar', 'must be a valid color'),
+        ('42', 'must be a valid color'),
+        ('foo(1, 2, 3)', "foo not in ['rgba', 'rgb', 'hsva', 'hsv']"),
+        ('rgb(1, 2, 3', 'must be a valid color'),
+        ('rgb)', 'must be a valid color'),
+        ('rgb(1, 2, 3))', 'must be a valid color value'),
+        ('rgb((1, 2, 3)', 'must be a valid color value'),
+        ('rgb()', 'expected 3 values for rgb'),
+        ('rgb(1, 2, 3, 4)', 'expected 3 values for rgb'),
+        ('rgba(1, 2, 3)', 'expected 4 values for rgba'),
+        ('rgb(10%%, 0, 0)', 'must be a valid color value'),
     ])
-    def test_invalid(self, klass, val):
-        with pytest.raises(configexc.ValidationError):
+    def test_invalid(self, klass, val, msg):
+        with pytest.raises(configexc.ValidationError) as excinfo:
             klass().to_py(val)
+        assert str(excinfo.value).endswith(msg)
 
 
 class TestQssColor:


### PR DESCRIPTION
100% for a hue slot should correspond to 359, not 255.
This bug was introduced deliberately in 66cc5f5 for compatibility with
Qt's faulty behavior.

QTBUG-70897 was fixed, so we should do the same on our end.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4606)
<!-- Reviewable:end -->
