### PR TITLE
Implement trie for bindings

### DIFF
--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -31,7 +31,6 @@ from qutebrowser.keyinput import keyutils
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from typing import MutableMapping, Optional
 
 

--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -20,6 +20,7 @@
 """Base class for vim-like key sequence parser."""
 
 import string
+import collections
 
 from PyQt5.QtCore import pyqtSignal, QObject
 from PyQt5.QtGui import QKeySequence
@@ -27,6 +28,88 @@ from PyQt5.QtGui import QKeySequence
 from qutebrowser.config import config
 from qutebrowser.utils import usertypes, log, utils
 from qutebrowser.keyinput import keyutils
+
+MYPY = False
+if MYPY:
+    # pylint: disable=unused-import,useless-suppression
+    from typing import MutableMapping, Optional
+
+
+class BindingTrie(collections.abc.MutableMapping):
+
+    """Helper class for key parser. Represents a set of bindings.
+
+    Except for the root item, there is no children BindingTrie with no bound
+    commands.
+
+    This class works like a dict[keyutils.KeySequence, str], but with matches
+    method added.
+
+    Attributes:
+        child: A map. Keys of this map can be get from the KeyInfo.to_int
+               method.
+        command: Command associated with this trie node.
+    """
+
+    __slots__ = 'child', 'command'
+
+    def __init__(self):
+        self.child = {}  # type: MutableMapping[int, BindingTrie]
+        self.command = None  # type: Optional[str]
+
+    def __getitem__(self, sequence: keyutils.KeySequence):
+        matchtype, command = self.matches(sequence)
+        if matchtype != QKeySequence.ExactMatch:
+            raise KeyError(sequence)
+        return command
+
+    def __setitem__(
+            self, sequence: keyutils.KeySequence, command: str):
+        node = self
+        for key in sequence:
+            key_int = key.to_int()
+            if key_int not in node.child:
+                node.child[key_int] = BindingTrie()
+            node = node.child[key_int]
+
+        node.command = command
+
+    def __delitem__(self, sequence: keyutils.KeySequence):
+        raise NotImplementedError
+
+    def __iter__(self):
+        raise NotImplementedError
+
+    def __len__(self):
+        raise NotImplementedError
+
+    def matches(self, sequence: keyutils.KeySequence):
+        """Try to match a given keystring with any bound keychain.
+
+        Args:
+            sequence: The command string to find.
+
+        Return:
+            A tuple (matchtype, binding).
+                matchtype: QKeySequence.ExactMatch, QKeySequence.PartialMatch
+                           or QKeySequence.NoMatch.
+                binding: - None with QKeySequence.PartialMatch or
+                           QKeySequence.NoMatch.
+                         - The found binding with QKeySequence.ExactMatch.
+        """
+        node = self
+        for key in sequence:
+            try:
+                node = node.child[key.to_int()]
+            except KeyError:
+                return QKeySequence.NoMatch, None
+
+        if node.command is not None:
+            return QKeySequence.ExactMatch, node.command
+        elif node.child:
+            return QKeySequence.PartialMatch, None
+        else:  # This can only happen when there is no bindings
+            return QKeySequence.NoMatch, None
 
 
 class BaseKeyParser(QObject):
@@ -75,7 +158,7 @@ class BaseKeyParser(QObject):
         self._sequence = keyutils.KeySequence()
         self._count = ''
         self._supports_count = supports_count
-        self.bindings = {}
+        self.bindings = BindingTrie()
         config.instance.changed.connect(self._on_config_changed)
 
     def __repr__(self):
