### PR TITLE
Add cache for icon padding on tabbar

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -20,7 +20,6 @@
 """The tab widget used for TabbedBrowser from browser.py."""
 
 import functools
-import enum
 import contextlib
 
 import attr
@@ -35,13 +34,6 @@ from qutebrowser.utils import qtutils, objreg, utils, usertypes, log
 from qutebrowser.config import config
 from qutebrowser.misc import objects
 from qutebrowser.browser import browsertab
-
-
-class PixelMetrics(enum.IntEnum):
-
-    """Custom PixelMetrics attributes."""
-
-    icon_padding = QStyle.PM_CustomBase
 
 
 class TabWidget(QTabWidget):
@@ -564,13 +556,12 @@ class TabBar(QTabBar):
             A QSize of the smallest tab size we can make.
         """
         icon = self.tabIcon(index)
-        icon_padding = self.style().pixelMetric(PixelMetrics.icon_padding,
-                                                None, self)
         if icon.isNull():
             icon_width = 0
         else:
-            icon_width = min(icon.actualSize(self.iconSize()).width(),
-                             self.iconSize().width()) + icon_padding
+            icon_width = min(
+                icon.actualSize(self.iconSize()).width(),
+                self.iconSize().width()) + TabBarStyle.ICON_PADDING
 
         pinned = self._tab_pinned(index)
         if not self.vertical and pinned and config.val.tabs.pinned.shrink:
@@ -760,6 +751,8 @@ class TabBarStyle(QCommonStyle):
     https://code.google.com/p/makehuman/source/browse/trunk/makehuman/lib/qtgui.py
     """
 
+    ICON_PADDING = 4
+
     def __init__(self):
         """Initialize all functions we're not overriding.
 
@@ -865,8 +858,6 @@ class TabBarStyle(QCommonStyle):
                       QStyle.PM_TabBarTabVSpace,
                       QStyle.PM_TabBarScrollButtonWidth]:
             return 0
-        elif metric == PixelMetrics.icon_padding:
-            return 4
         else:
             return self._style.pixelMetric(metric, option, widget)
 
@@ -942,8 +933,8 @@ class TabBarStyle(QCommonStyle):
 
         icon_rect = self._get_icon_rect(opt, text_rect)
         if icon_rect.isValid():
-            icon_padding = self.pixelMetric(PixelMetrics.icon_padding, opt)
-            text_rect.adjust(icon_rect.width() + icon_padding, 0, 0, 0)
+            text_rect.adjust(
+                icon_rect.width() + TabBarStyle.ICON_PADDING, 0, 0, 0)
 
         text_rect = self._style.visualRect(opt.direction, opt.rect, text_rect)
         return Layouts(text=text_rect, icon=icon_rect,


### PR DESCRIPTION
I was profiling large numbers of tabs again and I found that getting the style for the icon width is pretty slow for some reason. These profiles are cloning up to 200 tabs and waiting until idle.

```
Total time: 5.74861 s
File: /home/jay/Code/qutebrowser/qutebrowser/mainwindow/tabwidget.py
Function: minimumTabSizeHint at line 555

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   555                                               @profile
   556                                               def minimumTabSizeHint(self, index: int, ellipsis: bool = True) -> QSize:
   567    256015     315532.0      1.2      5.5          icon = self.tabIcon(index)
   568    256015    1894999.0      7.4     33.0          style = self.style()
   569    256015     217275.0      0.8      3.8          icon_padding = style.pixelMetric(PixelMetrics.icon_padding,
   570    256015    1214014.0      4.7     21.1                                           None, self)
   571    256015     200296.0      0.8      3.5          if icon.isNull():
   572    210094      97306.0      0.5      1.7              icon_width = 0
   573                                                   else:
   574     45921     113303.0      2.5      2.0              icon_width = min(icon.actualSize(self.iconSize()).width(),
   575     45921      70370.0      1.5      1.2                               self.iconSize().width()) + icon_padding
   576                                           
   577    256015     680670.0      2.7     11.8          pinned = self._tab_pinned(index)
   578    256015     145549.0      0.6      2.5          if not self.vertical and pinned and config.val.tabs.pinned.shrink:
   579                                                       # Never consider ellipsis an option for horizontal pinned tabs
   580                                                       ellipsis = False
   581    256015     359968.0      1.4      6.3          return self._minimum_tab_size_hint_helper(self.tabText(index),
   582    256015     123404.0      0.5      2.1                                                    icon_width, ellipsis,
   583    256015     315928.0      1.2      5.5                                                    pinned)
```
I just pre-computed the icon padding and stored it in the class. I don't think that style is changed anywhere, but just to be safe I overrode getStyle and made the change there.

```
Total time: 2.05785 s
File: /home/jay/Code/qutebrowser/qutebrowser/mainwindow/tabwidget.py
Function: minimumTabSizeHint at line 560

Line #      Hits         Time  Per Hit   % Time  Line Contents
==============================================================
   560                                               @profile
   561                                               def minimumTabSizeHint(self, index: int, ellipsis: bool = True) -> QSize:
   572    244598     275421.0      1.1     13.4          icon = self.tabIcon(index)
   573    244598     169228.0      0.7      8.2          if icon.isNull():
   574    196992      86499.0      0.4      4.2              icon_width = 0
   575                                                   else:
   576     47606      97161.0      2.0      4.7              icon_width = min(icon.actualSize(self.iconSize()).width(),
   577     47606      66376.0      1.4      3.2                               self.iconSize().width()) + self._icon_padding
   578                                           
   579    244598     553837.0      2.3     26.9          pinned = self._tab_pinned(index)
   580    244598     124233.0      0.5      6.0          if not self.vertical and pinned and config.val.tabs.pinned.shrink:
   581                                                       # Never consider ellipsis an option for horizontal pinned tabs
   582                                                       ellipsis = False
   583    244598     301842.0      1.2     14.7          return self._minimum_tab_size_hint_helper(self.tabText(index),
   584    244598     105149.0      0.4      5.1                                                    icon_width, ellipsis,
   585    244598     278103.0      1.1     13.5                                                    pinned)
```

Kernprof tells us over 2x faster for minimumTabSizeHint, which seems a bit higher than I expected. Our benchmarks say quite less, so I'm guessing it's much better with many tabs:

```
Name (time in ns)                                        Min                         Max                      Median          
------------------------------------------------------------------------------------------------------------------------------
test_add_remove_tab_benchmark[True-70]      170,990,319.9808 (>1000.0)  175,749,699.0031 (>1000.0)  173,344,943.9926 (>1000.0)
test_add_remove_tab_benchmark[False-70]     451,486,924.0229 (>1000.0)  667,273,462.0515 (>1000.0)  630,096,047.0107 (>1000.0)
-- to
test_add_remove_tab_benchmark[True-70]      161,701,133.0090 (>1000.0)  166,311,462.9919 (>1000.0)  163,478,587.9578 (>1000.0)
test_add_remove_tab_benchmark[False-70]     433,768,063.0269 (>1000.0)  655,127,703.0376 (>1000.0)  590,780,508.9955 (>1000.0)
```
I don't think that this value should change without the style changing, right?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4727)
<!-- Reviewable:end -->
