### PR TITLE
Optimize getting mutable config values by using ListView and DictView

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -381,7 +381,7 @@ class Config(QObject):
         """
         self.get_opt(name)  # To make sure it exists
         value = self._values[name].get_for_url(url, fallback=fallback)
-        return self._maybe_copy(value)
+        return utils.immutable_view(value)
 
     def get_obj_for_pattern(
             self, name: str, *,
@@ -394,7 +394,7 @@ class Config(QObject):
         """
         self.get_opt(name)  # To make sure it exists
         value = self._values[name].get_for_pattern(pattern, fallback=False)
-        return self._maybe_copy(value)
+        return utils.immutable_view(value)
 
     def get_mutable_obj(self, name: str, *,
                         pattern: urlmatch.UrlPattern = None) -> Any:

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -177,8 +177,10 @@ class BaseType:
                 raise configexc.ValidationError(value, "may not be null!")
             return
 
-        if (not isinstance(value, pytype) or
-                pytype is int and isinstance(value, bool)):
+        if ((isinstance(value, bool) and pytype is int) or
+                not (isinstance(value, pytype) or
+                     (isinstance(value, utils.ListView) and pytype is list) or
+                     (isinstance(value, utils.DictView) and pytype is dict))):
             if isinstance(pytype, tuple):
                 expected = ' or '.join(typ.__name__ for typ in pytype)
             else:

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -36,7 +36,6 @@ import shlex
 import glob
 import mimetypes
 from collections import abc
-import attr
 
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QColor, QClipboard, QDesktopServices
@@ -755,12 +754,14 @@ def immutable_view(x):
         return x
 
 
-@attr.s
 class ListView(abc.Sequence):
 
     """Immutable view for a list."""
 
-    data = attr.ib(type=list)
+    __slots__ = ['data']
+
+    def __init__(self, data: list):
+        self.data = data
 
     def __getitem__(self, index):
         return immutable_view(self.data[index])
@@ -768,13 +769,18 @@ class ListView(abc.Sequence):
     def __len__(self):
         return len(self.data)
 
+    def __eq__(self, other):
+        return self.data == other
 
-@attr.s
+
 class DictView(abc.Mapping):
 
     """Immutable view for a dict."""
 
-    data = attr.ib(type=dict)
+    __slots__ = ['data']
+
+    def __init__(self, data: dict):
+        self.data = data
 
     def __getitem__(self, key):
         return immutable_view(self.data[key])

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -35,6 +35,8 @@ import socket
 import shlex
 import glob
 import mimetypes
+from collections import abc
+import attr
 
 from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QColor, QClipboard, QDesktopServices
@@ -740,3 +742,45 @@ def ceil_log(number, base):
         result += 1
         accum *= base
     return result
+
+
+def immutable_view(x):
+    """Create an immutable view of the object x."""
+    if isinstance(x, list):
+        return ListView(x)
+    elif isinstance(x, dict):
+        return DictView(x)
+    else:
+        assert x.__hash__ is not None, x
+        return x
+
+
+@attr.s
+class ListView(abc.Sequence):
+
+    """Immutable view for a list."""
+
+    data = attr.ib(type=list)
+
+    def __getitem__(self, index):
+        return immutable_view(self.data[index])
+
+    def __len__(self):
+        return len(self.data)
+
+
+@attr.s
+class DictView(abc.Mapping):
+
+    """Immutable view for a dict."""
+
+    data = attr.ib(type=dict)
+
+    def __getitem__(self, key):
+        return immutable_view(self.data[key])
+
+    def __iter__(self):
+        return iter(self.data)
+
+    def __len__(self):
+        return len(self.data)


### PR DESCRIPTION
Related: #4344 

Some notes regarding the change:

* While the view objects don't copy the underlying objects, if the whole object is accessed the overhead is higher (for example, in the config_write_py function it's actually faster to use the current approach, although if there's a way to make the view object optimize to be just a reference it would be even faster. (By the way the "dict" around the "get_mutable_obj" is unnecessary))
* The viewer objects should not be a sub class of list/dict because they're not usable as a list/dict (they do not support modification), however "to_py" must accept them (they're the expected return value of get functions, and it's fine to pass them to set functions because they do an (usually unnecessary) deep copy anyway)
* Set functions remain as inefficient (with two deep copies), and so the speed of loading config.py is not better.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4702)
<!-- Reviewable:end -->
