### PR TITLE
[WIP] Move all stylesheet to per-window stylesheet

### DIFF
--- a/qutebrowser/browser/downloadview.py
+++ b/qutebrowser/browser/downloadview.py
@@ -25,7 +25,6 @@ from PyQt5.QtCore import pyqtSlot, QSize, Qt, QTimer
 from PyQt5.QtWidgets import QListView, QSizePolicy, QMenu, QStyleFactory
 
 from qutebrowser.browser import downloads
-from qutebrowser.config import config
 from qutebrowser.utils import qtutils, utils, objreg
 from qutebrowser.qt import sip
 

--- a/qutebrowser/browser/downloadview.py
+++ b/qutebrowser/browser/downloadview.py
@@ -62,22 +62,10 @@ class DownloadView(QListView):
         _model: The currently set model.
     """
 
-    STYLESHEET = """
-        QListView {
-            background-color: {{ conf.colors.downloads.bar.bg }};
-            font: {{ conf.fonts.downloads }};
-        }
-
-        QListView::item {
-            padding-right: 2px;
-        }
-    """
-
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
         if not utils.is_mac:
             self.setStyle(QStyleFactory.create('Fusion'))
-        config.set_register_stylesheet(self)
         self.setResizeMode(QListView.Adjust)
         self.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOff)
         self.setSizePolicy(QSizePolicy.MinimumExpanding, QSizePolicy.Fixed)

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -54,53 +54,7 @@ class CompletionView(QTreeView):
     """
 
     # Drawing the item foreground will be done by CompletionItemDelegate, so we
-    # don't define that in this stylesheet.
-    STYLESHEET = """
-        QTreeView {
-            font: {{ conf.fonts.completion.entry }};
-            background-color: {{ conf.colors.completion.even.bg }};
-            alternate-background-color: {{ conf.colors.completion.odd.bg }};
-            outline: 0;
-            border: 0px;
-        }
-
-        QTreeView::item:disabled {
-            background-color: {{ conf.colors.completion.category.bg }};
-            border-top: 1px solid
-                {{ conf.colors.completion.category.border.top }};
-            border-bottom: 1px solid
-                {{ conf.colors.completion.category.border.bottom }};
-        }
-
-        QTreeView::item:selected, QTreeView::item:selected:hover {
-            border-top: 1px solid
-                {{ conf.colors.completion.item.selected.border.top }};
-            border-bottom: 1px solid
-                {{ conf.colors.completion.item.selected.border.bottom }};
-            background-color: {{ conf.colors.completion.item.selected.bg }};
-        }
-
-        QTreeView:item::hover {
-            border: 0px;
-        }
-
-        QTreeView QScrollBar {
-            width: {{ conf.completion.scrollbar.width }}px;
-            background: {{ conf.colors.completion.scrollbar.bg }};
-        }
-
-        QTreeView QScrollBar::handle {
-            background: {{ conf.colors.completion.scrollbar.fg }};
-            border: {{ conf.completion.scrollbar.padding }}px solid
-                    {{ conf.colors.completion.scrollbar.bg }};
-            min-height: 10px;
-        }
-
-        QTreeView QScrollBar::sub-line, QScrollBar::add-line {
-            border: none;
-            background: none;
-        }
-    """
+    # don't define that in the stylesheet for this class.
 
     update_geometry = pyqtSignal()
     selection_changed = pyqtSignal(str)
@@ -116,7 +70,6 @@ class CompletionView(QTreeView):
         self._delegate = completiondelegate.CompletionItemDelegate(self)
         self.setItemDelegate(self._delegate)
         self.setStyle(QStyleFactory.create('Fusion'))
-        config.set_register_stylesheet(self)
         self.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
         self.setHeaderHidden(True)
         self.setAlternatingRowColors(True)

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -127,6 +127,45 @@ def get_target_window():
         return None
 
 
