### PR TITLE
New readability userscript based on Mozilla's readability library

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -10,6 +10,7 @@
 //   - NODE_PATH might be required to point to your global node libraries (e.g. /usr/lib/node_modules)
 //   - Mozilla's readability library (npm install -g https://github.com/mozilla/readability.git)
 //     NOTE: You might have to *login* as root for a system-wide installation to work (e.g. sudo -s)
+//   - jsdom (npm install -g jsdom)
 //   - qutejs (npm install -g qutejs)
 // 
 // # Usage

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -46,7 +46,7 @@ const HEADER = `
         }
     </style>
 </head>`;
-const scriptsDir = path.join(process.env.QUTE_DATA_DIR, 'userscripts.html');
+const scriptsDir = path.join(process.env.QUTE_DATA_DIR, 'userscripts');
 const tmpFile = path.join(scriptsDir, '/readability.html');
 
 if (!fs.existsSync(scriptsDir)){

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -54,10 +54,10 @@ JSDOM.fromURL(process.env.QUTE_URL).then(dom => {
 
     fs.writeFile(tmpFile, content, (err) => {
         if (err) {
-            qute._execFifo(null, ['message-error', err]);
+            qute.messageError([err]);
             return 1;
         }
         // Success
-        qute._execFifo(null, ['open', '-t', tmpFile]);
+        qute.open(['-t', tmpFile]);
     })
 });

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -60,7 +60,7 @@ JSDOM.fromFile(process.env.QUTE_HTML, { url: process.env.QUTE_URL }).then(dom =>
 
     fs.writeFile(tmpFile, content, (err) => {
         if (err) {
-            qute.messageError([err]);
+            qute.messageError([`"${err}"`])
             return 1;
         }
         // Success

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// 
+// # Description
+// 
+// Summarize the current page in a new tab, by processing it with the standalone readability
+// library used for Firefox Reader View.
+// 
+// # Prerequisites
+// 
+//   - NODE_PATH might be required to point to your global node libraries (e.g. /usr/lib/node_modules)
+//   - Mozilla's readability library (npm install -g https://github.com/mozilla/readability.git)
+//     NOTE: You might have to *login* as root for a system-wide installation to work (e.g. sudo -s)
+//   - qutejs (npm install -g qutejs)
+// 
+// # Usage
+// 
+// :spawn --userscript readability-js
+// 
+// One may wish to define an easy to type command alias in Qutebrowser's configuration file:
+// c.aliases = {"readability" : "spawn --userscript readability-js", ...}
+
+const Readability = require('readability');
+const qute = require('qutejs');
+const JSDOM = require('jsdom').JSDOM;
+const fs = require('fs');
+const path = require('path');
+const util = require('util');
+
+const tmpFile = path.join(process.env.QUTE_DATA_DIR, 'userscripts/readability.html');
+const HEADER = `
+<!DOCTYPE html>
+<html>
+<head>
+    <meta name="viewport" content="width=device-width, initial-scale=1, text/html, charset=UTF-8" http-equiv="Content-Type">
+    </meta>
+    <title>%s</title>
+    <style type="text/css">
+        body {
+            margin: 30px auto;
+            max-width: 650px;
+            line-height: 1.4;
+            padding: 0 10px;
+        }
+        h1, h2, h3 {
+            line-height: 1.2;
+        }
+    </style>
+</head>`;
+
+JSDOM.fromURL(process.env.QUTE_URL).then(dom => {
+    let reader = new Readability(dom.window.document);
+    let article = reader.parse();
+    let content = util.format(HEADER, article.title) + article.content;
+
+    fs.writeFile(tmpFile, content, (err) => {
+        if (err) {
+            qute._execFifo(null, ['message-error', err]);
+            return 1;
+        }
+        // Success
+        qute._execFifo(null, ['open', '-t', tmpFile]);
+    })
+});

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -27,7 +27,6 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 
-const tmpFile = path.join(process.env.QUTE_DATA_DIR, 'userscripts/readability.html');
 const HEADER = `
 <!DOCTYPE html>
 <html>
@@ -47,6 +46,12 @@ const HEADER = `
         }
     </style>
 </head>`;
+const scriptsDir = path.join(process.env.QUTE_DATA_DIR, 'userscripts.html');
+const tmpFile = path.join(scriptsDir, '/readability.html');
+
+if (!fs.existsSync(scriptsDir)){
+    fs.mkdirSync(scriptsDir);
+}
 
 JSDOM.fromFile(process.env.QUTE_HTML, { url: process.env.QUTE_URL }).then(dom => {
     let reader = new Readability(dom.window.document);

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -47,7 +47,7 @@ const HEADER = `
     </style>
 </head>`;
 
-JSDOM.fromURL(process.env.QUTE_URL).then(dom => {
+JSDOM.fromFile(process.env.QUTE_HTML, { url: process.env.QUTE_URL }).then(dom => {
     let reader = new Readability(dom.window.document);
     let article = reader.parse();
     let content = util.format(HEADER, article.title) + article.content;


### PR DESCRIPTION
The main reason for switching to a new library is that the previously used readability libraries seem largely unmaintained, and hence often rendered a lot distracting elements (see e.g.  the discussion in https://github.com/qutebrowser/qutebrowser/pull/4991). In contrast, Mozilla's readability library will be maintained for the foreseeable future (possibly as long as Firefox is around). Other improvements I observed include slightly more retained textual information and images, as well as the preservation of hyperlinks. The latter feature requires accessing the `QUTE_URL` variable, in contrast to the `QUTE_HTML` variable that was used in the previous script. Apart from this change, this script should be functional equivalent to the older, python based version. 

Possibly interesting downside is that I found it to be noticeably slower, although it's not that bad (I think it generally finishes within 1-3 secs).

This is basically my first attempt at javascript, so excuse my mistakes. 