### PR TITLE
Add KDE Platform to known distributions

### DIFF
--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -74,7 +74,8 @@ class DistributionInfo:
 pastebin_url = None
 Distribution = enum.Enum(
     'Distribution', ['unknown', 'ubuntu', 'debian', 'void', 'arch',
-                     'gentoo', 'fedora', 'opensuse', 'linuxmint', 'manjaro'])
+                     'gentoo', 'fedora', 'opensuse', 'linuxmint', 'manjaro',
+                     'org.kde.Platform'])
 
 
 def distribution():


### PR DESCRIPTION
The platform does not specify a pretty name yet, so that remains *Unknown* for now. I will see if I can get a pretty name into upstream.