### PR TITLE
Only update stylesheet when related config option changes

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -346,6 +346,10 @@ class Config(QObject):
                 name, deleted=deleted, renamed=renamed)
             raise exception from None
 
+    def ensure_has_opt(self, name: str) -> None:
+        """Raise NoOptionError if the given setting does not exist."""
+        self.get_opt(name)
+
     def get(self,
             name: str,
             url: QUrl = None, *,
@@ -379,7 +383,7 @@ class Config(QObject):
         Note that the returned values are not watched for mutation.
         If a URL is given, return the value which should be used for that URL.
         """
-        self.get_opt(name)  # To make sure it exists
+        self.ensure_has_opt(name)
         value = self._values[name].get_for_url(url, fallback=fallback)
         return self._maybe_copy(value)
 
@@ -392,7 +396,7 @@ class Config(QObject):
         This gets the overridden value for a given pattern, or
         configutils.UNSET if no such override exists.
         """
-        self.get_opt(name)  # To make sure it exists
+        self.ensure_has_opt(name)
         value = self._values[name].get_for_pattern(pattern, fallback=False)
         return self._maybe_copy(value)
 
@@ -404,7 +408,7 @@ class Config(QObject):
         Note that it's impossible to get a mutable object for a URL as we
         wouldn't know what pattern to apply.
         """
-        self.get_opt(name)  # To make sure it exists
+        self.ensure_has_opt(name)
 
         # If we allow mutation, there is a chance that prior mutations already
         # entered the mutable dictionary and thus further copies are unneeded

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -146,3 +146,14 @@ def test_autoescape(escape):
 
     template = jinja.environment.from_string("{{ v }}")
     assert template.render(v='<foo') == '&lt;foo'
+
+
+@pytest.mark.parametrize('template, expected', [
+    ('{{ func1(conf.aliases) }} {{ func2(conf.backend) }}',
+     ['aliases', 'backend']),
+    ('{{ conf.auto_save.interval + conf.hints.min_chars }}',
+     ['auto_save.interval', 'hints.min_chars']),
+    ('{{ notconf.a.b.c }}', []),
+])
+def test_template_config_variables(template, expected, config_stub):
+    assert jinja.template_config_variables(template) == frozenset(expected)

--- a/tests/unit/utils/test_jinja.py
+++ b/tests/unit/utils/test_jinja.py
@@ -28,6 +28,7 @@ import pytest
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.utils import utils, jinja
+from qutebrowser.config import configexc
 
 
 @pytest.fixture(autouse=True)
@@ -151,9 +152,20 @@ def test_autoescape(escape):
 @pytest.mark.parametrize('template, expected', [
     ('{{ func1(conf.aliases) }} {{ func2(conf.backend) }}',
      ['aliases', 'backend']),
+    ('{{ conf.aliases["a"].propname }}', ['aliases']),
     ('{{ conf.auto_save.interval + conf.hints.min_chars }}',
      ['auto_save.interval', 'hints.min_chars']),
     ('{{ notconf.a.b.c }}', []),
 ])
 def test_template_config_variables(template, expected, config_stub):
     assert jinja.template_config_variables(template) == frozenset(expected)
+
+
+@pytest.mark.parametrize('template', [
+    '{{ func1(conf.aaa) }}',
+    '{{ conf.bbb["a"].propname }}',
+    '{{ conf.ccc + 1 }}',
+])
+def test_template_config_variables_no_option(template, config_stub):
+    with pytest.raises(configexc.NoOptionError):
+        jinja.template_config_variables(template)


### PR DESCRIPTION
Huge performance improvement with `:config-source`.

Note that further improvement is possible by batching all calls at the end of `:config-source`.

-------------

By the way, (with master branch, not this branch) I once got this result

```
$ time qutebrowser ':repeat 3 config-source ;; quit'
Segmentation fault (core dumped)
```

No idea why that happens, but may be related to doing `config-source` before some Qt objects are ready.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4808)
<!-- Reviewable:end -->
