### PR TITLE
Disable logging completely on --loglines=0

### DIFF
--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -585,7 +585,10 @@ class ReportDialog(_CrashDialog):
             ("Objects", self._qobjects),
         ]
         try:
-            self._crash_info.append(("Debug log", log.ram_handler.dump_log()))
+            text = "Log output was disabled."
+            if log.ram_handler is not None:
+                text = log.ram_handler.dump_log()
+            self._crash_info.append(("Debug log", text))
         except Exception:
             self._crash_info.append(("Debug log", traceback.format_exc()))
 

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -199,6 +199,12 @@ def init_log(args):
         root.addHandler(console)
     if ram is not None:
         root.addHandler(ram)
+    else:
+        # If we add no handler, we shouldn't process non visible logs at all
+        #
+        # disable blocks the current level (while setHandler shows the current
+        # level), so -1 to avoid blocking handled messages.
+        logging.disable(numeric_level - 1)
     root.setLevel(logging.NOTSET)
     logging.captureWarnings(True)
     _init_py_warnings()


### PR DESCRIPTION
Logging is rather expensive in python, and it's quite hard to just tweak the ones that are the worst ones (as it seems to me like there's a very long tail on these).

This pr disables logging completely when passing `--loglines=0`, which provides an easy opt-out, and while it's still measurable, it's much less overhead than actually logging .

As a bonus, I also fixed an exception when passing `--loglines=0` in the reporter. If you'd like that in a separate PR, I can split that commit off though.

http://bugs.python.org/issue30962 is interesting as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4719)
<!-- Reviewable:end -->
