### PR TITLE
Fix some 5.13 test failures

### DIFF
--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -141,18 +141,26 @@ Feature: Downloading things from a website.
         And I wait until the download is finished
         Then the downloaded file download with spaces.bin should exist
 
-    @qtwebkit_skip @qt<5.9
-    Scenario: Downloading a file with evil content-disposition header (Qt 5.8 or older)
+    @qtwebkit_skip @qt<5.9 @qt>=5.13
+    Scenario: Downloading a file with evil content-disposition header (Qt 5.8 or older and 5.13 and newer)
         # Content-Disposition: download; filename=..%2Ffoo
         When I open response-headers?Content-Disposition=download;%20filename%3D..%252Ffoo without waiting
         And I wait until the download is finished
         Then the downloaded file ../foo should not exist
         And the downloaded file foo should exist
 
-    @qtwebkit_skip @qt>=5.9
-    Scenario: Downloading a file with evil content-disposition header (Qt 5.9 or newer)
+    @qtwebkit_skip @qt<5.13 @qt>=5.9
+    Scenario: Downloading a file with evil content-disposition header (Qt 5.9 to 5.12)
         # Content-Disposition: download; filename=..%2Ffoo
         When I open response-headers?Content-Disposition=download;%20filename%3D..%252Ffoo without waiting
+        And I wait until the download is finished
+        Then the downloaded file ../foo should not exist
+        And the downloaded file ..%2Ffoo should exist
+
+    @qtwebkit_skip @qt>=5.13
+    Scenario: Downloading a file with evil content-disposition header (Qt 5.13 or newer)
+        # Content-Disposition: download; filename=..%252Ffoo
+        When I open response-headers?Content-Disposition=download;%20filename%3D..%25252Ffoo without waiting
         And I wait until the download is finished
         Then the downloaded file ../foo should not exist
         And the downloaded file ..%2Ffoo should exist

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -57,7 +57,7 @@ Feature: Page history
         When I run :tab-only
         And I open data/javascript/window_open.html
         And I run :click-element id open-invalid
-        Then "Changing title for idx 1 to 'about:blank'" should be logged
+        Then "load status for * LoadStatus.success" should be logged
 
     Scenario: History with data URL
         When I open data/data_link.html

--- a/tests/unit/browser/test_caret.py
+++ b/tests/unit/browser/test_caret.py
@@ -24,7 +24,7 @@ import textwrap
 import pytest
 from PyQt5.QtCore import QUrl
 
-from qutebrowser.utils import usertypes, qtutils
+from qutebrowser.utils import usertypes
 
 
 @pytest.fixture
@@ -335,12 +335,10 @@ class TestFollowSelected:
     def expose(self, web_tab):
         """Expose the web view if needed.
 
-        On QtWebKit, or Qt < 5.11 on QtWebEngine, we need to show the tab for
-        selections to work properly.
+        On QtWebKit, or Qt < 5.11 and > 5.12 on QtWebEngine, we need to
+        show the tab for selections to work properly.
         """
-        if (web_tab.backend == usertypes.Backend.QtWebKit or
-                not qtutils.version_check('5.11', compiled=False)):
-            web_tab.container.expose()
+        web_tab.container.expose()
 
     def test_follow_selected_without_a_selection(self, qtbot, caret, selection, web_tab,
                                                  mode_manager):


### PR DESCRIPTION
Fixes a couple of test failures in https://github.com/qutebrowser/qutebrowser/issues/4592
These fixes are independant and can be merged separately.

### Failing test: Downloading a file with evil content-disposition header (Qt 5.9 or newer)

It seems more stuff is being URL decoded in the content disposition header now. We still don't save downloads to ../whatever though so only changes to tests required.

### test_history_with_invalid_url failure

There have been more changes to the signals that are fired on page load. In this case pages with invalid URLs don't get urlChanged signals. I'm pretty sure the test in question was only using the title as a proxy for watching for a page load anyway. The tests around actually checking the URL doesn't end up in history are still passing.

### Test failures with :follow-selected after search

This one isn't failing for me. (Although on appveyor it says at one point it is looking for `http://localhost:1058/data/hello\\.txt/?` in the logs, should the query be there?)

### Test failures with scrolling

I know the problem with this one, I don't know the fix. We should definitely report it upstream but I don't know if we can work around it.

We register for a scroll event with `page.scrollPositionChanged.connect()` It still gets to WebEngineScroller but gets filtered out because `contents_size.width()` and `self._widget.width()` appear to always be the same now (same for the `.height()` methods). I don't know how we can get the page dimensions anymore. I couldn't see anything on the page and on the view there are `view.childrenRegion().boundingRect()` and `view.childrenRect()` and `view.contentsRect()` but they all have the viewport size even on 5.11.
I'm not seeing any relevant changes recently in `src/core/render_widget_host_view_qt.cpp:RenderWidgetHostViewQt::SubmitCompositorFrame()` which looks to be where the content_size is updated.

So it looks like at the moment we can't figure out the scroll percentage in python. `:scroll-to-perc` still seems to work so switching back to the JS method (https://github.com/qutebrowser/qutebrowser/issues/2822) which had issues might be a possibility.

I opened an issue upstream for it https://bugreports.qt.io/browse/QTBUG-74847

### No load_finished when loading :follow-selected testdata

`window.getSelection()` doesn't return anything when the view isn't exposed, exposing in all configurations the same as was done to fix the hint tests fixed it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4689)
<!-- Reviewable:end -->
