### PR TITLE
Add ".html" suffix to mktemp in userscript "format_json"

### DIFF
--- a/misc/userscripts/format_json
+++ b/misc/userscripts/format_json
@@ -25,7 +25,7 @@ MAX_SIZE_PRETTIFY=10485760  # 10 MB
 # default style to monokai if none is provided
 STYLE=${1:-monokai}
 
-TEMP_FILE="$(mktemp)"
+TEMP_FILE="$(mktemp --suffix .html)"
 jq . "$QUTE_TEXT" >"$TEMP_FILE"
 
 # try GNU stat first and then OSX stat if the former fails


### PR DESCRIPTION
It doesn't work without the ".html", maybe because of changes in Chromium/Qt.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4735)
<!-- Reviewable:end -->
