### PR TITLE
Switch to tab if URL is open

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -342,6 +342,7 @@
 |<<tabs.select_on_remove,tabs.select_on_remove>>|Which tab to select when the focused tab is removed.
 |<<tabs.show,tabs.show>>|When to show the tab bar.
 |<<tabs.show_switching_delay,tabs.show_switching_delay>>|Duration (in milliseconds) to show the tab bar before hiding it when tabs.show is set to 'switching'.
+|<<tabs.switch_to_open_url,tabs.switch_to_open_url>>|Switch to an existing tab if its URL is already open, instead of opening a duplicate.
 |<<tabs.tabs_are_windows,tabs.tabs_are_windows>>|Open a new window for every tab.
 |<<tabs.title.alignment,tabs.title.alignment>>|Alignment of the text inside of tabs.
 |<<tabs.title.elide,tabs.title.elide>>|Position of ellipsis in truncated title of tabs.
@@ -1835,6 +1836,7 @@ Valid values:
  * +bookmarks+
  * +history+
  * +filesystem+
+ * +tabs+
 
 Default: 
 
@@ -4530,6 +4532,14 @@ Duration (in milliseconds) to show the tab bar before hiding it when tabs.show i
 Type: <<types,Int>>
 
 Default: +pass:[800]+
+
+[[tabs.switch_to_open_url]]
+=== tabs.switch_to_open_url
+Switch to an existing tab if its URL is already open, instead of opening a duplicate.
+
+Type: <<types,Bool>>
+
+Default: +pass:[false]+
 
 [[tabs.tabs_are_windows]]
 === tabs.tabs_are_windows

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -53,7 +53,7 @@ from qutebrowser.misc import (ipc, savemanager, sessions, crashsignal,
                               earlyinit, sql, cmdhistory, backendproblem,
                               objects, quitter, nativeeventfilter)
 from qutebrowser.utils import (log, version, message, utils, urlutils, objreg,
-                               resources, usertypes, standarddir,
+                               resources, usertypes, standarddir, tabutils,
                                error, qtutils, debug)
 # pylint: disable=unused-import
 # We import those to run the cmdutils.register decorators.
@@ -287,6 +287,15 @@ def open_url(url, target=None, no_raise=False, via_ipc=True):
         The MainWindow of a window that was used to open the URL.
     """
     target = target or config.val.new_instance_open_target
+
+    existing_tab = tabutils.tab_for_url(
+        url, private=target == 'private-window')
+    if config.val.tabs.switch_to_open_url and existing_tab is not None:
+        tabutils.switch_to_tab(existing_tab)
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window=existing_tab.win_id)
+        return tabbed_browser.widget.window()
+
     background = target in {'tab-bg', 'tab-bg-silent'}
     window = mainwindow.get_window(via_ipc=via_ipc, target=target, no_raise=no_raise)
     log.init.debug("About to open URL: {}".format(url.toDisplayString()))

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -288,10 +288,9 @@ def open_url(url, target=None, no_raise=False, via_ipc=True):
     """
     target = target or config.val.new_instance_open_target
 
-    existing_tab = tabutils.tab_for_url(
+    existing_tab = tabutils.switch_to_open_url(
         url, private=target == 'private-window')
-    if config.val.tabs.switch_to_open_url and existing_tab is not None:
-        tabutils.switch_to_tab(existing_tab)
+    if existing_tab is not None:
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=existing_tab.win_id)
         return tabbed_browser.widget.window()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -22,7 +22,7 @@ from qutebrowser.browser import (urlmarks, browsertab, navigate, webelem,
                                  downloads)
 from qutebrowser.keyinput import modeman, keyutils
 from qutebrowser.utils import (message, usertypes, log, qtutils, urlutils,
-                               objreg, utils, standarddir, debug)
+                               objreg, utils, standarddir, tabutils, debug)
 from qutebrowser.utils.usertypes import KeyMode
 from qutebrowser.misc import editor, guiprocess, objects
 from qutebrowser.completion.models import urlmodel, miscmodels
@@ -106,6 +106,7 @@ class CommandDispatcher:
         window: bool = False,
         related: bool = False,
         private: Optional[bool] = None,
