### PR TITLE
Enable TOTP support in Bitwarden userscript

### DIFF
--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -79,6 +79,8 @@ group.add_argument('--username-only', '-e',
                    action='store_true', help='Only insert username')
 group.add_argument('--password-only', '-w',
                    action='store_true', help='Only insert password')
+group.add_argument('--totp-only', '-T',
+                   action='store_true', help='Only insert totp code')
 
 stderr = functools.partial(print, file=sys.stderr)
 
@@ -253,11 +255,22 @@ def main(arguments):
 
     username = selection['login']['username']
     password = selection['login']['password']
+    totp = selection['login']['totp']
 
     if arguments.username_only:
         fake_key_raw(username)
     elif arguments.password_only:
         fake_key_raw(password)
+    elif arguments.totp_only:
+        # No point in moving it to the clipboard in this case
+        fake_key_raw(
+            get_totp_code(
+                selection['id'],
+                selection['name'],
+                arguments.io_encoding,
+                arguments.auto_lock
+            )
+        )
     else:
         # Enter username and password using fake-key and <Tab> (which seems to work almost universally), then switch
         # back into insert-mode, so the form can be directly submitted by
@@ -271,7 +284,7 @@ def main(arguments):
 
     # If it finds a TOTP code, it copies it to the clipboard,
     # which is the same behaviour as the Firefox add-on.
-    if (selection['login']['totp'] is not None) and arguments.totp:
+    if not arguments.totp_only and totp and arguments.totp:
         # The import is done here, to make pyperclip an optional dependency
         import pyperclip
         pyperclip.copy(

--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -164,7 +164,7 @@ def pass_(domain, encoding, auto_lock):
     return out
 
 
-def get_totp_code(selection_id, domani_name, encoding, auto_lock):
+def get_totp_code(selection_id, domain_name, encoding, auto_lock):
     session_key = get_session_key(auto_lock)
     process = subprocess.run(
         ['bw', 'get', 'totp', '--session', session_key, selection_id],

--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -266,6 +266,9 @@ def main(arguments):
         qute_command('fake-key <Tab>')
         fake_key_raw(password)
 
+    if arguments.insert_mode:
+        qute_command('enter-mode insert')
+
     # If it finds a TOTP code, it copies it to the clipboard,
     # which is the same behaviour as the Firefox add-on.
     if (selection['login']['totp'] is not None) and arguments.totp:
@@ -279,9 +282,6 @@ def main(arguments):
                 arguments.auto_lock
             )
         )
-
-    if arguments.insert_mode:
-        qute_command('enter-mode insert')
 
     return ExitCodes.SUCCESS
 

--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -27,6 +27,9 @@ USAGE = """The domain of the site has to be in the name of the Bitwarden entry, 
 "websites/github.com".  The login information is inserted by emulating key events using qutebrowser's fake-key command in this manner:
 [USERNAME]<Tab>[PASSWORD], which is compatible with almost all login forms.
 
+If enabled, with the `--totp` flag, it will also move the TOTP code to the
+clipboard, much like the Firefox add-on.
+
 You must log into Bitwarden CLI using `bw login` prior to use of this script.
 The session key will be stored using keyctl for the number of seconds passed to
 the --auto-lock option.
@@ -34,8 +37,9 @@ the --auto-lock option.
 To use in qutebrowser, run: `spawn --userscript qute-bitwarden`
 """
 
-EPILOG = """Dependencies: tldextract (Python 3 module), Bitwarden CLI (1.7.4 is
-known to work but older versions may well also work)
+EPILOG = """Dependencies: tldextract (Python 3 module), pyperclip (optional
+Python module, used for TOTP codes), Bitwarden CLI (1.7.4 is known to work
+but older versions may well also work)
 
 WARNING: The login details are viewable as plaintext in qutebrowser's debug log
 (qute://log) and might be shared if you decide to submit a crash report!"""
@@ -62,6 +66,8 @@ argument_parser.add_argument('--dmenu-invocation', '-d', default='rofi -dmenu -i
                              help='Invocation used to execute a dmenu-provider')
 argument_parser.add_argument('--no-insert-mode', '-n', dest='insert_mode', action='store_false',
                              help="Don't automatically enter insert mode")
+argument_parser.add_argument('--totp', '-t', action='store_true',
+                             help="Copy TOTP key to clipboard")
 argument_parser.add_argument('--io-encoding', '-i', default='UTF-8',
                              help='Encoding used to communicate with subprocesses')
 argument_parser.add_argument('--merge-candidates', '-m', action='store_true',
@@ -158,6 +164,26 @@ def pass_(domain, encoding, auto_lock):
     return out
 
 
+def get_totp_code(selection_id, domani_name, encoding, auto_lock):
+    session_key = get_session_key(auto_lock)
+    process = subprocess.run(
+        ['bw', 'get', 'totp', '--session', session_key, selection_id],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+    err = process.stderr.decode(encoding).strip()
+    if err:
+        # domain_name instead of selection_id to make it more user-friendly
+        msg = 'Bitwarden CLI returned for {:s} - {:s}'.format(domain_name, err)
+        stderr(msg)
+        return '[]'
+
+    out = process.stdout.decode(encoding).strip()
+
+    return out
+
+
 def dmenu(items, invocation, encoding):
     command = shlex.split(invocation)
     process = subprocess.run(command, input='\n'.join(
@@ -239,6 +265,20 @@ def main(arguments):
         fake_key_raw(username)
         qute_command('fake-key <Tab>')
         fake_key_raw(password)
+
+    # If it finds a TOTP code, it copies it to the clipboard,
+    # which is the same behaviour as the Firefox add-on.
+    if (selection['login']['totp'] is not None) and arguments.totp:
+        # The import is done here, to make pyperclip an optional dependency
+        import pyperclip
+        pyperclip.copy(
+            get_totp_code(
+                selection['id'],
+                selection['name'],
+                arguments.io_encoding,
+                arguments.auto_lock
+            )
+        )
 
     if arguments.insert_mode:
         qute_command('enter-mode insert')


### PR DESCRIPTION
Moves the TOTP code to clipboard, which can be then pasted by the user,
much like the Firefox add-on. Uses the pyperclip Python module, which
is cross-platform (currently doesn't support wayland, but there is an
open issue).