### PR TITLE
Don't execute pass if it's not needed

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -174,7 +174,17 @@ def main(arguments):
     if not selection:
         return ExitCodes.SUCCESS
 
-    secret = pass_(selection, arguments.io_encoding)
+    # If username-target is path and user asked for username-only, we don't need to run pass
+    secret = None
+    if not (arguments.username_target == 'path' and arguments.username_only):
+        secret = pass_(selection, arguments.io_encoding)
+
+        # Match password
+        match = re.match(arguments.password_pattern, secret)
+        if not match:
+            stderr('Failed to match password pattern on secret!')
+            return ExitCodes.COULD_NOT_MATCH_PASSWORD
+        password = match.group(1)
 
     # Match username
     target = selection if arguments.username_target == 'path' else secret
@@ -183,13 +193,6 @@ def main(arguments):
         stderr('Failed to match username pattern on {}!'.format(arguments.username_target))
         return ExitCodes.COULD_NOT_MATCH_USERNAME
     username = match.group(1)
-
-    # Match password
-    match = re.match(arguments.password_pattern, secret)
-    if not match:
-        stderr('Failed to match password pattern on secret!')
-        return ExitCodes.COULD_NOT_MATCH_PASSWORD
-    password = match.group(1)
 
     if arguments.username_only:
         fake_key_raw(username)


### PR DESCRIPTION
If you execute qute-pass with `username-target=path` and `username-only`, qute-pass still asks you for your password even though it only needs to read the username from the filename. This PR checks for that particular combination of arguments and only executes pass if needed.