### PR TITLE
Ignore duplicate consecutive history entries from the same url

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -149,7 +149,7 @@ class WebHistory(sql.SqlTable):
                          parent=parent)
         self._progress = progress
         # Store the last saved url to avoid duplicate immedate saves.
-        self.last_url = None
+        self._last_url = None
 
         self.completion = CompletionHistory(parent=self)
         self.metainfo = CompletionMetaInfo(parent=self)
@@ -278,7 +278,7 @@ class WebHistory(sql.SqlTable):
             self.delete_all()
             self.completion.delete_all()
         self.history_cleared.emit()
-        self.last_url = None
+        self._last_url = None
 
     def delete_url(self, url):
         """Remove all history entries with the given url.
@@ -290,8 +290,8 @@ class WebHistory(sql.SqlTable):
         qtutils.ensure_valid(qurl)
         self.delete('url', self._format_url(qurl))
         self.completion.delete('url', self._format_completion_url(qurl))
-        if self.last_url == url:
-            self.last_url = None
+        if self._last_url == url:
+            self._last_url = None
         self.url_cleared.emit(qurl)
 
     @pyqtSlot(QUrl, QUrl, str)
@@ -311,9 +311,9 @@ class WebHistory(sql.SqlTable):
             # If the url of the page is different than the url of the link
             # originally clicked, save them both.
             self.add_url(requested_url, title, redirect=True)
-        if url != self.last_url:
+        if url != self._last_url:
             self.add_url(url, title)
-            self.last_url = url
+            self._last_url = url
 
     def add_url(self, url, title="", *, redirect=False, atime=None):
         """Called via add_from_tab when a URL should be added to the history.

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -234,17 +234,17 @@ class TestAdd:
         url2 = QUrl("http://example2.com")
         web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
         hist = list(web_history)
-        assert list(web_history)
+        assert hist
         web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
         assert list(web_history) == hist
         web_history.add_from_tab(QUrl(url2), QUrl(url2), 'title')
-        assert len(list(web_history)) != hist
+        assert list(web_history) != hist
 
     def test_delete_add_tab(self, web_history, mock_time):
         url = QUrl("http://example.com")
         web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
         hist = list(web_history)
-        assert list(web_history)
+        assert hist
         web_history.delete_url(QUrl(url))
         assert len(web_history) == 0
         web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
@@ -254,7 +254,7 @@ class TestAdd:
         url = QUrl("http://example.com")
         web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
         hist = list(web_history)
-        assert list(web_history)
+        assert hist
         web_history.clear(force=True)
         assert len(web_history) == 0
         web_history.add_from_tab(QUrl(url), QUrl(url), 'title')

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -117,6 +117,9 @@ class TestDelete:
         web_history.clear(force=True)
         assert not len(web_history)
         assert not len(web_history.completion)
+        web_history.add_url(QUrl('http://www.qutebrowser.org/'))
+        assert len(web_history)
+        assert len(web_history.completion)
 
     @pytest.mark.parametrize('raw, escaped', [
         ('http://example.com/1', 'http://example.com/1'),
@@ -138,6 +141,11 @@ class TestDelete:
         completion_diff = completion_before.difference(
             set(web_history.completion))
         assert completion_diff == {(raw, '', 0)}
+
+        # ensure we can add the url back
+        web_history.add_url(QUrl(raw), atime=0)
+        assert before == set(web_history)
+        assert completion_before == set(web_history.completion)
 
 
 class TestAdd:
@@ -228,6 +236,18 @@ class TestAdd:
         web_history.add_from_tab(url, url, 'title')
         assert list(web_history)
         assert not list(web_history.completion)
+
+    def test_no_immedate_duplicates(self, web_history, caplog, mock_time, mocker):
+        m = mocker.patch('qutebrowser.browser.history.WebHistory.add_url')
+        url = QUrl("http://example.com")
+        url2 = QUrl("http://example2.com")
+        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
+        m.assert_called_once()
+        m.reset_mock()
+        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
+        m.assert_not_called()
+        web_history.add_from_tab(QUrl(url2), QUrl(url2), 'title')
+        m.assert_called_once()
 
 
 class TestHistoryInterface:


### PR DESCRIPTION
I'm finding that on newer versions of qt, I'm getting many duplicate entries in my history list, which is causing my history file to balloon. On a computer that I started using about ~9 months ago, my history file is ~250mb. This is due to a combination of:

1. https://github.com/qutebrowser/qutebrowser/issues/3596
2. We save history blindly every time.

This PR is a naiive solution (to be more similar to chrome's history list) which only saves into history if the last URL wasn't the exact same. At the very least, this avoids double saves on every url (which I'm getting at the moment). The main difference is that chrome updates the access time to be the newer access, while this dosen't. I think there's more value in the older time personally, and I'd rather keep things simple, so I'm trying to avoid implementing that.

Unfortunately, anchor changes will still get through (which is the main cause of my problem), but fixing that's a more intrusive change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4699)
<!-- Reviewable:end -->
