### PR TITLE
Add missing docs for delete hint target to :hint

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -631,6 +631,7 @@ Start hinting.
  - `userscript`: Call a userscript with `$QUTE_URL` set to the
  link.
  - `spawn`: Spawn a command.
+ - `delete`: Delete the selected element.
  
 
 

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -680,6 +680,7 @@ class HintManager(QObject):
                 - `userscript`: Call a userscript with `$QUTE_URL` set to the
                                 link.
                 - `spawn`: Spawn a command.
+                - `delete`: Delete the selected element.
 
             mode: The hinting mode to use.
 


### PR DESCRIPTION
I messed up and only inserted the docs in the HintContext docs block, this should be a trivial commit to fix it :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4782)
<!-- Reviewable:end -->
