### PR TITLE
[readability-js] Encode input as UTF-8

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -49,12 +49,13 @@ const HEADER = `
 </head>`;
 const scriptsDir = path.join(process.env.QUTE_DATA_DIR, 'userscripts');
 const tmpFile = path.join(scriptsDir, '/readability.html');
+const domOpts = {url: process.env.QUTE_URL, contentType: "text/html; charset=utf-8"}
 
 if (!fs.existsSync(scriptsDir)){
     fs.mkdirSync(scriptsDir);
 }
 
-JSDOM.fromFile(process.env.QUTE_HTML, { url: process.env.QUTE_URL }).then(dom => {
+JSDOM.fromFile(process.env.QUTE_HTML, domOpts).then(dom => {
     let reader = new Readability(dom.window.document);
     let article = reader.parse();
     let content = util.format(HEADER, article.title) + article.content;


### PR DESCRIPTION
Most websites work fine without explicitly specifying an UTF-8 encoding, even if they have unicode characters (e.g. the wiki article on [Japanese](https://en.wikipedia.org/wiki/Japanese_language)). However, I encountered [this website](https://www.frontiersin.org/articles/10.3389/fnhum.2013.00443/full), which renders some characters incorrectly when the input is not encoded as UTF-8. The python readability script works fine on the latter website, mainly because it reads `QUTE_HTML` as UTF-8:

```python
with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
    data = source.read()
```

This PR adds the same explicit encoding to the `readability-js` script. 