### PR TITLE
Pdfjs persistent

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -443,7 +443,7 @@ class AbstractDownloadItem(QObject):
     error = pyqtSignal(str)
     cancelled = pyqtSignal()
     remove_requested = pyqtSignal()
-    pdfjs_requested = pyqtSignal(str)
+    pdfjs_requested = pyqtSignal(str, str)
 
     def __init__(self, parent=None):
         super().__init__(parent)
@@ -603,6 +603,10 @@ class AbstractDownloadItem(QObject):
             self.retry()
         except UnsupportedOperationError as e:
             message.error(str(e))
+
+    def url(self) -> str:
+        """Get the download's origin URL."""
+        raise NotImplementedError
 
     def _get_open_filename(self):
         """Get the filename to open a download.
@@ -774,7 +778,8 @@ class AbstractDownloadItem(QObject):
         if filename is None:  # pragma: no cover
             log.downloads.error("No filename to open the download!")
             return
-        self.pdfjs_requested.emit(os.path.basename(filename))
+        self.pdfjs_requested.emit(os.path.basename(filename),
+                                  self.url())
 
     def set_target(self, target):
         """Set the target for a given download.
@@ -850,12 +855,13 @@ class AbstractDownloadManager(QObject):
             dl.stats.update_speed()
         self.data_changed.emit(-1)
 
-    @pyqtSlot(str)
-    def _on_pdfjs_requested(self, filename):
+    @pyqtSlot(str, str)
+    def _on_pdfjs_requested(self, filename: str, original_url: str):
         """Open PDF.js when a download requests it."""
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window='last-focused')
-        tabbed_browser.tabopen(pdfjs.get_main_url(filename), background=False)
+        tabbed_browser.tabopen(pdfjs.get_main_url(filename, original_url),
+                               background=False)
 
     def _init_item(self, download, auto_remove, suggested_filename):
         """Initialize a newly created DownloadItem."""

--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -237,11 +237,12 @@ def should_use_pdfjs(mimetype, url):
     return is_pdf and not is_download_url and config_enabled
 
 
-def get_main_url(filename):
+def get_main_url(filename: str, original_url: str):
     """Get the URL to be opened to view a local PDF."""
     url = QUrl('qute://pdfjs/web/viewer.html')
     query = QUrlQuery()
     query.addQueryItem('filename', filename)  # read from our JS
     query.addQueryItem('file', '')  # to avoid pdfjs opening the default PDF
+    query.addQueryItem('source', original_url)
     url.setQuery(query)
     return url

--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -102,6 +102,7 @@ class DownloadItem(downloads.AbstractDownloadItem):
         self._read_timer.setInterval(500)
         self._read_timer.timeout.connect(self._on_read_timer_timeout)
         self._redirects = 0
+        self._url = reply.url().toString()
         self._init_reply(reply)
 
     def _create_fileobj(self):
@@ -188,6 +189,10 @@ class DownloadItem(downloads.AbstractDownloadItem):
         if filename is None:
             filename = getattr(self.fileobj, 'name', None)
         return filename
+
+    def url(self) -> str:
+        # Note: self._reply is deleted when the download finishes
+        return self._url
 
     def _ensure_can_set_filename(self, filename):
         if self.fileobj is not None:  # pragma: no cover

--- a/qutebrowser/browser/webengine/webenginedownloads.py
+++ b/qutebrowser/browser/webengine/webenginedownloads.py
@@ -39,15 +39,16 @@ class DownloadItem(downloads.AbstractDownloadItem):
         _qt_item: The wrapped item.
     """
 
-    def __init__(self, qt_item, parent=None):
+    def __init__(self, qt_item: QWebEngineDownloadItem, parent=None):
         super().__init__(parent)
         self._qt_item = qt_item
-        qt_item.downloadProgress.connect(self.stats.on_download_progress)
-        qt_item.stateChanged.connect(self._on_state_changed)
+        qt_item.downloadProgress.connect(  # type: ignore
+            self.stats.on_download_progress)
+        qt_item.stateChanged.connect(self._on_state_changed)  # type: ignore
 
         # Ensure wrapped qt_item is deleted manually when the wrapper object
         # is deleted. See https://github.com/qutebrowser/qutebrowser/issues/3373
-        self.destroyed.connect(self._qt_item.deleteLater)
+        self.destroyed.connect(self._qt_item.deleteLater)  # type: ignore
 
     def _is_page_download(self):
         """Check if this item is a page (i.e. mhtml) download."""
@@ -116,6 +117,9 @@ class DownloadItem(downloads.AbstractDownloadItem):
 
     def _get_open_filename(self):
         return self._filename
+
+    def url(self) -> str:
+        return self._qt_item.url().toString()
 
     def _set_fileobj(self, fileobj, *, autoclose=True):
         raise downloads.UnsupportedOperationError

--- a/tests/unit/browser/test_pdfjs.py
+++ b/tests/unit/browser/test_pdfjs.py
@@ -254,5 +254,6 @@ def test_should_use_pdfjs_url_pattern(config_stub, url, expected):
 
 def test_get_main_url():
     expected = ('qute://pdfjs/web/viewer.html?filename='
-                'hello?world.pdf&file=')
-    assert pdfjs.get_main_url('hello?world.pdf') == QUrl(expected)
+                'hello?world.pdf&file=&source=http://a.com/hello?world.pdf')
+    assert pdfjs.get_main_url('hello?world.pdf',
+                              'http://a.com/hello?world.pdf') == QUrl(expected)

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -209,8 +209,18 @@ class TestPDFJSHandler:
 
     def test_viewer_page(self, data_tmpdir):
         """Load the /web/viewer.html page."""
+        filename = 'foobar.pdf'
+        path = os.path.join(downloads.temp_download_manager.get_tmpdir().name,
+                            filename)
+
+        # Make sure that the file exists otherwise the handler will attempt to
+        # redirect to source (it's not necessary to make sure that it's valid
+        # PDF content)
+        with open(path, 'w', encoding='utf-8') as f:
+            f.write('<pdf content>')
+
         _mimetype, data = qutescheme.data_for_url(
-            QUrl('qute://pdfjs/web/viewer.html?filename=foobar'))
+            QUrl('qute://pdfjs/web/viewer.html?filename=' + filename))
         assert b'PDF.js' in data
 
     def test_viewer_no_filename(self):


### PR DESCRIPTION
Closes #4303. (using the workaround stated there because nobody said anything about it)

<!-- PR 5000 :) -->

note:

* It opens in a new tab.
* Probably won't work for PDFs got with a POST request.

todo:

- [x] Is any data lost by converting `QUrl(url.toString())`? (`toString` uses `PrettyDecoded` by default) -> No.
- [ ] Currently there's no test... What's the best way to test this? Delete the temp file?
- [x] What happens when the page trigger download of the PDF without being a direct link to the PDF? --> For `<embed class="pdfobject">` objects (with plugins enabled) it works properly. (May need tests)
- [ ] Does this work with webkit? --> Yes, except for local file, where it raises a permission error "Not allowed to load local resource" (in the console log) (The file `qutebrowser/browser/qtnetworkdownloads.py` is used by webkit. Why isn't it in webkit folder?)
- [x] What should be returned when there is no `source`? -> Causes an invalid URL error (when there is no source) or ERR_FAILED when the URL being redirected to is invalid.

<!-- What happened with "this change is reviewable"? -->