+        reuse: bool = True,
     ) -> None:
         """Helper function to open a page.
 
@@ -116,8 +117,19 @@ class CommandDispatcher:
             window: Whether to open in a new window
             private: If opening a new window, open it in private browsing mode.
                      If not given, inherit the current window's mode.
+            reuse: With tabs.switch_to_open_url set, switch to an existing tab
+                   showing the URL instead of opening it again. Pass False to
+                   force a fresh open (e.g. when taking a tab).
         """
         urlutils.raise_cmdexc_if_invalid(url)
+
+        existing_tab = tabutils.tab_for_url(
+            url, private=self._tabbed_browser.is_private)
+        if config.val.tabs.switch_to_open_url and reuse and \
+                existing_tab is not None:
+            tabutils.switch_to_tab(existing_tab)
+            return
+
         tabbed_browser = self._tabbed_browser
         cmdutils.check_exclusive((tab, background, window, private or False), 'tbwp')
         if window and private is None:
@@ -309,6 +321,13 @@ class CommandDispatcher:
             if secure and cur_url.scheme() == 'http':
                 cur_url.setScheme('https')
 
+            # The current-tab path below bypasses _open(), so check here too.
+            existing_tab = tabutils.tab_for_url(
+                cur_url, private=self._tabbed_browser.is_private)
+            if config.val.tabs.switch_to_open_url and existing_tab is not None:
+                tabutils.switch_to_tab(existing_tab)
+                continue
+
             if not window and i > 0:
                 tab = False
                 bg = True
@@ -450,7 +469,7 @@ class CommandDispatcher:
             raise cmdutils.CommandError("Can't take a tab from the same "
                                         "window")
 
-        self._open(tab.url(), tab=True)
+        self._open(tab.url(), tab=True, reuse=False)
         if not keep:
             tabbed_browser.close_tab(tab, add_undo=False, transfer=True)
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -123,11 +123,9 @@ class CommandDispatcher:
         """
         urlutils.raise_cmdexc_if_invalid(url)
 
-        existing_tab = tabutils.tab_for_url(
-            url, private=self._tabbed_browser.is_private)
-        if config.val.tabs.switch_to_open_url and reuse and \
-                existing_tab is not None:
-            tabutils.switch_to_tab(existing_tab)
+        if tabutils.switch_to_open_url(
+                url, private=self._tabbed_browser.is_private,
+                reuse=reuse) is not None:
             return
 
         tabbed_browser = self._tabbed_browser
@@ -321,11 +319,10 @@ class CommandDispatcher:
             if secure and cur_url.scheme() == 'http':
                 cur_url.setScheme('https')
 
-            # The current-tab path below bypasses _open(), so check here too.
-            existing_tab = tabutils.tab_for_url(
-                cur_url, private=self._tabbed_browser.is_private)
-            if config.val.tabs.switch_to_open_url and existing_tab is not None:
-                tabutils.switch_to_tab(existing_tab)
+            # The current-tab path below bypasses _open(), so switch here too.
+            if tabutils.switch_to_open_url(
+                    cur_url, private=self._tabbed_browser.is_private) \
+                    is not None:
                 continue
 
             if not window and i > 0:

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -10,7 +10,7 @@ from qutebrowser.completion.models import (completionmodel, filepathcategory,
                                            listcategory, histcategory,
                                            BaseCategory)
 from qutebrowser.browser import history
-from qutebrowser.utils import log, objreg
+from qutebrowser.utils import log, objreg, tabutils
 from qutebrowser.config import config
 
 
@@ -46,6 +46,7 @@ def url(*, info):
     - quickmarks
     - search engines
     - web history URLs
+    - open tabs
 
     Used for the `open` command.
     """
@@ -71,6 +72,15 @@ def url(*, info):
     if bookmarks and 'bookmarks' in categories:
         models['bookmarks'] = listcategory.ListCategory(
             'Bookmarks', bookmarks, delete_func=_delete_bookmark, sort=False)
+
+    if 'tabs' in categories:
+        tabs = []
+        for win_id, win_tabs in tabutils.all_tabs_by_window().items():
+            for i, tab in enumerate(win_tabs):
+                tabs.append((tab.url().toDisplayString(), tab.title(),
+                             '{}/{}'.format(win_id, i + 1)))
+        models['tabs'] = listcategory.ListCategory(
+            'Tabs', tabs, delete_func=tabutils.delete_tab(2), sort=False)
 
     history_disabled = info.config.get('completion.web_history.max_items') == 0
     if not history_disabled and 'history' in categories:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1501,7 +1501,7 @@ downloads.location.suggestion:
 completion.open_categories:
   type:
     name: FlagList
