### PR TITLE
Fix load started/finished signals

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -1016,13 +1016,6 @@ class AbstractTab(QWidget):
             return
 
         sess_manager.save_autosave()
-        # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
-        if qtutils.version_check('5.10', compiled=False):
-            if not ok:
-                self._update_load_status(ok)
-        else:
-            self._update_load_status(ok)
-
         self.load_finished.emit(ok)
 
         if not self.title():
@@ -1051,8 +1044,6 @@ class AbstractTab(QWidget):
     def _on_load_progress(self, perc: int) -> None:
         self._progress = perc
         self.load_progress.emit(perc)
-        if perc == 100 and qtutils.version_check('5.10', compiled=False):
-            self._update_load_status(ok=True)
 
     def url(self, *, requested: bool = False) -> QUrl:
         raise NotImplementedError

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1349,7 +1349,9 @@ class WebEngineTab(browsertab.AbstractTab):
         WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
         """
         super()._on_load_progress(perc)
-        if perc == 100 and qtutils.version_check('5.10', compiled=False):
+        if (perc == 100 and
+                qtutils.version_check('5.10', compiled=False) and
+                self.load_status() != usertypes.LoadStatus.error):
             self._update_load_status(ok=True)
 
     @pyqtSlot(bool)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1344,7 +1344,10 @@ class WebEngineTab(browsertab.AbstractTab):
 
     @pyqtSlot(int)
     def _on_load_progress(self, perc: int) -> None:
-        """QtWebEngine-specific loadProgress workarounds."""
+        """QtWebEngine-specific loadProgress workarounds.
+
+        WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
+        """
         super()._on_load_progress(perc)
         if perc == 100 and qtutils.version_check('5.10', compiled=False):
             self._update_load_status(ok=True)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1524,7 +1524,6 @@ class WebEngineTab(browsertab.AbstractTab):
             self._on_render_process_terminated)
         view.iconChanged.connect(self.icon_changed)
 
-        page.loadProgress.connect(self._on_load_progress)
         page.loadFinished.connect(self._on_history_trigger)
         page.loadFinished.connect(self._restore_zoom)
         page.loadFinished.connect(self._on_load_finished)

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -791,6 +791,11 @@ class WebKitTab(browsertab.AbstractTab):
         # Make sure the icon is cleared when navigating to a page without one.
         self.icon_changed.emit(QIcon())
 
+    @pyqtSlot(bool)
+    def _on_load_finished(self, ok: bool) -> None:
+        super()._on_load_finished(ok)
+        self._update_load_status(ok)
+
     @pyqtSlot()
     def _on_frame_load_finished(self):
         """Make sure we emit an appropriate status when loading finished.

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -487,8 +487,7 @@ class MainWindow(QWidget):
         # statusbar
         self.tabbed_browser.current_tab_changed.connect(status.on_tab_changed)
 
-        self.tabbed_browser.cur_progress.connect(status.prog.setValue)
-        self.tabbed_browser.cur_load_finished.connect(status.prog.hide)
+        self.tabbed_browser.cur_progress.connect(status.prog.on_load_progress)
         self.tabbed_browser.cur_load_started.connect(
             status.prog.on_load_started)
 

--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -60,6 +60,12 @@ class Progress(QProgressBar):
         self.setValue(0)
         self.setVisible(self.enabled)
 
+    @pyqtSlot(int)
+    def on_load_progress(self, value):
+        self.setValue(value)
+        if value == 100:
+            self.hide()
+
     def on_tab_changed(self, tab):
         """Set the correct value when the current tab changed."""
         self.setValue(tab.progress())

--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -62,6 +62,13 @@ class Progress(QProgressBar):
 
     @pyqtSlot(int)
     def on_load_progress(self, value):
+        """Hide the statusbar when loading finished.
+
+        We use this instead of loadFinished because we sometimes get
+        loadStarted and loadProgress(100) without loadFinished from Qt.
+
+        WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
+        """
         self.setValue(value)
         if value == 100:
             self.hide()

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -120,9 +120,15 @@ class TabbedBrowser(QWidget):
         self.widget.tabCloseRequested.connect(self.on_tab_close_requested)
         self.widget.new_tab_requested.connect(self.tabopen)
         self.widget.currentChanged.connect(self.on_current_changed)
-        self.cur_load_started.connect(self.on_cur_load_started)
         self.cur_fullscreen_requested.connect(self.widget.tabBar().maybe_hide)
         self.widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
+
+        # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-65223
+        if qtutils.version_check('5.10', compiled=False):
+            self.cur_load_finished.connect(self._leave_modes_on_load)
+        else:
+            self.cur_load_started.connect(self._leave_modes_on_load)
+
         self._undo_stack = []
         self._filter = signalfilter.SignalFilter(win_id, self)
         self._now_focused = None
@@ -584,7 +590,7 @@ class TabbedBrowser(QWidget):
             self._update_window_title()
 
     @pyqtSlot()
-    def on_cur_load_started(self):
+    def _leave_modes_on_load(self):
         """Leave insert/hint mode when loading started."""
         try:
             url = self.current_url()


### PR DESCRIPTION
This contains the following changes around loadStarted/Finished signals:

- `load_finished` is always emitted when Qt does it, i.e., only on full page loads - mostly reverts #3427 and fixes #4535
- The load status (used to color the URL) is rewired to use the workaround, so that #3110 doesn't regress.
- The progress bar always hides on 100% progress instead of loadFinished, so that #3401 doesn't regress.
- Modes are left on loadFinished rather than loadStarted, which fixes #3596

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4723)
<!-- Reviewable:end -->
