### PR TITLE
Inspector inside Tabs - second attempt

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -29,7 +29,7 @@ from PyQt5.QtCore import pyqtSlot, Qt, QUrl, QEvent, QUrlQuery
 
 from qutebrowser.commands import userscripts, runners
 from qutebrowser.api import cmdutils
-from qutebrowser.config import config, configdata
+from qutebrowser.config import config, configdata, configfiles
 from qutebrowser.browser import (urlmarks, browsertab, inspector, navigate,
                                  webelem, downloads)
 from qutebrowser.keyinput import modeman, keyutils
@@ -1214,23 +1214,43 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', name='inspector',
                        scope='window')
-    def toggle_inspector(self):
+    @cmdutils.argument('position', choices=['right', 'left', 'top', 'bottom',
+                                            'window'])
+    def toggle_inspector(self, position=None):
         """Toggle the web inspector.
 
         Note: Due a bug in Qt, the inspector will show incorrect request
         headers in the network tab.
+
+        Args:
+            position: Where to open the inspector
+                      (right/left/top/bottom/window).
         """
         tab = self._current_widget()
         # FIXME:qtwebengine have a proper API for this
         page = tab._widget.page()  # pylint: disable=protected-access
 
+        @pyqtSlot()
+        def _on_inspector_closed():
+            tab.data.inspector = None
+
         try:
             if tab.data.inspector is None:
-                tab.data.inspector = inspector.create()
+                if position is None:
+                    try:
+                        position = configfiles.state['general'][
+                            'inspector_last_position']
+                    except KeyError:
+                        position = 'right'
+                tab.data.inspector = inspector.create(tab.data.splitter)
                 tab.data.inspector.inspect(page)
-                tab.data.inspector.show()
-            else:
-                tab.data.inspector.toggle(page)
+                tab.data.inspector.closed.connect(_on_inspector_closed)
+            tab.data.inspector.set_position(position)
+
+            if position:
+                configfiles.state['general'][
+                    'inspector_last_position'] = position
+
         except inspector.WebInspectorError as e:
             raise cmdutils.CommandError(e)
 

--- a/qutebrowser/browser/inspector.py
+++ b/qutebrowser/browser/inspector.py
@@ -79,7 +79,7 @@ class AbstractWebInspector(QWidget):
         self._layout.wrap(self, widget)
 
     def set_position(self, position):
-        """Set the position of the inspector."""
+        """Set the position of the inspector. Will close the inspector if position is None."""
         if position != self._position:
             if self._position == 'window':
                 self._save_state_geometry()

--- a/qutebrowser/browser/webengine/webengineinspector.py
+++ b/qutebrowser/browser/webengine/webengineinspector.py
@@ -31,8 +31,8 @@ class WebEngineInspector(inspector.AbstractWebInspector):
 
     """A web inspector for QtWebEngine."""
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self, splitter, parent=None):
+        super().__init__(splitter, parent)
         self.port = None
         view = QWebEngineView()
         settings = view.settings()

--- a/qutebrowser/browser/webkit/webkitinspector.py
+++ b/qutebrowser/browser/webkit/webkitinspector.py
@@ -29,8 +29,8 @@ class WebKitInspector(inspector.AbstractWebInspector):
 
     """A web inspector for QtWebKit."""
 
-    def __init__(self, parent=None):
-        super().__init__(parent)
+    def __init__(self, splitter, parent=None):
+        super().__init__(splitter, parent)
         qwebinspector = QWebInspector()
         self._set_widget(qwebinspector)
 


### PR DESCRIPTION
New clean branch/PR based on current master - replacing PR #4290 .
Fixes #1400

It is now possible tell the inspector where to go. For example `:inspector bottom`. Possible values: `right, left, top, bottom, window`.
`:inspector` will open the inspector in the last used position or close it if it is already open.

