### PR TITLE
Fix string migration when type coercion is used

### DIFF
--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -261,11 +261,11 @@ class YamlConfig(QObject):
                               source: str, target: str) -> None:
         if name in settings:
             for scope, val in settings[name].items():
-                assert isinstance(val, str)
-                new_val = re.sub(source, target, val)
-                if new_val != val:
-                    settings[name][scope] = new_val
-                    self._mark_changed()
+                if isinstance(val, str):
+                    new_val = re.sub(source, target, val)
+                    if new_val != val:
+                        settings[name][scope] = new_val
+                        self._mark_changed()
 
     def _handle_migrations(self, settings: _SettingsType) -> '_SettingsType':
         """Migrate older configs to the newest format."""

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -290,6 +290,8 @@ class TestYaml:
         ('eve{title}duna', 'eve{current_title}duna'),
         ('eve{{title}}duna', 'eve{{title}}duna'),
         ('{{title}}', '{{title}}'),
+        ('', ''),
+        (None, None),
     ])
     def test_title_format_migrations(self, migration_test, setting, old, new):
         migration_test(setting, old, new)


### PR DESCRIPTION
#4737 was unsafe, string values seem to be coerced to null by the config system.

I added some tests to cover this case as well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4751)
<!-- Reviewable:end -->
