### PR TITLE
Greasemonkey shared window proxy

### DIFF
--- a/qutebrowser/javascript/greasemonkey_wrapper.js
+++ b/qutebrowser/javascript/greasemonkey_wrapper.js
@@ -145,47 +145,47 @@
         }
     };
 
+    const unsafeWindow = window;
     {% if use_proxy %}
-      /*
-       * Try to give userscripts an environment that they expect. Which
-       * seems to be that the global window object should look the same as
-       * the page's one and that if a script writes to an attribute of
-       * window it should be able to access that variable in the global
-       * scope.
-       * Use a Proxy to stop scripts from actually changing the global
-       * window (that's what unsafeWindow is for).
-       * Use the "with" statement to make the proxy provide what looks
-       * like global scope.
-       *
-       * There are other Proxy functions that we may need to override.
-       * set, get and has are definitely required.
-       */
-      const unsafeWindow = window;
-      const qute_gm_window_shadow = {};  // stores local changes to window
-      const qute_gm_windowProxyHandler = {
-        get: function(target, prop) {
-          if (prop in qute_gm_window_shadow)
-            return qute_gm_window_shadow[prop];
-          if (prop in target) {
-            if (typeof target[prop] === 'function' && typeof target[prop].prototype == 'undefined')
-              // Getting TypeError: Illegal Execution when callers try to execute
-              // eg addEventListener from here because they were returned
-              // unbound
-              return target[prop].bind(target);
-            return target[prop];
-          }
-        },
-        set: function(target, prop, val) {
-          return qute_gm_window_shadow[prop] = val;
-        },
-        has: function(target, key) {
-          return key in qute_gm_window_shadow || key in target;
-        }
-      };
-      const qute_gm_window_proxy = new Proxy(
-        unsafeWindow, qute_gm_windowProxyHandler);
+    /*
+     * Try to give userscripts an environment that they expect. Which seems
+     * to be that the global window object should look the same as the page's
+     * one and that if a script writes to an attribute of window all other
+     * scripts should be able to access that variable in the global scope.
+     * Use a Proxy to stop scripts from actually changing the global window
+     * (that's what unsafeWindow is for). Use the "with" statement to make
+     * the proxy provide what looks like global scope.
+     *
+     * There are other Proxy functions that we may need to override.  set,
+     * get and has are definitely required.
+     */
 
-      with (qute_gm_window_proxy) {
+    if (!window._qute_gm_window_proxy) {
+        const qute_gm_window_shadow = {}; // stores local changes to window
+        const qute_gm_windowProxyHandler = {
+            get: function (target, prop) {
+                if (prop in qute_gm_window_shadow)
+                    return qute_gm_window_shadow[prop];
+                if (prop in target) {
+                    if (typeof target[prop] === 'function' && typeof target[prop].prototype == 'undefined')
+                        // Getting TypeError: Illegal Execution when callers try
+                        // to execute eg addEventListener from here because they
+                        // were returned unbound
+                        return target[prop].bind(target);
+                    return target[prop];
+                }
+            },
+            set: function(target, prop, val) {
+                return qute_gm_window_shadow[prop] = val;
+            },
+            has: function(target, key) {
+                return key in qute_gm_window_shadow || key in target;
+            }
+        };
+        window._qute_gm_window_proxy = new Proxy(unsafeWindow, qute_gm_windowProxyHandler);
+    }
+    const qute_gm_window_proxy = window._qute_gm_window_proxy;
+    with (qute_gm_window_proxy) {
         // We can't return `this` or `qute_gm_window_proxy` from
         // `qute_gm_window_proxy.get('window')` because the Proxy implementation
         // does typechecking on read-only things. So we have to shadow `window`
@@ -194,10 +194,10 @@
         // ====== The actual user script source ====== //
 {{ scriptSource }}
         // ====== End User Script ====== //
-      };
+    };
     {% else %}
-      // ====== The actual user script source ====== //
+        // ====== The actual user script source ====== //
 {{ scriptSource }}
-      // ====== End User Script ====== //
+        // ====== End User Script ====== //
     {% endif %}
 })();

--- a/tests/unit/javascript/test_greasemonkey.py
+++ b/tests/unit/javascript/test_greasemonkey.py
@@ -315,3 +315,55 @@ class TestWindowIsolation:
         elem.evaluateJavaScript(setup.setup_script)
         result = elem.evaluateJavaScript(setup.test_script)
         assert result == setup.expected
+
+
+class TestSharedWindowProxy:
+    """Check that all scripts have access to the same window proxy."""
+
+    @pytest.fixture
+    def setup(self):
+        # pylint: disable=attribute-defined-outside-init
+        class SetupData:
+            pass
+        ret = SetupData()
+
+        # Greasemonkey script to add a property to the window proxy.
+        ret.test_script_a = greasemonkey.GreasemonkeyScript.parse(
+            textwrap.dedent("""
+                // ==UserScript==
+                // @name a
+                // ==/UserScript==
+                // Set a value from script a
+                window.$ = 'test';
+            """)
+        ).code()
+
+        # Greasemonkey script to retrieve a property from the window proxy.
+        ret.test_script_b = greasemonkey.GreasemonkeyScript.parse(
+            textwrap.dedent("""
+                // ==UserScript==
+                // @name b
+                // ==/UserScript==
+                // Check that the value is accessible from script b
+                return [window.$, $];
+            """)
+        ).code()
+
+        # What we expect the script to report back.
+        ret.expected = ["test", "test"]
+        return ret
+
+    def test_webengine(self, qtbot, webengineview, setup):
+        page = webengineview.page()
+
+        with qtbot.wait_callback() as callback:
+            page.runJavaScript(setup.test_script_a, callback)
+        with qtbot.wait_callback() as callback:
+            page.runJavaScript(setup.test_script_b, callback)
+        callback.assert_called_with(setup.expected)
+
+    def test_webkit(self, webview, setup):
+        elem = webview.page().mainFrame().documentElement()
+        elem.evaluateJavaScript(setup.test_script_a)
+        result = elem.evaluateJavaScript(setup.test_script_b)
+        assert result == setup.expected


### PR DESCRIPTION
Introduces a shared `window` proxy for Greasemonkey scripts as discussed in #5266. I also edited `greasemonkey_wrapper.js` to use a consistent level of indentation throughout. I added a unit test which passess (at least on my machine). In the browser the test scripts end up executing in a random order, so they only work correctly some of the time. This pull request does not address the execution order of scripts because Qt doesn't currently provide a method to control this. See this [issue](https://codereview.qt-project.org/c/qt/qtwebengine/+/281433).