### PR TITLE
Disable bad-builtin pylint rule

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -39,7 +39,8 @@ disable=locally-disabled,
         too-many-locals,
         too-many-branches,
         too-many-statements,
-        too-few-public-methods
+        too-few-public-methods,
+        bad-builtin
 
 [BASIC]
 function-rgx=[a-z_][a-z0-9_]{2,50}$


### PR DESCRIPTION
I don't really think that list comprehensions are any clearer than `map` or a simple for loop (I would say list comprehensions are much more confusing than all the alternatives). The worst example is:
`[str(x) for x in [1,2,3]]`
"run 'str' on a temp variable for elements in [1,2,3]"
`map(str, [1,2,3])`
"map 'str' over [1,2,3]"

I couldn't find a way to disable this only for map, but I think filter is clearer than list comprehensions as well:
`[x for x in [True, False, True] if x]`
"collect a temp variable for elements in [t,f,t] if it's truthy"
`filter(None, [True, False, True])`
"Filter keeping truthy elements in [t,f,t]"

While more general examples are more disputable, I would still say this holds for most other cases:
`[x.atime for x in web_history_items]`
"get the atime attr on a temp variable for elements in web_history_items"
`map(operator.attrgetter('atime'), web_history_items)`
"get the atime attr on elements in web_history_items"

while it is a shame python has no threading operators builtin and crippled lambdas, it's not a reason to ban the more readable versions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4696)
<!-- Reviewable:end -->
