### PR TITLE
Improve config cache

### DIFF
--- a/qutebrowser/config/configcache.py
+++ b/qutebrowser/config/configcache.py
@@ -30,8 +30,8 @@ class ConfigCache:
     """A 'high-performance' cache for the config system.
 
     Useful for areas which call out to the config system very frequently, DO
-    NOT modify the value returned, DO NOT require per-url settings, do not
-    change frequently, and do not require partially 'expanded' config paths.
+    NOT modify the value returned, DO NOT require per-url settings, and do not
+    require partially 'expanded' config paths.
 
     If any of these requirements are broken, you will get incorrect or slow
     behavior.
@@ -43,7 +43,7 @@ class ConfigCache:
 
     def _on_config_changed(self, attr: str) -> None:
         if attr in self._cache:
-            self._cache[attr] = config.instance.get(attr)
+            del self._cache[attr]
 
     def __getitem__(self, attr: str) -> typing.Any:
         try:

--- a/qutebrowser/config/configcache.py
+++ b/qutebrowser/config/configcache.py
@@ -50,5 +50,5 @@ class ConfigCache:
             return self._cache[attr]
         except KeyError:
             assert not config.instance.get_opt(attr).supports_pattern
-            self._cache[attr] = config.instance.get(attr)
-            return self._cache[attr]
+            result = self._cache[attr] = config.instance.get(attr)
+            return result


### PR DESCRIPTION
Some people complain that this is micro optimization, but I think we should remove the "weird" restriction on when not to use config cache.



<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4797)
<!-- Reviewable:end -->
