### PR TITLE
Add setting to toggle tab tooltips

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -282,6 +282,7 @@
 |<<tabs.title.alignment,tabs.title.alignment>>|Alignment of the text inside of tabs.
 |<<tabs.title.format,tabs.title.format>>|Format to use for the tab title.
 |<<tabs.title.format_pinned,tabs.title.format_pinned>>|Format to use for the tab title for pinned tabs. The same placeholders like for `tabs.title.format` are defined.
+|<<tabs.tooltips,tabs.tooltips>>|Show tooltips on tabs.
 |<<tabs.undo_stack_size,tabs.undo_stack_size>>|Number of close tab actions to remember, per window (-1 for no maximum).
 |<<tabs.width,tabs.width>>|Width (in pixels or as percentage of the window) of the tab bar if it's vertical.
 |<<tabs.wrap,tabs.wrap>>|Wrap when changing tabs.
@@ -3537,6 +3538,15 @@ Format to use for the tab title for pinned tabs. The same placeholders like for 
 Type: <<types,FormatString>>
 
 Default: +pass:[{index}]+
+
+[[tabs.tooltips]]
+=== tabs.tooltips
+Show tooltips on tabs.
+This setting requires a restart.
+
+Type: <<types,Bool>>
+
+Default: +pass:[true]+
 
 [[tabs.undo_stack_size]]
 === tabs.undo_stack_size

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1780,6 +1780,12 @@ tabs.wrap:
   type: Bool
   desc: Wrap when changing tabs.
 
+tabs.tooltips:
+  default: true
+  type: Bool
+  restart: true
+  desc: Show tooltips on tabs.
+
 ## url
 
 url.auto_search:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -153,8 +153,9 @@ class TabWidget(QTabWidget):
         if tabbar.tabText(idx) != title:
             tabbar.setTabText(idx, title)
 
-        # always show only plain title in tooltips
-        tabbar.setTabToolTip(idx, fields['current_title'])
+        if config.cache['tabs.tooltips']:
+            # always show only plain title in tooltips
+            tabbar.setTabToolTip(idx, fields['current_title'])
 
     def get_tab_fields(self, idx):
         """Get the tab field data."""


### PR DESCRIPTION
To minimize changes, we can limit this setting to a restart. That way
we won't need to loop over every tab.

Closes #5042