### PR TITLE
Add :undo --window

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -128,7 +128,7 @@ possible to run or bind multiple commands by separating them with `;;`.
 |<<tab-prev,tab-prev>>|Switch to the previous tab, or switch [count] tabs back.
 |<<tab-take,tab-take>>|Take a tab from another window.
 |<<unbind,unbind>>|Unbind a keychain.
-|<<undo,undo>>|Re-open the last closed tab or tabs.
+|<<undo,undo>>|Re-open the last closed tab(s) or window.
 |<<version,version>>|Show version information.
 |<<view-source,view-source>>|Show the source of the current page in a new tab.
 |<<window-only,window-only>>|Close all windows except for the current one.
@@ -1467,7 +1467,12 @@ Unbind a keychain.
 
 [[undo]]
 === undo
-Re-open the last closed tab or tabs.
+Syntax: +:undo [*--window*]+
+
+Re-open the last closed tab(s) or window.
+
+==== optional arguments
+* +*-w*+, +*--window*+: Re-open the last closed window (and its tabs).
 
 [[version]]
 === version

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -313,7 +313,7 @@
 |<<tabs.title.format,tabs.title.format>>|Format to use for the tab title.
 |<<tabs.title.format_pinned,tabs.title.format_pinned>>|Format to use for the tab title for pinned tabs. The same placeholders like for `tabs.title.format` are defined.
 |<<tabs.tooltips,tabs.tooltips>>|Show tooltips on tabs.
-|<<tabs.undo_stack_size,tabs.undo_stack_size>>|Number of close tab actions to remember, per window (-1 for no maximum).
+|<<tabs.undo_stack_size,tabs.undo_stack_size>>|Number of closed tabs (per window) and closed windows to remember for :undo (-1 for no maximum).
 |<<tabs.width,tabs.width>>|Width (in pixels or as percentage of the window) of the tab bar if it's vertical.
 |<<tabs.wrap,tabs.wrap>>|Wrap when changing tabs.
 |<<url.auto_search,url.auto_search>>|What search to start when something else than a URL is entered.
@@ -4016,7 +4016,7 @@ Default: +pass:[true]+
 
 [[tabs.undo_stack_size]]
 === tabs.undo_stack_size
