### PR TITLE
Clean up filename handling in dictcli/spell.py

### DIFF
--- a/qutebrowser/browser/webengine/spell.py
+++ b/qutebrowser/browser/webengine/spell.py
@@ -29,7 +29,7 @@ import shutil
 from PyQt5.QtCore import QLibraryInfo
 from qutebrowser.utils import log, message, standarddir, qtutils
 
-dict_version_re = re.compile(r".+-(?P<version>[0-9]+-[0-9]+?)\.bdic")
+_DICT_VERSION_RE = re.compile(r".+-(?P<version>[0-9]+-[0-9]+?)\.bdic")
 
 
 def can_use_data_path():
@@ -43,7 +43,7 @@ def can_use_data_path():
 
 def version(filename):
     """Extract the version number from the dictionary file name."""
-    match = dict_version_re.match(filename)
+    match = _DICT_VERSION_RE.fullmatch(filename)
     if match is None:
         message.warning(
             "Found a dictionary with a malformed name: {}".format(filename))
@@ -87,7 +87,7 @@ def local_filename(code):
     number or None if the dictionary is not installed.
     """
     all_installed = local_files(code)
-    return os.path.splitext(all_installed[0])[0] if all_installed else None
+    return all_installed[0] if all_installed else None
 
 
 def init():

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -265,7 +265,7 @@ class ProfileSetter:
                                     "sources".format(code))
                 continue
 
-            filenames.append(local_filename)
+            filenames.append(os.path.splitext(local_filename)[0])
 
         log.config.debug("Found dicts: {}".format(filenames))
         self._profile.setSpellCheckLanguages(filenames)

--- a/scripts/dev/update_3rdparty.py
+++ b/scripts/dev/update_3rdparty.py
@@ -149,7 +149,7 @@ def test_dicts():
     configdata.init()
     for lang in dictcli.available_languages():
         print('Testing dictionary {}... '.format(lang.code), end='')
-        lang_url = urllib.parse.urljoin(dictcli.API_URL, lang.remote_path)
+        lang_url = urllib.parse.urljoin(dictcli.API_URL, lang.remote_filename)
         request = urllib.request.Request(lang_url, method='HEAD')
         response = urllib.request.urlopen(request)
         if response.status == 200:

--- a/scripts/dictcli.py
+++ b/scripts/dictcli.py
@@ -61,36 +61,23 @@ class Language:
     name = attr.ib()
     remote_filename = attr.ib()
     local_filename = attr.ib(default=None)
-    _file_extension = attr.ib('bdic', init=False)
 
     def __attrs_post_init__(self):
         if self.local_filename is None:
             self.local_filename = spell.local_filename(self.code)
 
     @property
-    def remote_path(self):
-        """Resolve the filename with extension the remote dictionary."""
-        return '.'.join([self.remote_filename, self._file_extension])
-
-    @property
-    def local_path(self):
-        """Resolve the filename with extension the local dictionary."""
-        if self.local_filename is None:
-            return None
-        return '.'.join([self.local_filename, self._file_extension])
-
-    @property
     def remote_version(self):
         """Resolve the version of the local dictionary."""
-        return spell.version(self.remote_path)
+        return spell.version(self.remote_filename)
 
     @property
     def local_version(self):
         """Resolve the version of the local dictionary."""
-        local_path = self.local_path
-        if local_path is None:
+        local_filename = self.local_filename
+        if local_filename is None:
             return None
-        return spell.version(local_path)
+        return spell.version(local_filename)
 
 
 def get_argparser():
@@ -143,7 +130,7 @@ def valid_languages():
 def parse_entry(entry):
     """Parse an entry from the remote API."""
     dict_re = re.compile(r"""
