### PR TITLE
Add new behavior for tabs_are_windows setting

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -852,8 +852,6 @@ class CommandDispatcher:
         if len(index_parts) == 2:
             win_id = int(index_parts[0])
             idx = int(index_parts[1])
-        elif len(index_parts) == 1 and config.val.tabs.tabs_are_windows:
-            win_id, idx = int(index_parts[0]) - 1, 1
         elif len(index_parts) == 1:
             idx = int(index_parts[0])
             active_win = QApplication.activeWindow()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1239,7 +1239,7 @@ class CommandDispatcher:
     def toggle_inspector(self):
         """Toggle the web inspector.
 
-        Note: Due a bug in Qt, the inspector will show incorrect request
+        Note: Due to a bug in Qt, the inspector will show incorrect request
         headers in the network tab.
         """
         tab = self._current_widget()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -434,6 +434,10 @@ class CommandDispatcher:
                    in which case the closest match will be taken.
             keep: If given, keep the old tab around.
         """
+        if config.val.tabs.tabs_are_windows:
+            raise cmdutils.CommandError("Can't take tabs when using "
+                                        "windows as tabs")
+
         tabbed_browser, tab = self._resolve_buffer_index(index)
 
         if tabbed_browser is self._tabbed_browser:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -848,6 +848,8 @@ class CommandDispatcher:
         if len(index_parts) == 2:
             win_id = int(index_parts[0])
             idx = int(index_parts[1])
+        elif len(index_parts) == 1 and config.val.tabs.tabs_are_windows:
+            win_id, idx = int(index_parts[0]) - 1, 1
         elif len(index_parts) == 1:
             idx = int(index_parts[0])
             active_win = QApplication.activeWindow()

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -113,7 +113,8 @@ def _buffer(skip_win_id=None):
     model = completionmodel.CompletionModel(column_widths=(6, 40, 54))
 
     tabs_are_windows = config.val.tabs.tabs_are_windows
-    windows = []  # list storing single-tab windows when tabs_are_windows
+    # list storing all single-tabbed windows when tabs_are_windows
+    windows = []  # type: typing.List[typing.Tuple[str, str, str]]
 
     for win_id in objreg.window_registry:
         if skip_win_id is not None and win_id == skip_win_id:
@@ -122,7 +123,7 @@ def _buffer(skip_win_id=None):
                                     window=win_id)
         if tabbed_browser.shutting_down:
             continue
-        tabs = []
+        tabs = []  # type: typing.List[typing.Tuple[str, str, str]]
         for idx in range(tabbed_browser.widget.count()):
             tab = tabbed_browser.widget.widget(idx)
             tabs.append(("{}/{}".format(win_id, idx + 1),

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -125,9 +125,8 @@ def _buffer(skip_win_id=None):
         tabs = []
         for idx in range(tabbed_browser.widget.count()):
             tab = tabbed_browser.widget.widget(idx)
-            label = (str(win_id + 1) if tabs_are_windows
-                     else "{}/{}".format(win_id, idx + 1))
-            tabs.append((label, tab.url().toDisplayString(),
+            tabs.append(("{}/{}".format(win_id, idx + 1),
+                         tab.url().toDisplayString(),
                          tabbed_browser.widget.page_title(idx)))
         if tabs_are_windows:
             windows += tabs

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1204,6 +1204,14 @@ Feature: Tab management
         And I run :tab-take 0/1
         Then the error "Can't take a tab from the same window" should be shown
 
+    Scenario: Take a tab while using tabs_are_windows
+        Given I have a fresh instance
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new window
+        And I set tabs.tabs_are_windows to true
+        And I run :tab-take 0/1
+        Then the error "Can't take tabs when using windows as tabs" should be shown
+
     # :tab-give
 
     @xfail_norun  # Needs qutewm

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -758,6 +758,36 @@ def test_tab_completion_not_sorted(qtmodeltester, fake_web_tab, win_registry,
     })
 
 
+def test_tab_completion_tabs_are_windows(qtmodeltester, fake_web_tab,
+                                         win_registry, tabbed_browser_stubs,
+                                         config_stub):
+    """Verify tabs across all windows are listed under a single category."""
+    config_stub.val.tabs.tabs.tabs_are_windows = True
+
+    tabbed_browser_stubs[0].widget.tabs = [
+        fake_web_tab(QUrl('https://github.com'), 'GitHub', 0),
+        fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia', 1),
+    ]
+    tabbed_browser_stubs[1].widget.tabs = [
+        fake_web_tab(QUrl('https://duckduckgo.com'), 'DuckDuckGo', 0),
+    ]
+    tabbed_browser_stubs[2].widget.tabs = [
+        fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
+    ]
+    model = miscmodels.buffer()
+    model.set_pattern('')
+    qtmodeltester.check(model)
+
+    _check_completions(model, {
+        'Windows': [
+            ('0/1', 'https://github.com', 'GitHub'),
+            ('0/2', 'https://wikipedia.org', 'Wikipedia'),
+            ('1/1', 'https://duckduckgo.com', 'DuckDuckGo'),
+            ('2/1', 'https://wiki.archlinux.org', 'ArchWiki'),
+        ]
+    })
+
+
 def test_other_buffer_completion(qtmodeltester, fake_web_tab, win_registry,
                                  tabbed_browser_stubs, info):
     tabbed_browser_stubs[0].widget.tabs = [

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -762,18 +762,16 @@ def test_tab_completion_tabs_are_windows(qtmodeltester, fake_web_tab,
                                          win_registry, tabbed_browser_stubs,
                                          config_stub):
     """Verify tabs across all windows are listed under a single category."""
-    config_stub.val.tabs.tabs.tabs_are_windows = True
-
     tabbed_browser_stubs[0].widget.tabs = [
         fake_web_tab(QUrl('https://github.com'), 'GitHub', 0),
         fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia', 1),
+        fake_web_tab(QUrl('https://duckduckgo.com'), 'DuckDuckGo', 2),
     ]
     tabbed_browser_stubs[1].widget.tabs = [
-        fake_web_tab(QUrl('https://duckduckgo.com'), 'DuckDuckGo', 0),
-    ]
-    tabbed_browser_stubs[2].widget.tabs = [
         fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
     ]
+
+    config_stub.val.tabs.tabs_are_windows = True
     model = miscmodels.buffer()
     model.set_pattern('')
     qtmodeltester.check(model)
@@ -782,8 +780,8 @@ def test_tab_completion_tabs_are_windows(qtmodeltester, fake_web_tab,
         'Windows': [
             ('0/1', 'https://github.com', 'GitHub'),
             ('0/2', 'https://wikipedia.org', 'Wikipedia'),
-            ('1/1', 'https://duckduckgo.com', 'DuckDuckGo'),
-            ('2/1', 'https://wiki.archlinux.org', 'ArchWiki'),
+            ('0/3', 'https://duckduckgo.com', 'DuckDuckGo'),
+            ('1/1', 'https://wiki.archlinux.org', 'ArchWiki'),
         ]
     })
 


### PR DESCRIPTION
* Window ID (category labels) are removed from completion

This PR is meant to address #5114 

A few points/uncertainties:
* `miscmodels.py` felt like the best place to make the change, since the requested behavior is specific to the `:buffer` command, though I could be wrong
* I'm not at all convinced that this was a good, let alone best, implementation of this behavior
* primarily I got a nagging feeling that it's a tad too verbose; but can't quite trim it down even after thinking about it for quite a while
* being a complete newcomer to qutebrowser (both as a user and a contributor), it's quite likely I missed some consideration related to this change, so please let me know if that's the case
* lastly if tests should be added to cover this change, just say the word