-Number of close tab actions to remember, per window (-1 for no maximum).
+Number of closed tabs (per window) and closed windows to remember for :undo (-1 for no maximum).
 
 Type: <<types,Int>>
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -606,6 +606,7 @@ Default:
 * +pass:[Sq]+: +pass:[open qute://bookmarks]+
 * +pass:[Ss]+: +pass:[open qute://settings]+
 * +pass:[T]+: +pass:[tab-focus]+
+* +pass:[U]+: +pass:[undo -w]+
 * +pass:[V]+: +pass:[enter-mode caret ;; toggle-selection --line]+
 * +pass:[ZQ]+: +pass:[quit]+
 * +pass:[ZZ]+: +pass:[quit --save]+

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -527,14 +527,21 @@ class Application(QApplication):
         )
 
     def _on_window_closing(self, window):
-        self._undos.append(window.tabbed_browser._undo_stack)
+        self._undos.append(mainwindow.WindowUndoEntry(
+            geometry=window.saveGeometry(),
+            private=window.tabbed_browser.is_private,
+            tab_stack=window.tabbed_browser._undo_stack,
+        ))
 
     @cmdutils.register(instance='app')
     def undo_last_window_close(self):
-        # TODO: save geometry too, and private
-        window = mainwindow.MainWindow(private=False)
+        event = self._undos.pop()
+        window = mainwindow.MainWindow(
+            private=event.private,
+            geometry=event.geometry,
+        )
         window.show()
-        window.tabbed_browser._undo_stack = self._undos.pop()
+        window.tabbed_browser._undo_stack = event.tab_stack
         window.tabbed_browser.undo()
 
     @pyqtSlot(QObject)

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -44,6 +44,7 @@ import tempfile
 import datetime
 import argparse
 import typing
+import collections
 
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtGui import QDesktopServices, QPixmap, QIcon
@@ -502,7 +503,7 @@ class Application(QApplication):
             Argument namespace from argparse.
         """
         self._last_focus_object = None
-        self._undos = []
+        self._undos = collections.deque(maxlen=100)
 
         qt_args = qtargs.qt_args(args)
         log.init.debug("Commandline args: {}".format(sys.argv[1:]))

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -39,6 +39,7 @@ blocks and spins the Qt mainloop.
 
 import os
 import sys
+import functools
 import tempfile
 import datetime
 import argparse
@@ -501,6 +502,7 @@ class Application(QApplication):
             Argument namespace from argparse.
         """
         self._last_focus_object = None
+        self._undos = []
 
         qt_args = qtargs.qt_args(args)
         log.init.debug("Commandline args: {}".format(sys.argv[1:]))
@@ -516,6 +518,24 @@ class Application(QApplication):
         self.focusObjectChanged.connect(  # type: ignore[attr-defined]
             self.on_focus_object_changed)
         self.setAttribute(Qt.AA_UseHighDpiPixmaps, True)
+
+        self.new_window.connect(self._on_new_window)
+
+    def _on_new_window(self, window):
+        window.tabbed_browser.shutting_down.connect(
+            functools.partial(self._on_window_closing, window)
+        )
+
+    def _on_window_closing(self, window):
+        self._undos.append(window.tabbed_browser._undo_stack)
+
+    @cmdutils.register(instance='app')
+    def undo_last_window_close(self):
+        # TODO: save geometry too, and private
+        window = mainwindow.MainWindow(private=False)
+        window.show()
+        window.tabbed_browser._undo_stack = self._undos.pop()
+        window.tabbed_browser.undo()
 
     @pyqtSlot(QObject)
     def on_focus_object_changed(self, obj):

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -533,8 +533,11 @@ class Application(QApplication):
             tab_stack=window.tabbed_browser._undo_stack,
         ))
 
-    @cmdutils.register(instance='app')
     def undo_last_window_close(self):
+        """Restore the last window to be closed.
+
+        It will have the same tab and undo stack as when it was closed.
+        """
         event = self._undos.pop()
         window = mainwindow.MainWindow(
             private=event.private,

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -530,7 +530,7 @@ class Application(QApplication):
         self._undos.append(mainwindow.WindowUndoEntry(
             geometry=window.saveGeometry(),
             private=window.tabbed_browser.is_private,
-            tab_stack=window.tabbed_browser._undo_stack,
+            tab_stack=window.tabbed_browser.save_undo_stack(),
         ))
 
     def undo_last_window_close(self):
@@ -544,7 +544,7 @@ class Application(QApplication):
             geometry=event.geometry,
         )
         window.show()
-        window.tabbed_browser._undo_stack = event.tab_stack
+        window.tabbed_browser.restore_undo_stack(event.tab_stack)
         window.tabbed_browser.undo()
 
     @pyqtSlot(QObject)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -780,10 +780,18 @@ class CommandDispatcher:
                 text="Are you sure you want to close pinned tabs?")
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def undo(self):
-        """Re-open the last closed tab or tabs."""
+    def undo(self, window: bool = False):
+        """Re-open the last closed tab(s) or window.
+
+        Args:
+            window: Re-open the last closed window (and its tabs).
+        """
         try:
-            self._tabbed_browser.undo()
+            if window:
+                app = QApplication.instance()
+                app.undo_last_window_close()
+            else:
+                self._tabbed_browser.undo()
         except IndexError:
             raise cmdutils.CommandError("Nothing to undo!")
 

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -128,7 +128,7 @@ def _buffer(*, win_id_filter=lambda _win_id: True, add_win_id=True):
 
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=win_id)
-        if tabbed_browser.shutting_down:
+        if tabbed_browser.is_shutting_down:
             continue
         tabs = []  # type: typing.List[typing.Tuple[str, str, str]]
         for idx in range(tabbed_browser.widget.count()):

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3099,6 +3099,7 @@ bindings.default:
       k: scroll up
       l: scroll right
       u: undo
