### PR TITLE
Add nohl command

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1544,6 +1544,15 @@ class CommandDispatcher:
             tab.search.prev_result()
         tab.search.prev_result(result_cb=cb)
 
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def nohl(self):
+        """Remove highlighting displayed from previous search"""
+        tab = self._current_widget()
+        
+        if tab.search.search_displayed:
+            tab.search.clear()
+        return
+
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_cmd_split=True)
     def jseval(self, js_code: str, file: bool = False, quiet: bool = False, *,


### PR DESCRIPTION
After a search I expected to be able to clear highlighted search terms using `:nohl`. You can clear search terms by simply typing `:search`, but I think it's more vim-like/intuitive to use `:nohl`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4646)
<!-- Reviewable:end -->