-        (?P<filename>(?P<code>[a-z]{2}(-[A-Z]{2})?).*)\.bdic
+        (?P<filename>(?P<code>[a-z]{2}(-[A-Z]{2})?).*\.bdic)
     """, re.VERBOSE)
     match = dict_re.fullmatch(entry['name'])
     if match is not None:
@@ -214,13 +201,13 @@ def filter_languages(languages, selected):
 
 def install_lang(lang):
     """Install a single lang given by the argument."""
-    lang_url = API_URL + lang.remote_path + '?format=TEXT'
+    lang_url = API_URL + lang.remote_filename + '?format=TEXT'
     if not os.path.isdir(spell.dictionary_dir()):
         msg = '{} does not exist, creating the directory'
         print(msg.format(spell.dictionary_dir()))
         os.makedirs(spell.dictionary_dir())
     print('Downloading {}'.format(lang_url))
-    dest = os.path.join(spell.dictionary_dir(), lang.remote_path)
+    dest = os.path.join(spell.dictionary_dir(), lang.remote_filename)
     download_dictionary(lang_url, dest)
     print('Installed to {}.'.format(dest))
 

--- a/tests/unit/browser/webengine/test_spell.py
+++ b/tests/unit/browser/webengine/test_spell.py
@@ -80,8 +80,8 @@ def test_local_filename_dictionary_installed(tmpdir, monkeypatch):
     monkeypatch.setattr(spell, 'dictionary_dir', lambda: str(tmpdir))
     for lang_file in ['en-US-11-0.bdic', 'en-US-7-1.bdic', 'pl-PL-3-0.bdic']:
         (tmpdir / lang_file).ensure()
-    assert spell.local_filename('en-US') == 'en-US-11-0'
-    assert spell.local_filename('pl-PL') == 'pl-PL-3-0'
+    assert spell.local_filename('en-US') == 'en-US-11-0.bdic'
+    assert spell.local_filename('pl-PL') == 'pl-PL-3-0.bdic'
 
 
 def test_local_filename_installed_malformed(tmpdir, monkeypatch, caplog):
@@ -92,7 +92,7 @@ def test_local_filename_installed_malformed(tmpdir, monkeypatch, caplog):
     for lang_file in ['en-US-11-0.bdic', 'en-US-7-1.bdic', 'en-US.bdic']:
         (tmpdir / lang_file).ensure()
     with caplog.at_level(logging.WARNING):
-        assert spell.local_filename('en-US') == 'en-US-11-0'
+        assert spell.local_filename('en-US') == 'en-US-11-0.bdic'
 
 
 class TestInit:

--- a/tests/unit/scripts/test_dictcli.py
+++ b/tests/unit/scripts/test_dictcli.py
@@ -29,23 +29,23 @@ from scripts import dictcli
 
 def afrikaans():
     return dictcli.Language(
-        'af-ZA',
-        'Afrikaans (South Africa)',
-        'af-ZA-3-0')
+        code='af-ZA',
+        name='Afrikaans (South Africa)',
+        remote_filename='af-ZA-3-0.bdic')
 
 
 def english():
     return dictcli.Language(
-        'en-US',
-        'English (United States)',
-        'en-US-7-1')
+        code='en-US',
+        name='English (United States)',
+        remote_filename='en-US-7-1.bdic')
 
 
 def polish():
     return dictcli.Language(
-        'pl-PL',
-        'Polish (Poland)',
-        'pl-PL-3-0')
+        code='pl-PL',
+        name='Polish (Poland)',
+        remote_filename='pl-PL-3-0.bdic')
 
 
 def langs():
@@ -67,13 +67,12 @@ def dict_tmpdir(tmpdir, monkeypatch):
 def test_language(dict_tmpdir):
     (dict_tmpdir / 'pl-PL-2-0.bdic').ensure()
     assert english().local_filename is None
-    assert english().local_path is None
     assert polish()
 
 
 def test_parse_entry():
-    assert dictcli.parse_entry({'name': 'en-US-7-1.bdic'}) == \
-        ('en-US', 'en-US-7-1')
+    assert (dictcli.parse_entry({'name': 'en-US-7-1.bdic'}) ==
+            ('en-US', 'en-US-7-1.bdic'))
 
 
 def test_latest_yet():
@@ -84,21 +83,27 @@ def test_latest_yet():
 
 
 def test_available_languages(dict_tmpdir, monkeypatch):
-    for f in ['pl-PL-2-0.bdic', english().remote_path]:
+    for f in ['pl-PL-2-0.bdic', english().remote_filename]:
         (dict_tmpdir / f).ensure()
     monkeypatch.setattr(dictcli, 'language_list_from_api', lambda: [
         (lang.code, lang.remote_filename) for lang in langs()
     ])
     assert sorted(dictcli.available_languages()) == [
         dictcli.Language(
-            'af-ZA', 'Afrikaans (South Africa)',
-            'af-ZA-3-0', None),
+            code='af-ZA',
+            name='Afrikaans (South Africa)',
+            remote_filename='af-ZA-3-0.bdic',
+            local_filename=None),
         dictcli.Language(
-            'en-US', 'English (United States)',
-            'en-US-7-1', 'en-US-7-1'),
+            code='en-US',
+            name='English (United States)',
+            remote_filename='en-US-7-1.bdic',
+            local_filename=None),
         dictcli.Language(
-            'pl-PL', 'Polish (Poland)',
-            'pl-PL-3-0', 'pl-PL-2-0')
+            code='pl-PL',
+            name='Polish (Poland)',
+            remote_filename='pl-PL-3-0.bdic',
+            local_filename='pl-PL-2-0.bdic'),
     ]
 
 
@@ -124,7 +129,7 @@ def test_install(dict_tmpdir, monkeypatch):
 
     # then
     installed_files = [f.basename for f in dict_tmpdir.listdir()]
-    expected_files = [lang.remote_path for lang in langs()]
+    expected_files = [lang.remote_filename for lang in langs()]
     assert sorted(installed_files) == sorted(expected_files)
 
 
@@ -148,7 +153,9 @@ def test_remove_old(dict_tmpdir, monkeypatch):
     monkeypatch.setattr(
         dictcli, 'download_dictionary',
         lambda _url, dest: py.path.local(dest).ensure())  # pylint: disable=no-member
-    for f in ['pl-PL-2-0.bdic', polish().remote_path, english().remote_path]:
+    for f in ['pl-PL-2-0.bdic',
+              polish().remote_filename,
+              english().remote_filename]:
         (dict_tmpdir / f).ensure()
 
     # when
@@ -156,5 +163,5 @@ def test_remove_old(dict_tmpdir, monkeypatch):
 
     # then
     installed_files = [f.basename for f in dict_tmpdir.listdir()]
-    expected_files = [polish().remote_path, english().remote_path]
+    expected_files = [polish().remote_filename, english().remote_filename]
     assert sorted(installed_files) == sorted(expected_files)


### PR DESCRIPTION
Before this change, we sometimes assumed that a dictionary filename had a .bdic
suffix, sometimes not, and sometimes we added it by hand.

For some reason (probably some minor API change?) this currently breaks running
dictcli.py.

While the minimal fix in #4986 works, it only does so because we use re.match
(not re.fullmatch) inside spell.py, so the .bdic suffix (which is present
there) is ignored.

This change instead refactors all dict handling so that the suffix is always
included in the filename, and only stripped off in the last moment when passing
it to QtWebEngine.

Closes #4986
Closes #5002