### PR TITLE
Fix missing branch coverage in migrate_string_value

### DIFF
--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -261,11 +261,11 @@ class YamlConfig(QObject):
                               source: str, target: str) -> None:
         if name in settings:
             for scope, val in settings[name].items():
-                if isinstance(val, str):
-                    new_val = re.sub(source, target, val)
-                    if new_val != val:
-                        settings[name][scope] = new_val
-                        self._mark_changed()
+                assert isinstance(val, str)
+                new_val = re.sub(source, target, val)
+                if new_val != val:
+                    settings[name][scope] = new_val
+                    self._mark_changed()
 
     def _handle_migrations(self, settings: _SettingsType) -> '_SettingsType':
         """Migrate older configs to the newest format."""


### PR DESCRIPTION
I missed the coverage check for a branch on #4733. Since I'm never expecting this value to not be a string, I just made it into an assert (even though I'd like to not crash in this case). Do you think this is the cleanest solution?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4737)
<!-- Reviewable:end -->
