### PR TITLE
Clear last_used_directory when download.location.directory changes

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -441,6 +441,9 @@ def _init_modules(args, crash_handler):
     log.init.debug("Initializing proxy...")
     proxy.init()
 
+    log.init.debug("Initializing downloads...")
+    downloads.init()
+
     log.init.debug("Initializing readline-bridge...")
     readline_bridge = readline.ReadlineBridge()
     objreg.register('readline-bridge', readline_bridge)

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -46,6 +46,9 @@ class ModelRole(enum.IntEnum):
 
     item = Qt.UserRole
 
+# Remember the last used directory
+last_used_directory = None
+
 # All REFRESH_INTERVAL milliseconds, speeds will be recalculated and downloads
 # redrawn.
 _REFRESH_INTERVAL = 500

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -46,6 +46,7 @@ class ModelRole(enum.IntEnum):
 
     item = Qt.UserRole
 
+
 # Remember the last used directory
 last_used_directory = None
 
@@ -67,16 +68,20 @@ class UnsupportedOperationError(Exception):
 
     """Raised when an operation is not supported with the given backend."""
 
+
 def init():
+    """Set the application wide downloads variables."""
     global last_used_directory
     last_used_directory = None
 
     config.instance.changed.connect(_clear_last_used)
 
+
 @config.change_filter('downloads.location.directory', function=True)
 def _clear_last_used():
     global last_used_directory
     last_used_directory = None
+
 
 def download_dir():
     """Get the download directory to use."""

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -46,11 +46,6 @@ class ModelRole(enum.IntEnum):
 
     item = Qt.UserRole
 
-
-# Remember the last used directory
-last_used_directory = None
-
-
 # All REFRESH_INTERVAL milliseconds, speeds will be recalculated and downloads
 # redrawn.
 _REFRESH_INTERVAL = 500
@@ -69,6 +64,16 @@ class UnsupportedOperationError(Exception):
 
     """Raised when an operation is not supported with the given backend."""
 
+def init():
+    global last_used_directory
+    last_used_directory = None
+
+    config.instance.changed.connect(_clear_last_used)
+
+@config.change_filter('downloads.location.directory', function=True)
+def _clear_last_used():
+    global last_used_directory
+    last_used_directory = None
 
 def download_dir():
     """Get the download directory to use."""

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -529,9 +529,9 @@ Feature: Downloading things from a website.
         And I open data/downloads/download.bin without waiting
         And I wait for the download prompt for "*/download.bin"
         And I run :prompt-accept (tmpdir)(dirsep)downloads(dirsep)subdir
-        And I set downloads.location.directory to (tmpdir)
+        And I run :set downloads.location.directory (tmpdir)(dirsep)downloads
         And I open data/downloads/download2.bin without waiting
-        Then the download prompt should be shown with "(tmpdir)/download2.bin"
+        Then the download prompt should be shown with "(tmpdir)/downloads/download2.bin"
 
     Scenario: Not remembering the last download directory
         When I set downloads.location.prompt to true

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -522,6 +522,17 @@ Feature: Downloading things from a website.
         And I open data/downloads/download2.bin without waiting
         Then the download prompt should be shown with "(tmpdir)/downloads/subdir/download2.bin"
 
+    Scenario: Clearing the last download directory when changing download location
+        When I set downloads.location.prompt to true
+        And I set downloads.location.suggestion to both
+        And I set downloads.location.remember to true
+        And I open data/downloads/download.bin without waiting
+        And I wait for the download prompt for "*/download.bin"
+        And I run :prompt-accept (tmpdir)(dirsep)downloads(dirsep)subdir
+        And I set downloads.location.directory to (tmpdir)
+        And I open data/downloads/download2.bin without waiting
+        Then the download prompt should be shown with "(tmpdir)/download2.bin"
+
     Scenario: Not remembering the last download directory
         When I set downloads.location.prompt to true
         And I set downloads.location.suggestion to both


### PR DESCRIPTION
If there is a change in the configuration download location, this new location is used instead of the last used directory. Fixes issue #4674

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4675)
<!-- Reviewable:end -->
