### PR TITLE
Refactor user agent handling and introduce site-specific quirks

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -68,6 +68,9 @@ Changed
 Fixed
 ~~~~~
 
+- Downloads (e.g. via `:download`) now see the same user agent header as
+  webpages, which fixes cases where overly restrictive servers/WAFs closed the
+  connection before.
 - dictcli.py now works correctly on Windows again.
 - The logic for `:restart` has been revisited which should fix issues with
   relative basedirs.

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -61,6 +61,9 @@ Changed
   a timeout) on PyQt 5.13.1 and newer.
 - The `:spawn` command has a new `-m` / `--output-messages` argument which
   shows qutebrowser messages based on a command's standard output/error.
+- If JavaScript is disabled globally, `file://*` now doesn't automatically have
+  it enabled anymore. Run `:set -u file://* content.javascript.enabled true` to
+  restore the previous behavior.
 - Performance improvements for the following areas:
   * Adding settings with URL patterns
   * Matching of settings using URL patterns

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -78,6 +78,8 @@ Fixed
   QtWebKit.
 - Workaround for a Qt bug where a page never finishes loading with a
   non-overridable TLS error (e.g. due to HSTS).
+- The `qute://configdiff` page now doesn't show built-in settings (e.g.
+  javascript being enabled for `qute://` and `chrome://` pages) anymore.
 - Various improvements for URL/searchengine detection:
   - Strings with a dot but with characters not allowed in a URL (e.g. an
     underscore) are now not treated as URL anymore.

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -32,6 +32,10 @@ Added
 Changed
 ~~~~~~~
 
+- The `content.headers.user_agent` setting now is a format string with the
+  default value resembling the behavior of it being set to null before.
+  This slightly changes the sent user agent for QtWebKit: Instead of mentioning
+  qutebrowser and its version it now mentions the Qt version.
 - The `qute-pass` userscript now has a new `--extra-url-suffixes` (`-s`)
   argument which passes extra URL suffixes to the tldextract library.
 - A stack is now used for `:tab-focus last` rather than just saving one tab.

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -28,6 +28,9 @@ Added
   - `fonts.contextmenu`
   - `colors.contextmenu.bg`
   - `colors.contextmenu.fg`
+- New `content.site_specific_quirks` setting which enables workarounds for
+  websites with broken user agent parsing (enabled by default, see the "Fixed"
+  section for fixed websites).
 
 Changed
 ~~~~~~~
@@ -94,6 +97,12 @@ Fixed
   - `url.open_base_url = True` together with `url.auto_search = 'never'` is now
     handled correctly.
   - Fixed crash when a search engine URL turns out to be invalid.
+- Site specific quirks which work around some broken websites:
+  - WhatsApp Web
+  - Google Accounts
+  - Slack (with older QtWebEngine versions)
+  - Dell.com support pages (with Qt 5.7)
+  - Google Docs (fixes broken IME/compose key)
 
 v1.8.3 (2019-12-05)
 -------------------

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -181,7 +181,7 @@
 |<<downloads.open_dispatcher,downloads.open_dispatcher>>|Default program used to open downloads.
 |<<downloads.position,downloads.position>>|Where to show the downloaded files.
 |<<downloads.remove_finished,downloads.remove_finished>>|Duration (in milliseconds) to wait before removing finished downloads.
-|<<editor.command,editor.command>>|Editor (and arguments) to use for the `open-editor` command. The following placeholders are defined:
+|<<editor.command,editor.command>>|Editor (and arguments) to use for the `open-editor` command.
 |<<editor.encoding,editor.encoding>>|Encoding to use for the editor.
 |<<fonts.completion.category,fonts.completion.category>>|Font used in the completion categories.
 |<<fonts.completion.entry,fonts.completion.entry>>|Font used in the completion widget.
@@ -1841,12 +1841,23 @@ Default: +pass:[same-domain]+
 [[content.headers.user_agent]]
 === content.headers.user_agent
 User agent to send.
+
 The following placeholders are defined:
