### PR TITLE
Fix colors.hints.match.fg with rgb() syntax.

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -103,7 +103,7 @@ class HintLabel(QLabel):
             matched = html.escape(matched)
             unmatched = html.escape(unmatched)
 
-        match_color = html.escape(config.cache['colors.hints.match.fg'])
+        match_color = config.cache['colors.hints.match.fg'].name()
         if matched:
             self.setText('<font color="{}">{}</font>{}'.format(
                 match_color, matched, unmatched))

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -103,8 +103,8 @@ class HintLabel(QLabel):
             matched = html.escape(matched)
             unmatched = html.escape(unmatched)
 
-        match_color = config.cache['colors.hints.match.fg'].name()
         if matched:
+            match_color = config.cache['colors.hints.match.fg'].name()
             self.setText('<font color="{}">{}</font>{}'.format(
                 match_color, matched, unmatched))
         else:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2078,7 +2078,7 @@ colors.hints.bg:
 
 colors.hints.match.fg:
   default: green
-  type: QssColor
+  type: QtColor
   desc: Font color for the matched part of hints.
 
 colors.keyhint.fg:


### PR DESCRIPTION
The other hint colors are being set in a Qt stylesheet, this one isn't.
I turned it into a QtColor because that returns a QtColor out of the box
and I don't need to construct a new one. `QColor.name()` returns a #RRGGBB
string by default.

No need for escaping since we will be inserting a fixed format now.

This means colors.hints.match.fg will no longer support gradients, as
per the QssColor/QtColor docs. I thing that doesn't make sense for text
color anyway, but I don't know about such things.

That config.cache access could be inside the conditional too. Though I
guess that only helps when they are initially shown or else they
wouldn't be rendered if they didn't have a matching part.

Fixes: #4893