+def _generate_stylesheet_statusbar():
+    flags = [
+        ('private', 'statusbar.private'),
+        ('caret', 'statusbar.caret'),
+        ('caret-selection', 'statusbar.caret.selection'),
+        ('prompt', 'prompts'),
+        ('insert', 'statusbar.insert'),
+        ('command', 'statusbar.command'),
+        ('passthrough', 'statusbar.passthrough'),
+        ('private-command', 'statusbar.command.private'),
+    ]
+    stylesheet = """
+        StatusBar,
+        StatusBar QLabel,
+        StatusBar QLineEdit {
+            font: {{ conf.fonts.statusbar }};
+            color: {{ conf.colors.statusbar.normal.fg }};
+        }
+
+        StatusBar {
+            background-color: {{ conf.colors.statusbar.normal.bg }};
+        }
+    """
+    for flag, option in flags:
+        stylesheet += """
+            StatusBar[color_flags~="%s"],
+            StatusBar[color_flags~="%s"] QLabel,
+            StatusBar[color_flags~="%s"] QLineEdit {
+                color: {{ conf.colors.%s }};
+            }
+
+            StatusBar[color_flags~="%s"] {
+                background-color: {{ conf.colors.%s }};
+            }
+        """ % (flag, flag, flag,  # noqa: S001
+               option + '.fg', flag, option + '.bg')
+    return stylesheet
+
+
 class MainWindow(QWidget):
 
     """The main window of qutebrowser.
@@ -155,7 +194,147 @@ class MainWindow(QWidget):
             padding-left: 3px;
             padding-right: 3px;
         }
-    """
+
+        CompletionView {
+            font: {{ conf.fonts.completion.entry }};
+            background-color: {{ conf.colors.completion.even.bg }};
+            alternate-background-color: {{ conf.colors.completion.odd.bg }};
+            outline: 0;
+            border: 0px;
+        }
+
+        CompletionView::item:disabled {
+            background-color: {{ conf.colors.completion.category.bg }};
+            border-top: 1px solid
+                {{ conf.colors.completion.category.border.top }};
+            border-bottom: 1px solid
+                {{ conf.colors.completion.category.border.bottom }};
+        }
+
+        CompletionView::item:selected, QTreeView::item:selected:hover {
+            border-top: 1px solid
+                {{ conf.colors.completion.item.selected.border.top }};
+            border-bottom: 1px solid
+                {{ conf.colors.completion.item.selected.border.bottom }};
+            background-color: {{ conf.colors.completion.item.selected.bg }};
+        }
+
+        CompletionView:item::hover {
+            border: 0px;
+        }
+
+        CompletionView QScrollBar {
+            width: {{ conf.completion.scrollbar.width }}px;
+            background: {{ conf.colors.completion.scrollbar.bg }};
+        }
+
+        CompletionView QScrollBar::handle {
+            background: {{ conf.colors.completion.scrollbar.fg }};
+            border: {{ conf.completion.scrollbar.padding }}px solid
+                    {{ conf.colors.completion.scrollbar.bg }};
+            min-height: 10px;
+        }
+
+        CompletionView QScrollBar::sub-line, QScrollBar::add-line {
+            border: none;
+            background: none;
+        }
+
+        PromptContainer {
+            {% if conf.statusbar.position == 'top' %}
+                border-bottom-left-radius: {{ conf.prompt.radius }}px;
+                border-bottom-right-radius: {{ conf.prompt.radius }}px;
+            {% else %}
+                border-top-left-radius: {{ conf.prompt.radius }}px;
+                border-top-right-radius: {{ conf.prompt.radius }}px;
+            {% endif %}
+        }
+
+        PromptContainer, PromptContainer QWidget {
+            font: {{ conf.fonts.prompts }};
+            color: {{ conf.colors.prompts.fg }};
+            background-color: {{ conf.colors.prompts.bg }};
+        }
+
+        PromptContainer QLineEdit {
+            border: {{ conf.colors.prompts.border }};
+        }
+
+        PromptContainer QTreeView {
+            selection-background-color: {{ conf.colors.prompts.selected.bg }};
+            border: {{ conf.colors.prompts.border }};
+        }
+
+        PromptContainer QTreeView::branch {
+            background-color: {{ conf.colors.prompts.bg }};
+        }
+
+        PromptContainer QTreeView::item:selected,
+        PromptContainer QTreeView::item:selected:hover,
+        PromptContainer QTreeView::branch:selected {
+            background-color: {{ conf.colors.prompts.selected.bg }};
+        }
+
+        UrlText[urltype="normal"] {
+            color: {{ conf.colors.statusbar.url.fg }};
+        }
+
+        UrlText[urltype="success"] {
+            color: {{ conf.colors.statusbar.url.success.http.fg }};
+        }
+
+        UrlText[urltype="success_https"] {
+            color: {{ conf.colors.statusbar.url.success.https.fg }};
+        }
+
+        UrlText[urltype="error"] {
+            color: {{ conf.colors.statusbar.url.error.fg }};
+        }
+
+        UrlText[urltype="warn"] {
+            color: {{ conf.colors.statusbar.url.warn.fg }};
+        }
+
+        UrlText[urltype="hover"] {
+            color: {{ conf.colors.statusbar.url.hover.fg }};
+        }
+
+        Progress {
+            border-radius: 0px;
+            border: 2px solid transparent;
+            background-color: transparent;
+            font: {{ conf.fonts.statusbar }};
+        }
+
+        Progress::chunk {
+            background-color: {{ conf.colors.statusbar.progress.bg }};
+        }
+
+        TabBar {
+            background-color: {{ conf.colors.tabs.bar.bg }};
+        }
+
+        KeyHintView {
+            font: {{ conf.fonts.keyhint }};
+            color: {{ conf.colors.keyhint.fg }};
+            background-color: {{ conf.colors.keyhint.bg }};
+            padding: 6px;
+            {% if conf.statusbar.position == 'top' %}
+                border-bottom-right-radius: {{ conf.keyhint.radius }}px;
+            {% else %}
+                border-top-right-radius: {{ conf.keyhint.radius }}px;
+            {% endif %}
+        }
+
+        DownloadView {
+            background-color: {{ conf.colors.downloads.bar.bg }};
+            font: {{ conf.fonts.downloads }};
+        }
+
+        DownloadView::item {
+            padding-right: 2px;
+        }
+    """ + _generate_stylesheet_statusbar()
 
     def __init__(self, *, private, geometry=None, parent=None):
         """Create a new main window.

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -242,41 +242,6 @@ class PromptContainer(QWidget):
         update_geometry: Emitted when the geometry should be updated.
     """
 
-    STYLESHEET = """
-        QWidget#PromptContainer {
-            {% if conf.statusbar.position == 'top' %}
-                border-bottom-left-radius: {{ conf.prompt.radius }}px;
-                border-bottom-right-radius: {{ conf.prompt.radius }}px;
-            {% else %}
-                border-top-left-radius: {{ conf.prompt.radius }}px;
-                border-top-right-radius: {{ conf.prompt.radius }}px;
-            {% endif %}
-        }
-
-        QWidget {
-            font: {{ conf.fonts.prompts }};
-            color: {{ conf.colors.prompts.fg }};
-            background-color: {{ conf.colors.prompts.bg }};
-        }
-
-        QLineEdit {
-            border: {{ conf.colors.prompts.border }};
-        }
-
-        QTreeView {
-            selection-background-color: {{ conf.colors.prompts.selected.bg }};
-            border: {{ conf.colors.prompts.border }};
-        }
-
-        QTreeView::branch {
-            background-color: {{ conf.colors.prompts.bg }};
-        }
-
-        QTreeView::item:selected, QTreeView::item:selected:hover,
-        QTreeView::branch:selected {
-            background-color: {{ conf.colors.prompts.selected.bg }};
-        }
-    """
     update_geometry = pyqtSignal()
 
     def __init__(self, win_id, parent=None):
@@ -286,9 +251,7 @@ class PromptContainer(QWidget):
         self._win_id = win_id
         self._prompt = None
 
-        self.setObjectName('PromptContainer')
         self.setAttribute(Qt.WA_StyledBackground, True)
-        config.set_register_stylesheet(self)
 
         message.global_bridge.prompt_done.connect(self._on_prompt_done)
         prompt_queue.show_prompts.connect(self._on_show_prompts)

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -256,6 +256,7 @@ class StatusBar(QWidget):
                 # Turning on is handled in on_current_caret_selection_toggled
                 log.statusbar.debug("Setting caret mode off")
                 self._color_flags.caret = ColorFlags.CaretMode.off
+        self.style().polish(self)
 
     def _set_mode_text(self, mode):
         """Set the mode text."""
@@ -341,6 +342,7 @@ class StatusBar(QWidget):
         else:
             self._set_mode_text("caret")
             self._color_flags.caret = ColorFlags.CaretMode.on
+        self.style().polish(self)
 
     def resizeEvent(self, e):
         """Extend resizeEvent of QWidget to emit a resized signal afterwards.

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -85,45 +85,6 @@ class ColorFlags:
         return strings
 
 
