### PR TITLE
Get rid of pylint disable unused import when import is only used in type comment

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -44,8 +44,6 @@ from qutebrowser.browser import mouse, hints
 from qutebrowser.qt import sip
 MYPY = False
 if MYPY:
-    # pylint can't interpret type comments with Python 3.7
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.browser import webelem
     from qutebrowser.browser.inspector import AbstractWebInspector
 

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -31,7 +31,6 @@ from qutebrowser.mainwindow import mainwindow
 from qutebrowser.utils import log, usertypes, utils, qtutils, objreg
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.browser import browsertab
 
 

--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -33,7 +33,6 @@ from qutebrowser.utils import log, javascript, urlutils, usertypes
 from qutebrowser.browser import webelem
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.browser.webengine import webenginetab
 
 

--- a/qutebrowser/browser/webkit/network/networkmanager.py
+++ b/qutebrowser/browser/webkit/network/networkmanager.py
@@ -32,8 +32,6 @@ from qutebrowser.config import config
 
 MYPY = False
 if MYPY:
-    # pylint can't interpret type comments with Python 3.7
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.mainwindow import prompt
 from qutebrowser.utils import (message, log, usertypes, utils, objreg,
                                urlutils, debug)

--- a/qutebrowser/browser/webkit/webkitelem.py
+++ b/qutebrowser/browser/webkit/webkitelem.py
@@ -30,7 +30,6 @@ from qutebrowser.utils import log, utils, javascript, usertypes
 from qutebrowser.browser import webelem
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.browser.webkit import webkittab
 
 

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -34,7 +34,6 @@ from qutebrowser.keyinput import keyutils
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from typing import Tuple, MutableMapping
     from qutebrowser.config import configcache, configfiles
     from qutebrowser.misc import savemanager

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -34,7 +34,6 @@ from qutebrowser.keyinput import keyutils
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.config.config import Config, KeyConfig
 
 

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -25,7 +25,7 @@ DATA: A dict of Option objects after init() has been called.
 """
 
 import typing
-from typing import Optional  # pylint: disable=unused-import,useless-suppression
+from typing import Optional
 import functools
 
 import attr

--- a/qutebrowser/config/configdiff.py
+++ b/qutebrowser/config/configdiff.py
@@ -19,7 +19,7 @@
 
 """Code to show a diff of the legacy config format."""
 
-import typing  # pylint: disable=unused-import,useless-suppression
+import typing
 import difflib
 import os.path
 

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -40,7 +40,6 @@ from qutebrowser.utils import standarddir, utils, qtutils, log, urlmatch
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import, useless-suppression
     from qutebrowser.misc import savemanager
 
 

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -31,7 +31,6 @@ from qutebrowser.config import configexc
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.config import configdata
 
 

--- a/qutebrowser/extensions/interceptors.py
+++ b/qutebrowser/extensions/interceptors.py
@@ -26,7 +26,6 @@ import attr
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from PyQt5.QtCore import QUrl
 
 

--- a/qutebrowser/extensions/loader.py
+++ b/qutebrowser/extensions/loader.py
@@ -36,7 +36,6 @@ from qutebrowser.utils import log, standarddir, objreg
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     import argparse
 
 

--- a/qutebrowser/misc/objects.py
+++ b/qutebrowser/misc/objects.py
@@ -26,7 +26,6 @@ import typing
 
 MYPY = False
 if MYPY:
-    # pylint: disable=unused-import,useless-suppression
     from qutebrowser.utils import usertypes
     from qutebrowser.commands import command
 

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -31,7 +31,7 @@ Module attributes:
 import io
 import operator
 import contextlib
-import typing  # pylint: disable=unused-import,useless-suppression
+import typing
 
 import pkg_resources
 from PyQt5.QtCore import (qVersion, QEventLoop, QDataStream, QByteArray,


### PR DESCRIPTION
As suggested in #4778.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4783)
<!-- Reviewable:end -->
