### PR TITLE
Ignore caret callbacks when outside of caret mode

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -437,6 +437,7 @@ class AbstractCaret(QObject):
         self._tab = tab
         self._widget = None
         self.selection_enabled = False
+        self._mode_manager = mode_manager
         mode_manager.entered.connect(self._on_mode_entered)
         mode_manager.left.connect(self._on_mode_left)
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -270,6 +270,9 @@ class WebEngineCaret(browsertab.AbstractCaret):
 
     def _selection_cb(self, enabled):
         """Emit selection_toggled based on setInitialCursor."""
+        if self._mode_manager.mode != usertypes.KeyMode.caret:
+            log.webview.debug("Ignoring selection cb due to mode change.")
+            return
         if enabled is None:
             log.webview.debug("Ignoring selection status None")
             return


### PR DESCRIPTION
Closes #4619

Not sure if this is the best way to get the current mode (but I would like to avoid objreg). I put the variable in the abstract base class for simplicity, but I could move it to the child if you would like (although I would need to make an init for that).

Not sure if we can / if it's worth adding a test for this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4620)
<!-- Reviewable:end -->
