### PR TITLE
Fixed blocked hosts misinterpretation

### DIFF
--- a/qutebrowser/components/adblock.py
+++ b/qutebrowser/components/adblock.py
@@ -178,8 +178,7 @@ class HostBlocker:
         try:
             with open(filename, 'r', encoding='utf-8') as f:
                 for line in f:
-                    for host in self._read_hosts_line(line):
-                        target.add(host)
+                    target.update(self._read_hosts_line(line))
 
         except (OSError, UnicodeDecodeError):
             logger.exception("Failed to read host blocklist!")
@@ -246,8 +245,7 @@ class HostBlocker:
             raw_line: The bytes object to parse.
 
         Returns:
-            A list containg parsed hosts if successful,
-            list containing 'error' otherwise.
+            A list containg parsed hosts.
         """
         if raw_line.startswith(b'#'):
             # Ignoring comments early so we don't have to care about
@@ -256,10 +254,8 @@ class HostBlocker:
 
         line = raw_line.decode('utf-8')
 
-        added_hosts = []
-        for host in self._read_hosts_line(line):
-            added_hosts.append(host)
-            self._blocked_hosts.add(host)
+        added_hosts = self._read_hosts_line(line)
+        self._blocked_hosts.update(added_hosts)
 
         return added_hosts
 

--- a/qutebrowser/components/adblock.py
+++ b/qutebrowser/components/adblock.py
@@ -147,7 +147,20 @@ class HostBlocker:
         try:
             with open(filename, 'r', encoding='utf-8') as f:
                 for line in f:
-                    target.add(line.strip())
+                    parts = line.strip().split()
+                    if len(parts) == 1:
+                        # "one host per line" format
+                        hosts = parts[:1]
+                    else:
+                        # /etc/hosts format
+                        hosts = parts[1:]
+                    
+                    for host in hosts:
+                        if ('.' in host and
+                                not host.endswith('.localdomain') and
+                                host != '0.0.0.0'):
+                            target.add(host)
+
         except (OSError, UnicodeDecodeError):
             logger.exception("Failed to read host blocklist!")
 

--- a/tests/unit/components/test_adblock.py
+++ b/tests/unit/components/test_adblock.py
@@ -268,7 +268,8 @@ def test_parsing_multiple_hosts_on_line(host_blocker_factory):
     """Ensure multiple hosts on a line get parsed correctly."""
     host_blocker = host_blocker_factory()
     bytes_host_line = ' '.join(BLOCKLIST_HOSTS).encode('utf-8')
-    host_blocker._parse_line(bytes_host_line)
+    parsed_hosts = host_blocker._read_hosts_line(bytes_host_line)
+    host_blocker._blocked_hosts |= parsed_hosts
     assert_urls(host_blocker, whitelisted=[])
 
 
@@ -294,7 +295,8 @@ def test_whitelisted_lines(host_blocker_factory, ip, host):
     """Make sure we don't block hosts we don't want to."""
     host_blocker = host_blocker_factory()
     line = ('{} {}'.format(ip, host)).encode('ascii')
-    host_blocker._parse_line(line)
+    parsed_hosts = host_blocker._read_hosts_line(line)
+    host_blocker._blocked_hosts |= parsed_hosts
     assert host not in host_blocker._blocked_hosts
 
 


### PR DESCRIPTION
This is a fix for https://github.com/qutebrowser/qutebrowser/issues/4473. I was able to:

* Change `_read_hosts_file` to be more like `_parse_line`
* Refactor `_parse_line` to return a list of found hosts (and update `_merge_file`) as well as implement `find` instead of a `try/except ValueError`

I was unable to reproduce https://github.com/qutebrowser/qutebrowser/issues/4325. I believe my changes would fix this problem anyway (using `line.strip()` on line 150 should remove extra spaces and produce an empty list) but I was unable to test if so.

I tested this own my own by adding `127.0.0.1 www.youtube.com` to `~/.config/qutebrowser/blocked-hosts`. Before, YouTube would not be blocked by this addition. Afterwards, YouTube is properly blocked.

I did not add any test cases for my changes. I'm not familiar with pytest and I did not feel I could properly write any tests after looking through `test_adblock.py`. However, I did sucessfully run all existing tests for the adblock module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4863)
<!-- Reviewable:end -->
