### PR TITLE
Add: new mode for Auto Search

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1932,6 +1932,7 @@ url.auto_search:
       - naive: Use simple/naive check.
       - dns: Use DNS requests (might be slow!).
       - never: Never search automatically.
+      - no-url-scheme: Auto search unless URL contains scheme.
   default: naive
   desc: What search to start when something else than a URL is entered.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1932,7 +1932,7 @@ url.auto_search:
       - naive: Use simple/naive check.
       - dns: Use DNS requests (might be slow!).
       - never: Never search automatically.
-      - no-url-scheme: Auto search unless URL contains scheme.
+      - schemeless: Always search automatically unless URL explicitly contains a scheme.
   default: naive
   desc: What search to start when something else than a URL is entered.
 

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -288,9 +288,9 @@ def is_url(urlstr: str) -> bool:
         # URLs with explicit schemes are always URLs
         log.url.debug("Contains explicit scheme")
         url = True
-    elif autosearch == 'no-url-scheme' and not _has_explicit_scheme(qurl):
-        # When autosearch=no-url-scheme, URLs must contain schemes to be valid
-        log.url.debug("No scheme in URL while using no-url-scheme.")
+    elif autosearch == 'schemeless' and not _has_explicit_scheme(qurl):
+        # When autosearch=schemeless, URLs must contain schemes to be valid
+        log.url.debug("No explicit scheme in given URL, treating as non-URL")
         url = False
     elif qurl_userinput.host() in ['localhost', '127.0.0.1', '::1']:
         log.url.debug("Is localhost.")

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -288,6 +288,10 @@ def is_url(urlstr: str) -> bool:
         # URLs with explicit schemes are always URLs
         log.url.debug("Contains explicit scheme")
         url = True
+    elif autosearch == 'no-url-scheme' and not _has_explicit_scheme(qurl):
+        # When autosearch=no-url-scheme, URLs must contain schemes to be valid
+        log.url.debug("No scheme in URL while using no-url-scheme.")
+        url = False
     elif qurl_userinput.host() in ['localhost', '127.0.0.1', '::1']:
         log.url.debug("Is localhost.")
         url = True

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -288,7 +288,7 @@ def is_url(urlstr: str) -> bool:
         # URLs with explicit schemes are always URLs
         log.url.debug("Contains explicit scheme")
         url = True
-    elif autosearch == 'schemeless' and not _has_explicit_scheme(qurl):
+    elif autosearch == 'schemeless' and (not _has_explicit_scheme(qurl) or ' ' in urlstr):
         # When autosearch=schemeless, URLs must contain schemes to be valid
         log.url.debug("No explicit scheme in given URL, treating as non-URL")
         url = False

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -288,7 +288,8 @@ def is_url(urlstr: str) -> bool:
         # URLs with explicit schemes are always URLs
         log.url.debug("Contains explicit scheme")
         url = True
-    elif autosearch == 'schemeless' and (not _has_explicit_scheme(qurl) or ' ' in urlstr):
+    elif (autosearch == 'schemeless' and
+          (not _has_explicit_scheme(qurl) or ' ' in urlstr)):
         # When autosearch=schemeless, URLs must contain schemes to be valid
         log.url.debug("No explicit scheme in given URL, treating as non-URL")
         url = False

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -358,65 +358,69 @@ class UrlParams:
     url = attr.ib()
     is_url = attr.ib(True)
     is_url_no_autosearch = attr.ib(True)
-    uses_dns = attr.ib(True)
+    use_dns = attr.ib(True)
     is_url_in_schemeless = attr.ib(False)
 
 