-    valid_values: [searchengines, quickmarks, bookmarks, history, filesystem]
+    valid_values: [searchengines, quickmarks, bookmarks, history, filesystem, tabs]
     none_ok: true
   default:
     - searchengines
@@ -2549,6 +2549,12 @@ tabs.tooltips:
     Show tooltips on tabs.
 
     Note this setting only affects windows opened after it has been set.
+
+tabs.switch_to_open_url:
+  default: false
+  type: Bool
+  desc: Switch to an existing tab if its URL is already open, instead of opening
+    a duplicate.
 
 ## url
 

--- a/qutebrowser/utils/tabutils.py
+++ b/qutebrowser/utils/tabutils.py
@@ -1,0 +1,119 @@
+# SPDX-FileCopyrightText: Freya Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Utilities to list and manipulate browser tabs."""
+
+from functools import partial
+from typing import Optional, TYPE_CHECKING
+from collections.abc import Callable, Iterator, Sequence
+
+from qutebrowser.qt.core import QUrl
+
+from qutebrowser.utils import objreg
+
+if TYPE_CHECKING:
+    from qutebrowser.browser import browsertab
+
+
+def all_tabs(
+    skip_win_id: Optional[int] = None,
+) -> Iterator['browsertab.AbstractTab']:
+    """Yield all tabs across all windows.
+
+    Args:
+        skip_win_id: A window id to skip, e.g. the current one.
+    """
+    for win_id in objreg.window_registry:
+        if win_id == skip_win_id:
+            continue
+
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window=win_id)
+
+        if tabbed_browser.is_shutting_down:
+            continue
+
+        for idx in range(tabbed_browser.widget.count()):
+            yield tabbed_browser.widget.widget(idx)
+
+
+def all_tabs_by_window(
+    skip_win_id: Optional[int] = None,
+) -> dict[int, list['browsertab.AbstractTab']]:
+    """Return a dict mapping each window id to its list of tabs.
+
+    Args:
+        skip_win_id: A window id to skip, e.g. the current one.
+    """
+    tabs: dict[int, list['browsertab.AbstractTab']] = {}
+
+    for win_id in objreg.window_registry:
+        if win_id == skip_win_id:
+            continue
+
+        tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                    window=win_id)
+
+        if tabbed_browser.is_shutting_down:
+            continue
+
+        tabs[win_id] = []
+        for idx in range(tabbed_browser.widget.count()):
+            tabs[win_id].append(tabbed_browser.widget.widget(idx))
+
+    return tabs
+
+
+def switch_to_tab(tab: 'browsertab.AbstractTab') -> None:
+    """Switch to an existing tab, raising its window."""
+    tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                window=tab.win_id)
+
+    window = tabbed_browser.widget.window()
+    window.activateWindow()
+    window.raise_()
+    tabbed_browser.widget.setCurrentWidget(tab)
+
+
+def tab_for_url(
+    url: QUrl,
+    *,
+    private: bool,
+) -> Optional['browsertab.AbstractTab']:
+    """Return the first tab that has the given URL open.
+
+    Only tabs matching the given privacy context are considered, so a switch
+    never crosses the private-browsing boundary.
+
+    Args:
+        url: The URL to look for.
+        private: Only match tabs whose privacy mode equals this value.
+    """
+    return next(
+        (tab for tab in all_tabs()
+         if bool(tab.is_private) == bool(private) and tab.url() == url),
+        None)
+
+
+def _delete_tab_func(i: int, data: Sequence[str]) -> None:
+    """Close the tab described by a completion data tuple.
+
+    Args:
+        i: The index of the "win_id/index" entry in the data tuple.
+        data: A tuple/list representing a tab (url, title, "win_id/index").
+    """
+    win_id, tab_index = data[i].split('/')
+    tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                window=int(win_id))
+
+    tabbed_browser.on_tab_close_requested(int(tab_index) - 1)
+
+
+def delete_tab(i: int) -> Callable[[Sequence[str]], None]:
+    """Build a delete_func for completions which closes the selected tab.
+
+    Args:
+        i: The index of the "win_id/index" entry in the data tuple.
+    """
+    return partial(_delete_tab_func, i)

