### PR TITLE
Fixes "Pressing shift resets hint keystring"

### DIFF
--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -71,8 +71,7 @@ def is_special(key, modifiers):
     _assert_plain_key(key)
     _assert_plain_modifier(modifiers)
     return not (_is_printable(key) and
-                modifiers in [Qt.ShiftModifier, Qt.NoModifier,
-                              Qt.KeypadModifier])
+                modifiers in [Qt.ShiftModifier, Qt.NoModifier])
 
 
 def is_modifier_key(key):
@@ -350,8 +349,7 @@ class KeyInfo:
                 key_string = key_string.lower()
 
         # "special" binding
-        assert (is_special(self.key, self.modifiers) or
-                self.modifiers == Qt.KeypadModifier)
+        assert is_special(self.key, self.modifiers)
         modifier_string = _modifiers_to_string(modifiers)
         return '<{}{}>'.format(modifier_string, key_string)
 

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -53,6 +53,19 @@ def _is_printable(key):
     return key <= 0xff and key not in [Qt.Key_Space, 0x0]
 
 
+def is_special_hint_mode(key, modifiers):
+    """Check whether this key should clear the keychain in hint mode.
+
+    When we press "s<Escape>", we don't want <Escape> to be handled as part of
+    a key chain in hint mode.
+    """
+    _assert_plain_key(key)
+    _assert_plain_modifier(modifiers)
+    return not (_is_printable(key) and
+                modifiers in [Qt.ShiftModifier, Qt.NoModifier,
+                              Qt.KeypadModifier])
+
+
 def is_special(key, modifiers):
     """Check whether this key requires special key syntax."""
     _assert_plain_key(key)

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -61,6 +61,8 @@ def is_special_hint_mode(key, modifiers):
     """
     _assert_plain_key(key)
     _assert_plain_modifier(modifiers)
+    if is_modifier_key(key):
+        return False
     return not (_is_printable(key) and
                 modifiers in [Qt.ShiftModifier, Qt.NoModifier,
                               Qt.KeypadModifier])

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -246,7 +246,7 @@ class HintKeyParser(CommandKeyParser):
         if dry_run:
             return super().handle(e, dry_run=True)
 
-        if keyutils.is_special(e.key(), e.modifiers()):
+        if keyutils.is_special_hint_mode(e.key(), e.modifiers()):
             log.keyboard.debug("Got special key, clearing keychain")
             self.clear_keystring()
 

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -544,6 +544,11 @@ def test_is_special_hint_mode(key, modifiers, special):
     (Qt.Key_X, Qt.NoModifier, False),
     (Qt.Key_2, Qt.KeypadModifier, True),
     (Qt.Key_2, Qt.NoModifier, False),
+    (Qt.Key_Shift, Qt.ShiftModifier, True),
+    (Qt.Key_Control, Qt.ControlModifier, True),
+    (Qt.Key_Alt, Qt.AltModifier, True),
+    (Qt.Key_Meta, Qt.MetaModifier, True),
+    (Qt.Key_Mode_switch, Qt.GroupSwitchModifier, True),
 ])
 def test_is_special(key, modifiers, special):
     assert keyutils.is_special(key, modifiers) == special

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -520,6 +520,28 @@ def test_is_printable(key, printable):
     (Qt.Key_Escape, Qt.ControlModifier, True),
     (Qt.Key_X, Qt.ControlModifier, True),
     (Qt.Key_X, Qt.NoModifier, False),
+    (Qt.Key_2, Qt.NoModifier, False),
+
+    # Keypad should not reset hint keychain - see #3735
+    (Qt.Key_2, Qt.KeypadModifier, False),
+
+    # Modifiers should not reset hint keychain - see #4264
+    (Qt.Key_Shift, Qt.ShiftModifier, False),
+    (Qt.Key_Control, Qt.ControlModifier, False),
+    (Qt.Key_Alt, Qt.AltModifier, False),
+    (Qt.Key_Meta, Qt.MetaModifier, False),
+    (Qt.Key_Mode_switch, Qt.GroupSwitchModifier, False),
+])
+def test_is_special_hint_mode(key, modifiers, special):
+    assert keyutils.is_special_hint_mode(key, modifiers) == special
+
+
+@pytest.mark.parametrize('key, modifiers, special', [
+    (Qt.Key_Escape, Qt.NoModifier, True),
+    (Qt.Key_Escape, Qt.ShiftModifier, True),
+    (Qt.Key_Escape, Qt.ControlModifier, True),
+    (Qt.Key_X, Qt.ControlModifier, True),
+    (Qt.Key_X, Qt.NoModifier, False),
     (Qt.Key_2, Qt.KeypadModifier, True),
     (Qt.Key_2, Qt.NoModifier, False),
 ])

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -520,7 +520,7 @@ def test_is_printable(key, printable):
     (Qt.Key_Escape, Qt.ControlModifier, True),
     (Qt.Key_X, Qt.ControlModifier, True),
     (Qt.Key_X, Qt.NoModifier, False),
-    (Qt.Key_2, Qt.KeypadModifier, False),
+    (Qt.Key_2, Qt.KeypadModifier, True),
     (Qt.Key_2, Qt.NoModifier, False),
 ])
 def test_is_special(key, modifiers, special):


### PR DESCRIPTION
The 2 first commits just move codes around, they don't change the behavior. The 3rd commit fixes #4264.

Related: #4504 .

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4691)
<!-- Reviewable:end -->
