### PR TITLE
Add setting to avoid cancelling hints on load

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1202,6 +1202,12 @@ hints.uppercase:
   type: Bool
   desc: Make characters in hint strings uppercase.
 
+hints.leave_on_load:
+  default: true
+  type: Bool
+  supports_pattern: false
+  desc: Leave hint mode when starting a new page load.
+
 ## input
 
 input.escape_quits_reporter:

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -598,8 +598,11 @@ class TabbedBrowser(QWidget):
                           'load started', maybe=True)
         else:
             log.modes.debug("Ignoring leave_on_load request due to setting.")
-        modeman.leave(self._win_id, usertypes.KeyMode.hint,
-                      'load started', maybe=True)
+        if config.cache['hints.leave_on_load']:
+            modeman.leave(self._win_id, usertypes.KeyMode.hint,
+                          'load started', maybe=True)
+        else:
+            log.modes.debug("Ignoring leave_on_load request due to setting.")
 
     @pyqtSlot(browsertab.AbstractTab, str)
     def on_title_changed(self, tab, text):

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -426,6 +426,21 @@ Feature: Using hints
         And I run :follow-hint 1
         Then data/numbers/7.txt should be loaded
 
+    ### hints.leave_on_load
+    Scenario: Leaving hint mode on reload
+        When I open data/hints/html/wrapped.html
+        And I hint with args "all"
+        And I run :reload
+        Then "Leaving mode KeyMode.hint (reason: load started)" should be logged
+
+    Scenario: Leaving hint mode on reload without leave_on_load
+        When I set hints.leave_on_load to false
+        And I open data/hints/html/simple.html
+        And I hint with args "all"
+        And I run :reload
+        Then "Leaving mode KeyMode.hint (reason: load started)" should not be logged
+
+
     ### hints.auto_follow option
 
     Scenario: Using hints.auto_follow = 'always' in letter mode


### PR DESCRIPTION
Even with #4723, #3596 causes hints to be cleared when page load is finished. Because of this, hints are cleared if hinting starts during page load. This adds a setting to tweak that.

I can't find any reason to make this per-domain so I didn't to minimize the increase in page load time.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4741)
<!-- Reviewable:end -->
