### PR TITLE
make qute-pass more informative when no matching pass entry is found

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -152,7 +152,9 @@ def main(arguments):
     # Try to find candidates using targets in the following order: fully-qualified domain name (includes subdomains),
     # the registered domain name and finally: the IPv4 address if that's what the URL represents
     candidates = set()
+    attempted_targets = []
     for target in filter(None, [extract_result.fqdn, extract_result.registered_domain, extract_result.ipv4]):
+        attempted_targets.append(target)
         target_candidates = find_pass_candidates(target, password_store_path)
         if not target_candidates:
             continue
@@ -162,7 +164,7 @@ def main(arguments):
             break
     else:
         if not candidates:
-            stderr('No pass candidates for URL {!r} found!'.format(arguments.url))
+            stderr('No pass candidates for URL {0!r} found! (I tried {1!r})'.format(arguments.url, attempted_targets))
             return ExitCodes.NO_PASS_CANDIDATES
 
     selection = candidates.pop() if len(candidates) == 1 else dmenu(sorted(candidates), arguments.dmenu_invocation,


### PR DESCRIPTION
I use `qute-pass` to fill in login prompts with qutebrowser. It works really well, however with some sites it's not always clear what domain name is being searched for, and so what to name my `pass` entries.

This PR makes a small change to `qute-pass` to add the list of domains tried to help the user name their pass entries correctly. Feedback welcome, of course. The change only affects the "no matching sites found" error (see below).

Original message:

> No pass candidates for URL 'https://www.access.service.gov.uk/login/signin/creds' found!

New message:
> No pass candidates for URL 'https://www.access.service.gov.uk/login/signin/creds' found! (I tried ['www.access.service.gov.uk', 'service.gov.uk'])

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4716)
<!-- Reviewable:end -->