-* `{os_info}`: Something like "X11; Linux x86_64". * `{webkit_version}`: The underlying WebKit version (set to a fixed value
+
+* `{os_info}`: Something like "X11; Linux x86_64".
+* `{webkit_version}`: The underlying WebKit version (set to a fixed value
   with QtWebEngine).
-* `{qt_key}`: "Qt" for QtWebKit, "QtWebEngine" for QtWebEngine. * `{qt_version}`: The underlying Qt version. * `{upstream_browser_key}`: "Version" for QtWebKit, "Chrome" for QtWebEngine. * `{upstream_browser_version}`: The corresponding Safari/Chrome version. * `{qutebrowser_version}`: The currently running qutebrowser version.
-The default value is equal to the unchanged user agent of QtWebKit/QtWebEngine.
+* `{qt_key}`: "Qt" for QtWebKit, "QtWebEngine" for QtWebEngine.
+* `{qt_version}`: The underlying Qt version.
+* `{upstream_browser_key}`: "Version" for QtWebKit, "Chrome" for QtWebEngine.
+* `{upstream_browser_version}`: The corresponding Safari/Chrome version.
+* `{qutebrowser_version}`: The currently running qutebrowser version.
+
+The default value is equal to the unchanged user agent of
+QtWebKit/QtWebEngine.
+
 Note that the value read from JavaScript is always the global value.
+
 
 This setting supports URL patterns.
 
@@ -2360,8 +2371,15 @@ Default: +pass:[-1]+
 
 [[editor.command]]
 === editor.command
-Editor (and arguments) to use for the `open-editor` command. The following placeholders are defined:
-* `{file}`: Filename of the file to be edited. * `{line}`: Line in which the caret is found in the text. * `{column}`: Column in which the caret is found in the text. * `{line0}`: Same as `{line}`, but starting from index 0. * `{column0}`: Same as `{column}`, but starting from index 0.
+Editor (and arguments) to use for the `open-editor` command.
+The following placeholders are defined:
+
+* `{file}`: Filename of the file to be edited.
+* `{line}`: Line in which the caret is found in the text.
+* `{column}`: Column in which the caret is found in the text.
+* `{line0}`: Same as `{line}`, but starting from index 0.
+* `{column0}`: Same as `{column}`, but starting from index 0.
+
 
 Type: <<types,ShellCommand>>
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -168,6 +168,7 @@
 |<<content.proxy,content.proxy>>|Proxy to use.
 |<<content.proxy_dns_requests,content.proxy_dns_requests>>|Send DNS requests over the configured proxy.
 |<<content.register_protocol_handler,content.register_protocol_handler>>|Allow websites to register protocol handlers via `navigator.registerProtocolHandler`.
+|<<content.site_specific_quirks,content.site_specific_quirks>>|Enable quirks (such as faked user agent headers) needed to get specific sites to work properly.
 |<<content.ssl_strict,content.ssl_strict>>|Validate SSL handshakes.
 |<<content.user_stylesheets,content.user_stylesheets>>|List of user stylesheet filenames to use.
 |<<content.webgl,content.webgl>>|Enable WebGL.
@@ -2221,6 +2222,15 @@ Default: +pass:[ask]+
 On QtWebEngine, this setting requires Qt 5.11 or newer.
 
 On QtWebKit, this setting is unavailable.
+
+[[content.site_specific_quirks]]
+=== content.site_specific_quirks
+Enable quirks (such as faked user agent headers) needed to get specific sites to work properly.
+This setting requires a restart.
+
+Type: <<types,Bool>>
+
+Default: +pass:[true]+
 
 [[content.ssl_strict]]
 === content.ssl_strict

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -138,7 +138,7 @@
 |<<content.headers.custom,content.headers.custom>>|Custom headers for qutebrowser HTTP requests.
 |<<content.headers.do_not_track,content.headers.do_not_track>>|Value to send in the `DNT` header.
 |<<content.headers.referer,content.headers.referer>>|When to send the Referer header.
-|<<content.headers.user_agent,content.headers.user_agent>>|User agent to send. Unset to send the default.
+|<<content.headers.user_agent,content.headers.user_agent>>|User agent to send.
 |<<content.host_blocking.enabled,content.host_blocking.enabled>>|Enable host blocking.
 |<<content.host_blocking.lists,content.host_blocking.lists>>|List of URLs of lists which contain hosts to block.
 |<<content.host_blocking.whitelist,content.host_blocking.whitelist>>|A list of patterns that should always be loaded, despite being ad-blocked.
@@ -1840,14 +1840,19 @@ Default: +pass:[same-domain]+
 
 [[content.headers.user_agent]]
 === content.headers.user_agent
-User agent to send. Unset to send the default.
+User agent to send.
+The following placeholders are defined:
+* `{os_info}`: Something like "X11; Linux x86_64". * `{webkit_version}`: The underlying WebKit version (set to a fixed value
+  with QtWebEngine).
+* `{qt_key}`: "Qt" for QtWebKit, "QtWebEngine" for QtWebEngine. * `{qt_version}`: The underlying Qt version. * `{upstream_browser_key}`: "Version" for QtWebKit, "Chrome" for QtWebEngine. * `{upstream_browser_version}`: The corresponding Safari/Chrome version. * `{qutebrowser_version}`: The currently running qutebrowser version.
+The default value is equal to the unchanged user agent of QtWebKit/QtWebEngine.
 Note that the value read from JavaScript is always the global value.
 
 This setting supports URL patterns.
 
-Type: <<types,String>>
+Type: <<types,FormatString>>
 
-Default: empty
+Default: +pass:[Mozilla/5.0 ({os_info}) AppleWebKit/{webkit_version} (KHTML, like Gecko) {qt_key}/{qt_version} {upstream_browser_key}/{upstream_browser_version} Safari/{webkit_version}]+
 
 [[content.host_blocking.enabled]]
 === content.host_blocking.enabled

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -821,14 +821,6 @@ class AbstractTabPrivate:
         """
         raise NotImplementedError
 
-    def user_agent(self) -> typing.Optional[str]:
-        """Get the user agent for this tab.
-
-        This is only implemented for QtWebKit.
-        For QtWebEngine, always returns None.
-        """
-        raise NotImplementedError
-
     def shutdown(self) -> None:
         raise NotImplementedError
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1269,7 +1269,6 @@ class CommandDispatcher:
             target = downloads.FileDownloadTarget(dest)
 
         tab = self._current_widget()
-        user_agent = tab.private_api.user_agent()
 
         if url:
             if mhtml_:
@@ -1277,7 +1276,7 @@ class CommandDispatcher:
                                             "page as mhtml.")
             url = urlutils.qurl_from_user_input(url)
             urlutils.raise_cmdexc_if_invalid(url)
-            download_manager.get(url, user_agent=user_agent, target=target)
+            download_manager.get(url, target=target)
         elif mhtml_:
             tab = self._current_widget()
             if tab.backend == usertypes.Backend.QtWebEngine:
@@ -1298,7 +1297,6 @@ class CommandDispatcher:
 
             download_manager.get(
                 self._current_url(),
-                user_agent=user_agent,
                 qnam=qnam,
                 target=target,
                 suggested_fn=suggested_fn

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -286,12 +286,10 @@ class HintActions:
 
         prompt = False if context.rapid else None
         qnam = context.tab.private_api.networkaccessmanager()
-        user_agent = context.tab.private_api.user_agent()
 
         # FIXME:qtwebengine do this with QtWebEngine downloads?
         download_manager = objreg.get('qtnetwork-download-manager')
-        download_manager.get(url, qnam=qnam, user_agent=user_agent,
-                             prompt_download_directory=prompt)
+        download_manager.get(url, qnam=qnam, prompt_download_directory=prompt)
 
     def call_userscript(self, elem: webelem.AbstractWebElement,
                         context: HintContext) -> None:

--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -29,7 +29,7 @@ import attr
 from PyQt5.QtCore import pyqtSlot, pyqtSignal, QTimer, QUrl
 from PyQt5.QtNetwork import QNetworkRequest, QNetworkReply
 
-from qutebrowser.config import config
+from qutebrowser.config import config, websettings
 from qutebrowser.utils import message, usertypes, log, urlutils, utils, debug
 from qutebrowser.browser import downloads
 from qutebrowser.browser.webkit import http
@@ -414,12 +414,11 @@ class DownloadManager(downloads.AbstractDownloadManager):
             private=config.val.content.private_browsing, parent=self)
 
     @pyqtSlot('QUrl')
-    def get(self, url, *, user_agent=None, **kwargs):
+    def get(self, url, **kwargs):
         """Start a download with a link URL.
 
         Args:
             url: The URL to get, as QUrl
-            user_agent: The UA to set for the request, or None.
             **kwargs: passed to get_request().
 
         Return:
@@ -428,9 +427,11 @@ class DownloadManager(downloads.AbstractDownloadManager):
         if not url.isValid():
             urlutils.invalid_url_error(url, "start download")
             return None
+
         req = QNetworkRequest(url)
-        if user_agent is not None:
-            req.setHeader(QNetworkRequest.UserAgentHeader, user_agent)
+        user_agent = websettings.user_agent(url)
+        req.setHeader(QNetworkRequest.UserAgentHeader, user_agent)
+
         return self.get_request(req, **kwargs)
 
     def get_mhtml(self, tab, target):

--- a/qutebrowser/browser/webengine/interceptor.py
+++ b/qutebrowser/browser/webengine/interceptor.py
@@ -25,7 +25,7 @@ from PyQt5.QtCore import QUrl, QByteArray
 from PyQt5.QtWebEngineCore import (QWebEngineUrlRequestInterceptor,
                                    QWebEngineUrlRequestInfo)
 
-from qutebrowser.config import config
+from qutebrowser.config import websettings
 from qutebrowser.browser import shared
 from qutebrowser.utils import utils, log, debug, qtutils
 from qutebrowser.extensions import interceptors
@@ -204,6 +204,5 @@ class RequestInterceptor(QWebEngineUrlRequestInterceptor):
         for header, value in shared.custom_headers(url=url):
             info.setHttpHeader(header, value)
 
-        user_agent = config.instance.get('content.headers.user_agent', url=url)
-        if user_agent is not None:
-            info.setHttpHeader(b'User-Agent', user_agent.encode('ascii'))
+        user_agent = websettings.user_agent(url)
+        info.setHttpHeader(b'User-Agent', user_agent.encode('ascii'))

--- a/qutebrowser/browser/webkit/webkitsettings.py
+++ b/qutebrowser/browser/webkit/webkitsettings.py
@@ -82,6 +82,8 @@ class WebKitSettings(websettings.AbstractSettings):
             Attr(QWebSettings.PrintElementBackgrounds),
         'content.xss_auditing':
             Attr(QWebSettings.XSSAuditingEnabled),
+        'content.site_specific_quirks':
+            Attr(QWebSettings.SiteSpecificQuirksEnabled),
 
         'input.spatial_navigation':
             Attr(QWebSettings.SpatialNavigationEnabled),

--- a/qutebrowser/browser/webkit/webkitsettings.py
+++ b/qutebrowser/browser/webkit/webkitsettings.py
@@ -27,8 +27,10 @@ Module attributes:
 import typing
 import os.path
 
+from PyQt5.QtCore import QUrl
 from PyQt5.QtGui import QFont
 from PyQt5.QtWebKit import QWebSettings
+from PyQt5.QtWebKitWidgets import QWebPage
 
 from qutebrowser.config import config, websettings
 from qutebrowser.config.websettings import AttributeInfo as Attr
@@ -38,6 +40,8 @@ from qutebrowser.browser import shared
 
 # The global WebKitSettings object
 global_settings = typing.cast('WebKitSettings', None)
+
+parsed_user_agent = None
 
 
 class WebKitSettings(websettings.AbstractSettings):
@@ -160,6 +164,12 @@ def _update_settings(option):
         _set_cache_maximum_pages(settings)
 
 
+def _init_user_agent():
+    global parsed_user_agent
+    ua = QWebPage().userAgentForUrl(QUrl())
+    parsed_user_agent = websettings.UserAgent.parse(ua)
+
+
 def init(_args):
     """Initialize the global QWebSettings."""
     cache_path = standarddir.cache()
@@ -177,6 +187,8 @@ def init(_args):
     _set_user_stylesheet(settings)
     _set_cookie_accept_policy(settings)
     _set_cache_maximum_pages(settings)
+
+    _init_user_agent()
 
     config.instance.changed.connect(_update_settings)
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -682,10 +682,6 @@ class WebKitTabPrivate(browsertab.AbstractTabPrivate):
     def networkaccessmanager(self):
         return self._widget.page().networkAccessManager()
 
-    def user_agent(self):
-        page = self._widget.page()
-        return page.userAgentForUrl(self._tab.url())
-
     def clear_ssl_errors(self):
         self.networkaccessmanager().clear_all_ssl_errors()
 

--- a/qutebrowser/browser/webkit/webpage.py
+++ b/qutebrowser/browser/webkit/webpage.py
@@ -29,7 +29,7 @@ from PyQt5.QtWidgets import QFileDialog
 from PyQt5.QtPrintSupport import QPrintDialog
 from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 
-from qutebrowser.config import config
+from qutebrowser.config import websettings
 from qutebrowser.browser import pdfjs, shared, downloads, greasemonkey
 from qutebrowser.browser.webkit import http
 from qutebrowser.browser.webkit.network import networkmanager
@@ -411,11 +411,7 @@ class BrowserPage(QWebPage):
 
     def userAgentForUrl(self, url):
         """Override QWebPage::userAgentForUrl to customize the user agent."""
-        ua = config.instance.get('content.headers.user_agent', url=url)
-        if ua is None:
-            return super().userAgentForUrl(url)
-        else:
-            return ua
+        return websettings.user_agent(url)
 
     def supportsExtension(self, ext):
         """Override QWebPage::supportsExtension to provide error pages.

--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -28,7 +28,7 @@ from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QSocketNotifier
 
 from qutebrowser.utils import message, log, objreg, standarddir, utils
 from qutebrowser.commands import runners
-from qutebrowser.config import config
+from qutebrowser.config import websettings
 from qutebrowser.misc import guiprocess
 from qutebrowser.browser import downloads
 
@@ -429,10 +429,8 @@ def run_async(tab, cmd, *args, win_id, env, verbose=False):
         lambda cmd:
         log.commands.debug("Got userscript command: {}".format(cmd)))
     runner.got_cmd.connect(commandrunner.run_safely)
-    user_agent = config.val.content.headers.user_agent
-    if user_agent is not None:
-        env['QUTE_USER_AGENT'] = user_agent
 
+    env['QUTE_USER_AGENT'] = websettings.user_agent()
     env['QUTE_CONFIG_DIR'] = standarddir.config()
     env['QUTE_DATA_DIR'] = standarddir.data()
     env['QUTE_DOWNLOAD_DIR'] = downloads.download_dir()

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -395,6 +395,15 @@ content.frame_flattening:
 
     This will flatten all the frames to become one scrollable page.
 
+content.site_specific_quirks:
+  default: true
+  restart: true
+  type: Bool
+  desc: 'Enable quirks (such as faked user agent headers) needed to get
+      specific sites to work properly.'
+
+# emacs: '
+
 content.geolocation:
   default: ask
   type: BoolAsk

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -469,10 +469,20 @@ content.headers.referer:
     No restart is needed with QtWebKit.
 
 content.headers.user_agent:
-  default: null
+  default: 'Mozilla/5.0 ({os_info})
+      AppleWebKit/{webkit_version} (KHTML, like Gecko)
+      {qt_key}/{qt_version} {upstream_browser_key}/{upstream_browser_version}
+      Safari/{webkit_version}'
   type:
-    name: String
-    none_ok: true
+    name: FormatString
+    fields:
+      - os_info
+      - webkit_version
+      - qt_key
+      - qt_version
+      - upstream_browser_key
+      - upstream_browser_version
+      - qutebrowser_version
     completions:
       # To update the following list of user agents, run the script
       # 'ua_fetch.py'
@@ -484,12 +494,23 @@ content.headers.user_agent:
       - - "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like
           Gecko) Chrome/76.0.3809.132 Safari/537.36"
         - Chrome 76 Linux
-      - - ""
-        - Use default QtWebKit/QtWebEngine User-Agent
-
   supports_pattern: true
   desc: >-
-    User agent to send. Unset to send the default.
+    User agent to send.
+
+    The following placeholders are defined:
+
+    * `{os_info}`: Something like "X11; Linux x86_64".
+    * `{webkit_version}`: The underlying WebKit version (set to a fixed value
+      with QtWebEngine).
+    * `{qt_key}`: "Qt" for QtWebKit, "QtWebEngine" for QtWebEngine.
+    * `{qt_version}`: The underlying Qt version.
+    * `{upstream_browser_key}`: "Version" for QtWebKit, "Chrome" for QtWebEngine.
+    * `{upstream_browser_version}`: The corresponding Safari/Chrome version.
+    * `{qutebrowser_version}`: The currently running qutebrowser version.
+
+    The default value is equal to the unchanged user agent of
+    QtWebKit/QtWebEngine.
 
     Note that the value read from JavaScript is always the global value.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -495,7 +495,7 @@ content.headers.user_agent:
           Gecko) Chrome/76.0.3809.132 Safari/537.36"
         - Chrome 76 Linux
   supports_pattern: true
-  desc: >-
+  desc: |
     User agent to send.
 
     The following placeholders are defined:
@@ -1029,7 +1029,7 @@ editor.command:
     name: ShellCommand
     placeholder: true
   default: ["gvim", "-f", "{file}", "-c", "normal {line}G{column0}l"]
-  desc: >-
+  desc: |
     Editor (and arguments) to use for the `open-editor` command.
     The following placeholders are defined:
 

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -271,6 +271,14 @@ class YamlConfig(QObject):
                     settings[name][scope] = true_value if val else false_value
                     self._mark_changed()
 
+    def _migrate_none(self, settings: _SettingsType, name: str,
+                      value: str) -> None:
+        if name in settings:
+            for scope, val in settings[name].items():
+                if val is None:
+                    settings[name][scope] = value
+                    self._mark_changed()
+
     def _migrate_string_value(self, settings: _SettingsType, name: str,
                               source: str, target: str) -> None:
         if name in settings:
@@ -342,6 +350,10 @@ class YamlConfig(QObject):
                   'window.title_format']:
             self._migrate_string_value(
                 settings, s, r'(?<!{)\{title\}(?!})', r'{current_title}')
+
+        # content.headers.user_agent can't be empty to get the default anymore.
+        s = 'content.headers.user_agent'
+        self._migrate_none(settings, s, configdata.DATA[s].default)
 
         return settings
 

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -106,8 +106,8 @@ class Values:
         self._domain_map = collections.defaultdict(set)  \
             # type: typing.Dict[typing.Optional[str], typing.Set[ScopedValue]]
 
-        for v in values:
-            self.add(value=v.value, pattern=v.pattern)
+        for scoped in values:
+            self._add_scoped(scoped)
 
     def __repr__(self) -> str:
         return utils.get_repr(self, opt=self.opt,
@@ -168,12 +168,17 @@ class Values:
         If hide_userconfig is given, the value is hidden from
         config.dump_userconfig() and thus qute://configdiff.
         """
-        self._check_pattern_support(pattern)
-        self.remove(pattern)
         scoped = ScopedValue(value, pattern, hide_userconfig=hide_userconfig)
-        self._vmap[pattern] = scoped
+        self._add_scoped(scoped)
 
-        host = pattern.host if pattern else None
+    def _add_scoped(self, scoped: ScopedValue) -> None:
+        """Add an existing ScopedValue object."""
+        self._check_pattern_support(scoped.pattern)
+        self.remove(scoped.pattern)
+
+        self._vmap[scoped.pattern] = scoped
+
+        host = scoped.pattern.host if scoped.pattern else None
         self._domain_map[host].add(scoped)
 
     def remove(self, pattern: urlmatch.UrlPattern = None) -> bool:

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -55,18 +55,22 @@ class ScopedValue:
     Attributes:
         value: The value itself.
         pattern: The UrlPattern for the value, or None for global values.
+        hide_userconfig: Hide this customization from config.dump_userconfig().
     """
 
     id_gen = itertools.count(0)
 
     def __init__(self, value: typing.Any,
-                 pattern: typing.Optional[urlmatch.UrlPattern]) -> None:
+                 pattern: typing.Optional[urlmatch.UrlPattern],
+                 hide_userconfig: bool = False) -> None:
         self.value = value
         self.pattern = pattern
+        self.hide_userconfig = hide_userconfig
         self.pattern_id = next(ScopedValue.id_gen)
 
     def __repr__(self) -> str:
         return utils.get_repr(self, value=self.value, pattern=self.pattern,
+                              hide_userconfig=self.hide_userconfig,
                               pattern_id=self.pattern_id)
 
 
@@ -112,18 +116,31 @@ class Values:
 
     def __str__(self) -> str:
         """Get the values as human-readable string."""
-        if not self:
-            return '{}: <unchanged>'.format(self.opt.name)
+        lines = self.dump(include_hidden=True)
+        if lines:
+            return '\n'.join(lines)
+        return '{}: <unchanged>'.format(self.opt.name)
 
+    def dump(self, include_hidden: bool = False) -> typing.Sequence[str]:
+        """Dump all customizations for this value.
+
+        Arguments:
+           include_hidden: Also show values with hide_userconfig=True.
+        """
         lines = []
+
         for scoped in self._vmap.values():
+            if scoped.hide_userconfig and not include_hidden:
+                continue
+
             str_value = self.opt.typ.to_str(scoped.value)
             if scoped.pattern is None:
                 lines.append('{} = {}'.format(self.opt.name, str_value))
             else:
                 lines.append('{}: {} = {}'.format(
                     scoped.pattern, self.opt.name, str_value))
-        return '\n'.join(lines)
+
+        return lines
 
     def __iter__(self) -> typing.Iterator['ScopedValue']:
         """Yield ScopedValue elements.
@@ -144,11 +161,16 @@ class Values:
             raise configexc.NoPatternError(self.opt.name)
 
     def add(self, value: typing.Any,
-            pattern: urlmatch.UrlPattern = None) -> None:
-        """Add a value with the given pattern to the list of values."""
+            pattern: urlmatch.UrlPattern = None, *,
+            hide_userconfig: bool = False) -> None:
+        """Add a value with the given pattern to the list of values.
+
+        If hide_userconfig is given, the value is hidden from
+        config.dump_userconfig() and thus qute://configdiff.
+        """
         self._check_pattern_support(pattern)
         self.remove(pattern)
