### PR TITLE
spell: fix regex for finding dictionary version

### DIFF
--- a/qutebrowser/browser/webengine/spell.py
+++ b/qutebrowser/browser/webengine/spell.py
@@ -29,7 +29,7 @@ import shutil
 from PyQt5.QtCore import QLibraryInfo
 from qutebrowser.utils import log, message, standarddir, qtutils
 
-dict_version_re = re.compile(r".+-(?P<version>[0-9]+-[0-9]+?)\.bdic")
+dict_version_re = re.compile(r".+-(?P<version>[0-9]+-[0-9]+?)")
 
 
 def can_use_data_path():


### PR DESCRIPTION
The .bdic extension is stripped off by the regex in dictcli.py:146, so for any
dictionaries that require this regex will fail and dictcli.py will not complete
successully.