### PR TITLE
Fix crash in :config-dict-add, :config-dict-remove, :config-list-add and :config-list-remove with invalid option

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -31,6 +31,7 @@ Changed
 
 Fixed
 ~~~~~
+- Crash when using `:config-{dict,list}-{add,remove}` with an invalid setting.
 
 v1.6.0
 ------

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -275,7 +275,8 @@ class ConfigCommands:
             value: The value to append to the end of the list.
             temp: Add value temporarily until qutebrowser is closed.
         """
-        opt = self._config.get_opt(option)
+        with self._handle_config_error():
+            opt = self._config.get_opt(option)
         valid_list_types = (configtypes.List, configtypes.ListOrValue)
         if not isinstance(opt.typ, valid_list_types):
             raise cmdutils.CommandError(":config-list-add can only be used "
@@ -300,7 +301,8 @@ class ConfigCommands:
             replace: Replace existing values. By default, existing values are
                      not overwritten.
         """
-        opt = self._config.get_opt(option)
+        with self._handle_config_error():
+            opt = self._config.get_opt(option)
         if not isinstance(opt.typ, configtypes.Dict):
             raise cmdutils.CommandError(":config-dict-add can only be used "
                                         "for dicts")
@@ -327,7 +329,8 @@ class ConfigCommands:
             value: The value to remove from the list.
             temp: Remove value temporarily until qutebrowser is closed.
         """
-        opt = self._config.get_opt(option)
+        with self._handle_config_error():
+            opt = self._config.get_opt(option)
         valid_list_types = (configtypes.List, configtypes.ListOrValue)
         if not isinstance(opt.typ, valid_list_types):
             raise cmdutils.CommandError(":config-list-remove can only be used "
@@ -355,7 +358,8 @@ class ConfigCommands:
             key: The key to remove from the dict.
             temp: Remove value temporarily until qutebrowser is closed.
         """
-        opt = self._config.get_opt(option)
+        with self._handle_config_error():
+            opt = self._config.get_opt(option)
         if not isinstance(opt.typ, configtypes.Dict):
             raise cmdutils.CommandError(":config-dict-remove can only be used "
                                         "for dicts")

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -299,6 +299,12 @@ class TestAdd:
         else:
             assert yaml_value(name)[-1] == value
 
+    def test_list_add_invalid_option(self, commands):
+        with pytest.raises(
+                cmdutils.CommandError,
+                match="No option 'nonexistent'"):
+            commands.config_list_add('nonexistent', 'value')
+
     def test_list_add_non_list(self, commands):
         with pytest.raises(
                 cmdutils.CommandError,
@@ -342,6 +348,12 @@ class TestAdd:
                           "overwrite!"):
                 commands.config_dict_add(name, key, value, replace=False)
 
+    def test_dict_add_invalid_option(self, commands):
+        with pytest.raises(
+                cmdutils.CommandError,
+                match="No option 'nonexistent'"):
+            commands.config_dict_add('nonexistent', 'key', 'value')
+
     def test_dict_add_non_dict(self, commands):
         with pytest.raises(
                 cmdutils.CommandError,
@@ -371,6 +383,12 @@ class TestRemove:
         else:
             assert value not in yaml_value(name)
 
+    def test_list_remove_invalid_option(self, commands):
+        with pytest.raises(
+                cmdutils.CommandError,
+                match="No option 'nonexistent'"):
+            commands.config_list_remove('nonexistent', 'value')
+
     def test_list_remove_non_list(self, commands):
         with pytest.raises(
                 cmdutils.CommandError,
@@ -395,6 +413,12 @@ class TestRemove:
             assert yaml_value(name) == configutils.UNSET
         else:
             assert key not in yaml_value(name)
+
+    def test_dict_remove_invalid_option(self, commands):
+        with pytest.raises(
+                cmdutils.CommandError,
+                match="No option 'nonexistent'"):
+            commands.config_dict_remove('nonexistent', 'key')
 
     def test_dict_remove_non_dict(self, commands):
         with pytest.raises(


### PR DESCRIPTION
```
$ qutebrowser --temp-basedir --debug ':config-dict-add alias test nop'
...
DEBUG    init       app:process_pos_args:287 Startup cmd ':config-dict-add alias test nop'
DEBUG    commands   command:run:535 command called: config-dict-add ['alias', 'test', 'nop']
DEBUG    commands   command:run:550 Calling qutebrowser.config.configcommands.ConfigCommands.config_dict_add(<qutebrowser.config.configcommands.ConfigCommands object at 0x7f0c4cc400b8>, 'alias', 'test', 'nop', False, False)
ERROR    misc       crashsignal:exception_hook:214 Uncaught exception
Traceback (most recent call last):
  File "/usr/bin/qutebrowser", line 11, in <module>
    load_entry_point('qutebrowser==1.6.0', 'gui_scripts', 'qutebrowser')()
  File "/usr/lib/python3.7/site-packages/qutebrowser/qutebrowser.py", line 194, in main
    return app.run(args)
  File "/usr/lib/python3.7/site-packages/qutebrowser/app.py", line 143, in run
    init(args, crash_handler)
  File "/usr/lib/python3.7/site-packages/qutebrowser/app.py", line 185, in init
    _process_args(args)
  File "/usr/lib/python3.7/site-packages/qutebrowser/app.py", line 225, in _process_args
    process_pos_args(args.command)
  File "/usr/lib/python3.7/site-packages/qutebrowser/app.py", line 289, in process_pos_args
    commandrunner.run_safely(cmd[1:])
  File "/usr/lib/python3.7/site-packages/qutebrowser/commands/runners.py", line 329, in run_safely
    self.run(text, count)
  File "/usr/lib/python3.7/site-packages/qutebrowser/commands/runners.py", line 308, in run
    result.cmd.run(self._win_id, args, count=count)
  File "/usr/lib/python3.7/site-packages/qutebrowser/commands/command.py", line 551, in run
    self.handler(*posargs, **kwargs)
  File "/usr/lib/python3.7/site-packages/qutebrowser/config/configcommands.py", line 303, in config_dict_add
    opt = self._config.get_opt(option)
  File "/usr/lib/python3.7/site-packages/qutebrowser/config/config.py", line 347, in get_opt
    raise exception from None
qutebrowser.config.configexc.NoOptionError: No option 'alias'

-> segmentation fault (core dumped)
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4650)
<!-- Reviewable:end -->
