### PR TITLE
Add support for redirection to interceptor api

### DIFF
--- a/qutebrowser/browser/webengine/interceptor.py
+++ b/qutebrowser/browser/webengine/interceptor.py
@@ -87,9 +87,8 @@ class RequestInterceptor(QWebEngineUrlRequestInterceptor):
         """Install the interceptor on the given QWebEngineProfile."""
         profile.setRequestInterceptor(self)
 
-    # pylint: disable=bad-builtin
-    WHITELIST_REQUEST_METHODS = frozenset(map(QByteArray, [b'GET', b'HEAD']))
-    # pylint: enable=bad-builtin
+    WHITELIST_REQUEST_METHODS = {QByteArray(b'GET'), QByteArray(b'HEAD')}
+
     @staticmethod
     def _handle_redirect(info: QWebEngineUrlRequestInfo, url: QUrl) -> bool:
         """Handle redirection on qtwebengine."""

--- a/qutebrowser/extensions/interceptors.py
+++ b/qutebrowser/extensions/interceptors.py
@@ -94,7 +94,10 @@ class Request:
         """
         if self._redirect_method is None:
             return False
-        return self._redirect_method(url)
+        retval = self._redirect_method(url)
+        # Once firing a redirect, refuse any other attempt
+        self._redirect_method = None
+        return retval
 
 
 #: Type annotation for an interceptor function.

--- a/qutebrowser/extensions/interceptors.py
+++ b/qutebrowser/extensions/interceptors.py
@@ -94,7 +94,9 @@ class Request:
         """
         if self._redirect_method is None:
             return False
+        # pylint: disable=not-callable
         retval = self._redirect_method(url)
+        # pylint: enable=not-callable
         # Once firing a redirect, refuse any other attempt
         self._redirect_method = None
         return retval


### PR DESCRIPTION
Not sure if we should/can add tests for this, but a quick manual test with a sample plugin seems to work as expected:

```
from qutebrowser.api import interceptor
from PyQt5.QtCore import QUrl
def f(info: interceptor.Request):
    """Block the given request if necessary."""
    url = info.request_url
    if (url.host() != 'jgkamat.gitlab.io'):
        info.redirect(QUrl("https://jgkamat.gitlab.io"))
interceptor.register(f)
```

Nothing too complicated here overall, pretty simple.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4667)
<!-- Reviewable:end -->
