### PR TITLE
Optimize loading hooks

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -781,7 +781,7 @@ class AbstractTabPrivate:
 
     def handle_auto_insert_mode(self, ok: bool) -> None:
         """Handle `input.insert_mode.auto_load` after loading finished."""
-        if not config.val.input.insert_mode.auto_load or not ok:
+        if not ok or not config.cache['input.insert_mode.auto_load']:
             return
 
         cur_mode = self._mode_manager.mode

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -130,19 +130,21 @@ def javascript_alert(url, js_msg, abort_on, *, escape_msg=True):
                 abort_on=abort_on, url=urlstr)
 
 
+JS_LOGMAP = {
+    'none': lambda arg: None,
+    'debug': log.js.debug,
+    'info': log.js.info,
+    'warning': log.js.warning,
+    'error': log.js.error,
+}
+
+
 def javascript_log_message(level, source, line, msg):
     """Display a JavaScript log message."""
     logstring = "[{}:{}] {}".format(source, line, msg)
     # Needs to line up with the values allowed for the
     # content.javascript.log setting.
-    logmap = {
-        'none': lambda arg: None,
-        'debug': log.js.debug,
-        'info': log.js.info,
-        'warning': log.js.warning,
-        'error': log.js.error,
-    }
-    logger = logmap[config.val.content.javascript.log[level.name]]
+    logger = JS_LOGMAP[config.cache['content.javascript.log'][level.name]]
     logger(logstring)
 
 

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -407,7 +407,7 @@ class StatusBar(QWidget):
 
     def minimumSizeHint(self):
         """Set the minimum height to the text height plus some padding."""
-        padding = config.val.statusbar.padding
+        padding = config.cache['statusbar.padding']
         width = super().minimumSizeHint().width()
         height = self.fontMetrics().height() + padding.top + padding.bottom
         return QSize(width, height)

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -101,6 +101,7 @@ class UrlText(textbase.TextBase):
 
     def _update_url(self):
         """Update the displayed URL if the url or the hover url changed."""
+        old_urltype = self._urltype
         if self._hover_url is not None:
             self.setText(self._hover_url)
             self._urltype = UrlType.hover
@@ -110,7 +111,10 @@ class UrlText(textbase.TextBase):
         else:
             self.setText('')
             self._urltype = UrlType.normal
-        config.set_register_stylesheet(self, update=False)
+        if old_urltype != self._urltype:
+            # We can avoid doing an unpolish here because the new style will
+            # always override the old one.
+            self.style().polish(self)
 
     @pyqtSlot(usertypes.LoadStatus)
     def on_load_status_changed(self, status):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -577,7 +577,7 @@ class TabbedBrowser(QWidget):
         if tab.data.keep_icon:
             tab.data.keep_icon = False
         else:
-            if (config.val.tabs.tabs_are_windows and
+            if (config.cache['tabs.tabs_are_windows'] and
                     tab.data.should_show_icon()):
                 self.widget.window().setWindowIcon(self.default_window_icon)
         if idx == self.widget.currentIndex():
@@ -754,12 +754,12 @@ class TabbedBrowser(QWidget):
             # We can get signals for tabs we already deleted...
             return
         if ok:
-            start = config.val.colors.tabs.indicator.start
-            stop = config.val.colors.tabs.indicator.stop
-            system = config.val.colors.tabs.indicator.system
+            start = config.cache['colors.tabs.indicator.start']
+            stop = config.cache['colors.tabs.indicator.stop']
+            system = config.cache['colors.tabs.indicator.system']
             color = utils.interpolate_color(start, stop, 100, system)
         else:
-            color = config.val.colors.tabs.indicator.error
+            color = config.cache['colors.tabs.indicator.error']
         self.widget.set_tab_indicator_color(idx, color)
         self.widget.update_tab_title(idx)
         if idx == self.widget.currentIndex():


### PR DESCRIPTION
I frequently use a website which triggers https://github.com/qutebrowser/qutebrowser/issues/3596 almost constantly, which is extremely annoying as it causes the webview to lag out a lot (making the site totally unusable).

With this patch, the website is barely usable.

The only questionable bit is the `polish` function (instead of applying the stylesheet). Normally you're supposed to unpolish then polish, but since we are always overriding a single value (the color) dynamically, I think we can get away with just a polish (doing a unpolish/polish is more expensive than setting the stylesheet).

(also, I would really like to reduce the amount of logging here, logging alone was taking up ~30% of the total profile when on this website).

Also see https://github.com/qutebrowser/qutebrowser/issues/4535

#4545 or https://github.com/qutebrowser/qutebrowser/pull/4087 is much more important than this (going from a total lock-up to barely useable), this patch only makes sense after that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4712)
<!-- Reviewable:end -->
