### PR TITLE
Fix single process mode 5.12.2

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -217,6 +217,12 @@ def _process_args(args):
     session_manager = objreg.get('session-manager')
     if not session_manager.did_load:
         log.init.debug("Initializing main window...")
+        private = config.val.content.private_browsing
+        if '--single-process' in q_app.arguments() and private is True:
+            err = Exception("Private windows are unavailable with "
+                            "the single-process process model.")
+            error.handle_fatal_exc(err, args, 'Cannot start in private mode')
+            sys.exit(usertypes.Exit.err_init)
         window = mainwindow.MainWindow(private=None)
         if not args.nowindow:
             window.show()

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -217,8 +217,7 @@ def _process_args(args):
     session_manager = objreg.get('session-manager')
     if not session_manager.did_load:
         log.init.debug("Initializing main window...")
-        private = config.val.content.private_browsing
-        if '--single-process' in q_app.arguments() and private is True:
+        if config.val.content.private_browsing and qtutils.is_single_process():
             err = Exception("Private windows are unavailable with "
                             "the single-process process model.")
             error.handle_fatal_exc(err, args, 'Cannot start in private mode')

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -30,12 +30,12 @@ import operator
 from PyQt5.QtGui import QFont
 from PyQt5.QtWebEngineWidgets import (QWebEngineSettings, QWebEngineProfile,
                                       QWebEnginePage)
-from PyQt5.QtWidgets import QApplication
 
 from qutebrowser.browser.webengine import spell, webenginequtescheme
 from qutebrowser.config import config, websettings
 from qutebrowser.config.websettings import AttributeInfo as Attr
-from qutebrowser.utils import utils, standarddir, qtutils, message, log
+from qutebrowser.utils import (utils, standarddir, qtutils, message, log,
+                               qtutils)
 
 # The default QWebEngineProfile
 default_profile = None
@@ -300,8 +300,7 @@ def _init_profiles():
     default_profile.setter.init_profile()
     default_profile.setter.set_persistent_cookie_policy()
 
-    args = QApplication.instance().arguments()
-    if '--single-process' not in args:
+    if not qtutils.is_single_process():
         private_profile = QWebEngineProfile()
         private_profile.setter = ProfileSetter(private_profile)
         assert private_profile.isOffTheRecord()

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -30,6 +30,7 @@ import operator
 from PyQt5.QtGui import QFont
 from PyQt5.QtWebEngineWidgets import (QWebEngineSettings, QWebEngineProfile,
                                       QWebEnginePage)
+from PyQt5.QtWidgets import QApplication
 
 from qutebrowser.browser.webengine import spell, webenginequtescheme
 from qutebrowser.config import config, websettings
