### PR TITLE
Add release information to appdata

### DIFF
--- a/misc/org.qutebrowser.qutebrowser.appdata.xml
+++ b/misc/org.qutebrowser.qutebrowser.appdata.xml
@@ -67,6 +67,7 @@
 		<release version="1.0.2" date="2017-10-17"/>
 		<release version="1.0.1" date="2017-10-13"/>
 		<release version="1.0.0" date="2017-10-12"/>
+		<release version="0.11.1" date="2017-10-09"/>
 		<release version="0.11.0" date="2017-07-04"/>
 		<release version="0.10.1" date="2017-03-08"/>
 		<release version="0.10.0" date="2017-02-25"/>
@@ -74,6 +75,7 @@
 		<release version="0.9.0" date="2016-12-28"/>
 		<release version="0.8.4" date="2016-11-06"/>
 		<release version="0.8.3" date="2016-11-05"/>
+		<release version="0.8.2" date="2016-08-02"/>
 		<release version="0.8.1" date="2016-07-27"/>
 		<release version="0.8.0" date="2016-07-26"/>
 		<release version="0.7.0" date="2016-06-10"/>
@@ -82,13 +84,15 @@
 		<release version="0.6.0" date="2016-04-04"/>
 		<release version="0.5.1" date="2016-01-18"/>
 		<release version="0.5.0" date="2016-01-05"/>
+		<release version="0.4.1" date="2015-09-30"/>
 		<release version="0.4.0" date="2015-09-11"/>
 		<release version="0.3.0" date="2015-06-28"/>
 		<release version="0.2.1" date="2015-04-19"/>
 		<release version="0.2.0" date="2015-04-19"/>
 		<release version="0.1.4" date="2015-03-19"/>
 		<release version="0.1.3" date="2015-02-12"/>
+		<release version="0.1.2" date="2015-01-09"/>
 		<release version="0.1.1" date="2014-12-28"/>
-		<release version="0.1.0" date="2014-04-25"/>
+		<release version="0.1" date="2014-12-14"/>
 	</releases>
 </component>


### PR DESCRIPTION
Assuming every tag is a release with the format `vVERSION`:

```sh
git tag \
  --sort=-creatordate \
  --format='%(refname:short)" date="%(creatordate:short)"/>' \
| sed 's/^v/		<release version="/'
```

Note that this drops `v0.1.0` as there doesn't seem to be a corresponding tag.