### PR TITLE
Always retain current working directory in restart

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -543,7 +543,7 @@ class Quitter:
                         compile(f.read(), fn, 'exec')
 
     def _get_restart_args(self, pages=(), session=None, override_args=None):
-        """Get the current working directory and args to relaunch qutebrowser.
+        """Get args to relaunch qutebrowser.
 
         Args:
             pages: The pages to re-open.
@@ -551,26 +551,15 @@ class Quitter:
             override_args: Argument overrides as a dict.
 
         Return:
-            An (args, cwd) tuple.
-                args: The commandline as a list of strings.
-                cwd: The current working directory as a string.
+            The commandline as a list of strings.
         """
         if os.path.basename(sys.argv[0]) == 'qutebrowser':
             # Launched via launcher script
             args = [sys.argv[0]]
-            cwd = None
         elif hasattr(sys, 'frozen'):
             args = [sys.executable]
-            cwd = os.path.abspath(os.path.dirname(sys.executable))
         else:
             args = [sys.executable, '-m', 'qutebrowser']
-            cwd = os.path.join(
-                os.path.abspath(os.path.dirname(qutebrowser.__file__)), '..')
-            if not os.path.isdir(cwd):
-                # Probably running from a python egg. Let's fallback to
-                # cwd=None and see if that works out.
-                # See https://github.com/qutebrowser/qutebrowser/issues/323
-                cwd = None
 
         # Add all open pages so they get reopened.
         page_args = []
@@ -607,9 +596,8 @@ class Quitter:
         args += ['--json-args', data]
 
         log.destroy.debug("args: {}".format(args))
-        log.destroy.debug("cwd: {}".format(cwd))
 
-        return args, cwd
+        return args
 
     @cmdutils.register(instance='quitter', name='restart')
     def restart_cmd(self):
@@ -662,11 +650,8 @@ class Quitter:
 
         # Open a new process and immediately shutdown the existing one
         try:
-            args, cwd = self._get_restart_args(pages, session, override_args)
-            if cwd is None:
-                subprocess.Popen(args)
-            else:
-                subprocess.Popen(args, cwd=cwd)
+            args = self._get_restart_args(pages, session, override_args)
+            subprocess.Popen(args)
         except OSError:
             log.destroy.exception("Failed to restart")
             return False


### PR DESCRIPTION
Running with tox [as instructed](https://github.com/qutebrowser/qutebrowser/blob/master/doc/install.asciidoc#installing-qutebrowser-with-tox), using relative basedir crashes at restart:
```
/tmp$ qutebrowser-git -B ./qute/ --debug --logfilter destroy
:restart

08:29:55 DEBUG    destroy    app:restart:658 sys.executable: /gitpath/.venv/bin/python3
08:29:55 DEBUG    destroy    app:restart:659 sys.path: ['/tmp', '/gitpath/.venv/lib/python37.zip', '/gitpath/.venv/lib/python3.7', '/gitpath/.venv/lib/python3.7/lib-dynload', '/usr/lib64/python3.7', '/usr/lib/python3.7', '/gitpath/.venv/lib/python3.7/site-packages', '/gitpath']
08:29:55 DEBUG    destroy    app:restart:660 sys.argv: ['/gitpath/qutebrowser/__main__.py', '-B', './qute/', '--debug', '--logfilter', 'destroy']
08:29:55 DEBUG    destroy    app:restart:661 frozen: False
08:29:55 DEBUG    destroy    app:_get_restart_args:618 args: ['/gitpath/.venv/bin/python3', '-m', 'qutebrowser', '--json-args', '{"basedir": "./qute/", "config_py": null, "version": false, "temp_settings": [], "session": "_restart", "override_restore": false, "target": null, "backend": null, "enable_webengine_inspector": false, "json_args": null, "temp_basedir_restarted": null, "loglevel": "info", "logfilter": "destroy", "loglines": 2000, "debug": true, "json_logging": false, "color": true, "force_color": false, "nowindow": false, "temp_basedir": false, "no_err_windows": false, "qt_arg": null, "qt_flag": null, "debug_flags": [], "command": [], "url": []}']
08:29:55 DEBUG    destroy    app:_get_restart_args:619 cwd: /gitpath/qutebrowser/..
08:29:55 WARNING  py.warnings warnings:_showwarnmsg:110 /usr/lib64/python3.7/subprocess.py:858: ResourceWarning: subprocess 1292383 is still running
  ResourceWarning, source=self)
...
08:29:55 DEBUG    destroy    app:exit:865 Now calling QApplication::exit.
08:29:56 ERROR    message    message:error:58 Session _restart not found!
08:29:56 ERROR    misc       crashsignal:exception_hook:220 Uncaught exception
Traceback (most recent call last):
  File "/usr/lib64/python3.7/runpy.py", line 193, in _run_module_as_main
    "__main__", mod_spec)
  File "/usr/lib64/python3.7/runpy.py", line 85, in _run_code
    exec(code, run_globals)
  File "/gitpath/qutebrowser/__main__.py", line 29, in <module>
    sys.exit(qutebrowser.qutebrowser.main())
  File "/gitpath/qutebrowser/qutebrowser.py", line 200, in main
    return app.run(args)
  File "/gitpath/qutebrowser/app.py", line 143, in run
    init(args, crash_handler)
  File "/gitpath/qutebrowser/app.py", line 188, in init
    _process_args(args)
  File "/gitpath/qutebrowser/app.py", line 219, in _process_args
    _load_session(args.session)
  File "/gitpath/qutebrowser/app.py", line 270, in _load_session
    session_manager.delete('_restart')
  File "/gitpath/qutebrowser/misc/sessions.py", line 461, in delete
    path = self._get_session_path(name, check_exists=True)
  File "/gitpath/qutebrowser/misc/sessions.py", line 138, in _get_session_path
    raise SessionNotFoundError(path)
qutebrowser.misc.sessions.SessionNotFoundError: /gitpath/qute/data/sessions/_restart.yml
```

I didn't see a reason for changing the working directory so I just removed that. [sys.executable](https://docs.python.org/3/library/sys.html#sys.executable) has absolute path and retaining cwd is the default in [Popen](https://docs.python.org/3/library/subprocess.html#subprocess.Popen).

Different environments should probably still be tested.
>&lt;arza&gt; i wonder if i can remove the whole cwd thing or if i should keep some special case
>&lt;The-Compiler&gt; arza: dunno, that code is 5 years old and has a lot of different scenarios it has to work in