### PR TITLE
Hint filter text is uneditable immediately after selecting a hint in rapid mode

### DIFF
--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -207,7 +207,7 @@ class HintKeyParser(CommandKeyParser):
                                "sequence '{}'".format(self._last_press,
                                                       self._filtertext,
                                                       self._sequence))
-            if self._last_press == LastPress.filtertext and self._filtertext:
+            if self._last_press != LastPress.keystring and self._filtertext:
                 self._filtertext = self._filtertext[:-1]
                 hintmanager.filter_hints(self._filtertext)
                 return QKeySequence.ExactMatch

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -427,6 +427,17 @@ Feature: Using hints
         And I hint with args "--rapid" and follow 00
         Then data/numbers/1.txt should be loaded
 
+    Scenario: Changing rapid hint filter after selecting hint
+        When I open data/hints/number.html
+        And I set hints.mode to number
+        And I hint with args "all tab-bg --rapid "
+        And I press the key "e"
+        And I press the key "2"
+        And I press the key "<Backspace>"
+        And I press the key "o"
+        And I press the key "0"
+        Then data/numbers/1.txt should be loaded
+
     Scenario: Using a specific hints mode
         When I open data/hints/number.html
         And I set hints.mode to letter


### PR DESCRIPTION
With number hinting, if you run a rapid hint, type a filter, and select a hint, the filter will not be affected by a backspace until the filter is added to again. This patch allows backspace to work even if there's no previous key press recorded.