### PR TITLE
Avoid un-needed queries in the completion

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -23,7 +23,9 @@ Defines a CompletionView which uses CompletionFiterModel and CompletionModel
 subclasses to provide completions.
 """
 
-from PyQt5.QtWidgets import QTreeView, QSizePolicy, QStyleFactory
+import typing
+
+from PyQt5.QtWidgets import QTreeView, QSizePolicy, QStyleFactory, QWidget
 from PyQt5.QtCore import pyqtSlot, pyqtSignal, Qt, QItemSelectionModel, QSize
 
 from qutebrowser.config import config
@@ -105,9 +107,10 @@ class CompletionView(QTreeView):
     update_geometry = pyqtSignal()
     selection_changed = pyqtSignal(str)
 
-    def __init__(self, win_id, parent=None):
+    def __init__(self, win_id: int,
+                 parent: typing.Optional[QWidget] = None) -> None:
         super().__init__(parent)
-        self.pattern = ''
+        self.pattern = None  # type: typing.Optional[str]
         self._win_id = win_id
         config.instance.changed.connect(self._on_config_changed)
 
@@ -305,15 +308,21 @@ class CompletionView(QTreeView):
 
         model.setParent(self)
         self._active = True
+        self.pattern = None
         self._maybe_show()
 
         self._resize_columns()
         for i in range(model.rowCount()):
             self.expand(model.index(i, 0))
 
-    def set_pattern(self, pattern):
+    def set_pattern(self, pattern: str) -> None:
         """Set the pattern on the underlying model."""
         if not self.model():
+            return
+        if self.pattern == pattern:
+            # no changes, abort
+            log.completion.debug(
+                "Ignoring pattern set request as pattern has not changed.")
             return
         self.pattern = pattern
         with debug.log_time(log.completion, 'Set pattern {}'.format(pattern)):

--- a/tests/unit/completion/test_histcategory.py
+++ b/tests/unit/completion/test_histcategory.py
@@ -241,3 +241,12 @@ def test_timestamp_fmt(fmt, expected, model_validator, config_stub, init_sql):
     model_validator.set_model(cat)
     cat.set_pattern('')
     model_validator.validate([('foo', '', expected)])
+
+
+def test_skip_duplicate_set(message_mock, caplog, hist):
+    cat = histcategory.HistoryCategory()
+    cat.set_pattern('foo')
+    cat.set_pattern('foobarbaz')
+    msg = caplog.messages[-1]
+    assert msg.startswith(
+        "Skipping query on foobarbaz due to prefix foo returning nothing.")


### PR DESCRIPTION
It seems like queries that have a lot of hits complete much faster than those that have few or no hits. I think this is because the completion seems to (?) not get all the results, but cache the first x relevant ones.

```
// many, many hits
12:03:01 DEBUG    sql        sql:run:215 query bindings: {':0': '%qute%'}
12:03:01 DEBUG    sql        debug:__exit__:265 Running completion query took 0.000519 seconds.
12:03:01 DEBUG    completion debug:__exit__:265 Set pattern qute took 0.003181 seconds.
// many hits
12:03:23 DEBUG    sql        sql:run:215 query bindings: {':0': '%qutebrowser.org%'}
12:03:23 DEBUG    sql        debug:__exit__:265 Running completion query took 0.001016 seconds.
12:03:23 DEBUG    completion debug:__exit__:265 Set pattern qutebrowser.org took 0.020116 seconds.
// no hits
12:03:47 DEBUG    sql        sql:run:212 Running SQL query: "SELECT url, title, strftime('%Y-%m-%d', last_atime, 'unixepoch', 'localtime') FROM CompletionHistory WHERE ((url LIKE :0 escape '\' OR title LIKE :0 escape '\'))  ORDER BY last_atime DESC"
12:03:47 DEBUG    sql        sql:run:215 query bindings: {':0': '%qutebrowser.orgJ%'}
12:03:47 DEBUG    sql        debug:__exit__:265 Running completion query took 0.017339 seconds.
12:03:47 DEBUG    completion debug:__exit__:265 Set pattern qutebrowser.orgj took 0.017792 seconds.
// not sure why completion starts being slow when the query is still fast in the first example. It's possible that it's because the query isn't actually running until that point.
```

In addition, I type a lot of search queries that end up eventually having no matches, after which point there's no reason for completion to be slow anymore (typing quickly when completion is empty makes qutebrowser take 60% of a core on one of my machines, and 100% on the other).

This PR tries to fix this for the general case by bypassing queries that continue expanding (to the right) after a single one returns no results. It's rather simple but it fixes the general case of just typing a long search query. Ideally we would stop querying for any insertions after a single empty result, but I don't think that's worth the effort.

In addition, I also fixed re-running the query every single time that the cursor position changed. Some code is needed in this case, but the query and most other things can be bypassed (I think). I did some basic tests and the expected behaviors (that I'm aware of) seem to still work when moving the cursor around, but if there's any doubt I could move this deeper into historywidget (although it won't be as good of a saving there).

```
12:12:46 DEBUG    sql        sql:run:215 query bindings: {':0': '%qute%'}
12:12:46 DEBUG    sql        debug:__exit__:265 Running completion query took 0.000286 seconds.
12:12:46 DEBUG    completion debug:__exit__:265 Set pattern qute took 0.001661 seconds.

12:13:09 DEBUG    sql        sql:run:215 query bindings: {':0': '%qutebrowser.org%'}
12:13:09 DEBUG    sql        debug:__exit__:265 Running completion query took 0.001004 seconds.
12:13:09 DEBUG    completion debug:__exit__:265 Set pattern qutebrowser.org took 0.019881 seconds.

12:13:20 DEBUG    sql        sql:run:215 query bindings: {':0': '%qutebrowser.orgJ%'}
12:13:20 DEBUG    sql        debug:__exit__:265 Running completion query took 0.019138 seconds.
12:13:20 DEBUG    completion debug:__exit__:265 Set pattern qutebrowser.orgj took 0.019568 seconds.
12:13:22 DEBUG    completion completionmodel:set_pattern:179 Setting completion pattern 'qutebrowser.orgJJ'
12:13:22 DEBUG    sql        histcategory:set_pattern:80 Skipping query on qutebrowser.orgJJ due to prefix qutebrowser.orgJ returning nothing.
12:13:22 DEBUG    completion debug:__exit__:265 Set pattern qutebrowser.orgjj took 0.000342 seconds.
```
For me, on my highest end computer:
Holding down 'j' takes 65% cpu (measured by `time`) before, and 25% after
Pasting a set of 'j's and moving around them with the arrow keys takes 58% cpu before, and 17% after.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4714)
<!-- Reviewable:end -->
