### PR TITLE
Fix open_url: the "load status success" line must be after the command called line

### DIFF
--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -656,8 +656,11 @@ class QuteProc(testprocess.Process):
         Args:
             count: The count to pass to the command.
             invalid: If True, we don't wait for "command called: ..." in the
-                     log
+                     log and return None.
             escape: Escape backslashes in the command
+
+        Return:
+            The parsed log line with "command called: ..." or None.
         """
         summary = command
         if count is not None:
@@ -672,9 +675,11 @@ class QuteProc(testprocess.Process):
                                                      command.lstrip(':'))
 
         self.send_ipc([command])
-        if not invalid:
-            self.wait_for(category='commands', module='command',
-                          function='run', message='command called: *')
+        if invalid:
+            return None
+        else:
+            return self.wait_for(category='commands', module='command',
+                                 function='run', message='command called: *')
 
     def get_setting(self, opt):
         """Get the value of a qutebrowser setting."""
@@ -716,19 +721,20 @@ class QuteProc(testprocess.Process):
 
         if as_url:
             self.send_cmd(url, invalid=True)
+            line = None
         elif new_tab:
-            self.send_cmd(':open -t ' + url)
+            line = self.send_cmd(':open -t ' + url)
         elif new_bg_tab:
-            self.send_cmd(':open -b ' + url)
+            line = self.send_cmd(':open -b ' + url)
         elif new_window:
-            self.send_cmd(':open -w ' + url)
+            line = self.send_cmd(':open -w ' + url)
         elif private:
-            self.send_cmd(':open -p ' + url)
+            line = self.send_cmd(':open -p ' + url)
         else:
-            self.send_cmd(':open ' + url)
+            line = self.send_cmd(':open ' + url)
 
         if wait:
-            self.wait_for_load_finished_url(url)
+            self.wait_for_load_finished_url(url, after=line)
 
     def mark_expected(self, category=None, loglevel=None, message=None):
         """Mark a given logging message as expected."""
@@ -737,7 +743,7 @@ class QuteProc(testprocess.Process):
         line.expected = True
 
     def wait_for_load_finished_url(self, url, *, timeout=None,
-                                   load_status='success'):
+                                   load_status='success', after=None):
         """Wait until a URL has finished loading."""
         __tracebackhide__ = (lambda e: e.errisinstance(
             testprocess.WaitForTimeout))
@@ -773,7 +779,7 @@ class QuteProc(testprocess.Process):
                     load_status=re.escape(load_status), url=re.escape(url)))
 
         try:
-            self.wait_for(message=pattern, timeout=timeout)
+            self.wait_for(message=pattern, timeout=timeout, after=after)
         except testprocess.WaitForTimeout:
             raise testprocess.WaitForTimeout("Timed out while waiting for {} "
                                              "to be loaded".format(url))


### PR DESCRIPTION
It appears that this makes a test in https://www.travis-ci.org/qutebrowser/qutebrowser/jobs/526048084 fail.

--------

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4752)
<!-- Reviewable:end -->