-        scoped = ScopedValue(value, pattern)
+        scoped = ScopedValue(value, pattern, hide_userconfig=hide_userconfig)
         self._vmap[pattern] = scoped
 
         host = pattern.host if pattern else None

--- a/qutebrowser/config/websettings.py
+++ b/qutebrowser/config/websettings.py
@@ -269,7 +269,8 @@ def init(args: argparse.Namespace) -> None:
     # Make sure special URLs always get JS support
     for pattern in ['file://*', 'chrome://*/*', 'qute://*/*']:
         config.instance.set_obj('content.javascript.enabled', True,
-                                pattern=urlmatch.UrlPattern(pattern))
+                                pattern=urlmatch.UrlPattern(pattern),
+                                hide_userconfig=True)
 
 
 @pyqtSlot()

--- a/qutebrowser/config/websettings.py
+++ b/qutebrowser/config/websettings.py
@@ -267,7 +267,7 @@ def init(args: argparse.Namespace) -> None:
         webkitsettings.init(args)
 
     # Make sure special URLs always get JS support
-    for pattern in ['file://*', 'chrome://*/*', 'qute://*/*']:
+    for pattern in ['chrome://*/*', 'qute://*/*']:
         config.instance.set_obj('content.javascript.enabled', True,
                                 pattern=urlmatch.UrlPattern(pattern),
                                 hide_userconfig=True)

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -25,7 +25,7 @@ import typing
 
 import attr
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QTimer
-from PyQt5.QtCore import QUrl  # pylint: disable=unused-import
+from PyQt5.QtCore import QUrl
 
 from qutebrowser.utils import log, qtutils, utils
 

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -45,11 +45,6 @@ try:
 except ImportError:  # pragma: no cover
     qWebKitVersion = None  # type: ignore  # noqa: N816
 
