### PR TITLE
Fix config path for Windows in doc

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -89,7 +89,7 @@ You can run `:config-edit` inside qutebrowser to open the file in your editor,
 The file should be located in the "config" location listed on
 link:qute://version[], which is typically `~/.config/qutebrowser/config.py` on
 Linux, `~/.qutebrowser/config.py` on macOS, and
-`%APPDATA%/qutebrowser/config.py` on Windows.
+`%APPDATA%/qutebrowser/config/config.py` on Windows.
 
 Two global objects are pre-defined when running `config.py`: `c` and `config`.
 


### PR DESCRIPTION
Just installed v1.6 on my windows work notebook and noticed that a config-source looks in the subfolder config/ for the config.py

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4629)
<!-- Reviewable:end -->