--- a/qutebrowser/utils/tabutils.py
+++ b/qutebrowser/utils/tabutils.py
@@ -10,6 +10,7 @@ from collections.abc import Callable, Iterator, Sequence
 
 from qutebrowser.qt.core import QUrl
 
+from qutebrowser.config import config
 from qutebrowser.utils import objreg
 
 if TYPE_CHECKING:
@@ -94,6 +95,30 @@ def tab_for_url(
         (tab for tab in all_tabs()
          if bool(tab.is_private) == bool(private) and tab.url() == url),
         None)
+
+
+def switch_to_open_url(
+    url: QUrl,
+    *,
+    private: Optional[bool],
+    reuse: bool = True,
+) -> Optional['browsertab.AbstractTab']:
+    """Switch to a tab already showing url, if tabs.switch_to_open_url is set.
+
+    Returns the tab switched to, or None if nothing was switched (feature off,
+    reuse suppressed, or no matching tab in the same privacy context).
+
+    Args:
+        url: The URL to switch to.
+        private: The privacy context to match (see tab_for_url).
+        reuse: Pass False to force a fresh open (e.g. when taking a tab).
+    """
+    if not (reuse and config.val.tabs.switch_to_open_url):
+        return None
+    tab = tab_for_url(url, private=bool(private))
+    if tab is not None:
+        switch_to_tab(tab)
+    return tab
 
 
 def _delete_tab_func(i: int, data: Sequence[str]) -> None:

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -133,3 +133,49 @@ Feature: Opening pages
         When I run :quickmark-add http://localhost:(port)/data/numbers/10.txt quickmarktest
         And I run :open quickmarktest
         Then data/numbers/10.txt should be loaded
+
+    Scenario: :open an open URL with tabs.switch_to_open_url set
+        Given I open about:blank
+        When I run :tab-only
+        And I run :window-only
+        And I run :open http://localhost:(port)/data/numbers/1.txt
+        And I wait until data/numbers/1.txt is loaded
+        And I run :open -t http://localhost:(port)/data/numbers/2.txt
+        And I wait until data/numbers/2.txt is loaded
+        And I set tabs.switch_to_open_url to true
+        And I run :open -t http://localhost:(port)/data/numbers/1.txt
+        Then the following tabs should be open:
+            """
+            - data/numbers/1.txt (active)
+            - data/numbers/2.txt
+            """
+
+    Scenario: :open in the current tab switches with tabs.switch_to_open_url set
+        Given I open about:blank
+        When I run :tab-only
+        And I run :window-only
+        And I run :open http://localhost:(port)/data/numbers/1.txt
+        And I wait until data/numbers/1.txt is loaded
+        And I run :open -t http://localhost:(port)/data/numbers/2.txt
+        And I wait until data/numbers/2.txt is loaded
+        And I set tabs.switch_to_open_url to true
+        And I run :open http://localhost:(port)/data/numbers/1.txt
+        Then the following tabs should be open:
+            """
+            - data/numbers/1.txt (active)
+            - data/numbers/2.txt
+            """
+
+    Scenario: :open an open URL in a new tab without tabs.switch_to_open_url
+        Given I open about:blank
+        When I run :tab-only
+        And I run :window-only
+        And I run :open http://localhost:(port)/data/numbers/1.txt
+        And I wait until data/numbers/1.txt is loaded
+        And I run :open -t http://localhost:(port)/data/numbers/1.txt
+        And I wait until data/numbers/1.txt is loaded
+        Then the following tabs should be open:
+            """
+            - data/numbers/1.txt
+            - data/numbers/1.txt (active)
+            """

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -533,7 +533,9 @@ def mode_manager(win_registry, config_stub, key_config_stub, qapp):
     mm = modeman.init(win_id=0, parent=qapp)
     yield mm
     objreg.delete('mode-manager', scope='window', window=0)
-    mm.deleteLater()
+    # Delete synchronously (not deleteLater) so the key parsers'
+    # QApplication-parented timers don't survive into later tests.
+    sip.delete(mm)
 
 
 def standarddir_tmpdir(folder, monkeypatch, tmpdir):

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -504,6 +504,8 @@ class TabWidgetStub(QObject):
         self._qtabbar = QTabBar()
         self.index_of = None
         self.current_index = None
+        self._window = None
+        self.current_widget = None
 
     def count(self):
         return len(self.tabs)
@@ -535,6 +537,15 @@ class TabWidgetStub(QObject):
         if idx == -1:
             return None
         return self.tabs[idx - 1]