@@ -52,8 +53,9 @@ class _SettingsWrapper:
     """
 
     def __init__(self):
-        self._settings = [default_profile.settings(),
-                          private_profile.settings()]
+        self._settings = [default_profile.settings()]
+        if private_profile:
+            self._settings.append(private_profile.settings())
 
     def setAttribute(self, *args, **kwargs):
         for settings in self._settings:
@@ -265,10 +267,12 @@ def _update_settings(option):
     if option in ['content.headers.user_agent',
                   'content.headers.accept_language']:
         default_profile.setter.set_http_headers()
-        private_profile.setter.set_http_headers()
+        if private_profile:
+            private_profile.setter.set_http_headers()
     elif option == 'content.cache.size':
         default_profile.setter.set_http_cache_size()
-        private_profile.setter.set_http_cache_size()
+        if private_profile:
+            private_profile.setter.set_http_cache_size()
     elif (option == 'content.cookies.store' and
           # https://bugreports.qt.io/browse/QTBUG-58650
           qtutils.version_check('5.9', compiled=False)):
@@ -276,7 +280,8 @@ def _update_settings(option):
         # We're not touching the private profile's cookie policy.
     elif option == 'spellcheck.languages':
         default_profile.setter.set_dictionary_language()
-        private_profile.setter.set_dictionary_language(warn=False)
+        if private_profile:
+            private_profile.setter.set_dictionary_language(warn=False)
 
 
 def _init_profiles():
@@ -292,10 +297,12 @@ def _init_profiles():
     default_profile.setter.init_profile()
     default_profile.setter.set_persistent_cookie_policy()
 
-    private_profile = QWebEngineProfile()
-    private_profile.setter = ProfileSetter(private_profile)
-    assert private_profile.isOffTheRecord()
-    private_profile.setter.init_profile()
+    args = QApplication.instance().arguments()
+    if '--single-process' not in args:
+        private_profile = QWebEngineProfile()
+        private_profile.setter = ProfileSetter(private_profile)
+        assert private_profile.isOffTheRecord()
+        private_profile.setter.init_profile()
 
 
 def init(args):

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -44,6 +44,8 @@ private_profile = None
 # The global WebEngineSettings object
 global_settings = None
 
+default_user_agent = None
+
 
 class _SettingsWrapper:
 
@@ -286,9 +288,10 @@ def _update_settings(option):
 
 def _init_profiles():
     """Init the two used QWebEngineProfiles."""
-    global default_profile, private_profile
+    global default_profile, private_profile, default_user_agent
 
     default_profile = QWebEngineProfile.defaultProfile()
+    default_user_agent = default_profile.httpUserAgent()
     default_profile.setter = ProfileSetter(default_profile)
     default_profile.setCachePath(
         os.path.join(standarddir.cache(), 'webengine'))

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -57,28 +57,34 @@ def init():
     log.init.debug("Initializing qute://* handler...")
     _qute_scheme_handler = webenginequtescheme.QuteSchemeHandler(parent=app)
     _qute_scheme_handler.install(webenginesettings.default_profile)
-    _qute_scheme_handler.install(webenginesettings.private_profile)
+    if webenginesettings.private_profile:
+        _qute_scheme_handler.install(webenginesettings.private_profile)
 
     log.init.debug("Initializing request interceptor...")
     args = objreg.get('args')
     req_interceptor = interceptor.RequestInterceptor(args=args, parent=app)
     req_interceptor.install(webenginesettings.default_profile)
-    req_interceptor.install(webenginesettings.private_profile)
+    if webenginesettings.private_profile:
+        req_interceptor.install(webenginesettings.private_profile)
 
     log.init.debug("Initializing QtWebEngine downloads...")
     download_manager = webenginedownloads.DownloadManager(parent=app)
     download_manager.install(webenginesettings.default_profile)
-    download_manager.install(webenginesettings.private_profile)
+    if webenginesettings.private_profile:
+        download_manager.install(webenginesettings.private_profile)
     objreg.register('webengine-download-manager', download_manager)
 
     log.init.debug("Initializing cookie filter...")
     cookies.install_filter(webenginesettings.default_profile)
-    cookies.install_filter(webenginesettings.private_profile)
+    if webenginesettings.private_profile:
+        cookies.install_filter(webenginesettings.private_profile)
 
     # Clear visited links on web history clear
     hist = objreg.get('web-history')
     for p in [webenginesettings.default_profile,
               webenginesettings.private_profile]:
+        if not p:
+            continue
         hist.history_cleared.connect(p.clearAllVisitedLinks)
         hist.url_cleared.connect(lambda url, profile=p:
                                  profile.clearVisitedLinks([url]))

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -43,6 +43,7 @@ class WebEngineView(QWebEngineView):
 
         theme_color = self.style().standardPalette().color(QPalette.Base)
         if private:
+            assert webenginesettings.private_profile is not None
             profile = webenginesettings.private_profile
             assert profile.isOffTheRecord()
         else:

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -111,6 +111,8 @@ class TabbedBrowser(QWidget):
     new_tab = pyqtSignal(browsertab.AbstractTab, int)
 
     def __init__(self, *, win_id, private, parent=None):
+        if private:
+            assert not qtutils.is_single_process()
         super().__init__(parent)
         self.widget = tabwidget.TabWidget(win_id, parent=self)
         self._win_id = win_id

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -443,8 +443,7 @@ class SessionManager(QObject):
         if data is None:
             raise SessionError("Got empty session file")
 
-        args = QApplication.instance().arguments()
-        if '--single-process' in args:
+        if qtutils.is_single_process():
             if any(win.get('private') for win in data['windows']):
                 raise SessionError("Can't load a session with private windows "
                                    "in single process mode.")

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -404,6 +404,27 @@ class SessionManager(QObject):
         except ValueError as e:
             raise SessionError(e)
 
+    def _load_window(self, win):
+        """Turn yaml data into windows."""
+        window = mainwindow.MainWindow(geometry=win['geometry'],
+                                       private=win.get('private', None))
+        window.show()
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window=window.win_id)
+        tab_to_focus = None
+        for i, tab in enumerate(win['tabs']):
+            new_tab = tabbed_browser.tabopen(background=False)
+            self._load_tab(new_tab, tab)
+            if tab.get('active', False):
+                tab_to_focus = i
+            if new_tab.data.pinned:
+                tabbed_browser.widget.set_tab_pinned(new_tab,
+                                                     new_tab.data.pinned)
+        if tab_to_focus is not None:
+            tabbed_browser.widget.setCurrentIndex(tab_to_focus)
+        if win.get('active', False):
+            QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
+
     def load(self, name, temp=False):
         """Load a named session.
 
