### PR TITLE
add indicator if autoconfig.yml is loaded to :version

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -284,6 +284,7 @@ class Config(QObject):
         self._mutables = {}  # type: MutableMapping[str, Tuple[Any, Any]]
         self._yaml = yaml_config
         self._init_values()
+        self.yaml_loaded = False
 
     def _init_values(self) -> None:
         """Populate the self._values dict."""
@@ -330,6 +331,7 @@ class Config(QObject):
     def read_yaml(self) -> None:
         """Read the YAML settings from self._yaml."""
         self._yaml.load()
+        self.yaml_loaded = True
         for values in self._yaml:
             for scoped in values:
                 self._set_value(values.opt, scoped.value,

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -53,6 +53,7 @@ import qutebrowser
 from qutebrowser.utils import log, utils, standarddir, usertypes, message
 from qutebrowser.misc import objects, earlyinit, sql, httpclient, pastebin
 from qutebrowser.browser import pdfjs
+from qutebrowser.config import config
 
 try:
     from qutebrowser.browser.webengine import webenginesettings
@@ -384,6 +385,10 @@ def _uptime() -> datetime.timedelta:
     return time_delta
 
 
+def _autoconfig_loaded() -> str:
+    return ("yes" if config.instance.yaml_loaded else "no")
+
+
 def version():
     """Return a string with various version information."""
     lines = ["qutebrowser v{}".format(qutebrowser.__version__)]
@@ -449,8 +454,12 @@ def version():
         lines += ['{}: {}'.format(name, path)]
 
     lines += [
-        '',
-        'Uptime: {}'.format(_uptime()),
+        "",
+        "Autoconfig loaded: {}".format(_autoconfig_loaded())
+    ]
+
+    lines += [
+        'Uptime: {}'.format(_uptime())
     ]
 
     return '\n'.join(lines)

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -386,7 +386,7 @@ def _uptime() -> datetime.timedelta:
 
 
 def _autoconfig_loaded() -> str:
-    return ("yes" if config.instance.yaml_loaded else "no")
+    return "yes" if config.instance.yaml_loaded else "no"
 
 
 def version():

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -455,10 +455,7 @@ def version():
 
     lines += [
         "",
-        "Autoconfig loaded: {}".format(_autoconfig_loaded())
-    ]
-
-    lines += [
+        "Autoconfig loaded: {}".format(_autoconfig_loaded()),
         'Uptime: {}'.format(_uptime())
     ]
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -883,6 +883,7 @@ class VersionParams:
     with_webkit = attr.ib(True)
     known_distribution = attr.ib(True)
     ssl_support = attr.ib(True)
+    autoconfig_loaded = attr.ib(True)
 
 
 @pytest.mark.parametrize('params', [
@@ -893,9 +894,9 @@ class VersionParams:
     VersionParams('no-webkit', with_webkit=False),
     VersionParams('unknown-dist', known_distribution=False),
     VersionParams('no-ssl', ssl_support=False),
+    VersionParams('autoconfig_loaded', autoconfig_loaded=False),
 ], ids=lambda param: param.name)
-@pytest.mark.parametrize('autoconfig_loaded', [True, False])
-def test_version_output(params, stubs, monkeypatch, autoconfig_loaded):
+def test_version_output(params, stubs, monkeypatch):
     """Test version.version()."""
     class FakeWebEngineSettings:
         default_user_agent = ('Toaster/4.0.4 Chrome/CHROMIUMVERSION '
@@ -924,7 +925,7 @@ def test_version_output(params, stubs, monkeypatch, autoconfig_loaded):
         'QLibraryInfo.location': (lambda _loc: 'QT PATH'),
         'sql.version': lambda: 'SQLITE VERSION',
         '_uptime': lambda: datetime.timedelta(hours=1, minutes=23, seconds=45),
-        '_autoconfig_loaded': lambda: ("yes" if autoconfig_loaded else "no")
+        '_autoconfig_loaded': lambda: ("yes" if params.autoconfig_loaded else "no")
     }
 
     substitutions = {
@@ -934,6 +935,8 @@ def test_version_output(params, stubs, monkeypatch, autoconfig_loaded):
         'frozen': str(params.frozen),
         'import_path': import_path,
         'python_path': 'EXECUTABLE PATH',
+        'uptime': "1:23:45",
+        'autoconfig_loaded': ("yes" if params.autoconfig_loaded else "no")
     }
 
     if params.with_webkit:
@@ -969,10 +972,6 @@ def test_version_output(params, stubs, monkeypatch, autoconfig_loaded):
         monkeypatch.setattr(sys, 'frozen', True, raising=False)
     else:
         monkeypatch.delattr(sys, 'frozen', raising=False)
-
-    substitutions['uptime'] = "1:23:45"
-    substitutions['autoconfig_loaded'] = (
-        "yes" if autoconfig_loaded else "no")
 
     template = textwrap.dedent("""
         qutebrowser vVERSION{git_commit}

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -894,7 +894,8 @@ class VersionParams:
     VersionParams('unknown-dist', known_distribution=False),
     VersionParams('no-ssl', ssl_support=False),
 ], ids=lambda param: param.name)
-def test_version_output(params, stubs, monkeypatch):
+@pytest.mark.parametrize('autoconfig_loaded', [True, False])
+def test_version_output(params, stubs, monkeypatch, autoconfig_loaded):
     """Test version.version()."""
     class FakeWebEngineSettings:
         default_user_agent = ('Toaster/4.0.4 Chrome/CHROMIUMVERSION '
@@ -923,6 +924,7 @@ def test_version_output(params, stubs, monkeypatch):
         'QLibraryInfo.location': (lambda _loc: 'QT PATH'),
         'sql.version': lambda: 'SQLITE VERSION',
         '_uptime': lambda: datetime.timedelta(hours=1, minutes=23, seconds=45),
+        '_autoconfig_loaded': lambda: ("yes" if autoconfig_loaded else "no")
     }
 
     substitutions = {
@@ -969,6 +971,8 @@ def test_version_output(params, stubs, monkeypatch):
         monkeypatch.delattr(sys, 'frozen', raising=False)
 
     substitutions['uptime'] = "1:23:45"
+    substitutions['autoconfig_loaded'] = (
+        "yes" if autoconfig_loaded else "no")
 
     template = textwrap.dedent("""
         qutebrowser vVERSION{git_commit}
@@ -993,6 +997,7 @@ def test_version_output(params, stubs, monkeypatch):
         Paths:
         PATH DESC: PATH NAME
 
+        Autoconfig loaded: {autoconfig_loaded}
         Uptime: {uptime}
     """.lstrip('\n'))
 


### PR DESCRIPTION
after the "paths" section in :version there is a line indicating when the autoconfig.yml is loaded
this is related to #3504 and #4941 