### PR TITLE
qute-pass: Add support for private domains (e.g. "myrouter.local")

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -151,10 +151,17 @@ def main(arguments):
     password_store_path = os.path.expanduser(arguments.password_store)
 
     # Try to find candidates using targets in the following order: fully-qualified domain name (includes subdomains),
-    # the registered domain name and finally: the IPv4 address if that's what the URL represents
+    # the registered domain name, the IPv4 address if that's what the URL represents and finally the private domain
+    # (if a non-public suffix was used).
     candidates = set()
     attempted_targets = []
-    for target in filter(None, [extract_result.fqdn, extract_result.registered_domain, extract_result.ipv4]):
+
+    private_domain = ''
+    if not extract_result.suffix:
+        private_domain = ('.'.join((extract_result.subdomain, extract_result.domain))
+                          if extract_result.subdomain else extract_result.domain)
+
+    for target in filter(None, [extract_result.fqdn, extract_result.registered_domain, extract_result.ipv4, private_domain]):
         attempted_targets.append(target)
         target_candidates = find_pass_candidates(target, password_store_path)
         if not target_candidates:


### PR DESCRIPTION
Currently, qute-pass can only be used if the domain is either a public
domain (which means that its suffix needs to be included in the Public
Suffix List [PSL]), or if an IPv4 address is used.

Some uses might want to use qute-pass to login into the web interface of
their router, printer, NAS or other network-enabled device that is only
accessible from the local network. However, currently users to need
to remember or bookmark the IPv4 addresses of these devices.

If a local DNS server is used to assign domains like "mydevice.local" to
these devices, qute-pass won't work because all potential targets are
empty:

    >>> tldextract.extract('https://mydevice.local')
    ExtractResult(subdomain='mydevice', domain='local', suffix='')
    >>> tldextract.extract('https://mydevice.local').fqdn
    ''
    >>> tldextract.extract('https://mydevice.local').registered_domain
    ''
    >>> tldextract.extract('https://mydevice.local').ipv4
    ''

This adds an additional potential target by joining subdomain and domain
if (and only if) the suffix is empty.