+
+    def setWindow(self, window):
+        self._window = window
+
+    def window(self):
+        return self._window
+
+    def setCurrentWidget(self, widget):
+        self.current_widget = widget
 
 
 class HTTPPostStub(QObject):

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -597,6 +597,36 @@ def test_url_completion(qtmodeltester, config_stub, web_history_populated,
     })
 
 
+def test_url_completion_tabs(qtmodeltester, config_stub, fake_web_tab,
+                             win_registry, tabbed_browser_stubs,
+                             quickmark_manager_stub, bookmark_manager_stub,
+                             info):
+    """The tabs category shows open tabs when 'tabs' is in open_categories.
+
+    It is gated only on the category being enabled, independent of
+    tabs.switch_to_open_url.
+    """
+    config_stub.val.completion.open_categories = ['tabs']
+    tabbed_browser_stubs[0].widget.tabs = [
+        fake_web_tab(QUrl('https://github.com'), 'GitHub', 0),
+        fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia', 1),
+    ]
+    tabbed_browser_stubs[1].widget.tabs = [
+        fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
+    ]
+    model = urlmodel.url(info=info)
+    model.set_pattern('')
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        'Tabs': [
+            ('https://github.com', 'GitHub', '0/1'),
+            ('https://wikipedia.org', 'Wikipedia', '0/2'),
+            ('https://wiki.archlinux.org', 'ArchWiki', '1/1'),
+        ],
+    })
+
+
 def test_search_only_default(qtmodeltester, config_stub, web_history_populated,
                              quickmarks, bookmarks, info):
     """Test that search engines are not shown with only the default engine."""

--- a/tests/unit/test_app.py
+++ b/tests/unit/test_app.py
@@ -4,9 +4,12 @@
 
 """Tests for the qutebrowser.app module."""
 
-from qutebrowser.qt.core import QBuffer
+from unittest import mock
+
+from qutebrowser.qt.core import QBuffer, QUrl
 
 from qutebrowser.misc import objects
+from qutebrowser.mainwindow import mainwindow
 from qutebrowser import app
 
 
@@ -23,3 +26,47 @@ def test_on_focus_changed_issue1484(monkeypatch, qapp, caplog):
 
     expected = "on_focus_changed called with non-QWidget {!r}".format(buf)
     assert caplog.messages == [expected]
+
+
+def test_open_url_switches_to_existing_tab(monkeypatch, config_stub,
+                                           tabbed_browser_stubs, fake_web_tab):
+    """With the option on, open_url switches and returns the existing window."""
+    config_stub.val.tabs.switch_to_open_url = True
+
+    url = QUrl('http://example.com/')
+    tab = fake_web_tab(url, 'Example')
+    # Real browser tabs report is_private as None, not False. Pin it so this
+    # exercises the same None-vs-bool comparison the IPC entry point hits.
+    tab.is_private = None
+    tabbed_browser_stubs[0].widget.tabs = [tab]
+    existing_window = mock.Mock()
+    tabbed_browser_stubs[0].widget.setWindow(existing_window)
+
+    new_window = mock.Mock()
+    monkeypatch.setattr(mainwindow, 'get_window', lambda **kwargs: new_window)
+
+    result = app.open_url(url, target='tab', via_ipc=False)
+
+    assert result is existing_window
+    assert existing_window.activateWindow.called
+    assert not new_window.tabbed_browser.tabopen.called
+
+
+def test_open_url_no_switch_when_disabled(monkeypatch, config_stub,
+                                          tabbed_browser_stubs, fake_web_tab):
+    """With the option off, open_url opens normally even with a matching tab."""
+    config_stub.val.tabs.switch_to_open_url = False
+
+    url = QUrl('http://example.com/')
+    tabbed_browser_stubs[0].widget.tabs = [fake_web_tab(url, 'Example')]
+    existing_window = mock.Mock()
+    tabbed_browser_stubs[0].widget.setWindow(existing_window)
+
+    new_window = mock.Mock()
+    monkeypatch.setattr(mainwindow, 'get_window', lambda **kwargs: new_window)
+
+    result = app.open_url(url, target='tab', via_ipc=False)
+
+    assert result is new_window
+    assert new_window.tabbed_browser.tabopen.called
+    assert not existing_window.activateWindow.called

