### PR TITLE
Prevent keyhint timer from eating all CPU.

### DIFF
--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -71,6 +71,7 @@ class KeyHintView(QLabel):
         self.hide()
         self._show_timer = usertypes.Timer(self, 'keyhint_show')
         self._show_timer.timeout.connect(self.show)
+        self._show_timer.setSingleShot(True)
         config.set_register_stylesheet(self)
 
     def __repr__(self):


### PR DESCRIPTION
By default, timers are not single-shot, which means they will keep
firing every `interval` seconds after being started. This is unnecessary
for the keyhint timer, and causes it to eat ~100% CPU with
keyhint.delay=0.

Fixes #4742.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4743)
<!-- Reviewable:end -->
