### PR TITLE
add a combined :open + :buffer command

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -860,7 +860,7 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
-    @cmdutils.argument('text')
+    @cmdutils.argument('text', completion=urlmodel.url_or_buffer)
     def switch_buffer_or_open(self, text=None):
         try:
             self.buffer(index=text)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -865,6 +865,15 @@ class CommandDispatcher:
         try:
             self.buffer(index=text)
         except cmdexc.CommandError:
+            self.openurl(url=text)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window',
+                       maxsplit=0)
+    @cmdutils.argument('text', completion=urlmodel.url_or_buffer)
+    def switch_buffer_or_open_tab(self, text=None):
+        try:
+            self.buffer(index=text)
+        except cmdexc.CommandError:
             self.openurl(url=text, tab=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -860,6 +860,15 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0)
+    @cmdutils.argument('text')
+    def switch_buffer_or_open(self, text=None):
+        try:
+            self.buffer(index=text)
+        except cmdexc.CommandError:
+            self.openurl(url=text, tab=True)
+
+    @cmdutils.register(instance='command-dispatcher', scope='window',
+                       maxsplit=0)
     @cmdutils.argument('index', completion=miscmodels.buffer)
     @cmdutils.argument('count', value=cmdutils.Value.count)
     def buffer(self, index=None, count=None):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -864,7 +864,7 @@ class CommandDispatcher:
     def switch_buffer_or_open(self, text=None):
         try:
             self.buffer(index=text)
-        except cmdexc.CommandError:
+        except cmdutils.CommandError:
             self.openurl(url=text)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
@@ -873,7 +873,7 @@ class CommandDispatcher:
     def switch_buffer_or_open_tab(self, text=None):
         try:
             self.buffer(index=text)
-        except cmdexc.CommandError:
+        except cmdutils.CommandError:
             self.openurl(url=text, tab=True)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',

--- a/qutebrowser/completion/models/urlmodel.py
+++ b/qutebrowser/completion/models/urlmodel.py
@@ -115,13 +115,13 @@ def url_or_buffer(*, info):
         if tabbed_browser.shutting_down:
             continue
         tabs = []
-        for idx in range(tabbed_browser.count()):
-            tab = tabbed_browser.widget(idx)
+        for idx in range(tabbed_browser.widget.count()):
+            tab = tabbed_browser.widget.widget(idx)
             tabs.append(("{}/{}".format(win_id, idx + 1),
                          tab.url().toDisplayString(),
-                         tabbed_browser.page_title(idx)))
-        cat = listcategory.ListCategory("{}".format(win_id), tabs,
-                                        delete_func=delete_buffer)
+                         tabbed_browser.widget.page_title(idx)))
+        cat = listcategory.ListCategory(
+            str(win_id), tabs, delete_func=delete_buffer, sort=False)
         model.add_category(cat)
 
     quickmarks = [(url, name) for (name, url)
@@ -136,7 +136,7 @@ def url_or_buffer(*, info):
         model.add_category(listcategory.ListCategory(
             'Bookmarks', bookmarks, delete_func=_delete_bookmark, sort=False))
 
-    if info.config.get('completion.web_history_max_items') != 0:
+    if info.config.get('completion.web_history.max_items') != 0:
         hist_cat = histcategory.HistoryCategory(delete_func=_delete_history)
         model.add_category(hist_cat)
     return model


### PR DESCRIPTION
This was suggested and discussed in #3194. As #836 is still open this is implemented as a new command instead of a switch to `:open` or `:buffer`.

ToDo List:
* [ ] write doc blocks
* [ ] change the command name from `switch-buffer-or-open{,-tab}` to `goto [-t]`.