+      U: undo -w
       <Ctrl-Shift-T>: undo
       gg: scroll-to-perc 0
       G: scroll-to-perc

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1922,7 +1922,8 @@ tabs.undo_stack_size:
     name: Int
     minval: -1
     maxval: maxint
-  desc: Number of close tab actions to remember, per window (-1 for no maximum).
+  desc: Number of closed tabs (per window) and closed windows to remember for
+    :undo (-1 for no maximum).
 
 tabs.wrap:
   default: true

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -25,6 +25,7 @@ import itertools
 import functools
 import typing
 
+import attr
 from PyQt5.QtCore import (pyqtSignal, pyqtSlot, QRect, QPoint, QTimer, Qt,
                           QCoreApplication, QEventLoop)
 from PyQt5.QtWidgets import QWidget, QVBoxLayout, QApplication, QSizePolicy
@@ -130,6 +131,16 @@ def get_target_window():
 
 
 _OverlayInfoType = typing.Tuple[QWidget, pyqtSignal, bool, str]
+
+
+@attr.s
+class WindowUndoEntry:
+
+    """Information needed for :undo -w."""
+
+    private = attr.ib()
+    geometry = attr.ib()
+    tab_stack = attr.ib()
 
 
 class MainWindow(QWidget):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -387,8 +387,8 @@ class TabbedBrowser(QWidget):
         # Reverse tabs so we don't have to recalculate tab titles over and over
         # Removing first causes [2..-1] to be recomputed
         # Removing the last causes nothing to be recomputed