-def _generate_stylesheet():
-    flags = [
-        ('private', 'statusbar.private'),
-        ('caret', 'statusbar.caret'),
-        ('caret-selection', 'statusbar.caret.selection'),
-        ('prompt', 'prompts'),
-        ('insert', 'statusbar.insert'),
-        ('command', 'statusbar.command'),
-        ('passthrough', 'statusbar.passthrough'),
-        ('private-command', 'statusbar.command.private'),
-    ]
-    stylesheet = """
-        QWidget#StatusBar,
-        QWidget#StatusBar QLabel,
-        QWidget#StatusBar QLineEdit {
-            font: {{ conf.fonts.statusbar }};
-            color: {{ conf.colors.statusbar.normal.fg }};
-        }
-
-        QWidget#StatusBar {
-            background-color: {{ conf.colors.statusbar.normal.bg }};
-        }
-    """
-    for flag, option in flags:
-        stylesheet += """
-            QWidget#StatusBar[color_flags~="%s"],
-            QWidget#StatusBar[color_flags~="%s"] QLabel,
-            QWidget#StatusBar[color_flags~="%s"] QLineEdit {
-                color: {{ conf.colors.%s }};
-            }
-
-            QWidget#StatusBar[color_flags~="%s"] {
-                background-color: {{ conf.colors.%s }};
-            }
-        """ % (flag, flag, flag,  # noqa: S001
-               option + '.fg', flag, option + '.bg')
-    return stylesheet
-
-
 class StatusBar(QWidget):
 
     """The statusbar at the bottom of the mainwindow.
@@ -153,14 +114,10 @@ class StatusBar(QWidget):
     _severity = None
     _color_flags = None
 
-    STYLESHEET = _generate_stylesheet()
-
     def __init__(self, *, win_id, private, parent=None):
         super().__init__(parent)
         objreg.register('statusbar', self, scope='window', window=win_id)
-        self.setObjectName(self.__class__.__name__)
         self.setAttribute(Qt.WA_StyledBackground)
-        config.set_register_stylesheet(self)
 
         self.setSizePolicy(QSizePolicy.Ignored, QSizePolicy.Fixed)
 
@@ -299,7 +256,6 @@ class StatusBar(QWidget):
                 # Turning on is handled in on_current_caret_selection_toggled
                 log.statusbar.debug("Setting caret mode off")
                 self._color_flags.caret = ColorFlags.CaretMode.off
-        config.set_register_stylesheet(self, update=False)
 
     def _set_mode_text(self, mode):
         """Set the mode text."""
@@ -385,7 +341,6 @@ class StatusBar(QWidget):
         else:
             self._set_mode_text("caret")
             self._color_flags.caret = ColorFlags.CaretMode.on
-        config.set_register_stylesheet(self, update=False)
 
     def resizeEvent(self, e):
         """Extend resizeEvent of QWidget to emit a resized signal afterwards.

