### PR TITLE
support PASSWORD_STORE_DIR environmental variable

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -55,7 +55,8 @@ import tldextract
 
 argument_parser = argparse.ArgumentParser(description=__doc__, usage=USAGE, epilog=EPILOG)
 argument_parser.add_argument('url', nargs='?', default=os.getenv('QUTE_URL'))
-argument_parser.add_argument('--password-store', '-p', default=os.path.expanduser('~/.password-store'),
+argument_parser.add_argument('--password-store', '-p',
+                             default=os.getenv('PASSWORD_STORE_DIR', default=os.path.expanduser('~/.password-store')),
                              help='Path to your pass password-store')
 argument_parser.add_argument('--username-pattern', '-u', default=r'.*/(.+)',
                              help='Regular expression that matches the username')


### PR DESCRIPTION
The current script does not respect the PASSWORD_STORE_DIR environmental variable used by pass.  This pull request fixes that, but retains the scripts -p argument for use with alternative / multiple password stores.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4739)
<!-- Reviewable:end -->
