### PR TITLE
Use a domain mapping to reduce complexity of per-domain lookups

### DIFF
--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -210,9 +210,15 @@ class Values:
         self._check_pattern_support(url)
         candidates = []  # type: typing.List[ScopedValue]
         if url is not None:
-            widened_hosts = itertools.chain(
-                urlutils.widened_hostnames(url.host()),
-                (None,))
+            widened_hosts = (
+                None,)  # type: typing.Iterable[typing.Optional[str]]
+            domains_len = len(self._domain_map)
+            if None in self._domain_map:
+                domains_len -= 1
+            if domains_len > 0:
+                widened_hosts = itertools.chain(
+                    urlutils.widened_hostnames(url.host()),
+                    widened_hosts)
             for host in widened_hosts:
                 host_set = self._domain_map.get(host, ())
                 for scoped in host_set:

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -51,7 +51,7 @@ class Unset:
 UNSET = Unset()
 
 
-@attr.s(frozen=True, cmp=False)
+@attr.s(frozen=True, cmp=False, hash=False)
 class ScopedValue:
 
     """A configuration value which is valid for a UrlPattern.

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -187,7 +187,7 @@ class Values:
 
     def _get_fallback(self, fallback: typing.Any) -> typing.Any:
         """Get the fallback global/default value."""
-        for scoped in self._domain_map[None]:
+        for scoped in self._domain_map.get(None, ()):
             # We must loop over all patterns here, as a rule with no domain at
             # all will fall in the 'None' bucket.
             if scoped.pattern is None:

--- a/qutebrowser/utils/urlmatch.py
+++ b/qutebrowser/utils/urlmatch.py
@@ -28,6 +28,7 @@ https://cs.chromium.org/chromium/src/extensions/common/url_pattern.h
 import ipaddress
 import fnmatch
 import urllib.parse
+import typing
 
 from PyQt5.QtCore import QUrl
 
@@ -68,9 +69,9 @@ class UrlPattern:
         # Make sure all attributes are initialized if we exit early.
         self._pattern = pattern
         self._match_all = False
-        self._match_subdomains = False
+        self._match_subdomains = False  # type: bool
         self._scheme = None
-        self._host = None
+        self._host = None  # type: typing.Optional[str]
         self._path = None
         self._port = None
 
@@ -304,3 +305,10 @@ class UrlPattern:
             return False
 
         return True
+
+    def get_host_information(self) -> typing.Tuple[
+            typing.Optional[str], bool]:
+        """Get host information for this pattern.
+
+        Returns a tuple with (host, matches_subdomains)."""
+        return self._host, self._match_subdomains

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -25,6 +25,7 @@ import os.path
 import ipaddress
 import posixpath
 import urllib.parse
+import typing
 
 from PyQt5.QtCore import QUrl, QUrlQuery
 from PyQt5.QtNetwork import QHostInfo, QHostAddress, QNetworkProxy
@@ -702,3 +703,12 @@ def proxy_from_url(url):
     if url.password():
         proxy.setPassword(url.password())
     return proxy
+
+
+def widened_hostnames(hostname: str) -> typing.Iterable[str]:
+    """A generator for widening string hostnames.
+
+    Ex: a.c.foo -> [a.c.foo, c.foo, foo]"""
+    while hostname:
+        yield hostname
+        hostname = hostname.partition(".")[-1]

--- a/scripts/dev/run_vulture.py
+++ b/scripts/dev/run_vulture.py
@@ -133,6 +133,9 @@ def whitelist_generator():  # noqa
     # component hooks
     yield 'qutebrowser.components.adblock.on_config_changed'
 
+    # type hints
+    yield 'qutebrowser.config.configutils.VMAP_KEY'
+
 
 def filter_func(item):
     """Check if a missing function should be filtered or not.

--- a/tests/unit/config/test_configutils.py
+++ b/tests/unit/config/test_configutils.py
@@ -222,3 +222,19 @@ def test_add_url_benchmark(values, benchmark):
                 values.add(False, urlmatch.UrlPattern(line))
 
     benchmark(_add_blocked)
+
+
+@pytest.mark.parametrize('url', [
+    'http://www.qutebrowser.com/',
+    'http://foo.bar.baz/',
+    'http://bop.foo.bar.baz/',
+])
+def test_domain_lookup_sparse_benchmark(url, values, benchmark):
+    blocked_hosts = os.path.join(utils.abs_datapath(), 'blocked-hosts')
+    url = QUrl(url)
+    values.add(False, urlmatch.UrlPattern("*.foo.bar.baz"))
+    with open(blocked_hosts, 'r', encoding='utf-8') as f:
+        for line in f:
+            values.add(False, urlmatch.UrlPattern(line))
+
+    benchmark(lambda: values.get_for_url(url))

--- a/tests/unit/config/test_configutils.py
+++ b/tests/unit/config/test_configutils.py
@@ -171,6 +171,16 @@ def test_get_multiple_matches(values):
     assert values.get_for_url(url) == 'new value'
 
 
+def test_get_non_domain_patterns(empty_values):
+    """With multiple matching pattern, the last added should win."""
+    pat1 = urlmatch.UrlPattern('*://*/*')
+    empty_values.add('fallback')
+    empty_values.add('value', pat1)
+
+    assert empty_values.get_for_url(QUrl("http://qutebrowser.org")) == 'value'
+    assert empty_values.get_for_url() == 'fallback'
+
+
 def test_get_matching_pattern(values, pattern):
     assert values.get_for_pattern(pattern, fallback=False) == 'example value'
 

