### PR TITLE
Search netrc for {host:port} when port is present in url

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -311,7 +311,9 @@ def netrc_authentication(url, authenticator):
     try:
         net = netrc.netrc(config.val.content.netrc_file)
         if url.port():
-            authenticators = net.authenticators("{}:{}".format(url.host(), url.port()))
+            authenticators = net.authenticators(
+                "{}:{}".format(url.host(), url.port())
+            )
         if not authenticators:
             authenticators = net.authenticators(url.host())
         if authenticators is not None:

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -311,7 +311,7 @@ def netrc_authentication(url, authenticator):
     try:
         net = netrc.netrc(config.val.content.netrc_file)
         if url.port():
-            authenticators = net.authenticators(f"{url.host()}:{url.port()}")
+            authenticators = net.authenticators("{}:{}".format(url.host(), url.port()))
         if not authenticators:
             authenticators = net.authenticators(url.host())
         if authenticators is not None:

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -310,7 +310,7 @@ def netrc_authentication(url, authenticator):
     user, password = None, None
     try:
         net = netrc.netrc(config.val.content.netrc_file)
-        if url.port():
+        if url.port() != -1:
             authenticators = net.authenticators(
                 "{}:{}".format(url.host(), url.port())
             )

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -310,7 +310,10 @@ def netrc_authentication(url, authenticator):
     user, password = None, None
     try:
         net = netrc.netrc(config.val.content.netrc_file)
-        authenticators = net.authenticators(url.host())
+        if url.port():
+            authenticators = net.authenticators(f"{url.host()}:{url.port()}")
+        if not authenticators:
+            authenticators = net.authenticators(url.host())
         if authenticators is not None:
             (user, _account, password) = authenticators
     except FileNotFoundError:


### PR DESCRIPTION
This allows qutebrowser to find netrc entries for things like "localhost:7777" instead of just looking for "localhost".