--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -22,7 +22,6 @@
 from PyQt5.QtCore import pyqtSlot, QSize
 from PyQt5.QtWidgets import QProgressBar, QSizePolicy
 
-from qutebrowser.config import config
 from qutebrowser.utils import utils, usertypes
 
 

--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -30,22 +30,8 @@ class Progress(QProgressBar):
 
     """The progress bar part of the status bar."""
 
-    STYLESHEET = """
-        QProgressBar {
-            border-radius: 0px;
-            border: 2px solid transparent;
-            background-color: transparent;
-            font: {{ conf.fonts.statusbar }};
-        }
-
-        QProgressBar::chunk {
-            background-color: {{ conf.colors.statusbar.progress.bg }};
-        }
-    """
-
     def __init__(self, parent=None):
         super().__init__(parent)
-        config.set_register_stylesheet(self)
         self.enabled = False
         self.setSizePolicy(QSizePolicy.Fixed, QSizePolicy.Fixed)
         self.setTextVisible(False)

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -24,7 +24,6 @@ import enum
 from PyQt5.QtCore import pyqtSlot, pyqtProperty, QUrl
 
 from qutebrowser.mainwindow.statusbar import textbase
-from qutebrowser.config import config
 from qutebrowser.utils import usertypes, urlutils
 
 

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -53,36 +53,8 @@ class UrlText(textbase.TextBase):
 
     _urltype = None
 
-    STYLESHEET = """
-        QLabel#UrlText[urltype="normal"] {
-            color: {{ conf.colors.statusbar.url.fg }};
-        }
-
-        QLabel#UrlText[urltype="success"] {
-            color: {{ conf.colors.statusbar.url.success.http.fg }};
-        }
-
-        QLabel#UrlText[urltype="success_https"] {
-            color: {{ conf.colors.statusbar.url.success.https.fg }};
-        }
-
-        QLabel#UrlText[urltype="error"] {
-            color: {{ conf.colors.statusbar.url.error.fg }};
-        }
-
-        QLabel#UrlText[urltype="warn"] {
-            color: {{ conf.colors.statusbar.url.warn.fg }};
-        }
-
-        QLabel#UrlText[urltype="hover"] {
-            color: {{ conf.colors.statusbar.url.hover.fg }};
-        }
-    """
-
     def __init__(self, parent=None):
         super().__init__(parent)
