### PR TITLE
Fullscreen enter option

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -556,12 +556,14 @@ How many pages to go forward.
 
 [[fullscreen]]
 === fullscreen
-Syntax: +:fullscreen [*--leave*]+
+Syntax: +:fullscreen [*--leave*] [*--enter*]+
 
 Toggle fullscreen mode.
 
 ==== optional arguments
 * +*-l*+, +*--leave*+: Only leave fullscreen if it was entered by the page.
+* +*-e*+, +*--enter*+: Activate fullscreen and do not toggle if it is already active.
+
 
 [[greasemonkey-reload]]
 === greasemonkey-reload

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1739,14 +1739,11 @@ class CommandDispatcher:
 
         window = self._tabbed_browser.widget.window()
 
-        if enter:
-            if window.isFullScreen():
-                return
-            window.setWindowState(Qt.WindowFullScreen)
-            return
-
         if not window.isFullScreen():
             window.state_before_fullscreen = window.windowState()
+        if enter:
+            window.setWindowState(window.windowState() | Qt.WindowFullScreen)
+            return
         window.setWindowState(window.windowState() ^ Qt.WindowFullScreen)
 
         log.misc.debug('state before fullscreen: {}'.format(

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1721,11 +1721,13 @@ class CommandDispatcher:
                          private=private, related=related)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def fullscreen(self, leave=False):
+    def fullscreen(self, leave=False, enter=False):
         """Toggle fullscreen mode.
 
         Args:
             leave: Only leave fullscreen if it was entered by the page.
+            enter: Activate fullscreen and do not toggle if it is already
+                   active.
         """
         if leave:
             tab = self._current_widget()
@@ -1736,6 +1738,12 @@ class CommandDispatcher:
             return
 
         window = self._tabbed_browser.widget.window()
+
+        if enter:
+            if window.isFullScreen():
+                return
+            window.setWindowState(Qt.WindowFullScreen)
+            return
 
         if not window.isFullScreen():
             window.state_before_fullscreen = window.windowState()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1743,8 +1743,8 @@ class CommandDispatcher:
             window.state_before_fullscreen = window.windowState()
         if enter:
             window.setWindowState(window.windowState() | Qt.WindowFullScreen)
-            return
-        window.setWindowState(window.windowState() ^ Qt.WindowFullScreen)
+        else:
+            window.setWindowState(window.windowState() ^ Qt.WindowFullScreen)
 
         log.misc.debug('state before fullscreen: {}'.format(
             debug.qflags_key(Qt, window.state_before_fullscreen)))


### PR DESCRIPTION
Add `--enter` to `:fullscreen` to only enter, but never leave fullscreen mode. Without any force :-)

Closes: #4828

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4833)
<!-- Reviewable:end -->
