### PR TITLE
 Fix ":tab-focus last" after moving current tab

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -697,6 +697,9 @@ class TabbedBrowser(QWidget):
             log.webview.debug("on_current_changed got called with invalid "
                               "index {}".format(idx))
             return
+        if (self._now_focused is not None and
+                self._now_focused.tab_id is tab.tab_id):
+            return
 
         log.modes.debug("Current tab changed, focusing {!r}".format(tab))
         tab.setFocus()

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -292,6 +292,15 @@ Feature: Tab management
         When I run :tab-focus last
         Then the error "No last focused tab!" should be shown
 
+    Scenario: :tab-focus last after moving current tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-move 1
+        And I run :tab-focus last
+        Then the following tabs should be open:
+            - data/numbers/2.txt
+            - data/numbers/1.txt (active)
+
     # tab-prev/tab-next
 
     Scenario: :tab-prev


### PR DESCRIPTION
Currently `:tab-focus last` doesn't do anything after moving current tab.