### PR TITLE
Register debug-cache-stats with a decorator

### DIFF
--- a/qutebrowser/browser/webkit/webkithistory.py
+++ b/qutebrowser/browser/webkit/webkithistory.py
@@ -24,6 +24,7 @@ import functools
 from PyQt5.QtWebKit import QWebHistoryInterface
 
 from qutebrowser.utils import debug
+from qutebrowser.misc import debugcachestats
 
 
 class WebHistoryInterface(QWebHistoryInterface):
@@ -42,6 +43,7 @@ class WebHistoryInterface(QWebHistoryInterface):
     def addHistoryEntry(self, url_string):
         """Required for a QWebHistoryInterface impl, obsoleted by add_url."""
 
+    @debugcachestats.register(name='history')
     @functools.lru_cache(maxsize=32768)
     def historyContains(self, url_string):
         """Called by WebKit to determine if a URL is contained in the history.

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -29,7 +29,7 @@ from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QUrl
 
 from qutebrowser.config import configdata, configexc, configutils
 from qutebrowser.utils import utils, log, jinja, urlmatch
-from qutebrowser.misc import objects
+from qutebrowser.misc import objects, debugcachestats
 from qutebrowser.keyinput import keyutils
 
 MYPY = False
@@ -625,6 +625,7 @@ def set_register_stylesheet(obj: QObject, *,
     observer.register()
 
 
+@debugcachestats.register()
 @functools.lru_cache()
 def _render_stylesheet(stylesheet: str) -> str:
     """Render the given stylesheet jinja template."""

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -31,6 +31,7 @@ import functools
 import attr
 from qutebrowser.config import configtypes
 from qutebrowser.utils import usertypes, qtutils, utils
+from qutebrowser.misc import debugcachestats
 
 DATA = typing.cast(typing.Mapping[str, 'Option'], None)
 MIGRATIONS = typing.cast('Migrations', None)
@@ -267,6 +268,7 @@ def _read_yaml(
     return parsed, migrations
 
 
+@debugcachestats.register()
 @functools.lru_cache(maxsize=256)
 def is_valid_prefix(prefix: str) -> bool:
     """Check whether the given prefix is a valid prefix for some option."""

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -60,7 +60,7 @@ from PyQt5.QtGui import QColor, QFont
 from PyQt5.QtWidgets import QTabWidget, QTabBar
 from PyQt5.QtNetwork import QNetworkProxy
 
-from qutebrowser.misc import objects
+from qutebrowser.misc import objects, debugcachestats
 from qutebrowser.config import configexc, configutils
 from qutebrowser.utils import (standarddir, utils, qtutils, urlutils, urlmatch,
                                usertypes)
@@ -205,6 +205,7 @@ class BaseType:
         BaseType._basic_str_validation_cache(value)
 
     @staticmethod
+    @debugcachestats.register(name='str validation cache')
     @functools.lru_cache(maxsize=2**9)
     def _basic_str_validation_cache(value: str) -> None:
         """Cache validation result to prevent looping over strings."""

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -32,7 +32,7 @@ from PyQt5.QtGui import QIcon, QPalette, QColor
 
 from qutebrowser.utils import qtutils, objreg, utils, usertypes, log
 from qutebrowser.config import config
-from qutebrowser.misc import objects
+from qutebrowser.misc import objects, debugcachestats
 from qutebrowser.browser import browsertab
 
 
@@ -569,6 +569,7 @@ class TabBar(QTabBar):
                                                   icon_width, ellipsis,
                                                   pinned)
 
+    @debugcachestats.register(name='tab width cache')
     @functools.lru_cache(maxsize=2**9)
     def _minimum_tab_size_hint_helper(self, tab_text: str,
                                       icon_width: int,

--- a/qutebrowser/misc/debugcachestats.py
+++ b/qutebrowser/misc/debugcachestats.py
@@ -1,0 +1,49 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2019 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Implementation of the command debug-cache-stats.
+
+Because many modules depend on this command, this needs to have as few
+dependencies as possible to avoid cyclic dependencies.
+"""
+
+import typing
+from typing import TypeVar, Callable
+
+
+# The second element of each tuple should be a lru_cache wrapped function
+_CACHE_FUNCTIONS = []  # type: typing.List[typing.Tuple[str, typing.Any]]
+
+
+_T = TypeVar('_T', bound=Callable)
+
+
+def register(name: typing.Optional[str] = None) -> Callable[[_T], _T]:
+    """Register a lru_cache wrapped function for debug_cache_stats."""
+    def wrapper(fn: _T) -> _T:
+        _CACHE_FUNCTIONS.append((fn.__name__ if name is None else name, fn))
+        return fn
+    return wrapper
+
+
+def debug_cache_stats() -> None:
+    """Print LRU cache stats."""
+    from qutebrowser.utils import log
+    for name, fn in _CACHE_FUNCTIONS:
+        log.misc.info('{}: {}'.format(name, fn.cache_info()))

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -31,8 +31,7 @@ from qutebrowser.browser import qutescheme
 from qutebrowser.utils import log, objreg, usertypes, message, debug, utils
 from qutebrowser.commands import runners
 from qutebrowser.api import cmdutils
-from qutebrowser.config import config, configdata, configtypes
-from qutebrowser.misc import consolewidget
+from qutebrowser.misc import consolewidget, debugcachestats
 from qutebrowser.utils.version import pastebin_version
 from qutebrowser.qt import sip
 
@@ -121,35 +120,7 @@ def debug_all_objects():
 @cmdutils.register(debug=True)
 def debug_cache_stats():
     """Print LRU cache stats."""
-    prefix_info = configdata.is_valid_prefix.cache_info()
-    # pylint: disable=protected-access
-    render_stylesheet_info = config._render_stylesheet.cache_info()
-    # pylint: enable=protected-access
-
-    history_info = None
-    try:
-        from PyQt5.QtWebKit import QWebHistoryInterface
-        interface = QWebHistoryInterface.defaultInterface()
-        if interface is not None:
-            history_info = interface.historyContains.cache_info()
-    except ImportError:
-        pass
-
-    tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                window='last-focused')
-    # pylint: disable=protected-access
-    tab_bar = tabbed_browser.widget.tabBar()
-    tabbed_browser_info = tab_bar._minimum_tab_size_hint_helper.cache_info()
-
-    str_validation_info = (configtypes.BaseType.
-                           _basic_str_validation_cache.cache_info())
-    # pylint: enable=protected-access
-
-    log.misc.info('is_valid_prefix: {}'.format(prefix_info))
-    log.misc.info('_render_stylesheet: {}'.format(render_stylesheet_info))
-    log.misc.info('history: {}'.format(history_info))
-    log.misc.info('tab width cache: {}'.format(tabbed_browser_info))
-    log.misc.info('str validation cache: {}'.format(str_validation_info))
+    debugcachestats.debug_cache_stats()
 
 
 @cmdutils.register(debug=True)

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -202,6 +202,7 @@ PERFECT_FILES = [
 # 100% coverage because of end2end tests, but no perfect unit tests yet.
 WHITELISTED_FILES = [
     'browser/webkit/webkitinspector.py',
+    'misc/debugcachestats.py',
     'keyinput/macros.py',
     'browser/webkit/webkitelem.py',
     'api/interceptor.py',


### PR DESCRIPTION
While doing https://github.com/qutebrowser/qutebrowser/pull/4808#discussion_r288973940, I feel that it should be done properly. (although this is just a refactor)

------


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4819)
<!-- Reviewable:end -->
