### PR TITLE
Apply hint stylesheet on main application

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -71,6 +71,8 @@ class HintLabel(QLabel):
         self.elem = elem
 
         self.setAttribute(Qt.WA_StyledBackground, True)
+        # Zero out extra indent provided.
+        self.setIndent(0)
 
         self._context.tab.contents_size_changed.connect(self._move_to_elem)
         self._move_to_elem()

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -71,7 +71,6 @@ class HintLabel(QLabel):
         self.elem = elem
 
         self.setAttribute(Qt.WA_StyledBackground, True)
-        self.setObjectName("hint")
 
         self._context.tab.contents_size_changed.connect(self._move_to_elem)
         self._move_to_elem()

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -65,24 +65,13 @@ class HintLabel(QLabel):
         _context: The current hinting context.
     """
 
-    STYLESHEET = """
-        QLabel {
-            background-color: {{ conf.colors.hints.bg }};
-            color: {{ conf.colors.hints.fg }};
-            font: {{ conf.fonts.hints }};
-            border: {{ conf.hints.border }};
-            padding-left: -3px;
-            padding-right: -3px;
-        }
-    """
-
     def __init__(self, elem, context):
         super().__init__(parent=context.tab)
         self._context = context
         self.elem = elem
 
         self.setAttribute(Qt.WA_StyledBackground, True)
-        config.set_register_stylesheet(self)
+        self.setObjectName("hint")
 
         self._context.tab.contents_size_changed.connect(self._move_to_elem)
         self._move_to_elem()

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -152,7 +152,8 @@ class MainWindow(QWidget):
             color: {{ conf.colors.hints.fg }};
             font: {{ conf.fonts.hints }};
             border: {{ conf.hints.border }};
-            padding-left: -3px;
+            padding-left: 3px;
+            padding-right: 3px;
         }
     """
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -147,7 +147,7 @@ class MainWindow(QWidget):
 
     # Application wide stylesheets
     STYLESHEET = """
-        QLabel#hint {
+        HintLabel {
             background-color: {{ conf.colors.hints.bg }};
             color: {{ conf.colors.hints.fg }};
             font: {{ conf.fonts.hints }};

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -145,6 +145,17 @@ class MainWindow(QWidget):
         _private: Whether the window is in private browsing mode.
     """
 
+    # Application wide stylesheets
+    STYLESHEET = """
+        QLabel#hint {
+            background-color: {{ conf.colors.hints.bg }};
+            color: {{ conf.colors.hints.fg }};
+            font: {{ conf.fonts.hints }};
+            border: {{ conf.hints.border }};
+            padding-left: -3px;
+        }
+    """
+
     def __init__(self, *, private, geometry=None, parent=None):
         """Create a new main window.
 
@@ -240,6 +251,7 @@ class MainWindow(QWidget):
         self._set_decoration(config.val.window.hide_decoration)
 
         self.state_before_fullscreen = self.windowState()
+        config.set_register_stylesheet(self)
 
     def _init_geometry(self, geometry):
         """Initialize the window geometry or load it from disk."""


### PR DESCRIPTION
Before, we applied a custom stylesheet on every hint object, which was
slow. It's much faster to apply it globally and change the objectName
to tweak access.

Also see https://github.com/qutebrowser/qutebrowser/pull/4334.

For me, before:
```
------------------------------------- benchmark: 4 tests -------------------------------------
Name (time in ms)                        Min                 Max              Median          
----------------------------------------------------------------------------------------------
test_match_benchmark[webengine]       3.1533 (1.0)        3.2160 (1.0)        3.1791 (1.0)    
test_match_benchmark[webkit]          3.1607 (1.00)       3.5663 (1.11)       3.1819 (1.00)   
test_show_benchmark[webkit]         144.1625 (45.72)    167.2484 (52.00)    145.0850 (45.64)  
test_show_benchmark[webengine]      158.2411 (50.18)    187.8405 (58.41)    165.0677 (51.92)  
----------------------------------------------------------------------------------------------
```

After
```
------------------------------------ benchmark: 4 tests -----------------------------------
Name (time in ms)                       Min                Max             Median          
-------------------------------------------------------------------------------------------
test_match_benchmark[webengine]      3.1809 (1.0)       3.6953 (1.0)       3.2325 (1.0)    
test_match_benchmark[webkit]         3.2034 (1.01)      5.2814 (1.43)      3.2416 (1.00)   
test_show_benchmark[webkit]         48.9318 (15.38)    78.5892 (21.27)    51.2181 (15.84)  
test_show_benchmark[webengine]      60.6947 (19.08)    90.3746 (24.46)    66.5492 (20.59)  
-------------------------------------------------------------------------------------------
```

I'm not sure why the `padding-right` key is no longer needed. I don't think that the padding keys are 'correct' as well, but I've tried to keep the size as close to before as possible.

cc: @user202729, I *think* this will provide a bigger improvement than #4334, could you try to compare them? It's possible that both can be beneficial together though, as I'm still seeing a lot of time spent in initialize.

![2019-03-10-161522_516x537_scrot](https://user-images.githubusercontent.com/4349709/54092987-d8c86580-434f-11e9-871a-f9cdbeb346c4.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4637)
<!-- Reviewable:end -->
