### PR TITLE
add documentation for client cert usage

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -262,6 +262,58 @@ How do I change the `WM_CLASS` used by qutebrowser windows?::
     qutebrowser instance (unless you use `--temp-basedir` or `--basedir`), so
     they all will share the same `WM_CLASS`.
 
+How do I use X.509 Client Certificates?::
+Right now there is no certificate-chooser prompt implemented when there are
+multiple matches. Subscribe to https://github.com/qutebrowser/qutebrowser/issues/4587[Issue#4587]
+for progress notifications.
++
+Currently QtWebEngine will attempt to use certificates stored in
+`${HOME}/.pki/nssdb` by default. Assuming you have a CA Certificate and a
+Client Certificate that you want for authenticating yourself on a web
+service that validates against this CA Certificate, you need to perform
+the following steps.
++
+1. Import the CA Certificate
++
+----
+certutil -D "sql:${HOME}/.pki/nssdb" -A -i <path_to_ca_cert.pem> -n "My Fancy CA" -t "TC,C,T"
+----
++
+2. Merge your `<cert.crt>` and `<privkey.pem>` files into a single `PKCS#12`
+certificate file (optional, skip if your Client Certificate already is in
+`PKCS#12` format)
++
+----
+openssl pkcs12 -export -in <path_to_client_cert.crt> -inkey <path_to_client_cert_privkey.pem> -out my_fancy_client_cert.pkcs12
+----
++
+3. Import your Client Certificate into the certificate store
++
+----
+pk12util -d "sql:${HOME}/.pki/nssdb" -i <path_to_my_fancy_client_cert.pkcs12> -n "My Fancy Client Certificate"
+----
++
+Upon visiting a website that requests a Client Certificate you should now
+be prompted by qutebrowser whether you want to submit the newly imported
+Client Certificate or not.
++
+If you ever need to renew any of these certificates, you can take a look
+at the currently imported certificates using:
++
+----
+certutil -D "sql:${HOME}/.pki/nssdb" -L
+----
++
+Then remove the expired certificates using:
++
+----
+certutil -D "sql:${HOME}/.pki/nssdb" -D -n "My Fancy Certificate Nickname"
+----
++
+And then import the new and valid certificates using the procedure
+described above.
+
+
 == Troubleshooting
 
 Unable to view Flash content.::


### PR DESCRIPTION
I've recently found myself in the situation where I needed to update a CA cert and a client cert because they had expired.
After reading some manpages and fiddling around I managed to do it.
Since I was unable to find any documentation / examples regarding the use of client certificates I went ahead and added a section to the FAQ.