### PR TITLE
run_profile: Set default profile file for --profile-tool=none

### DIFF
--- a/doc/contributing.asciidoc
+++ b/doc/contributing.asciidoc
@@ -183,17 +183,21 @@ tox -e py35-cov -- tests/unit/browser/test_webelem.py
 Profiling
 ~~~~~~~~~
 
-In the _scripts/_ subfolder there's a `run_profile.py` which profiles the code
-and shows a graphical representation of what takes how much time.
+In the _scripts/dev/_ subfolder there's `run_profile.py` which profiles the
+code and shows a graphical representation of what takes how much time.
 
 It uses the built-in Python
-https://docs.python.org/3.6/library/profile.html[cProfile] module and can show
-the output in four different ways:
+https://docs.python.org/3/library/profile.html[cProfile] module. It launches a
+qutebrowser instance, waits for it to exit and then shows the graph.
 
-* Raw profile file (`--profile-tool=none`)
+Available methods for visualization are:
+
+* https://jiffyclub.github.io/snakeviz/[SnakeViz] (`--profile-tool=snakeviz`, the default)
 * https://pypi.python.org/pypi/pyprof2calltree/[pyprof2calltree] and http://kcachegrind.sourceforge.net/html/Home.html[KCacheGrind] (`--profile-tool=kcachegrind`)
-* https://jiffyclub.github.io/snakeviz/[SnakeViz] (`--profile-tool=snakeviz`)
-* https://github.com/jrfonseca/gprof2dot[gprof2dot] (needs `dot` from http://graphviz.org/[Graphviz] and http://feh.finalrewind.org/[feh])
+* https://github.com/jrfonseca/gprof2dot[gprof2dot] (`--profile-tool=gprof2dot`, needs `dot` from http://graphviz.org/[Graphviz] and http://feh.finalrewind.org/[feh])
+* https://github.com/nschloe/tuna[tuna] (`--profile-tool=tuna`)
+
+You can also save the binary profile data to a file (`--profile-tool=none`).
 
 Debugging
 ~~~~~~~~~

--- a/scripts/dev/run_profile.py
+++ b/scripts/dev/run_profile.py
@@ -81,7 +81,7 @@ def main():
     profiler.dump_stats(profilefile)
 
     if args.profile_tool == 'none':
-        pass
+        print("Profile data written to {}".format(profilefile))
     elif args.profile_tool == 'gprof2dot':
         # yep, shell=True. I know what I'm doing.
         subprocess.run(

--- a/scripts/dev/run_profile.py
+++ b/scripts/dev/run_profile.py
@@ -49,6 +49,7 @@ def parse_args():
                         default='snakeviz',
                         help="The tool to use to view the profiling data")
     parser.add_argument('--profile-file', metavar='FILE', action='store',
+                        default="profile_data",
                         help="The filename to use with --profile-tool=none")
     parser.add_argument('--profile-test', action='store_true',
                         help="Run pytest instead of qutebrowser")


### PR DESCRIPTION
Fixed TypeError crash:
```
$ scripts/dev/run_profile.py --profile-tool=none           
Traceback (most recent call last):
  File "scripts/dev/run_profile.py", line 102, in <module>
    main()
  File "scripts/dev/run_profile.py", line 63, in main
    profilefile = os.path.join(os.getcwd(), args.profile_file)
  File "/usr/lib/python3.7/posixpath.py", line 94, in join
    genericpath._check_arg_types('join', a, *p)
  File "/usr/lib/python3.7/genericpath.py", line 149, in _check_arg_types
    (funcname, s.__class__.__name__)) from None
TypeError: join() argument must be str or bytes, not 'NoneType'
```
Updated and improved the docs.