@@ -429,24 +450,7 @@ class SessionManager(QObject):
                                    "in single process mode.")
 
         for win in data['windows']:
-            window = mainwindow.MainWindow(geometry=win['geometry'],
-                                           private=win.get('private', None))
-            window.show()
-            tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                        window=window.win_id)
-            tab_to_focus = None
-            for i, tab in enumerate(win['tabs']):
-                new_tab = tabbed_browser.tabopen(background=False)
-                self._load_tab(new_tab, tab)
-                if tab.get('active', False):
-                    tab_to_focus = i
-                if new_tab.data.pinned:
-                    tabbed_browser.widget.set_tab_pinned(new_tab,
-                                                         new_tab.data.pinned)
-            if tab_to_focus is not None:
-                tabbed_browser.widget.setCurrentIndex(tab_to_focus)
-            if win.get('active', False):
-                QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
+            self._load_window(win)
 
         if data['windows']:
             self.did_load = True

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -422,6 +422,12 @@ class SessionManager(QObject):
         if data is None:
             raise SessionError("Got empty session file")
 
+        args = QApplication.instance().arguments()
+        if '--single-process' in args:
+            if any(win.get('private') for win in data['windows']):
+                raise SessionError("Can't load a session with private windows "
+                                   "in single process mode.")
+
         for win in data['windows']:
             window = mainwindow.MainWindow(geometry=win['geometry'],
                                            private=win.get('private', None))

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -37,10 +37,14 @@ import pkg_resources
 from PyQt5.QtCore import (qVersion, QEventLoop, QDataStream, QByteArray,
                           QIODevice, QSaveFile, QT_VERSION_STR,
                           PYQT_VERSION_STR, QFileDevice, QObject)
+from PyQt5.QtWidgets import QApplication
 try:
     from PyQt5.QtWebKit import qWebKitVersion
 except ImportError:  # pragma: no cover
     qWebKitVersion = None  # type: ignore  # noqa: N816
+
+from qutebrowser.misc import objects
+from qutebrowser.utils import usertypes
 
 
 MAXVALS = {
@@ -109,6 +113,13 @@ def is_new_qtwebkit() -> bool:
     assert qWebKitVersion is not None
     return (pkg_resources.parse_version(qWebKitVersion()) >
             pkg_resources.parse_version('538.1'))
+
+
+def is_single_process():
+    if objects.backend == usertypes.Backend.QtWebKit:
+        return False
+    args = QApplication.instance().arguments()
+    return '--single-process' in args
 
 
 def check_overflow(arg: int, ctype: str, fatal: bool = True) -> int:

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -44,15 +44,15 @@ try:
 except ImportError:  # pragma: no cover
     qWebKitVersion = None  # type: ignore  # noqa: N816
 
-try:
-    from PyQt5.QtWebEngineWidgets import QWebEngineProfile
-except ImportError:  # pragma: no cover
-    QWebEngineProfile = None  # type: ignore
-
 import qutebrowser
 from qutebrowser.utils import log, utils, standarddir, usertypes, message
 from qutebrowser.misc import objects, earlyinit, sql, httpclient, pastebin
 from qutebrowser.browser import pdfjs
+
+try:
+    from qutebrowser.browser.webengine import webenginesettings
+except ImportError:  # pragma: no cover
+    webenginesettings = None  # type: ignore
 
 
 @attr.s
@@ -344,11 +344,11 @@ def _chromium_version():
     Also see https://www.chromium.org/developers/calendar
     and https://chromereleases.googleblog.com/
     """
-    if QWebEngineProfile is None:
+    if webenginesettings is None:
         # This should never happen
         return 'unavailable'
-    profile = QWebEngineProfile()
-    ua = profile.httpUserAgent()
+    ua = webenginesettings.default_user_agent
+    assert ua is not None, ua
     match = re.search(r' Chrome/([^ ]*) ', ua)
     if not match:
         log.misc.error("Could not get Chromium version from: {}".format(ua))

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -44,6 +44,11 @@ try:
 except ImportError:  # pragma: no cover
     qWebKitVersion = None  # type: ignore  # noqa: N816
 
+try:
+    from PyQt5.QtWebEngineWidgets import QWebEngineProfile
+except ImportError:  # pragma: no cover
+    QWebEngineProfile = None  # type: ignore
+
 import qutebrowser
 from qutebrowser.utils import log, utils, standarddir, usertypes, message
 from qutebrowser.misc import objects, earlyinit, sql, httpclient, pastebin
@@ -344,11 +349,13 @@ def _chromium_version():
     Also see https://www.chromium.org/developers/calendar
     and https://chromereleases.googleblog.com/
     """
-    if webenginesettings is None:
+    if webenginesettings is None or QWebEngineProfile is None:
         # This should never happen
         return 'unavailable'
     ua = webenginesettings.default_user_agent
-    assert ua is not None, ua
+    if ua is None:
+        profile = QWebEngineProfile.defaultProfile()
+        ua = profile.httpUserAgent()
     match = re.search(r' Chrome/([^ ]*) ', ua)
     if not match:
         log.misc.error("Could not get Chromium version from: {}".format(ua))

--- a/tests/unit/browser/webengine/test_webenginesettings.py
+++ b/tests/unit/browser/webengine/test_webenginesettings.py
@@ -86,3 +86,7 @@ def test_spell_check_disabled(config_stub, monkeypatch):
     for profile in [webenginesettings.default_profile,
                     webenginesettings.private_profile]:
         assert not profile.isSpellCheckEnabled()
+
+
+def test_default_user_agent_saved():
+    assert webenginesettings.default_user_agent is not None

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -821,20 +821,21 @@ class FakeQSslSocket:
      'QtWebEngine/5.8.0 Chrome/53.0.2785.148 Safari/537.36', '53.0.2785.148'),
 ])
 def test_chromium_version(monkeypatch, caplog, ua, expected):
