### PR TITLE
Fix some flaky tests by using <enter> in fake-key -g instead of command-accept

### DIFF
--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1357,20 +1357,16 @@ Feature: Tab management
         And I run :fake-key -g new
         Then the javascript message "contents: existingnew" should be logged
 
-    @flaky
     Scenario: Focused prompt after opening link in bg
         When I open data/hints/link_input.html
         When I run :set-cmd-text -s :message-info
         And I open data/hello.txt in a new background tab
-        And I run :fake-key -g hello-world
-        And I run :command-accept
+        And I run :fake-key -g hello-world<enter>
         Then the message "hello-world" should be shown
 
-    @flaky
     Scenario: Focused prompt after opening link in fg
         When I open data/hints/link_input.html
         When I run :set-cmd-text -s :message-info
         And I open data/hello.txt in a new tab
-        And I run :fake-key -g hello-world
-        And I run :command-accept
+        And I run :fake-key -g hello-world<enter>
         Then the message "hello-world" should be shown


### PR DESCRIPTION
It seems like that those tests fail for some recent PRs.

Note that `<enter>` is not strictly equivalent to `command-accept`; however if `fake-key` correctly enter text into the status bar then it would be reasonable to assume that the `<enter>` goes to the status bar as well.

~~(I didn't run tests locally)~~ (the relevant tests seems to pass on AppVeyor, but some other tests break. I think they are unrelated)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4750)
<!-- Reviewable:end -->
