### PR TITLE
Use OR instead of concatenation for queries

### DIFF
--- a/qutebrowser/completion/models/histcategory.py
+++ b/qutebrowser/completion/models/histcategory.py
@@ -74,11 +74,11 @@ class HistoryCategory(QSqlQueryModel):
 
         # build a where clause to match all of the words in any order
         # given the search term "a b", the WHERE clause would be:
-        # ((url || ' ' || title) LIKE '%a%') AND
-        # ((url || ' ' || title) LIKE '%b%')
+        # (url LIKE '%a%' OR title LIKE '%a%') AND
+        # (url LIKE '%b%' OR title LIKE '%b%')
         where_clause = ' AND '.join(
-            "(url || ' ' || title) LIKE :{} escape '\\'".format(i)
-            for i in range(len(words)))
+            "(url LIKE :{val} escape '\\' OR title LIKE :{val} escape '\\')"
+            .format(val=i) for i in range(len(words)))
 
         # replace ' in timestamp-format to avoid breaking the query
         timestamp_format = config.val.completion.timestamp_format or ''


### PR DESCRIPTION
Testing with: `python3 -m qutebrowser --basedir /tmp/qbtest --debug --logfilter sql` and pasting `i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i i qutebrowser.org` with my history.sqlite.

Master:
```
21:44:34 DEBUG    sql        debug:__exit__:265 Running completion query took 0.035386 seconds.
```
(the queries are especially slow while deleting/retyping the `.org` part of the query

Patch:
```
21:46:13 DEBUG    sql        debug:__exit__:265 Running completion query took 0.013893 seconds.
```
(at least for me, deleting and re-typing the 'org' part of the URL becomes bearable)

and, moving the `qutebrower.org` to the front (which is what my next patch will probably be):
Master: `0.016221 seconds`
Patch: `0.004146 seconds`

My best guess for the difference in the first is we're avoiding the overhead for concatenation, and for the second: `((url || ' ' || title) blah) AND ((url || ' ' || title) blah)` might be doing everything twice (as the match string is dynamically generated(?)) whereas it can filter each statement one at a time in the new query.

Maybe this will help slightly for #1099, but I doubt it. See https://github.com/qutebrowser/qutebrowser/issues/3989

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4683)
<!-- Reviewable:end -->
