### PR TITLE
Make :undo reopen the [count]th to last closed tab

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -784,10 +784,15 @@ class CommandDispatcher:
                 text="Are you sure you want to close pinned tabs?")
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def undo(self):
-        """Re-open the last closed tab or tabs."""
+    @cmdutils.argument('count', value=cmdutils.Value.count)
+    def undo(self, count=1):
+        """Re-open the ([count]th to) last closed tab or tabs.
+
+        Args:
+            count: How deep in the undo stack to find the tab or tabs to re-open.
+        """
         try:
-            self._tabbed_browser.undo()
+            self._tabbed_browser.undo(count)
         except IndexError:
             raise cmdutils.CommandError("Nothing to undo!")
 

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -481,7 +481,7 @@ class TabbedBrowser(QWidget):
             tab.layout().unwrap()
             tab.deleteLater()
 
-    def undo(self):
+    def undo(self, count=1):
         """Undo removing of a tab or tabs."""
         # Remove unused tab which may be created after the last tab is closed
         last_close = config.val.tabs.last_close
@@ -501,7 +501,9 @@ class TabbedBrowser(QWidget):
             use_current_tab = (only_one_tab_open and no_history and
                                last_close_url_used)
 
-        for entry in reversed(self._undo_stack.pop()):
+        entries = self._undo_stack[-count]
+        del self._undo_stack[-count]
+        for entry in reversed(entries):
             if use_current_tab:
                 newtab = self.widget.widget(0)
                 use_current_tab = False

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -896,6 +896,24 @@ Feature: Tab management
             - data/numbers/2.txt
             - data/numbers/3.txt
 
+    Scenario: Undo the second to last closed tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-close
+        And I run :tab-close
+        And I run :undo with count 2
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+            - data/numbers/3.txt
+
+    Scenario: Undo with a too-high count
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-close
+        And I run :undo with count 2
+        Then the error "Nothing to undo!" should be shown
+
     # tabs.last_close
 
     # FIXME:qtwebengine


### PR DESCRIPTION
Probably the main situation in which this is useful is when you close a couple of tabs in quick succession and want to reopen one other than the most recent. Currently you have to either manually find the url in your history and reopen it, or :undo repeatedly until you get the one you want and then reclose the others.

The competing possible implementation of a count for :undo is reopening everything from the end of the stack down to and including [count] instead of skipping through and just reopening [count], but I find the latter more useful. If someone really wants that behavior it would be pretty easy to add with a config option in the future.