--- a/tests/unit/utils/test_tabutils.py
+++ b/tests/unit/utils/test_tabutils.py
@@ -193,6 +193,77 @@ def test_tab_for_url_private_open_skips_normal_tab(stub_tabs,
                                 private=True) is None
 
 
+def test_switch_to_open_url_switches(stub_tabs, tabbed_browser_stubs,
+                                     config_stub):
+    """With the option on and a matching tab, the helper switches to it."""
+    config_stub.val.tabs.switch_to_open_url = True
+    win_0 = FakeWindow(0)
+    tabbed_browser_stubs[0].widget.setWindow(win_0)
+
+    url = QUrl('https://github.com')
+    tab = tabutils.switch_to_open_url(url, private=False)
+
+    assert tab is not None
+    assert tab.url() == url
+    assert win_0.isactive()
+    assert tabbed_browser_stubs[0].widget.current_widget.url() == url
+
+
+def test_switch_to_open_url_disabled(stub_tabs, tabbed_browser_stubs,
+                                     config_stub):
+    """With the option off, the helper returns None and does not switch."""
+    config_stub.val.tabs.switch_to_open_url = False
+    win_0 = FakeWindow(0)
+    tabbed_browser_stubs[0].widget.setWindow(win_0)
+
+    tab = tabutils.switch_to_open_url(QUrl('https://github.com'),
+                                      private=False)
+
+    assert tab is None
+    assert not win_0.isactive()
+
+
+def test_switch_to_open_url_reuse_false(stub_tabs, tabbed_browser_stubs,
+                                        config_stub):
+    """reuse=False suppresses the switch even with the option on."""
+    config_stub.val.tabs.switch_to_open_url = True
+    win_0 = FakeWindow(0)
+    tabbed_browser_stubs[0].widget.setWindow(win_0)
+
+    tab = tabutils.switch_to_open_url(QUrl('https://github.com'),
+                                      private=False, reuse=False)
+
+    assert tab is None
+    assert not win_0.isactive()
+
+
+def test_switch_to_open_url_no_match(stub_tabs, config_stub):
+    """With no matching tab, the helper returns None."""
+    config_stub.val.tabs.switch_to_open_url = True
+
+    assert tabutils.switch_to_open_url(QUrl('https://no-such-tab.example'),
+                                       private=False) is None
+
+
+def test_switch_to_open_url_private_skips_normal_tab(stub_tabs, config_stub):
+    """A private switch never lands on a normal tab (privacy boundary)."""
+    config_stub.val.tabs.switch_to_open_url = True
+
+    assert tabutils.switch_to_open_url(QUrl('https://github.com'),
+                                       private=True) is None
+
+
+def test_switch_to_open_url_normal_skips_private_tab(stub_tabs,
+                                                     tabbed_browser_stubs,
+                                                     config_stub):
+    """A normal switch never lands on a private tab (privacy boundary)."""
+    config_stub.val.tabs.switch_to_open_url = True
+    tabbed_browser_stubs[0].widget.tabs[0].is_private = True
+
+    assert tabutils.switch_to_open_url(QUrl('https://github.com'),
+                                       private=False) is None
+
+
 def test_switch_to_tab(stub_tabs, tabbed_browser_stubs, fake_web_tab):
     widget = tabbed_browser_stubs[0].widget
     win_0 = FakeWindow(0)

