### PR TITLE
Fix key auto-repeat

### DIFF
--- a/qutebrowser/keyinput/modeman.py
+++ b/qutebrowser/keyinput/modeman.py
@@ -209,8 +209,11 @@ class ModeManager(QObject):
             True if event should be filtered, False otherwise.
         """
         # handle like matching KeyPress
+        # also filter out key repeats when in passthrough mode
         keyevent = KeyEvent.from_event(event)
-        if keyevent in self._releaseevents_to_pass:
+        passthrough = self._parsers[self.mode].passthrough
+        if (not (event.isAutoRepeat() and passthrough) and
+                keyevent in self._releaseevents_to_pass):
             self._releaseevents_to_pass.remove(keyevent)
             filter_this = False
         else:


### PR DESCRIPTION
Qt generates alternating key press and release events when auto repeating key
the spec requires repeat keys to only generate keydown without keyup, qute generates alternating
keydown and keyup events as can be tested here: https://unixpapa.com/js/testkey.html
this breaks anything which relies on holding down a key, like walking in games.

This can be fixed by checking if QKeyEvent is a repeat using isAutoRepeat()
and filtering out the release event.

I tested this on a game called CrossCode, demo available here: https://cross-code.com/en/start