-try:
-    from PyQt5.QtWebEngineWidgets import QWebEngineProfile
-except ImportError:  # pragma: no cover
-    QWebEngineProfile = None  # type: ignore
-
 import qutebrowser
 from qutebrowser.utils import log, utils, standarddir, usertypes, message
 from qutebrowser.misc import objects, earlyinit, sql, httpclient, pastebin
@@ -369,18 +364,11 @@ def _chromium_version() -> str:
     Also see https://www.chromium.org/developers/calendar
     and https://chromereleases.googleblog.com/
     """
-    if webenginesettings is None or QWebEngineProfile is None:  # type: ignore
-        # This should never happen
-        return 'unavailable'  # type: ignore
-    ua = webenginesettings.default_user_agent
-    if ua is None:
-        profile = QWebEngineProfile.defaultProfile()
-        ua = profile.httpUserAgent()
-    match = re.search(r' Chrome/([^ ]*) ', ua)
-    if not match:
-        log.misc.error("Could not get Chromium version from: {}".format(ua))
-        return 'unknown'
-    return match.group(1)
+    if webenginesettings.parsed_user_agent is None:
+        webenginesettings.init_user_agent()
+        assert webenginesettings.parsed_user_agent is not None
+
+    return webenginesettings.parsed_user_agent.upstream_browser_version
 
 
 def _backend() -> str:

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -362,13 +362,6 @@ Feature: Various utility commands.
         Then the header User-Agent should be set to toaster
         And the javascript message "toaster" should be logged
 
-    Scenario: Setting the default user-agent header
-        When I set content.headers.user_agent to <empty>
-        And I open headers
-        And I run :jseval console.log(window.navigator.userAgent)
-        Then the header User-Agent should be set to Mozilla/5.0 *
-        And the javascript message "Mozilla/5.0 *" should be logged
-
     ## https://github.com/qutebrowser/qutebrowser/issues/1523
 
     Scenario: Completing a single option argument

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -204,12 +204,13 @@ def web_tab_setup(qtbot, tab_registry, session_manager_stub,
 
 @pytest.fixture
 def webkit_tab(web_tab_setup, qtbot, cookiejar_and_cache, mode_manager,
-               widget_container):
+               widget_container, webpage):
     webkittab = pytest.importorskip('qutebrowser.browser.webkit.webkittab')
 
     tab = webkittab.WebKitTab(win_id=0, mode_manager=mode_manager,
                               private=False)
     widget_container.set_widget(tab)
+
     return tab
 
 
@@ -416,6 +417,7 @@ def webengineview(qtbot, monkeypatch, web_tab_setup):
 def webpage(qnam):
     """Get a new QWebPage object."""
     QtWebKitWidgets = pytest.importorskip('PyQt5.QtWebKitWidgets')
+
     class WebPageStub(QtWebKitWidgets.QWebPage):
 
         """QWebPage with default error pages disabled."""
@@ -425,8 +427,13 @@ def webpage(qnam):
             return False
 
     page = WebPageStub()
+
     page.networkAccessManager().deleteLater()
     page.setNetworkAccessManager(qnam)
+
+    from qutebrowser.browser.webkit import webkitsettings
+    webkitsettings._init_user_agent()
+
     return page
 
 

--- a/tests/unit/browser/webengine/test_webenginesettings.py
+++ b/tests/unit/browser/webengine/test_webenginesettings.py
@@ -33,6 +33,7 @@ from qutebrowser.misc import objects
 def init(qapp, config_stub, cache_tmpdir, data_tmpdir, monkeypatch):
     monkeypatch.setattr(webenginesettings.webenginequtescheme, 'init',
                         lambda: None)
+    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
     init_args = types.SimpleNamespace(enable_webengine_inspector=False)
     webenginesettings.init(init_args)
     config_stub.changed.disconnect(webenginesettings._update_settings)
@@ -49,7 +50,6 @@ def test_big_cache_size(config_stub):
 @pytest.mark.skipif(
     not qtutils.version_check('5.8'), reason="Needs Qt 5.8 or newer")
 def test_non_existing_dict(config_stub, monkeypatch, message_mock, caplog):
-    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
     monkeypatch.setattr(webenginesettings.spell, 'local_filename',
                         lambda _code: None)
     config_stub.val.spellcheck.languages = ['af-ZA']
@@ -66,7 +66,6 @@ def test_non_existing_dict(config_stub, monkeypatch, message_mock, caplog):
 @pytest.mark.skipif(
     not qtutils.version_check('5.8'), reason="Needs Qt 5.8 or newer")
 def test_existing_dict(config_stub, monkeypatch):
-    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
     monkeypatch.setattr(webenginesettings.spell, 'local_filename',
                         lambda _code: 'en-US-8-0')
     config_stub.val.spellcheck.languages = ['en-US']
@@ -80,7 +79,6 @@ def test_existing_dict(config_stub, monkeypatch):
 @pytest.mark.skipif(
     not qtutils.version_check('5.8'), reason="Needs Qt 5.8 or newer")
 def test_spell_check_disabled(config_stub, monkeypatch):
-    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
     config_stub.val.spellcheck.languages = []
     webenginesettings._update_settings('spellcheck.languages')
     for profile in [webenginesettings.default_profile,
@@ -89,4 +87,11 @@ def test_spell_check_disabled(config_stub, monkeypatch):
 
 
 def test_default_user_agent_saved():
-    assert webenginesettings.default_user_agent is not None
+    assert webenginesettings.parsed_user_agent is not None
+
+
+def test_parsed_user_agent(qapp):
+    webenginesettings.init_user_agent()
+    parsed = webenginesettings.parsed_user_agent
+    assert parsed.upstream_browser_key == 'Chrome'
+    assert parsed.qt_key == 'QtWebEngine'

--- a/tests/unit/browser/webkit/test_webkitsettings.py
+++ b/tests/unit/browser/webkit/test_webkitsettings.py
@@ -1,0 +1,31 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2019 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+pytest.importorskip('PyQt5.QtWebKitWidgets')
+
+from qutebrowser.browser.webkit import webkitsettings
+
+
+def test_parsed_user_agent(qapp):
+    webkitsettings._init_user_agent()
+
+    parsed = webkitsettings.parsed_user_agent
+    assert parsed.upstream_browser_key == 'Version'
+    assert parsed.qt_key == 'Qt'

--- a/tests/unit/config/test_configfiles.py
+++ b/tests/unit/config/test_configfiles.py
@@ -354,6 +354,17 @@ class TestYaml:
     def test_title_format_migrations(self, migration_test, setting, old, new):
         migration_test(setting, old, new)
 
+    @pytest.mark.parametrize('old, new', [
+        (None, ('Mozilla/5.0 ({os_info}) '
+                'AppleWebKit/{webkit_version} (KHTML, like Gecko) '
+                '{qt_key}/{qt_version} '
+                '{upstream_browser_key}/{upstream_browser_version} '
+                'Safari/{webkit_version}')),
+        ('toaster', 'toaster'),
+    ])
+    def test_user_agent_migration(self, migration_test, old, new):
+        migration_test('content.headers.user_agent', old, new)
+
     def test_renamed_key_unknown_target(self, monkeypatch, yaml,
                                         autoconfig):
         """A key marked as renamed with invalid name should raise an error."""

--- a/tests/unit/config/test_configutils.py
+++ b/tests/unit/config/test_configutils.py
@@ -82,6 +82,10 @@ def test_str(values):
     assert str(values) == '\n'.join(expected)
 
 
+def test_str_empty(empty_values):
+    assert str(empty_values) == 'example.option: <unchanged>'
+
+
 def test_str_mixed(mixed_values):
     expected = [
         'example.option = global value',

--- a/tests/unit/config/test_websettings.py
+++ b/tests/unit/config/test_websettings.py
@@ -90,3 +90,15 @@ def test_user_agent(monkeypatch, config_stub, qapp):
 
     config_stub.val.content.headers.user_agent = 'test2 {qt_key}'
     assert websettings.user_agent() == 'test2 QtWebEngine'
+
+
+def test_config_init(request, monkeypatch, config_stub):
+    if request.config.webengine:
+        from qutebrowser.browser.webengine import webenginesettings
+        monkeypatch.setattr(webenginesettings, 'init', lambda _args: None)
+    else:
+        from qutebrowser.browser.webkit import webkitsettings
+        monkeypatch.setattr(webkitsettings, 'init', lambda _args: None)
+
+    websettings.init(args=None)
+    assert config_stub.dump_userconfig() == '<Default configuration>'

--- a/tests/unit/config/test_websettings.py
+++ b/tests/unit/config/test_websettings.py
@@ -1,0 +1,92 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2019 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+import pytest
+
+from qutebrowser.config import websettings
+from qutebrowser.misc import objects
+from qutebrowser.utils import usertypes
+
+
+@pytest.mark.parametrize([
+    'user_agent', 'os_info', 'webkit_version',
+    'upstream_browser_key', 'upstream_browser_version', 'qt_key'
+], [
+    (
+        # QtWebEngine, Linux
+        # (no differences other than Chrome version with older Qt Versions)
+        ("Mozilla/5.0 (X11; Linux x86_64) "
+         "AppleWebKit/537.36 (KHTML, like Gecko) "
+         "QtWebEngine/5.14.0 Chrome/77.0.3865.98 Safari/537.36"),
+        "X11; Linux x86_64",
+        "537.36",
+        "Chrome", "77.0.3865.98",
+        "QtWebEngine",
+    ), (
+        # QtWebKit, Linux
+        ("Mozilla/5.0 (X11; Linux x86_64) "
+         "AppleWebKit/602.1 (KHTML, like Gecko) "
+         "qutebrowser/1.8.3 "
+         "Version/10.0 Safari/602.1"),
+        "X11; Linux x86_64",
+        "602.1",
+        "Version", "10.0",
+        "Qt",
+    ), (
+        # QtWebEngine, macOS
+        ("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) "
+         "AppleWebKit/537.36 (KHTML, like Gecko) "
+         "QtWebEngine/5.13.2 Chrome/73.0.3683.105 Safari/537.36"),
+        "Macintosh; Intel Mac OS X 10_12_6",
+        "537.36",
+        "Chrome", "73.0.3683.105",
+        "QtWebEngine",
+    ), (
+        # QtWebEngine, Windows
+        ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+         "AppleWebKit/537.36 (KHTML, like Gecko) "
+         "QtWebEngine/5.12.5 Chrome/69.0.3497.128 Safari/537.36"),
+        "Windows NT 10.0; Win64; x64",
+        "537.36",
+        "Chrome", "69.0.3497.128",
+        "QtWebEngine",
+    )
+])
+def test_parse_user_agent(user_agent, os_info, webkit_version,
+                          upstream_browser_key, upstream_browser_version,
+                          qt_key):
+    parsed = websettings.UserAgent.parse(user_agent)
+    assert parsed.os_info == os_info
+    assert parsed.webkit_version == webkit_version
+    assert parsed.upstream_browser_key == upstream_browser_key
+    assert parsed.upstream_browser_version == upstream_browser_version
+    assert parsed.qt_key == qt_key
+
+
+def test_user_agent(monkeypatch, config_stub, qapp):
+    webenginesettings = pytest.importorskip(
+        "qutebrowser.browser.webengine.webenginesettings")
+    monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
+    webenginesettings.init_user_agent()
+
+    config_stub.val.content.headers.user_agent = 'test {qt_key}'
+    assert websettings.user_agent() == 'test QtWebEngine'
+
+    config_stub.val.content.headers.user_agent = 'test2 {qt_key}'
+    assert websettings.user_agent() == 'test2 QtWebEngine'

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -851,36 +851,32 @@ class FakeQSslSocket:
         return self._version
 
 
-@pytest.mark.parametrize('ua, expected', [
-    (None, 'unavailable'),  # No QWebEngineProfile
-    ('Mozilla/5.0', 'unknown'),
-    ('Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
-     'QtWebEngine/5.8.0 Chrome/53.0.2785.148 Safari/537.36', '53.0.2785.148'),
-])
-def test_chromium_version(monkeypatch, caplog, ua, expected):
+_QTWE_USER_AGENT = ("Mozilla/5.0 (X11; Linux x86_64) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "QtWebEngine/5.14.0 Chrome/{} Safari/537.36")
+
+
+def test_chromium_version(monkeypatch, caplog):
     pytest.importorskip('PyQt5.QtWebEngineWidgets')
-    if ua is None:
-        monkeypatch.setattr(version, 'webenginesettings', None)
-    else:
-        monkeypatch.setattr(version.webenginesettings,
-                            'default_user_agent', ua)
+
+    ver = '77.0.3865.98'
+    version.webenginesettings._init_user_agent_str(
+        _QTWE_USER_AGENT.format(ver))
 
     with caplog.at_level(logging.ERROR):
-        assert version._chromium_version() == expected
+        assert version._chromium_version() == ver
 
 
 def test_chromium_version_prefers_saved_user_agent(monkeypatch):
     pytest.importorskip('PyQt5.QtWebEngineWidgets')
-    monkeypatch.setattr(
-        version.webenginesettings, 'default_user_agent',
-        'QtWebEngine/5.8.0 Chrome/53.0.2785.148 Safari/537.36'
-    )
+    version.webenginesettings._init_user_agent_str(_QTWE_USER_AGENT)
 
     class FakeProfile:
         def defaultProfile(self):
             raise AssertionError("Should not be called")
 
-    monkeypatch.setattr(version, 'QWebEngineProfile', FakeProfile())
+    monkeypatch.setattr(version.webenginesettings, 'QWebEngineProfile',
+                        FakeProfile())
 
     version._chromium_version()
 
@@ -918,12 +914,9 @@ class VersionParams:
 ], ids=lambda param: param.name)
 def test_version_output(params, stubs, monkeypatch, config_stub):
     """Test version.version()."""
-    class FakeWebEngineSettings:
-        default_user_agent = ('Toaster/4.0.4 Chrome/CHROMIUMVERSION '
-                              'Teapot/4.1.8')
-
     config.instance.config_py_loaded = params.config_py_loaded
     import_path = os.path.abspath('/IMPORTPATH')
+
     patches = {
         'qutebrowser.__file__': os.path.join(import_path, '__init__.py'),
         'qutebrowser.__version__': 'VERSION',
@@ -960,6 +953,12 @@ def test_version_output(params, stubs, monkeypatch, config_stub):
         'autoconfig_loaded': "yes" if params.autoconfig_loaded else "no",
     }
 
+    ua = _QTWE_USER_AGENT.format('CHROMIUMVERSION')
+    if version.webenginesettings is None:
+        patches['_chromium_version'] = lambda: 'CHROMIUMVERSION'
+    else:
+        version.webenginesettings._init_user_agent_str(ua)
+
     if params.config_py_loaded:
         substitutions["config_py_loaded"] = "{} has been loaded".format(
             standarddir.config_py())
@@ -975,8 +974,6 @@ def test_version_output(params, stubs, monkeypatch, config_stub):
         monkeypatch.delattr(version, 'qtutils.qWebKitVersion', raising=False)
         patches['objects.backend'] = usertypes.Backend.QtWebEngine
         substitutions['backend'] = 'QtWebEngine (Chromium CHROMIUMVERSION)'
-        patches['webenginesettings'] = FakeWebEngineSettings
-        patches['QWebEngineProfile'] = True
 
     if params.known_distribution:
         patches['distribution'] = lambda: version.DistributionInfo(


### PR DESCRIPTION
This PR refactors user-agent handling so we don't directly use the default UA from QtWebKit/QtWebEngine anymore (#513). To do so, the `user_agent` setting now is a template string, getting filled from information we parse from the default UA.

With that change, we can also fix issues like #2800 properly, as we now can get a proper UA without having a QWebEngineProfile/QWebPage handy.

I also added some code so specific `ScopedValue` settings can be hidden from `qute://configdiff`, which fixes #4076. Finally, this allows us to introduce "site specific quirks", i.e. custom user agents for badly behaving websites such as Google, WhatsApp or Slack (#4810 and others).

Since this turned out to be a quite big change, I'd love some feedback. Looking at the commits, for most commits one of you made some changes in those areas, so I'd appreciate if you'd at least review those if time allows - thanks!

- 4151680e9 Refactor user agent handling (@toofar because of #4653)
- de466b3c7 Fix doc formatting
- 069b5cb62 Use correct user agent for downloads
- 5985b474c Make it possible to hide ScopedValues from dump_userconfig() (@jgkamat because of #4707, #4544)
- 337d1186a Use existing ScopedValues for `Values.__init__` (@jgkamat, ditto)
- c4b674730 Don't enable JavaScript for file:// by default
- b20eba35e Add site specific quirks