--- a/tests/unit/utils/test_tabutils.py
+++ b/tests/unit/utils/test_tabutils.py
@@ -1,0 +1,217 @@
+# SPDX-FileCopyrightText: Freya Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for qutebrowser.utils.tabutils."""
+
+import pytest
+from qutebrowser.qt.core import QUrl
+from qutebrowser.utils import tabutils
+
+
+@pytest.fixture
+def stub_tabs(fake_web_tab, tabbed_browser_stubs):
+    tabbed_browser_stubs[0].widget.tabs = [
+        fake_web_tab(QUrl('https://github.com'), 'GitHub'),
+        fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia'),
+        fake_web_tab(QUrl('https://duckduckgo.com'), 'DuckDuckGo'),
+    ]
+
+    tab_1_1 = fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki')
+    tab_1_1.win_id = 1
+
+    tab_1_2 = fake_web_tab(QUrl('https://google.com'), 'Google')
+    tab_1_2.win_id = 1
+
+    tabbed_browser_stubs[1].widget.tabs = [tab_1_1, tab_1_2]
+
+
+class FakeWindow:
+
+    def __init__(self, win_id):
+        self.win_id = win_id
+        self._active = False
+        self._raised = False
+
+    def activateWindow(self):
+        self._active = True
+
+    def raise_(self):
+        self._raised = True
+
+    def isactive(self):
+        return self._active
+
+    def israised(self):
+        return self._raised
+
+
+def test_all_tabs(stub_tabs):
+    tabs = [(t.win_id, t.url(), t.title()) for t in tabutils.all_tabs()]
+
+    assert tabs == [
+        (0, QUrl('https://github.com'), 'GitHub'),
+        (0, QUrl('https://wikipedia.org'), 'Wikipedia'),
+        (0, QUrl('https://duckduckgo.com'), 'DuckDuckGo'),
+        (1, QUrl('https://wiki.archlinux.org'), 'ArchWiki'),
+        (1, QUrl('https://google.com'), 'Google'),
+    ]
+
+
+def test_all_tabs_skip_win_id(stub_tabs):
+    tabs = [(t.win_id, t.url(), t.title()) for t in
+            tabutils.all_tabs(skip_win_id=0)]
+
+    assert list(tabs) == [
+        (1, QUrl('https://wiki.archlinux.org'), 'ArchWiki'),
+        (1, QUrl('https://google.com'), 'Google'),
+    ]
+
+
+def test_all_tabs_shutting_down(stub_tabs, tabbed_browser_stubs):
+    tabbed_browser_stubs[0].is_shutting_down = True
+
+    tabs = [(t.win_id, t.url(), t.title()) for t in tabutils.all_tabs()]
+
+    assert list(tabs) == [
+        (1, QUrl('https://wiki.archlinux.org'), 'ArchWiki'),
+        (1, QUrl('https://google.com'), 'Google'),
+    ]
+
+
+def test_all_tabs_by_window(stub_tabs):
+    tabs_by_window = {}
+
+    for w, tabs in tabutils.all_tabs_by_window().items():
+        tabs = [(t.win_id, t.url(), t.title()) for t in tabs]
+        tabs_by_window[w] = tabs
+
+    assert tabs_by_window == {
+        0: [
+            (0, QUrl('https://github.com'), 'GitHub'),
+            (0, QUrl('https://wikipedia.org'), 'Wikipedia'),
+            (0, QUrl('https://duckduckgo.com'), 'DuckDuckGo'),
+        ],
+        1: [
+            (1, QUrl('https://wiki.archlinux.org'), 'ArchWiki'),
+            (1, QUrl('https://google.com'), 'Google'),
+        ]
+    }
+
+
+def test_all_tabs_by_window_skip_win_id(stub_tabs):
+    tabs_by_window = {}
+
+    for w, tabs in tabutils.all_tabs_by_window(0).items():
+        tabs = [(t.win_id, t.url(), t.title()) for t in tabs]
+        tabs_by_window[w] = tabs
+
+    assert tabs_by_window == {
+        1: [
+            (1, QUrl('https://wiki.archlinux.org'), 'ArchWiki'),
+            (1, QUrl('https://google.com'), 'Google'),
+        ]
+    }
+
+
+def test_all_tabs_by_window_skips_empty_shutting_down(stub_tabs,
+                                                      tabbed_browser_stubs):
+    tabbed_browser_stubs[0].is_shutting_down = True
+
+    tabs_by_window = tabutils.all_tabs_by_window()
+
+    assert list(tabs_by_window) == [1]
+
+
+def test_delete_tab_index_on_0(stub_tabs):
+    tabutils.delete_tab(0)(('1/2', '', ''))
+
+    tabs = ((t.title()) for t in tabutils.all_tabs())
+    assert list(tabs) == ['GitHub', 'Wikipedia', 'DuckDuckGo', 'ArchWiki']
+
+
+def test_delete_tab_index_on_2(stub_tabs):
+    tabutils.delete_tab(2)(('', '', '0/1'))
+
+    tabs = ((t.title()) for t in tabutils.all_tabs())
+    assert list(tabs) == ['Wikipedia', 'DuckDuckGo', 'ArchWiki', 'Google']
+
+
+def test_tab_for_url_no_match(stub_tabs):
+    assert tabutils.tab_for_url(QUrl('foobar'), private=False) is None
+
+
+def test_tab_for_url(stub_tabs):
+    tab = tabutils.tab_for_url(QUrl('https://wiki.archlinux.org'),
+                               private=False)
+
+    assert tab.url() == QUrl('https://wiki.archlinux.org')
+    assert tab.title() == 'ArchWiki'
+    assert tab.win_id == 1
+
+
+def test_tab_for_url_same_privacy(stub_tabs, tabbed_browser_stubs):
+    tabbed_browser_stubs[0].widget.tabs[0].is_private = True
+
+    tab = tabutils.tab_for_url(QUrl('https://github.com'), private=True)
+
+    assert tab is not None
+    assert tab.title() == 'GitHub'
+
+
+def test_tab_for_url_skips_other_privacy(stub_tabs, tabbed_browser_stubs):
+    tabbed_browser_stubs[0].widget.tabs[0].is_private = True
+
+    assert tabutils.tab_for_url(QUrl('https://github.com'),
+                                private=False) is None
+
+
+def test_tab_for_url_normal_tab_none_privacy(stub_tabs, tabbed_browser_stubs):
+    """A normal tab whose is_private is None still matches a normal open.
+
+    Real browser tabs report is_private as None, not False, so a strict `==`
+    comparison against the bool False excludes them and a duplicate opens.
+    """
+    tabbed_browser_stubs[0].widget.tabs[0].is_private = None
+
+    tab = tabutils.tab_for_url(QUrl('https://github.com'), private=False)
+
+    assert tab is not None
+    assert tab.title() == 'GitHub'
+
+
+def test_tab_for_url_private_open_skips_normal_tab(stub_tabs,
+                                                   tabbed_browser_stubs):
+    """A private open never matches a normal tab, even one with None privacy.
+
+    bool(None) == bool(True) is False, so the privacy boundary still rejects
+    the match and a private context cannot land on a normal tab.
+    """
+    tabbed_browser_stubs[0].widget.tabs[0].is_private = None
+
+    assert tabutils.tab_for_url(QUrl('https://github.com'),
+                                private=True) is None
+
+
+def test_switch_to_tab(stub_tabs, tabbed_browser_stubs, fake_web_tab):
+    widget = tabbed_browser_stubs[0].widget
+    win_0 = FakeWindow(0)
+    widget.setWindow(win_0)
+
+    win_1 = FakeWindow(1)
+    tabbed_browser_stubs[1].widget.setWindow(win_1)
+
+    tab = fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia', 2)
+    tab.win_id = 0
+
+    tabutils.switch_to_tab(tab)
+
+    assert win_0.isactive()
+    assert win_0.israised()
+    assert widget.current_widget.url() == widget.tabs[1].url() == tab.url()
+    assert widget.current_widget.title() == widget.tabs[1].title() == \
+        tab.title()
+    assert widget.current_widget.win_id == widget.tabs[1].win_id == tab.win_id
+
+    assert not win_1.isactive()
+    assert not win_1.israised()

