### PR TITLE
Add config to limit size of undo stack

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1764,6 +1764,14 @@ tabs.pinned.frozen:
     default: True
     desc: Force pinned tabs to stay at fixed URL.
 
+tabs.undo_stack_size:
+  default: 100
+  type:
+    name: Int
+    minval: -1
+    maxval: maxint
+  desc: Number of close tab actions to remember, per window (-1 for no maximum).
+
 tabs.wrap:
   default: true
   type: Bool


### PR DESCRIPTION
For me, with this stress test patch (http://paste.debian.net/plain/1084216) (as a super naiive calculation), memory increases about 40mb every tab delete (of a default tab), which means that currently, every tab delete (that's not undone) costs us about 1/3rd of a kb at minimum, since I didn't have any history. Assuming this minimum per tab average, this will cap this usage to 33kb by default.

Similar to #4801

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4814)
<!-- Reviewable:end -->