-        self.setObjectName(self.__class__.__name__)
-        config.set_register_stylesheet(self)
         self._hover_url = None
         self._normal_url = None
         self._normal_url_type = UrlType.normal
@@ -110,7 +82,6 @@ class UrlText(textbase.TextBase):
         else:
             self.setText('')
             self._urltype = UrlType.normal
-        config.set_register_stylesheet(self, update=False)
 
     @pyqtSlot(usertypes.LoadStatus)
     def on_load_status_changed(self, status):

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -81,6 +81,7 @@ class UrlText(textbase.TextBase):
         else:
             self.setText('')
             self._urltype = UrlType.normal
+        self.style().polish(self)
 
     @pyqtSlot(usertypes.LoadStatus)
     def on_load_status_changed(self, status):

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -375,12 +375,6 @@ class TabBar(QTabBar):
         new_tab_requested: Emitted when a new tab is requested.
     """
 
-    STYLESHEET = """
-        TabBar {
-            background-color: {{ conf.colors.tabs.bar.bg }};
-        }
-    """
-
     new_tab_requested = pyqtSignal()
 
     def __init__(self, win_id, parent=None):
@@ -396,7 +390,6 @@ class TabBar(QTabBar):
         self._on_show_switching_delay_changed()
         self.setAutoFillBackground(True)
         self.drag_in_progress = False
-        config.set_register_stylesheet(self)
         QTimer.singleShot(0, self.maybe_hide)
 
     def __repr__(self):

--- a/qutebrowser/misc/keyhintwidget.py
+++ b/qutebrowser/misc/keyhintwidget.py
@@ -48,19 +48,6 @@ class KeyHintView(QLabel):
         update_geometry: Emitted when this widget should be resized/positioned.
     """
 
-    STYLESHEET = """
-        QLabel {
-            font: {{ conf.fonts.keyhint }};
-            color: {{ conf.colors.keyhint.fg }};
-            background-color: {{ conf.colors.keyhint.bg }};
-            padding: 6px;
-            {% if conf.statusbar.position == 'top' %}
-                border-bottom-right-radius: {{ conf.keyhint.radius }}px;
-            {% else %}
-                border-top-right-radius: {{ conf.keyhint.radius }}px;
-            {% endif %}
-        }
-    """
     update_geometry = pyqtSignal()
 
     def __init__(self, win_id, parent=None):
@@ -72,7 +59,6 @@ class KeyHintView(QLabel):
         self._show_timer = usertypes.Timer(self, 'keyhint_show')
         self._show_timer.timeout.connect(self.show)
         self._show_timer.setSingleShot(True)
-        config.set_register_stylesheet(self)
 
     def __repr__(self):
         return utils.get_repr(self, win_id=self._win_id)


### PR DESCRIPTION
#4686

Problem:

* ~~The status bar is black regardless of mode. [1] However incognito (private) mode is still gray.~~
* ~~Same problem with `UrlText` color.~~
* Originally the `PromptContainer, PromptContainer QWidget` applies to all `QWidget` inside `PromptContainer`. If there's no child `QWidget` inside `PromptContainer` (or it doesn't matter) then that can be reduced to `PromptContainer`.
* Currently the test tests/unit/misc/test_keyhints.py::test_position_change [fails](https://travis-ci.org/qutebrowser/qutebrowser/jobs/537189125) because it check for the style sheet of the item, not its computed style.

[1]: Fixed. ([source](https://forum.qt.io/topic/81644/stylesheet-recomputing-after-property-change/3). In this case only the color changes, so it's sufficient. However I'm not sure if there's any problem with polishing twice.)

------

Currently we set the stylesheet for *everything* while only some (or even none) config options change, because of bad implementation.

With this change, at best we must set the stylesheet for *everything* when any config option related to style change. However more of the code are shifted to Qt so it may be better.

Ideally only the relevant objects have style sheet changed, which is the fastest possible option.

May need benchmark to see which option is faster.

-----

It seems that config-source is still rather slow, unfortunately.

--------

(the branch name is misleading. Sorry for that)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4806)
<!-- Reviewable:end -->
