### PR TITLE
Complete release information in appdata

### DIFF
--- a/misc/org.qutebrowser.qutebrowser.appdata.xml
+++ b/misc/org.qutebrowser.qutebrowser.appdata.xml
@@ -43,8 +43,29 @@
 	<content_rating type="oars-1.1">
 	</content_rating>
 	<releases>
+		<release version="1.6.3" date="2019-06-18"/>
+		<release version="1.6.2" date="2019-05-06"/>
+		<release version="1.6.1" date="2019-03-20"/>
+		<release version="1.6.0" date="2019-02-25"/>
+		<release version="1.5.2" date="2018-10-26"/>
+		<release version="1.5.1" date="2018-10-10"/>
+		<release version="1.5.0" date="2018-10-03"/>
+		<release version="1.4.2" date="2018-09-02"/>
+		<release version="1.4.1" date="2018-07-11"/>
+		<release version="1.4.0" date="2018-07-03"/>
+		<release version="1.3.3" date="2018-06-21"/>
+		<release version="1.3.2" date="2018-06-10"/>
+		<release version="1.3.1" date="2018-05-29"/>
 		<release version="1.3.0" date="2018-05-04"/>
 		<release version="1.2.1" date="2018-03-14"/>
 		<release version="1.2.0" date="2018-03-09"/>
+		<release version="1.1.2" date="2018-03-01"/>
+		<release version="1.1.1" date="2018-01-20"/>
+		<release version="1.1.0" date="2018-01-15"/>
+		<release version="1.0.4" date="2017-11-28"/>
+		<release version="1.0.3" date="2017-11-04"/>
+		<release version="1.0.2" date="2017-10-17"/>
+		<release version="1.0.1" date="2017-10-13"/>
+		<release version="1.0.0" date="2017-10-12"/>
 	</releases>
 </component>


### PR DESCRIPTION
Having up-to-date release information is nice, because it gives store frontends more information to show to the user. https://flathub.org/apps/details/org.qutebrowser.qutebrowser shows the latest version from the current appdata file in the *Updated* section.

It would be nice if we could add such a release string to the appdata file with the same commit that bumps `__version_info__` in `__init__.py`. Maybe a small script could do both at once?