### PR TITLE
Check if the tab is current in HintManager._start_cb

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -591,6 +591,18 @@ class HintManager(QObject):
             message.error("No elements found.")
             return
 
+        # Because _start_cb is called asynchronously, it's possible that the
+        # user switched to another tab or closed the tab/window. In that case
+        # we should not start hinting.
+        tabbed_browser = objreg.get('tabbed-browser', default=None,
+                                    scope='window', window=self._win_id)
+        tab = tabbed_browser.widget.currentWidget()
+        if tab.tab_id != self._tab_id:
+            log.hints.debug(
+                "Current tab changed ({} -> {}) before _start_cb is run."
+                .format(self._tab_id, tab.tab_id))
+            return
+
         strings = self._hint_strings(elems)
         log.hints.debug("hints: {}".format(', '.join(strings)))
 

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -19,12 +19,6 @@ Feature: Using hints
         When I run :hint --mode=foobar
         Then the error "Invalid mode: Invalid value 'foobar' - valid values: number, letter, word" should be shown
 
-    Scenario: Switching tab between :hint and start_cb (issue 3892)
-        When I open data/hints/html/simple.html
-        And I open data/hints/html/simple.html in a new tab
-        And I run :hint ;; tab-prev
-        Then "Current tab changed (* -> *) before _start_cb is run." should be logged
-
     ### Opening in current or new tab
 
     Scenario: Following a hint and force to open in current tab.

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -23,7 +23,7 @@ Feature: Using hints
         When I open data/hints/html/simple.html
         And I open data/hints/html/simple.html in a new tab
         And I run :hint ;; tab-prev
-        And I wait for regex "hints: .*|Current tab changed (\d* -> \d*) before _start_cb is run." in the log
+        And I wait for regex "hints: .*|Current tab changed \(\d* -> \d*\) before _start_cb is run." in the log
         # 'hints: .*' is logged when _start_cb is called before tab-prev (on
         # qtwebkit, _start_cb is called synchronously)
         And I run :follow-hint a

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -19,6 +19,12 @@ Feature: Using hints
         When I run :hint --mode=foobar
         Then the error "Invalid mode: Invalid value 'foobar' - valid values: number, letter, word" should be shown
 
+    Scenario: Switching tab between :hint and start_cb (issue 3892)
+        When I open data/hints/html/simple.html
+        And I open data/hints/html/simple.html in a new tab
+        And I run :hint ;; tab-prev
+        Then "Current tab changed (* -> *) before _start_cb is run." should be logged
+
     ### Opening in current or new tab
 
     Scenario: Following a hint and force to open in current tab.

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -19,6 +19,16 @@ Feature: Using hints
         When I run :hint --mode=foobar
         Then the error "Invalid mode: Invalid value 'foobar' - valid values: number, letter, word" should be shown
 
+    Scenario: Switching tab between :hint and start_cb (issue 3892)
+        When I open data/hints/html/simple.html
+        And I open data/hints/html/simple.html in a new tab
+        And I run :hint ;; tab-prev
+        And I wait for regex "hints: .*|Current tab changed (\d* -> \d*) before _start_cb is run." in the log
+        # 'hints: .*' is logged when _start_cb is called before tab-prev (on
+        # qtwebkit, _start_cb is called synchronously)
+        And I run :follow-hint a
+        Then the error "follow-hint: This command is only allowed in hint mode, not normal." should be shown
+
     ### Opening in current or new tab
 
     Scenario: Following a hint and force to open in current tab.

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -23,7 +23,7 @@ Feature: Using hints
         When I open data/hints/html/simple.html
         And I open data/hints/html/simple.html in a new tab
         And I run :hint ;; tab-prev
-        And I wait for regex "hints: .*|Current tab changed \(\d* -> \d*\) before _start_cb is run." in the log
+        And I wait for regex "hints: .*|Current tab changed \(\d* -> \d*\) before _start_cb is run\." in the log
         # 'hints: .*' is logged when _start_cb is called before tab-prev (on
         # qtwebkit, _start_cb is called synchronously)
         And I run :follow-hint a

--- a/tests/unit/browser/test_hints.py
+++ b/tests/unit/browser/test_hints.py
@@ -54,7 +54,8 @@ def test_show_benchmark(benchmark, tabbed_browser, qtbot, message_bridge,
     with qtbot.wait_signal(tab.load_finished):
         tab.load_url(QUrl('qute://testdata/data/hints/benchmark.html'))
 
-    manager = qutebrowser.browser.hints.HintManager(0, 0)
+    manager = qutebrowser.browser.hints.HintManager(
+        win_id=0, tab_id=tab.tab_id)
 
     def bench():
         with qtbot.wait_signal(mode_manager.entered):
@@ -75,7 +76,8 @@ def test_match_benchmark(benchmark, tabbed_browser, qtbot, message_bridge,
         tab.load_url(QUrl('qute://testdata/data/hints/benchmark.html'))
 
     config_stub.val.hints.scatter = False
-    manager = qutebrowser.browser.hints.HintManager(0, 0)
+    manager = qutebrowser.browser.hints.HintManager(
+        win_id=0, tab_id=tab.tab_id)
 
     with qtbot.wait_signal(mode_manager.entered):
         manager.start()


### PR DESCRIPTION
Reopen this because accidentally closed #4763.

Currently tabbed_browser and tab are not check for None because

> I think at this time, the tab should not be closed (because otherwise find_css would raise an error), so tabbed_browser cannot be None.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4764)
<!-- Reviewable:end -->