--- a/tox.ini
+++ b/tox.ini
@@ -125,7 +125,7 @@ deps =
     -r{toxinidir}/misc/requirements/requirements-pyqt.txt
     -r{toxinidir}/misc/requirements/requirements-pyqt-5.txt
 commands =
-    {envpython} -m pylint scripts qutebrowser --output-format=colorized --reports=no {posargs}
+    {envpython} -m pylint {posargs:scripts qutebrowser} --output-format=colorized --reports=no
     {envpython} scripts/dev/run_pylint_on_tests.py {toxinidir} --output-format=colorized --reports=no {posargs}
 
 [testenv:pylint-pyqtlink]


### PR DESCRIPTION
Switch to an already-open tab instead of opening duplicates

Add a `tabs.switch_to_open_url` setting, `off` by default. When it is `on`, opening a URL that is already loaded in some tab focuses that tab and its window instead of opening a second copy. The check runs after URL validation in `_open()`, in the `openurl()` current-tab path, and in `app.open_url()` for command-line and IPC opens.

A switch only considers tabs in the same privacy context, so opening a normal URL never jumps to a private-browsing tab. Taking a tab with `:tab-take` passes reuse=False so it is never turned into a switch.

The `:open` completion also shows a tabs category whenever tabs is in `completion.open_categories`.

Discussed on #2198 

*edit by @The-Compiler: Fixes #5037*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/qutebrowser/qutebrowser/4955)
<!-- Reviewable:end -->