+    pytest.importorskip('PyQt5.QtWebEngineWidgets')
     if ua is None:
-        monkeypatch.setattr(version, 'QWebEngineProfile', None)
+        monkeypatch.setattr(version, 'webenginesettings', None)
     else:
-        class FakeWebEngineProfile:
-            def httpUserAgent(self):
-                return ua
-        monkeypatch.setattr(version, 'QWebEngineProfile', FakeWebEngineProfile)
+        monkeypatch.setattr(version.webenginesettings,
+                            'default_user_agent', ua)
 
     with caplog.at_level(logging.ERROR):
         assert version._chromium_version() == expected
 
 
-def test_chromium_version_unpatched(qapp):
+def test_chromium_version_unpatched(qapp, cache_tmpdir, data_tmpdir,
+                                    config_stub):
     pytest.importorskip('PyQt5.QtWebEngineWidgets')
+    webenginesettings._init_profiles()
     assert version._chromium_version() not in ['', 'unknown', 'unavailable']
 
 
@@ -861,9 +862,9 @@ class VersionParams:
 ], ids=lambda param: param.name)
 def test_version_output(params, stubs, monkeypatch):
     """Test version.version()."""
-    class FakeWebEngineProfile:
-        def httpUserAgent(self):
-            return 'Toaster/4.0.4 Chrome/CHROMIUMVERSION Teapot/4.1.8'
+    class FakeWebEngineSettings:
+        default_user_agent = \
+            'Toaster/4.0.4 Chrome/CHROMIUMVERSION Teapot/4.1.8'
 
     import_path = os.path.abspath('/IMPORTPATH')
     patches = {
@@ -902,13 +903,13 @@ def test_version_output(params, stubs, monkeypatch):
     if params.with_webkit:
         patches['qWebKitVersion'] = lambda: 'WEBKIT VERSION'
         patches['objects.backend'] = usertypes.Backend.QtWebKit
-        patches['QWebEngineProfile'] = None
+        patches['webenginesettings'] = None
         substitutions['backend'] = 'new QtWebKit (WebKit WEBKIT VERSION)'
     else:
         monkeypatch.delattr(version, 'qtutils.qWebKitVersion', raising=False)
         patches['objects.backend'] = usertypes.Backend.QtWebEngine
-        patches['QWebEngineProfile'] = FakeWebEngineProfile
         substitutions['backend'] = 'QtWebEngine (Chromium CHROMIUMVERSION)'
+        patches['webenginesettings'] = FakeWebEngineSettings
 
     if params.known_distribution:
         patches['distribution'] = lambda: version.DistributionInfo(


### PR DESCRIPTION
Qutebrowser no longer launches in single process mode on Qt5.12.2 ([relevant change](https://codereview.qt-project.org/#/c/248197/)) because we are constructing two `QWebEngineProfile`s. This PR has two main changes:

* don't create a private profile when in single process mode
* handle the private profile possibly being null

The second part is a little more widespread than it should have been because it turns out that the [previous attempt](https://github.com/qutebrowser/qutebrowser/commit/574d7c6a11030) at preventing private windows from being created in single process mode missed a couple of cases, starting fresh with the `content.private_browsing` setting set and loading a session with private windows.

This change will also stop `qutebrowser -T -s qt.args "['single-process']" -s content.private_browsing true` from working on older QT versions where it would technically work. The only way we could support that going forward is by changing the default profile to be off the record.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4653)
<!-- Reviewable:end -->
