### PR TITLE
Properly(?) fix tab history title test on WebKit

### DIFF
--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -428,7 +428,15 @@ def webengineview(qtbot, monkeypatch, web_tab_setup):
 def webpage(qnam):
     """Get a new QWebPage object."""
     QtWebKitWidgets = pytest.importorskip('PyQt5.QtWebKitWidgets')
-    page = QtWebKitWidgets.QWebPage()
+    class WebPageStub(QtWebKitWidgets.QWebPage):
+
+        """QWebPage with default error pages disabled."""
+
+        def supportsExtension(self, _ext):
+            """No extensions needed."""
+            return False
+
+    page = WebPageStub()
     page.networkAccessManager().deleteLater()
     page.setNetworkAccessManager(qnam)
     return page

--- a/tests/unit/browser/webkit/test_tabhistory.py
+++ b/tests/unit/browser/webkit/test_tabhistory.py
@@ -115,8 +115,7 @@ def test_original_urls(objects, i, item):
 @pytest.mark.parametrize('i, item', enumerate(ITEMS))
 def test_titles(objects, i, item):
     """Check if the titles were loaded correctly."""
-    title = objects.history.itemAt(i).title()
-    assert title in [item.title, 'Network access is disabled']
+    assert objects.history.itemAt(i).title() == item.title
 
 
 def test_no_active_item():


### PR DESCRIPTION
Disable error pages in webpage fixture.

Due to a [change](https://github.com/annulen/webkit/commit/3b3724183bbe) in webkit that introduced a default error page the the webkit/test_tabhistory.py::test_titles broke with the active tab because network access is disable in the webpage fixture, so the error page was rendered.

This change disables the default error pages in the fixture by telling the error notify thing that it doesn't support doing anything with the errors. It also disables the `ChooseMultipleFilesExtension` which should be used with this fixture since we override that for real in qutebrowser

I'm declaring the class inside the method because I don't know how to skip declaring a class in stubs.py with importskip.

Fixes: #4811

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4824)
<!-- Reviewable:end -->
