### PR TITLE
Fix crash when closing prompt

### DIFF
--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -331,9 +331,14 @@ class PromptContainer(QWidget):
 
         if not question.interrupted:
             # If this question was interrupted, we already connected the signal
-            question.aborted.connect(
-                lambda: modeman.leave(self._win_id, prompt.KEY_MODE, 'aborted',
-                                      maybe=True))
+            def on_aborted():
+                try:
+                    modeman.leave(self._win_id, prompt.KEY_MODE,
+                                  'aborted', maybe=True)
+                except objreg.RegistryUnavailableError:
+                    # window was deleted: ignore
+                    pass
+            question.aborted.connect(on_aborted)
         modeman.enter(self._win_id, prompt.KEY_MODE, 'question asked')
 
         self.setSizePolicy(prompt.sizePolicy())


### PR DESCRIPTION
If a window is closed when a prompt is displayed on all windows, leaving prompt
mode later would cause a crash.

This patch fixes the crash simply by ignoring the RegistryUnavailableError
caused by looking up a non-existent window.

Fixes #3378.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4608)
<!-- Reviewable:end -->