-@pytest.mark.parametrize('auto_search', ['dns', 'naive', 'schemeless', 'never'])
+@pytest.mark.parametrize('auto_search',
+                         ['dns', 'naive', 'schemeless', 'never'])
 @pytest.mark.parametrize('url_params', [
     # Normal hosts
-    UrlParams('http://foobar', uses_dns=False, is_url_in_schemeless=True),
-    UrlParams('localhost:8080', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('http://foobar', use_dns=False, is_url_in_schemeless=True),
+    UrlParams('localhost:8080', use_dns=False, is_url_in_schemeless=True),
     UrlParams('qutebrowser.org'),
     UrlParams(' qutebrowser.org '),
-    UrlParams('http://user:password@example.com/foo?bar=baz#fish', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('http://user:password@example.com/foo?bar=baz#fish',
+              use_dns=False, is_url_in_schemeless=True),
     UrlParams('existing-tld.domains'),
     # Internationalized domain names
     UrlParams('\u4E2D\u56FD.\u4E2D\u56FD'),  # Chinese TLD
     UrlParams('xn--fiqs8s.xn--fiqs8s'),  # Chinese TLD
     # Encoded space in explicit url
-    UrlParams('http://sharepoint/sites/it/IT%20Documentation/Forms/AllItems.aspx', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('http://sharepoint/sites/it/IT%20Documentation/Forms/AllItems.aspx', use_dns=False, is_url_in_schemeless=True),
     # IPs
-    UrlParams('127.0.0.1', uses_dns=False),
-    UrlParams('::1', uses_dns=False),
+    UrlParams('127.0.0.1', use_dns=False),
+    UrlParams('::1', use_dns=False),
     UrlParams('2001:41d0:2:6c11::1'),
     UrlParams('[2001:41d0:2:6c11::1]:8000'),
     UrlParams('94.23.233.17'),
     UrlParams('94.23.233.17:8000'),
     # Special URLs
-    UrlParams('file:///tmp/foo', uses_dns=False, is_url_in_schemeless=True),
-    UrlParams('about:blank', uses_dns=False, is_url_in_schemeless=True),
-    UrlParams('qute:version', uses_dns=False, is_url_in_schemeless=True),
-    UrlParams('qute://version', uses_dns=False, is_url_in_schemeless=True),
-    UrlParams('localhost', uses_dns=False),
+    UrlParams('file:///tmp/foo', use_dns=False, is_url_in_schemeless=True),
+    UrlParams('about:blank', use_dns=False, is_url_in_schemeless=True),
+    UrlParams('qute:version', use_dns=False, is_url_in_schemeless=True),
+    UrlParams('qute://version', use_dns=False, is_url_in_schemeless=True),
+    UrlParams('localhost', use_dns=False),
     # _has_explicit_scheme False, special_url True
-    UrlParams('qute::foo', uses_dns=False),
-    UrlParams('qute:://foo', uses_dns=False),
+    UrlParams('qute::foo', use_dns=False),
+    UrlParams('qute:://foo', use_dns=False),
     # Invalid URLs
-    UrlParams('', is_url=False, is_url_no_autosearch=False, uses_dns=False),
-    UrlParams('onlyscheme:', is_url=False, uses_dns=False),
-    UrlParams('http:foo:0', is_url=False, uses_dns=False),
+    UrlParams('', is_url=False, is_url_no_autosearch=False, use_dns=False),
+    UrlParams('onlyscheme:', is_url=False, use_dns=False),
+    UrlParams('http:foo:0', is_url=False, use_dns=False),
     # Not URLs
-    UrlParams('foo bar', is_url=False, uses_dns=False),  # no DNS because of space
-    UrlParams('localhost test', is_url=False, uses_dns=False),  # no DNS because of space
-    UrlParams('another . test', is_url=False, uses_dns=False),  # no DNS because of space
+    UrlParams('foo bar', is_url=False, use_dns=False),  # no DNS b/c of space
+    UrlParams('localhost test', is_url=False, use_dns=False),  # no DNS b/c spc
+    UrlParams('another . test', is_url=False, use_dns=False),  # no DNS b/c spc
     UrlParams('foo', is_url=False),
-    UrlParams('this is: not a URL', is_url=False, uses_dns=False),  # no DNS because of space
-    UrlParams('foo user@host.tld', is_url=False, uses_dns=False),  # no DNS because of space
-    UrlParams('23.42', is_url=False, uses_dns=False),  # no DNS because bogus-IP
-    UrlParams('1337', is_url=False, uses_dns=False),  # no DNS because bogus-IP
+    UrlParams('this is: not a URL', is_url=False, use_dns=False),  # no DNS spc
+    UrlParams('foo user@host.tld', is_url=False, use_dns=False),  # no DNS, spc
+    UrlParams('23.42', is_url=False, use_dns=False),  # no DNS b/c bogus-IP
+    UrlParams('1337', is_url=False, use_dns=False),  # no DNS b/c bogus-IP
     UrlParams('deadbeef', is_url=False),
     UrlParams('hello.', is_url=False),
-    UrlParams('site:cookies.com oatmeal raisin', is_url=False, uses_dns=False),
+    UrlParams('site:cookies.com oatmeal raisin', is_url=False, use_dns=False),
     UrlParams('example.search_string', is_url=False),
     UrlParams('example_search.string', is_url=False),
     # no DNS because there is no host
-    UrlParams('foo::bar', is_url=False, uses_dns=False),
+    UrlParams('foo::bar', is_url=False, use_dns=False),
     # Valid search term with autosearch
-    UrlParams('test foo', is_url=False, is_url_no_autosearch=False, uses_dns=False),
-    UrlParams('test user@host.tld', is_url=False, is_url_no_autosearch=False, uses_dns=False),
+    UrlParams('test foo', is_url=False,
+              is_url_no_autosearch=False, use_dns=False),
+    UrlParams('test user@host.tld', is_url=False,
+              is_url_no_autosearch=False, use_dns=False),
     # autosearch = False
-    UrlParams('This is a URL without autosearch', is_url=False, uses_dns=False),
+    UrlParams('This is a URL without autosearch', is_url=False, use_dns=False),
 ], ids=lambda param: 'URL: ' + param.url)
 def test_is_url(config_stub, fake_dns, auto_search, url_params):
     """Test is_url().
@@ -428,20 +432,20 @@ def test_is_url(config_stub, fake_dns, auto_search, url_params):
         * is_url: Whether the given string is a URL with auto_search dns/naive.
         * is_url_no_autosearch: Whether the given string is a URL with
                                 auto_search false.
-        * uses_dns: Whether the given string should fire a DNS request for the
-                    given URL.
+        * use_dns: Whether the given string should fire a DNS request for the
+                   given URL.
         * is_url_in_schemeless: Whether the given string is treated as a URL
                                 when auto_search=schemeless.
     """
     url = url_params.url
     is_url = url_params.is_url
     is_url_no_autosearch = url_params.is_url_no_autosearch
-    uses_dns = url_params.uses_dns
+    use_dns = url_params.use_dns
     is_url_in_schemeless = url_params.is_url_in_schemeless
 
     config_stub.val.url.auto_search = auto_search
     if auto_search == 'dns':
-        if uses_dns:
+        if use_dns:
             fake_dns.answer = True
             result = urlutils.is_url(url)
             assert fake_dns.used

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -352,75 +352,93 @@ def test_get_search_url_invalid(url):
         urlutils._get_search_url(url)
 
 
-@pytest.mark.parametrize('is_url, is_url_no_autosearch, uses_dns, url', [
+@attr.s
+class UrlParams:
+
+    url = attr.ib()
+    is_url = attr.ib(True)
+    is_url_no_autosearch = attr.ib(True)
+    uses_dns = attr.ib(True)
+    is_url_in_schemeless = attr.ib(False)
+
+
+@pytest.mark.parametrize('auto_search', ['dns', 'naive', 'schemeless', 'never'])
+@pytest.mark.parametrize('url_params', [
     # Normal hosts
-    (True, True, False, 'http://foobar'),
-    (True, True, False, 'localhost:8080'),
-    (True, True, True, 'qutebrowser.org'),
-    (True, True, True, ' qutebrowser.org '),
-    (True, True, False, 'http://user:password@example.com/foo?bar=baz#fish'),
-    (True, True, True, 'existing-tld.domains'),
+    UrlParams('http://foobar', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('localhost:8080', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('qutebrowser.org'),
+    UrlParams(' qutebrowser.org '),
+    UrlParams('http://user:password@example.com/foo?bar=baz#fish', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('existing-tld.domains'),
     # Internationalized domain names
-    (True, True, True, '\u4E2D\u56FD.\u4E2D\u56FD'),  # Chinese TLD
-    (True, True, True, 'xn--fiqs8s.xn--fiqs8s'),  # The same in punycode
+    UrlParams('\u4E2D\u56FD.\u4E2D\u56FD'),  # Chinese TLD
+    UrlParams('xn--fiqs8s.xn--fiqs8s'),  # Chinese TLD
     # Encoded space in explicit url
-    (True, True, False, 'http://sharepoint/sites/it/IT%20Documentation/Forms/AllItems.aspx'),
+    UrlParams('http://sharepoint/sites/it/IT%20Documentation/Forms/AllItems.aspx', uses_dns=False, is_url_in_schemeless=True),
     # IPs
-    (True, True, False, '127.0.0.1'),
-    (True, True, False, '::1'),
-    (True, True, True, '2001:41d0:2:6c11::1'),
-    (True, True, True, '[2001:41d0:2:6c11::1]:8000'),
-    (True, True, True, '94.23.233.17'),
-    (True, True, True, '94.23.233.17:8000'),
+    UrlParams('127.0.0.1', uses_dns=False),
+    UrlParams('::1', uses_dns=False),
+    UrlParams('2001:41d0:2:6c11::1'),
+    UrlParams('[2001:41d0:2:6c11::1]:8000'),
+    UrlParams('94.23.233.17'),
+    UrlParams('94.23.233.17:8000'),
     # Special URLs
-    (True, True, False, 'file:///tmp/foo'),
-    (True, True, False, 'about:blank'),
-    (True, True, False, 'qute:version'),
-    (True, True, False, 'qute://version'),
-    (True, True, False, 'localhost'),
+    UrlParams('file:///tmp/foo', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('about:blank', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('qute:version', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('qute://version', uses_dns=False, is_url_in_schemeless=True),
+    UrlParams('localhost', uses_dns=False),
     # _has_explicit_scheme False, special_url True
-    (True, True, False, 'qute::foo'),
-    (True, True, False, 'qute:://foo'),
+    UrlParams('qute::foo', uses_dns=False),
+    UrlParams('qute:://foo', uses_dns=False),
     # Invalid URLs
-    (False, False, False, ''),
-    (False, True, False, 'onlyscheme:'),
-    (False, True, False, 'http:foo:0'),
+    UrlParams('', is_url=False, is_url_no_autosearch=False, uses_dns=False),
+    UrlParams('onlyscheme:', is_url=False, uses_dns=False),
+    UrlParams('http:foo:0', is_url=False, uses_dns=False),
     # Not URLs
-    (False, True, False, 'foo bar'),  # no DNS because of space
-    (False, True, False, 'localhost test'),  # no DNS because of space
-    (False, True, False, 'another . test'),  # no DNS because of space
-    (False, True, True, 'foo'),
-    (False, True, False, 'this is: not a URL'),  # no DNS because of space
-    (False, True, False, 'foo user@host.tld'),  # no DNS because of space
-    (False, True, False, '23.42'),  # no DNS because bogus-IP
-    (False, True, False, '1337'),  # no DNS because bogus-IP
-    (False, True, True, 'deadbeef'),
-    (False, True, True, 'hello.'),
-    (False, True, False, 'site:cookies.com oatmeal raisin'),
-    (False, True, True, 'example.search_string'),
-    (False, True, True, 'example_search.string'),
+    UrlParams('foo bar', is_url=False, uses_dns=False),  # no DNS because of space
+    UrlParams('localhost test', is_url=False, uses_dns=False),  # no DNS because of space
+    UrlParams('another . test', is_url=False, uses_dns=False),  # no DNS because of space
+    UrlParams('foo', is_url=False),
+    UrlParams('this is: not a URL', is_url=False, uses_dns=False),  # no DNS because of space
+    UrlParams('foo user@host.tld', is_url=False, uses_dns=False),  # no DNS because of space
+    UrlParams('23.42', is_url=False, uses_dns=False),  # no DNS because bogus-IP
+    UrlParams('1337', is_url=False, uses_dns=False),  # no DNS because bogus-IP
+    UrlParams('deadbeef', is_url=False),
+    UrlParams('hello.', is_url=False),
+    UrlParams('site:cookies.com oatmeal raisin', is_url=False, uses_dns=False),
+    UrlParams('example.search_string', is_url=False),
+    UrlParams('example_search.string', is_url=False),
     # no DNS because there is no host
-    (False, True, False, 'foo::bar'),
+    UrlParams('foo::bar', is_url=False, uses_dns=False),
     # Valid search term with autosearch
-    (False, False, False, 'test foo'),
-    (False, False, False, 'test user@host.tld'),
+    UrlParams('test foo', is_url=False, is_url_no_autosearch=False, uses_dns=False),
+    UrlParams('test user@host.tld', is_url=False, is_url_no_autosearch=False, uses_dns=False),
     # autosearch = False
-    (False, True, False, 'This is a URL without autosearch'),
-])
-@pytest.mark.parametrize('auto_search', ['dns', 'naive', 'never'])
-def test_is_url(config_stub, fake_dns,
-                is_url, is_url_no_autosearch, uses_dns, url, auto_search):
+    UrlParams('This is a URL without autosearch', is_url=False, uses_dns=False),
+], ids=lambda param: 'URL: ' + param.url)
+def test_is_url(config_stub, fake_dns, auto_search, url_params):
     """Test is_url().
 
     Args:
-        is_url: Whether the given string is a URL with auto_search dns/naive.
-        is_url_no_autosearch: Whether the given string is a URL with
-                              auto_search false.
-        uses_dns: Whether the given string should fire a DNS request for the
-                  given URL.
-        url: The URL to test, as a string.
         auto_search: With which auto_search setting to test
+        url_params: instance of UrlParams; each containing the following attrs
+        * url: The URL to test, as a string.
+        * is_url: Whether the given string is a URL with auto_search dns/naive.
+        * is_url_no_autosearch: Whether the given string is a URL with
+                                auto_search false.
+        * uses_dns: Whether the given string should fire a DNS request for the
+                    given URL.
+        * is_url_in_schemeless: Whether the given string is treated as a URL
+                                when auto_search=schemeless.
     """
+    url = url_params.url
+    is_url = url_params.is_url
+    is_url_no_autosearch = url_params.is_url_no_autosearch
+    uses_dns = url_params.uses_dns
+    is_url_in_schemeless = url_params.is_url_in_schemeless
+
     config_stub.val.url.auto_search = auto_search
     if auto_search == 'dns':
         if uses_dns:
@@ -438,6 +456,9 @@ def test_is_url(config_stub, fake_dns,
             result = urlutils.is_url(url)
             assert not fake_dns.used
             assert result == is_url
+    elif auto_search == 'schemeless':
+        assert urlutils.is_url(url) == is_url_in_schemeless
+        assert not fake_dns.used
     elif auto_search == 'naive':
         assert urlutils.is_url(url) == is_url
         assert not fake_dns.used

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -415,8 +415,10 @@ class UrlParams:
     # no DNS because there is no host
     UrlParams('foo::bar', is_url=False, use_dns=False),
     # Valid search term with autosearch
-    UrlParams('test foo', is_url=False, is_url_no_autosearch=False, use_dns=False),
-    UrlParams('test user@host.tld', is_url=False, is_url_no_autosearch=False, use_dns=False),
+    UrlParams('test foo', is_url=False,
+              is_url_no_autosearch=False, use_dns=False),
+    UrlParams('test user@host.tld', is_url=False,
+              is_url_no_autosearch=False, use_dns=False),
     # autosearch = False
     UrlParams('This is a URL without autosearch', is_url=False, use_dns=False),
 ], ids=lambda param: 'URL: ' + param.url)

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -375,7 +375,7 @@ class UrlParams:
     UrlParams('existing-tld.domains'),
     # Internationalized domain names
     UrlParams('\u4E2D\u56FD.\u4E2D\u56FD'),  # Chinese TLD
-    UrlParams('xn--fiqs8s.xn--fiqs8s'),  # Chinese TLD
+    UrlParams('xn--fiqs8s.xn--fiqs8s'),  # The same in punycode
     # Encoded space in explicit url
     UrlParams('http://sharepoint/sites/it/IT%20Documentation/Forms/AllItems.aspx', use_dns=False, is_url_in_schemeless=True),
     # IPs

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -415,10 +415,8 @@ class UrlParams:
     # no DNS because there is no host
     UrlParams('foo::bar', is_url=False, use_dns=False),
     # Valid search term with autosearch
-    UrlParams('test foo', is_url=False,
-              is_url_no_autosearch=False, use_dns=False),
-    UrlParams('test user@host.tld', is_url=False,
-              is_url_no_autosearch=False, use_dns=False),
+    UrlParams('test foo', is_url=False, is_url_no_autosearch=False, use_dns=False),
+    UrlParams('test user@host.tld', is_url=False, is_url_no_autosearch=False, use_dns=False),
     # autosearch = False
     UrlParams('This is a URL without autosearch', is_url=False, use_dns=False),
 ], ids=lambda param: 'URL: ' + param.url)
@@ -429,13 +427,14 @@ def test_is_url(config_stub, fake_dns, auto_search, url_params):
         auto_search: With which auto_search setting to test
         url_params: instance of UrlParams; each containing the following attrs
         * url: The URL to test, as a string.
-        * is_url: Whether the given string is a URL with auto_search dns/naive.
+        * is_url: Whether the given string is considered a URL when auto_search
+                  is either dns or naive. [default: True]
         * is_url_no_autosearch: Whether the given string is a URL with
-                                auto_search false.
+                                auto_search false. [default: True]
         * use_dns: Whether the given string should fire a DNS request for the
-                   given URL.
+                   given URL. [default: True]
         * is_url_in_schemeless: Whether the given string is treated as a URL
-                                when auto_search=schemeless.
+                                when auto_search=schemeless. [default: False]
     """
     url = url_params.url
     is_url = url_params.is_url


### PR DESCRIPTION
* when `url.auto_search = 'no-url-scheme'`, URLs
  must contain schemes to be considered valid
* implements feature requested in #5038 

-------------------------
I'll add the tests in if the code looks good to you guys.