--- a/tests/unit/config/test_configutils.py
+++ b/tests/unit/config/test_configutils.py
@@ -56,8 +56,8 @@ def other_pattern():
 
 @pytest.fixture
 def values(opt, pattern):
-    scoped_values = [configutils.ScopedValue('global value', None),
-                     configutils.ScopedValue('example value', pattern)]
+    scoped_values = [configutils.ScopedValue('global value', None, 1),
+                     configutils.ScopedValue('example value', pattern, 2)]
     return configutils.Values(opt, scoped_values)
 
 
@@ -69,9 +69,10 @@ def empty_values(opt):
 def test_repr(opt, values):
     expected = ("qutebrowser.config.configutils.Values(opt={!r}, "
                 "vmap=odict_values([ScopedValue(value='global value',"
-                " pattern=None), "
+                " pattern=None, insert_id=0), "
                 "ScopedValue(value='example value', pattern=qutebrowser.utils."
-                "urlmatch.UrlPattern(pattern='*://www.example.com/'))]))"
+                "urlmatch.UrlPattern(pattern='*://www.example.com/'), "
+                "insert_id=1)]))"
                 .format(opt))
     assert repr(values) == expected
 
@@ -143,7 +144,7 @@ def test_get_unset(empty_values):
     assert empty_values.get_for_url(fallback=False) is configutils.UNSET
 
 
-def test_get_no_global(empty_values, other_pattern):
+def test_get_no_global(empty_values, other_pattern, pattern):
     empty_values.add('example.org value', pattern)
     assert empty_values.get_for_url(fallback=False) is configutils.UNSET
 

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -21,7 +21,6 @@
 
 import os.path
 import logging
-import functools
 
 import attr
 from PyQt5.QtCore import QUrl
@@ -849,6 +848,7 @@ class TestProxyFromUrl:
     def test_invalid(self, url, exception):
         with pytest.raises(exception):
             urlutils.proxy_from_url(QUrl(url))
+
 
 class TestWiden:
 

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -21,6 +21,7 @@
 
 import os.path
 import logging
+import functools
 
 import attr
 from PyQt5.QtCore import QUrl
@@ -848,3 +849,25 @@ class TestProxyFromUrl:
     def test_invalid(self, url, exception):
         with pytest.raises(exception):
             urlutils.proxy_from_url(QUrl(url))
+
+class TestWiden:
+
+    @pytest.mark.parametrize('hostname, expected', [
+        ('a.b.c', ['a.b.c', 'b.c', 'c']),
+        ('foobarbaz', ['foobarbaz']),
+        ('', []),
+        ('.c', ['.c', 'c']),
+        ('c.', ['c.']),
+        ('.c.', ['.c.', 'c.']),
+        (None, []),
+    ])
+    def test_widen_hostnames(self, hostname, expected):
+        assert list(urlutils.widened_hostnames(hostname)) == expected
+
+    @pytest.mark.parametrize('hostname', [
+        'test.qutebrowser.org',
+        'a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.z.y.z',
+        'qqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqqq.c',
+    ])
+    def test_bench_widen_hostnames(self, hostname, benchmark):
+        benchmark(lambda: list(urlutils.widened_hostnames(hostname)))


### PR DESCRIPTION
Requires #4544. Tentatively closes #4409

Before:
```
------------------------------------------------------ benchmark: 4 tests -----------------------------------------------------
Name (time in ms)                                                         Min                 Max              Median          
-------------------------------------------------------------------------------------------------------------------------------
test_domain_lookup_sparse_benchmark[http://www.qutebrowser.com/]     100.1871 (1.0)      102.9923 (1.00)     101.7632 (1.01)   
test_domain_lookup_sparse_benchmark[http://bop.foo.bar.baz/]         100.6100 (1.00)     106.1524 (1.03)     101.8571 (1.01)   
test_domain_lookup_sparse_benchmark[http://foo.bar.baz/]             100.7740 (1.01)     102.7752 (1.0)      101.1287 (1.0)    
test_add_url_benchmark                                               986.4504 (9.85)     995.4473 (9.69)     991.5167 (9.80)   
-------------------------------------------------------------------------------------------------------------------------------
```

After:
```
--------------------------------------------------------------- benchmark: 4 tests --------------------------------------------------------------
Name (time in us)                                                               Min                       Max                    Median          
-------------------------------------------------------------------------------------------------------------------------------------------------
test_domain_lookup_sparse_benchmark[http://www.qutebrowser.com/]             2.5300 (1.0)             12.6500 (1.0)              2.7000 (1.0)    
test_domain_lookup_sparse_benchmark[http://foo.bar.baz/]                     5.6400 (2.23)            12.9400 (1.02)             5.9200 (2.19)   
test_domain_lookup_sparse_benchmark[http://bop.foo.bar.baz/]                13.6600 (5.40)            33.2900 (2.63)            14.3000 (5.30)   
test_add_url_benchmark                                               1,120,911.2060 (>1000.0)  1,170,709.3470 (>1000.0)  1,124,790.6950 (>1000.0)
-------------------------------------------------------------------------------------------------------------------------------------------------
```
Not sure why the longer domain is way slower than the shorter one (on the same rules), it might be worth looking into.

There was a small regression in adding a url, but I think that's worth it.

I'm not handling subdomain matching at all currently, I'm letting the child matcher handle that for us.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4707)
<!-- Reviewable:end -->
