### PR TITLE
Only set background color on StatusBar

### DIFF
--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -101,8 +101,11 @@ def _generate_stylesheet():
         QWidget#StatusBar QLabel,
         QWidget#StatusBar QLineEdit {
             font: {{ conf.fonts.statusbar }};
-            background-color: {{ conf.colors.statusbar.normal.bg }};
             color: {{ conf.colors.statusbar.normal.fg }};
+        }
+
+        QWidget#StatusBar {
+            background-color: {{ conf.colors.statusbar.normal.bg }};
         }
     """
     for flag, option in flags:
@@ -111,10 +114,13 @@ def _generate_stylesheet():
             QWidget#StatusBar[color_flags~="%s"] QLabel,
             QWidget#StatusBar[color_flags~="%s"] QLineEdit {
                 color: {{ conf.colors.%s }};
+            }
+
+            QWidget#StatusBar[color_flags~="%s"] {
                 background-color: {{ conf.colors.%s }};
             }
         """ % (flag, flag, flag,  # noqa: S001
-               option + '.fg', option + '.bg')
+               option + '.fg', flag, option + '.bg')
     return stylesheet
 
 


### PR DESCRIPTION
This relies on the default background-color of widgets being transparent.

Discussion:

```
[21:56:43] <jgkamat> this is an interesting issue, not sure how we can fix it https://www.reddit.com/r/qutebrowser/comments/axccr0/lefttoright_gradient_as_status_bar_background/
[21:59:21] <The-Compiler> jgkamat: probably by all those widgets having a transparent background, and only the container widget being colored
[21:59:33] <The-Compiler> kinda surprised that isn't already the case
[21:59:41] <jgkamat> yah, that's what I thought we did already
[21:59:53] <jgkamat> otherwise we would need to update the background of all the widgets when mode changes
[21:59:58] <jgkamat> which I'm pretty sure we don't do
[22:00:26] <The-Compiler> not sure looking at _generate_stylesheet() in qutebrowser/mainwindow/statusbar/bar.py
[22:00:59] <The-Compiler> maybe `background-color` should only be set on `QWidget#StatusBar`, and not the children as well
[22:01:30] <jgkamat> aaah, I see, that would make sense
```
With

`set colors.statusbar.normal.bg 'qlineargradient(x1:0, y1:0.5, x2:1, y2:0.5, stop:0 red, stop:1 blue)'`
old:
![2019-03-04-180637_958x153_scrot](https://user-images.githubusercontent.com/4349709/53775664-46841580-3ea8-11e9-8cb5-73ebae44e36e.png)
new:
![2019-03-04-180311_785x104_scrot](https://user-images.githubusercontent.com/4349709/53775646-34a27280-3ea8-11e9-8bc9-2af12da6804c.png)

From https://www.reddit.com/r/qutebrowser/comments/axccr0/lefttoright_gradient_as_status_bar_background/

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4627)
<!-- Reviewable:end -->
