### PR TITLE
Add delete target for hints

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -41,7 +41,8 @@ from qutebrowser.utils import usertypes, log, qtutils, message, objreg, utils
 
 Target = enum.Enum('Target', ['normal', 'current', 'tab', 'tab_fg', 'tab_bg',
                               'window', 'yank', 'yank_primary', 'run', 'fill',
-                              'hover', 'download', 'userscript', 'spawn'])
+                              'hover', 'download', 'userscript', 'spawn',
+                              'delete'])
 
 
 class HintingError(Exception):
@@ -147,6 +148,7 @@ class HintContext:
                 download: Download the link.
                 userscript: Call a custom userscript.
                 spawn: Spawn a simple command.
+                delete: Delete the selected element.
         to_follow: The link to follow when enter is pressed.
         args: Custom arguments for userscript/spawn
         rapid: Whether to do rapid hinting.
@@ -327,6 +329,9 @@ class HintActions:
         except userscripts.Error as e:
             raise HintingError(str(e))
 
+    def delete(self, elem, _context):
+        elem.delete()
+
     def spawn(self, url, context):
         """Spawn a simple command from a hint.
 
@@ -371,6 +376,7 @@ class HintManager(QObject):
         Target.download: "Download hint",
         Target.userscript: "Call userscript via hint",
         Target.spawn: "Spawn command via hint",
+        Target.delete: "Delete an element",
     }
 
     def __init__(self, win_id, tab_id, parent=None):
@@ -888,6 +894,7 @@ class HintManager(QObject):
             # _download needs a QWebElement to get the frame.
             Target.download: self._actions.download,
             Target.userscript: self._actions.call_userscript,
+            Target.delete: self._actions.delete,
         }
         # Handlers which take a QUrl
         url_handlers = {

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -365,6 +365,10 @@ class AbstractWebElement(collections.abc.MutableMapping):
         """Fake a click by using the JS .click() method."""
         raise NotImplementedError
 
+    def delete(self) -> None:
+        """Delete this element from the DOM."""
+        raise NotImplementedError
+
     def _click_href(self, click_target: usertypes.ClickTarget) -> None:
         """Fake a click on an element with a href by opening the link."""
         baseurl = self._tab.url()

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -209,6 +209,9 @@ class WebEngineElement(webelem.AbstractWebElement):
             self._js_dict['attributes']['target'] = '_top'
         self._js_call('remove_blank_target')
 
+    def delete(self) -> None:
+        self._js_call('delete')
+
     def _move_text_cursor(self) -> None:
         if self.is_text_input() and self.is_editable():
             self._js_call('move_cursor_to_end')

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -324,6 +324,9 @@ class WebKitElement(webelem.AbstractWebElement):
                 break
             elem = elem._parent()  # pylint: disable=protected-access
 
+    def delete(self) -> None:
+        self._elem.evaluateJavaScript('this.remove();')
+
     def _move_text_cursor(self) -> None:
         if self.is_text_input() and self.is_editable():
             self._tab.caret.move_to_end_of_document()

--- a/qutebrowser/javascript/webelem.js
+++ b/qutebrowser/javascript/webelem.js
@@ -412,5 +412,10 @@ window._qutebrowser.webelem = (function() {
         elem.selectionEnd = elem.value.length;
     };
 
+    funcs.delete = (id) => {
+        const elem = elements[id];
+        elem.remove();
+    };
+
     return funcs;
 })();

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -569,3 +569,10 @@ Feature: Using hints
         And I run :jseval console.log(document.activeElement.id == "qute-input");
         And I run :leave-mode
         Then the javascript message "true" should be logged
+
+    # Delete hint target
+    Scenario: Deleting a simple target
+        When I open data/hints/html/simple.html
+        And I hint with args "all delete" and follow a
+        And I run :hint
+        Then the error "No elements found." should be shown


### PR DESCRIPTION
Add a hint target to delete the selected element. This can be useful for doing ad-hoc deletions of elements, although I don't think the currently defined targets make it fully useful.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4755)
<!-- Reviewable:end -->