@@ -104,17 +187,8 @@ class BaseKeyParser(QObject):
         """
         assert sequence
         assert not isinstance(sequence, str)
-        result = QKeySequence.NoMatch
 
-        for seq, cmd in self.bindings.items():
-            assert not isinstance(seq, str), seq
-            match = sequence.matches(seq)
-            if match == QKeySequence.ExactMatch:
-                return match, cmd
-            elif match == QKeySequence.PartialMatch:
-                result = QKeySequence.PartialMatch
-
-        return result, None
+        return self.bindings.matches(sequence)
 
     def _match_without_modifiers(self, sequence):
         """Try to match a key with optional modifiers stripped."""
@@ -216,6 +290,9 @@ class BaseKeyParser(QObject):
 
     @config.change_filter('bindings')
     def _on_config_changed(self):
+        # Note: This function is called which erases and rebuild the whole
+        # self.bindings object, even if it only needs to add or remove one
+        # item.
         self._read_config()
 
     def _read_config(self, modename=None):
@@ -234,7 +311,7 @@ class BaseKeyParser(QObject):
             modename = self._modename
         else:
             self._modename = modename
-        self.bindings = {}
+        self.bindings = BindingTrie()
 
         for key, cmd in config.key_instance.get_bindings_for(modename).items():
             assert not isinstance(key, str), key

--- a/tests/unit/keyinput/test_bindingtrie.py
+++ b/tests/unit/keyinput/test_bindingtrie.py
@@ -1,0 +1,93 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2019 Jay Kamat <jaygkamat@gmail.com>:
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Tests for the BindingTrie."""
+
+import string
+import itertools
+
+import pytest
+
+from PyQt5.QtGui import QKeySequence
+
+from qutebrowser.keyinput import basekeyparser
+from qutebrowser.keyinput import keyutils
+from unit.keyinput import test_keyutils
+
+
+@pytest.mark.parametrize('entered, configured, expected',
+                         test_keyutils.TestKeySequence.MATCH_TESTS)
+def test_matches_single(entered, configured, expected):
+    entered = keyutils.KeySequence.parse(entered)
+    configured = keyutils.KeySequence.parse(configured)
+    trie = basekeyparser.BindingTrie()
+    trie[configured] = "eeloo"
+    ret_expected = None
+    if expected == QKeySequence.ExactMatch:
+        ret_expected = "eeloo"
+    assert trie.matches(entered) == (expected, ret_expected)
+
+
+@pytest.mark.parametrize(
+    'configured, expected_tuple',
+    (((),
+      # null match
+      (('a', QKeySequence.NoMatch),
+       ('', QKeySequence.NoMatch))),
+     (('abcd',),
+      (('abcd', QKeySequence.ExactMatch),
+       ('abc', QKeySequence.PartialMatch))),
+     (('aa', 'ab', 'ac', 'ad'),
+      (('ac', QKeySequence.ExactMatch),
+       ('a', QKeySequence.PartialMatch),
+       ('f', QKeySequence.NoMatch),
+       ('acd', QKeySequence.NoMatch))),
+     (('aaaaaaab', 'aaaaaaac', 'aaaaaaad'),
+      (('aaaaaaab', QKeySequence.ExactMatch),
+       ('z', QKeySequence.NoMatch))),
+     (tuple(string.ascii_letters),
+      (('a', QKeySequence.ExactMatch),
+       ('!', QKeySequence.NoMatch)))))
+def test_matches_tree(configured, expected_tuple, benchmark):
+    trie = basekeyparser.BindingTrie()
+    trie.update(dict.fromkeys(
+        map(keyutils.KeySequence.parse, configured), "eeloo"))
+
+    def _run():
+        for entered, expected in expected_tuple:
+            entered = keyutils.KeySequence.parse(entered)
+            ret_expected = None
+            if expected == QKeySequence.ExactMatch:
+                ret_expected = "eeloo"
+            assert trie.matches(entered) == (expected, ret_expected)
+    benchmark(_run)
+
+
+@pytest.mark.parametrize(
+    'configured',
+    ('a',
+     itertools.permutations('asdfghjkl', 3)))
+def test_bench_create(configured, benchmark):
+    configured = dict.fromkeys(
+        map(keyutils.KeySequence.parse, configured), "dres")
+
+    def _run():
+        trie = basekeyparser.BindingTrie()
+        trie.update(configured)
+    benchmark(_run)

--- a/tests/unit/keyinput/test_keyutils.py
+++ b/tests/unit/keyinput/test_keyutils.py
@@ -317,7 +317,7 @@ class TestKeySequence:
         assert s1[3:5] == s2
         assert seq[3:5] == expected
 
-    @pytest.mark.parametrize('entered, configured, expected', [
+    MATCH_TESTS = [
         # config: abcd
         ('abc', 'abcd', QKeySequence.PartialMatch),
         ('abcd', 'abcd', QKeySequence.ExactMatch),
@@ -339,8 +339,9 @@ class TestKeySequence:
         # empty strings
         ('', '', QKeySequence.ExactMatch),
         ('', 'a', QKeySequence.PartialMatch),
-        ('a', '', QKeySequence.NoMatch),
-    ])
+        ('a', '', QKeySequence.NoMatch)]
+
+    @pytest.mark.parametrize('entered, configured, expected', MATCH_TESTS)
     def test_matches(self, entered, configured, expected):
         entered = keyutils.KeySequence.parse(entered)
         configured = keyutils.KeySequence.parse(configured)


### PR DESCRIPTION
Closes #4721.

Note:

* For operations like `1000j` it reduces the time from about 4.5s to about 3.0s (if `-OO --loglines=0` is used each one is reduced by about 0.5s)
* With PR #4536 the time for `1000j` is reduced about 1.5s - 2s further.
* This implementation is iterative. See /binding-trie branch for a recursive implementation (it looks worse).
* Regarding `1000j`: it only invokes `ShortcutOverride` event; but I think the result doesn't matter anyway because we don't have shortcut keys for arrow keys. I chose that because it's easy to test.
* Here ~~I didn't inherit `MutableMapping` because I'd need to implement some more methods (iter, len)~~ iter, len and delitem raises NotImplementedError, which (currently) the code don't need to use. Note that implementing `len` in constant time requires storing more information in each node and make the code more complex. `iter` however can be useful in the key hint widget, and `delitem` can be useful in unbind.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4730)
<!-- Reviewable:end -->
