### PR TITLE
Add colors.completion.item.selected.match.fg setting

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -214,8 +214,11 @@ class CompletionItemDelegate(QStyledItemDelegate):
             columns_to_filter = index.model().columns_to_filter(index)
             if index.column() in columns_to_filter and pattern:
                 pat = re.escape(pattern).replace(r'\ ', r'|')
-                _Highlighter(self._doc, pat,
-                             config.val.colors.completion.match.fg)
+                if self._opt.state & QStyle.State_Selected:
+                    color = config.val.colors.completion.item.selected.match.fg
+                else:
+                    color = config.val.colors.completion.match.fg
+                _Highlighter(self._doc, pat, color)
             self._doc.setPlainText(self._opt.text)
         else:
             self._doc.setHtml(

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1982,12 +1982,17 @@ colors.completion.item.selected.bg:
 colors.completion.item.selected.border.top:
   default: '#bbbb00'
   type: QssColor
-  desc: Top border color of the completion widget category headers.
+  desc: Top border color of the selected completion item.
 
 colors.completion.item.selected.border.bottom:
   default: '#bbbb00'
   type: QssColor
   desc: Bottom border color of the selected completion item.
+
+colors.completion.item.selected.match.fg:
+  default: '#ff4444'
+  type: QtColor
+  desc: Foreground color of the matched text in the selected completion item.
 
 colors.completion.match.fg:
   default: '#ff4444'


### PR DESCRIPTION
Matched text in my completion widget wasn't very readable on the selected line's background. With this option you can color the matched text differently in the selected item.

Also fixes a typo in the description of the `colors.completion.item.selected.border.top` setting.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4818)
<!-- Reviewable:end -->
