### PR TITLE
Update: link for tox in contributing.asciidoc

### DIFF
--- a/doc/contributing.asciidoc
+++ b/doc/contributing.asciidoc
@@ -105,7 +105,7 @@ Useful utilities
 Checkers
 ~~~~~~~~
 
-qutebrowser uses http://tox.readthedocs.org/en/latest/[tox] to run its
+qutebrowser uses https://tox.readthedocs.io/en/latest/[tox] to run its
 unittests and several linters/checkers.
 
 Currently, the following tox environments are available:


### PR DESCRIPTION
The old `.org` URL would 404 on me when I first tried to open the link. Though later on after finding the right address and having the new `.io` domain cached, the redirect on the old `.org` address worked fine.

Still, I think it's good to update it for future readers.