### PR TITLE
[readability script] Remove distracting and unnecessary tags

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -10,16 +10,8 @@
 # Usage:
 #   :spawn --userscript readability
 #
-from __future__ import absolute_import
 import codecs, os
-
-tmpfile = os.path.join(
-    os.environ.get('QUTE_DATA_DIR',
-                   os.path.expanduser('~/.local/share/qutebrowser')),
-    'userscripts/readability.html')
-
-if not os.path.exists(os.path.dirname(tmpfile)):
-    os.makedirs(os.path.dirname(tmpfile))
+import re
 
 # Styling for dynamic window margin scaling and line height
 HEADER = """
@@ -43,6 +35,17 @@ HEADER = """
 </head>
 """
 
+def remove_tag(content, tag_type):
+    return re.sub(r'<%s.*?>' % tag_type, '', content)
+
+tmpfile = os.path.join(
+    os.environ.get('QUTE_DATA_DIR',
+                   os.path.expanduser('~/.local/share/qutebrowser')),
+    'userscripts/readability.html')
+
+if not os.path.exists(os.path.dirname(tmpfile)):
+    os.makedirs(os.path.dirname(tmpfile))
+
 with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
     data = source.read()
 
@@ -57,6 +60,10 @@ with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
         title = doc.title()
         content = doc.summary().replace('<html>', HEADER % title)
 
+    # SVGs often look odd. Better remove them.
+    content = remove_tag(content, "svg")
+    content = remove_tag(content, "button")
+    
     with codecs.open(tmpfile, 'w', 'utf-8') as target:
         target.write(content.lstrip())
 

--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -10,17 +10,16 @@
 # Usage:
 #   :spawn --userscript readability
 #
-import codecs, os
-import re
+import os
+import xml.etree.ElementTree as ET
 
 # Styling for dynamic window margin scaling and line height
 HEADER = """
-<!DOCTYPE html>
 <html>
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="viewport" content="width=device-width, initial-scale=1, text/html, charset=UTF-8" http-equiv="Content-Type">
+    </meta>
     <title>%s</title>
-    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <style type="text/css">
         body {
             margin: 40px auto;
@@ -35,8 +34,11 @@ HEADER = """
 </head>
 """
 
-def remove_tag(content, tag_type):
-    return re.sub(r'<%s.*?>' % tag_type, '', content)
+def remove_tags(xml, tags):
+    for elem in xml.iter():
+        for child in list(elem):
+            if child.tag in tags:
+                elem.remove(child)
 
 tmpfile = os.path.join(
     os.environ.get('QUTE_DATA_DIR',
@@ -46,27 +48,30 @@ tmpfile = os.path.join(
 if not os.path.exists(os.path.dirname(tmpfile)):
     os.makedirs(os.path.dirname(tmpfile))
 
-with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
+with open(os.environ['QUTE_HTML'], 'r', encoding='UTF-8') as source:
     data = source.read()
 
-    try:
-        from breadability.readable import Article as reader
-        doc = reader(data)
-        title = doc._original_document.title
-        content = HEADER % title + doc.readable + "</html>"
-    except ImportError:
-        from readability import Document
-        doc = Document(data)
-        title = doc.title()
-        content = doc.summary().replace('<html>', HEADER % title)
+try:
+    from breadability.readable import Article as reader
+    doc = reader(data)
+    title = doc._original_document.title
+    content = HEADER % title + doc.readable + '</html>'
+except ImportError:
+    from readability import Document
+    doc = Document(data)
+    title = doc.title()
+    content = doc.summary().replace('<html>', HEADER % title)
 
-    # SVGs often look odd. Better remove them.
-    content = remove_tag(content, "svg")
-    content = remove_tag(content, "button")
-    content = remove_tag(content, "input")
-    
-    with codecs.open(tmpfile, 'w', 'utf-8') as target:
-        target.write(content.lstrip())
+xml = ET.fromstring(content)
+# SVGs often look odd. Better remove them.
+tags = ['svg', 'button', 'input']
+remove_tags(xml, tags)
 
-    with open(os.environ['QUTE_FIFO'], 'w') as fifo:
-        fifo.write('open -t %s' % tmpfile)
+with open(tmpfile, 'wb') as target: 
+    # When breadability is eventually depecrecated one day, write full HEADER here
+    # xml.etree removes DOCTYPE declarations
+    target.write("<!DOCTYPE html>\n".encode("UTF-8"))
+    ET.ElementTree(xml).write(target, "UTF-8", xml_declaration=False, method='html')
+
+with open(os.environ['QUTE_FIFO'], 'w') as fifo:
+    fifo.write('open -t %s' % tmpfile)

--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -63,6 +63,7 @@ with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
     # SVGs often look odd. Better remove them.
     content = remove_tag(content, "svg")
     content = remove_tag(content, "button")
+    content = remove_tag(content, "input")
     
     with codecs.open(tmpfile, 'w', 'utf-8') as target:
         target.write(content.lstrip())


### PR DESCRIPTION
SVGs often render way too big on most websites (see e.g. [github](https://github.com/baskerville/plato/blob/e6d071a3258f2ef9eb38881ff5641b8782c3c30f/doc/LIBRARY.md) and the [mozilla docs](https://developer.mozilla.org/en-US/docs/Learn/HTML/Multimedia_and_embedding/Adding_vector_graphics_to_the_Web), see also the screenshot below), providing quite the distraction. Moreover, they are generally non-informative parts of a website (I'm no web developer, but one common use is providing _structural_  rather than contentful information, such as with scaleable buttons/ui elements). Therefore, it might be a good idea to delete them, although this might be a manner of preference and  the upstream readability libraries keep them around (on the other hand, those libraries are pretty ill maintained). If  someone knows websites that use a lot of non-distracting SVGs this change is obviously not a good idea. 

It could be interesting to remove more tags, but I've kept it at a minimum.  For example, `<img>`  tags often don't render correctly, except when people use an absolute url. Still, from time to time images are  informative and rendered correctly, so it seems better to keep them around. 

The regex replacement currently used will most likely fail on malformed html, but checking that would add  too much complexity to this script for what is actually the website developer's job. 

![broken svg](https://i.imgur.com/B4kN3Ic.jpg)