### PR TITLE
Use QRegExp for highlighting search terms in completion

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -26,7 +26,7 @@ import re
 import html
 
 from PyQt5.QtWidgets import QStyle, QStyleOptionViewItem, QStyledItemDelegate
-from PyQt5.QtCore import QRectF, QSize, Qt
+from PyQt5.QtCore import QRectF, QRegExp, QSize, Qt
 from PyQt5.QtGui import (QIcon, QPalette, QTextDocument, QTextOption,
                          QAbstractTextDocumentLayout, QSyntaxHighlighter,
                          QTextCharFormat)
@@ -45,10 +45,12 @@ class _Highlighter(QSyntaxHighlighter):
 
     def highlightBlock(self, text):
         """Override highlightBlock for custom highlighting."""
-        for match in re.finditer(self._pattern, text, re.IGNORECASE):
-            start, end = match.span()
-            length = end - start
-            self.setFormat(start, length, self._format)
+        expression = QRegExp(self._pattern, Qt.CaseInsensitive)
+        index = expression.indexIn(text)
+        while index >= 0:
+            length = expression.matchedLength()
+            self.setFormat(index, length, self._format)
+            index = expression.indexIn(text, index + length)
 
 
 class CompletionItemDelegate(QStyledItemDelegate):


### PR DESCRIPTION
Fixes:

- wrong text colored after four-byte characters
![match_wide](https://user-images.githubusercontent.com/7052386/68764238-01150c00-0623-11ea-84aa-0aed2191d51a.png)

- only the beginning search term colored as part of another search term
![match_beginning](https://user-images.githubusercontent.com/7052386/68764255-070aed00-0623-11ea-918c-039751aa1f21.png)

Based on [a PyQt example](https://github.com/baoboa/pyqt5/blob/25bdb92c38d9c0a915c6366769cc00a63a1f04b2/examples/richtext/syntaxhighlighter.py#L167L173).