-        for tab in reversed(self.widgets()):
-            self._remove_tab(tab)
+        for idx, tab in enumerate(reversed(self.widgets())):
+            self._remove_tab(tab, new_undo=idx == 0)
         self.shutting_down.emit()
 
     def tab_close_prompt_if_pinned(

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -160,7 +160,7 @@ class TabbedBrowser(QWidget):
                               tabs.new_tab_position set to 'prev'.
         _tab_insert_idx_right: Same as above, for 'next'.
         _undo_stack: List of lists of UndoEntry objects of closed tabs.
-        shutting_down: Whether we're currently shutting down.
+        is_shutting_down: Whether we're currently shutting down.
         _local_marks: Jump markers local to each page
         _global_marks: Jump markers used across all pages
         default_window_icon: The qutebrowser window icon
@@ -206,7 +206,7 @@ class TabbedBrowser(QWidget):
         self._win_id = win_id
         self._tab_insert_idx_left = 0
         self._tab_insert_idx_right = -1
-        self.shutting_down = False
+        self.is_shutting_down = False
         self.widget.tabCloseRequested.connect(self.on_tab_close_requested)
         self.widget.new_tab_requested.connect(
             self.tabopen)  # type: ignore[arg-type]
@@ -381,7 +381,7 @@ class TabbedBrowser(QWidget):
 
     def shutdown(self):
         """Try to shut down all tabs cleanly."""
-        self.shutting_down = True
+        self.is_shutting_down = True
         # Reverse tabs so we don't have to recalculate tab titles over and over
         # Removing first causes [2..-1] to be recomputed
         # Removing the last causes nothing to be recomputed
@@ -822,7 +822,7 @@ class TabbedBrowser(QWidget):
     def _on_current_changed(self, idx):
         """Add prev tab to stack and leave hinting mode when focus changed."""
         mode_on_change = config.val.tabs.mode_on_change
-        if idx == -1 or self.shutting_down:
+        if idx == -1 or self.is_shutting_down:
             # closing the last tab (before quitting) or shutting down
             return
         tab = self.widget.widget(idx)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -497,8 +497,11 @@ class TabbedBrowser(QWidget):
         # Remove unused tab which may be created after the last tab is closed
         last_close = config.val.tabs.last_close
         use_current_tab = False
-        if last_close in ['blank', 'startpage', 'default-page']:
-            only_one_tab_open = self.widget.count() == 1
+        last_close_replaces = last_close in [
+            'blank', 'startpage', 'default-page'
+        ]
+        only_one_tab_open = self.widget.count() == 1
+        if only_one_tab_open and last_close_replaces:
             no_history = len(self.widget.widget(0).history) == 1
             urls = {
                 'blank': QUrl('about:blank'),

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -182,6 +182,7 @@ class TabbedBrowser(QWidget):
                  arg: The new size.
         current_tab_changed: The current tab changed to the emitted tab.
         new_tab: Emits the new WebView and its index when a new tab is opened.
+        shutting_down: This TabbedBrowser will be deleted soon.
     """
 
     cur_progress = pyqtSignal(int)
@@ -197,6 +198,7 @@ class TabbedBrowser(QWidget):
     resized = pyqtSignal('QRect')
     current_tab_changed = pyqtSignal(browsertab.AbstractTab)
     new_tab = pyqtSignal(browsertab.AbstractTab, int)
+    shutting_down = pyqtSignal()
 
     def __init__(self, *, win_id, private, parent=None):
         if private:
@@ -386,7 +388,8 @@ class TabbedBrowser(QWidget):
         # Removing first causes [2..-1] to be recomputed
         # Removing the last causes nothing to be recomputed
         for tab in reversed(self.widgets()):
-            self._remove_tab(tab, add_undo=False)
+            self._remove_tab(tab)
+        self.shutting_down.emit()
 
     def tab_close_prompt_if_pinned(
             self, tab, force, yes_action,

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -1043,3 +1043,11 @@ class TabbedBrowser(QWidget):
             tab.scroller.to_point(point)
         else:
             message.error("Mark {} is not set".format(key))
+
+    def save_undo_stack(self):
+        """Return the stack of UndoEntries."""
+        return self._undo_stack
+
+    def restore_undo_stack(self, stack):
+        """Set the stack of UndoEntries."""
+        self._undo_stack = stack

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -193,6 +193,11 @@ def pdfjs_available(data_tmpdir):
         pytest.skip("No pdfjs installation found.")
 
 
+@bdd.given('I clear the log')
+def clear_log_lines(quteproc):
+    quteproc.clear_data()
+
+
 ## When
 
 

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -902,7 +902,9 @@ Feature: Tab management
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new window
         And I run :close
+        And I wait for "removed: tabbed-browser" in the log
         And I run :undo -w
+        And I wait for "Focus object changed: *" in the log
         Then the session should look like:
             windows:
             - tabs:
@@ -921,7 +923,9 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new window
         And I open data/numbers/3.txt in a new tab
         And I run :close
+        And I wait for "removed: tabbed-browser" in the log
         And I run :undo -w
+        And I wait for "Focus object changed: *" in the log
         Then the session should look like:
             windows:
             - tabs:
@@ -943,8 +947,10 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-close
         And I run :close
+        And I wait for "removed: tabbed-browser" in the log
         And I run :undo -w
         And I run :undo
+        And I wait for "Focus object changed: *" in the log
         Then the session should look like:
             windows:
             - tabs:
@@ -966,7 +972,9 @@ Feature: Tab management
         And I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new tab
         And I run :tab-close
+        And I wait for "removed: tabbed-browser" in the log
         And I run :undo -w
+        And I wait for "Focus object changed: *" in the log
         Then the session should look like:
             windows:
             - tabs:

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -899,6 +899,7 @@ Feature: Tab management
     # :undo --window
 
     Scenario: Undo the closing of a window
+        Given I clear the log
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new window
         And I run :close
@@ -919,6 +920,7 @@ Feature: Tab management
                 - url: http://localhost:*/data/numbers/2.txt
 
     Scenario: Undo the closing of a window with multiple tabs
+        Given I clear the log
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new window
         And I open data/numbers/3.txt in a new tab
@@ -942,6 +944,7 @@ Feature: Tab management
                 - url: http://localhost:*/data/numbers/3.txt
 
     Scenario: Undo the closing of a window with multiple tabs with undo stack
+        Given I clear the log
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new window
         And I open data/numbers/3.txt in a new tab
@@ -967,6 +970,7 @@ Feature: Tab management
                 - url: http://localhost:*/data/numbers/3.txt
 
     Scenario: Undo the closing of a window with tabs are windows
+        Given I clear the log
         When I set tabs.last_close to close
         And I set tabs.tabs_are_windows to true
         And I open data/numbers/1.txt

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -896,6 +896,91 @@ Feature: Tab management
             - data/numbers/2.txt
             - data/numbers/3.txt
 
+    # :undo --window
+
+    Scenario: Undo the closing of a window
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I run :close
+        And I run :undo -w
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+            - active: true
+              tabs:
+              - active: true
+                history:
+                - url: http://localhost:*/data/numbers/2.txt
+
+    Scenario: Undo the closing of a window with multiple tabs
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I open data/numbers/3.txt in a new tab
+        And I run :close
+        And I run :undo -w
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+            - active: true
+              tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+              - active: true
+                history:
+                - url: http://localhost:*/data/numbers/3.txt
+
+    Scenario: Undo the closing of a window with multiple tabs with undo stack
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-close
+        And I run :close
+        And I run :undo -w
+        And I run :undo
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+            - active: true
+              tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+              - active: true
+                history:
+                - url: http://localhost:*/data/numbers/3.txt
+
+    Scenario: Undo the closing of a window with tabs are windows
+        When I set tabs.last_close to close
+        And I set tabs.tabs_are_windows to true
+        And I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-close
+        And I run :undo -w
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+            - active: true
+              tabs:
+              - active: true
+                history:
+                - url: http://localhost:*/data/numbers/2.txt
+
+
     # tabs.last_close
 
     # FIXME:qtwebengine

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -481,7 +481,7 @@ class TabbedBrowserStub(QObject):
     def __init__(self, parent=None):
         super().__init__(parent)
         self.widget = TabWidgetStub()
-        self.shutting_down = False
+        self.is_shutting_down = False
         self.loaded_url = None
         self.cur_url = None
 


### PR DESCRIPTION
Adds the ability to re-open the last closed windows with shift+u. Closed windows are stored in a global stack so it doesn't matter which window is focused when you run the command.

All of the hard work around managing restored tab order and such is done by the existing tab undo mechanism. We were already making undo entries for the closed tabs when closing a tabbed browser, with this PR we will be saving them somewhere. Where they are saved isn't particularly importand, I chose to save them to the main `Application` because the life-cycle fits. I suspect when we move window/tab access out of objreg there will be a new place to store them.

The other requirement is that they are stored somewhere that the command dispatcher can access/import. We are working around the importloop at the moment by using `QApplication.get_instance()`, I would rather be able to import something though. An alternative to saving the undo entries in the application is to save them on whichever window would become active after the closing one closes. That would be a much more complex PR though.

Apart from that that most contentious thing would likely be ... more bdd tests. I think this would be difficult to unit test because it crosses a couple of levels of abstraction (our QApplication, MainWindow, TabbedBrowser, backend behaviors) and all the complexity around tab close/open behaviours that is involved with opening and closing windows and tabs. The amount of mocking I would have to do to the the QApplication in a unit test scares me (although inheriting from the real one so we could ignore __init__ might work).

I think the tests for a feature like this would be more appropriate in integration tests. The only real setup we have for them right now is the bdd ones. I would like to bring back the `tests/integration` directory, but for python integration tests this time. I know I have been called out before for mocking too much stuff in unit tests but I would rather have unit tests focused on isolated bits of logic with evrything else mocked out and then have integration tests with real objects to make sure you haven't been testing a spherical cow. I am not sure quite what a full integration test would look like though; just run qutebrowser.main() and run everything up with all the bells and whistles?

Also sorry about yet another PR but I thought this one was pretty straightforward.

Closes: https://github.com/qutebrowser/qutebrowser/issues/1031

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4807)
<!-- Reviewable:end -->
