### PR TITLE
Add empty Content Rating to appdata

### DIFF
--- a/misc/org.qutebrowser.qutebrowser.appdata.xml
+++ b/misc/org.qutebrowser.qutebrowser.appdata.xml
@@ -40,6 +40,8 @@
 	<url type="help">https://qutebrowser.org/doc/help/</url>
 	<url type="bugtracker">https://github.com/qutebrowser/qutebrowser/issues/</url>
 	<url type="donation">https://github.com/qutebrowser/qutebrowser#donating</url>
+	<content_rating type="oars-1.1">
+	</content_rating>
 	<releases>
 		<release version="1.3.0" date="2018-05-04"/>
 		<release version="1.2.1" date="2018-03-14"/>


### PR DESCRIPTION
The Open Age Ratings Service (OARS) https://hughsie.github.io/oars generates information about the application based on answering some questions. Software front-ends like GNOME Software can then implement filtering based on this information.

This change implements minimal content rating without giving actual content information. Further items that should be added in my opinion are _Online Text-only Messaging_ and _Online Audio and Video Messaging_.

The empty environment is necessary to pass Flathub tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4834)
<!-- Reviewable:end -->
