### PR TITLE
Use (slightly) clearer wording

### DIFF
--- a/qutebrowser/commands/cmdexc.py
+++ b/qutebrowser/commands/cmdexc.py
@@ -30,12 +30,12 @@ class Error(Exception):
 
 class NoSuchCommandError(Error):
 
-    """Raised when a command wasn't found."""
+    """Raised when a command isn't found."""
 
 
 class ArgumentTypeError(Error):
 
-    """Raised when an argument had an invalid type."""
+    """Raised when an argument is an invalid type."""
 
 
 class PrerequisitesError(Error):
@@ -43,5 +43,5 @@ class PrerequisitesError(Error):
     """Raised when a cmd can't be used because some prerequisites aren't met.
 
     This is raised for example when we're in the wrong mode while executing the
-    command, or we need javascript enabled but don't have done so.
+    command, or we need javascript enabled but haven't done so.
     """


### PR DESCRIPTION
While perusing the file `qutebrowser/commands/cmdexc.py`, I noticed a minor grammar mistake in one of the docstrings. Then also reworded 2 others to make their verb tenses more consistent (sorry if this seems a bit nitpicky).