### PR TITLE
Delete disconnected IPC sockets.

### DIFF
--- a/qutebrowser/misc/ipc.py
+++ b/qutebrowser/misc/ipc.py
@@ -277,6 +277,8 @@ class IPCServer(QObject):
         log.ipc.debug("Client disconnected from socket 0x{:x}.".format(
             id(self._socket)))
         self._timer.stop()
+        if self._old_socket is not None:
+            self._old_socket.deleteLater()
         self._old_socket = self._socket
         self._socket = None
         # Maybe another connection is waiting.


### PR DESCRIPTION
I was looking into how to reproduce high memory usage in the python process by some means other
than using the process for a few weeks and ran across this false positive (I don't use an IPC client normally).

The [docs][0] for `nextPendingConnection` say:

> The socket is created as a child of the server, which means that it is automatically deleted when the QLocalServer object is destroyed. It is still a good idea to delete the object explicitly when you are done with it, to avoid wasting memory.

And indeed it does waste memory. You can test it by doing, for example,

    for _ in `seq 0 1000`;do open_url_in_instance.sh ":nop";done

For me the %MEM column in top for the qutebrowser python process rose
about .2 each time I ran that loop (so like 16M?).

I don't think we have to worry about use after free in the C++ server
code since the docs say to do exactly this.

[0]: https://doc.qt.io/qt-5/qlocalserver.html#nextPendingConnection

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4635)
<!-- Reviewable:end -->
