### PR TITLE
Add border radius and padding configuration options for hints

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -215,6 +215,7 @@
 |<<hints.auto_follow,hints.auto_follow>>|When a hint can be automatically followed without pressing Enter.
 |<<hints.auto_follow_timeout,hints.auto_follow_timeout>>|Duration (in milliseconds) to ignore normal-mode key bindings after a successful auto-follow.
 |<<hints.border,hints.border>>|CSS border value for hints.
+|<<hints.padding,hints.padding>>|CSS padding value for hints.
 |<<hints.radius,hints.radius>>|Rounding radius (in pixels) for the edges of hints.
 |<<hints.chars,hints.chars>>|Characters used for hint strings.
 |<<hints.dictionary,hints.dictionary>>|Dictionary file to be used by the word hints.
@@ -2680,6 +2681,14 @@ CSS border value for hints.
 Type: <<types,String>>
 
 Default: +pass:[1px solid #E3BE23]+
+
+[[hints.padding]]
+=== hints.padding
+CSS padding value for hints.
+
+Type: <<types,String>>
+
+Default: +pass:[0 3px]+
 
 [[hints.radius]]
 === hints.radius

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -215,7 +215,7 @@
 |<<hints.auto_follow,hints.auto_follow>>|When a hint can be automatically followed without pressing Enter.
 |<<hints.auto_follow_timeout,hints.auto_follow_timeout>>|Duration (in milliseconds) to ignore normal-mode key bindings after a successful auto-follow.
 |<<hints.border,hints.border>>|CSS border value for hints.
-|<<hints.padding,hints.padding>>|CSS padding value for hints.
+|<<hints.padding,hints.padding>>|Padding (in pixels) for hints.
 |<<hints.radius,hints.radius>>|Rounding radius (in pixels) for the edges of hints.
 |<<hints.chars,hints.chars>>|Characters used for hint strings.
 |<<hints.dictionary,hints.dictionary>>|Dictionary file to be used by the word hints.
@@ -2684,11 +2684,16 @@ Default: +pass:[1px solid #E3BE23]+
 
 [[hints.padding]]
 === hints.padding
-CSS padding value for hints.
+Padding (in pixels) for hints.
 
-Type: <<types,String>>
+Type: <<types,Padding>>
 
-Default: +pass:[0 3px]+
+Default:
+
+- +pass:[bottom]+: +pass:[0]+
+- +pass:[left]+: +pass:[3]+
+- +pass:[right]+: +pass:[3]+
+- +pass:[top]+: +pass:[0]+
 
 [[hints.radius]]
 === hints.radius

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -215,7 +215,7 @@
 |<<hints.auto_follow,hints.auto_follow>>|When a hint can be automatically followed without pressing Enter.
 |<<hints.auto_follow_timeout,hints.auto_follow_timeout>>|Duration (in milliseconds) to ignore normal-mode key bindings after a successful auto-follow.
 |<<hints.border,hints.border>>|CSS border value for hints.
-|<<hints.radius,hints.radius>>|CSS border radius value for hints.
+|<<hints.radius,hints.radius>>|Rounding radius (in pixels) for the edges of hints.
 |<<hints.chars,hints.chars>>|Characters used for hint strings.
 |<<hints.dictionary,hints.dictionary>>|Dictionary file to be used by the word hints.
 |<<hints.find_implementation,hints.find_implementation>>|Which implementation to use to find elements to hint.
@@ -2683,11 +2683,11 @@ Default: +pass:[1px solid #E3BE23]+
 
 [[hints.radius]]
 === hints.radius
-CSS border radius value for hints.
+Rounding radius (in pixels) for the edges of hints.
 
-Type: <<types,String>>
+Type: <<types,Int>>
 
-Default: +pass:[0px]+
+Default: +pass:[0]+
 
 [[hints.chars]]
 === hints.chars

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -215,6 +215,7 @@
 |<<hints.auto_follow,hints.auto_follow>>|When a hint can be automatically followed without pressing Enter.
 |<<hints.auto_follow_timeout,hints.auto_follow_timeout>>|Duration (in milliseconds) to ignore normal-mode key bindings after a successful auto-follow.
 |<<hints.border,hints.border>>|CSS border value for hints.
+|<<hints.radius,hints.radius>>|CSS border radius value for hints.
 |<<hints.chars,hints.chars>>|Characters used for hint strings.
 |<<hints.dictionary,hints.dictionary>>|Dictionary file to be used by the word hints.
 |<<hints.find_implementation,hints.find_implementation>>|Which implementation to use to find elements to hint.
@@ -2679,6 +2680,14 @@ CSS border value for hints.
 Type: <<types,String>>
 
 Default: +pass:[1px solid #E3BE23]+
+
+[[hints.radius]]
+=== hints.radius
+CSS border radius value for hints.
+
+Type: <<types,String>>
+
+Default: +pass:[0px]+
 
 [[hints.chars]]
 === hints.chars

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1102,7 +1102,9 @@ hints.padding:
 
 hints.radius:
   default: 0
-  type: Int
+  type:
+    name: Int
+    minval: 0
   desc: Rounding radius (in pixels) for the edges of hints.
 
 hints.chars:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1092,9 +1092,13 @@ hints.border:
   desc: CSS border value for hints.
 
 hints.padding:
-  default: '0 3px'
-  type: String
-  desc: CSS padding value for hints.
+  default:
+    top: 0
+    bottom: 0
+    left: 3
+    right: 3
+  type: Padding
+  desc: Padding (in pixels) for hints.
 
 hints.radius:
   default: 0

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1091,6 +1091,11 @@ hints.border:
   type: String
   desc: CSS border value for hints.
 
+hints.radius:
+  default: '0px'
+  type: String
+  desc: CSS border radius value for hints.
+
 hints.chars:
   default: asdfghjkl
   type:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1092,9 +1092,9 @@ hints.border:
   desc: CSS border value for hints.
 
 hints.radius:
-  default: '0px'
-  type: String
-  desc: CSS border radius value for hints.
+  default: 0
+  type: Int
+  desc: Rounding radius (in pixels) for the edges of hints.
 
 hints.chars:
   default: asdfghjkl

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1091,6 +1091,11 @@ hints.border:
   type: String
   desc: CSS border value for hints.
 
+hints.padding:
+  default: '0 3px'
+  type: String
+  desc: CSS padding value for hints.
+
 hints.radius:
   default: 0
   type: Int

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -150,7 +150,6 @@ class MainWindow(QWidget):
         _private: Whether the window is in private browsing mode.
     """
 
-
     # Application wide stylesheets
     STYLESHEET = """
         HintLabel {

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -157,6 +157,7 @@ class MainWindow(QWidget):
             color: {{ conf.colors.hints.fg }};
             font: {{ conf.fonts.hints }};
             border: {{ conf.hints.border }};
+            border-radius: {{ conf.hints.radius }};
             padding-left: 3px;
             padding-right: 3px;
         }

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -157,7 +157,7 @@ class MainWindow(QWidget):
             color: {{ conf.colors.hints.fg }};
             font: {{ conf.fonts.hints }};
             border: {{ conf.hints.border }};
-            border-radius: {{ conf.hints.radius }};
+            border-radius: {{ conf.hints.radius }}px;
             padding-left: 3px;
             padding-right: 3px;
         }

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -158,8 +158,7 @@ class MainWindow(QWidget):
             font: {{ conf.fonts.hints }};
             border: {{ conf.hints.border }};
             border-radius: {{ conf.hints.radius }}px;
-            padding-left: 3px;
-            padding-right: 3px;
+            padding: {{ conf.hints.padding }};
         }
 
         QMenu {

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -150,6 +150,7 @@ class MainWindow(QWidget):
         _private: Whether the window is in private browsing mode.
     """
 
+
     # Application wide stylesheets
     STYLESHEET = """
         HintLabel {
@@ -158,7 +159,10 @@ class MainWindow(QWidget):
             font: {{ conf.fonts.hints }};
             border: {{ conf.hints.border }};
             border-radius: {{ conf.hints.radius }}px;
-            padding: {{ conf.hints.padding }};
+            padding-top: {{ conf.hints.padding['top'] }}px;
+            padding-left: {{ conf.hints.padding['left'] }}px;
+            padding-right: {{ conf.hints.padding['right'] }}px;
+            padding-bottom: {{ conf.hints.padding['bottom'] }}px;
         }
 
         QMenu {


### PR DESCRIPTION
This pull request adds the ability to round the corners of hints with the configuration option `hints.radius`. The default value is set to `0px`.

I was not sure if I should make the corner radius an integer or a string that represents the CSS value. I went with the second, but let me know if you like it otherwise and I will fix the PR.

Known issues:
- Rounding stops working (it is no longer applied) with values higher than 14px (with border width 0). Looks like this is due to the small size of the hint widgets, since when I increase the border width, I can also increase the border radius.
- It does not work with CSS values such as `50%`. This could be related to the issue above or it could be a Qt limitation since Qt only implements a subset of CSS. A value of `50%` is supposed to turn the hint into a circle / ellipse.

By the way, thank you so much for working on this amazing browser <3
