### PR TITLE
Make the main window default geometry configurable

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1950,6 +1950,26 @@ window.title_format:
     Format to use for the window title. The same placeholders like for
     `tabs.title.format` are defined.
 
+window.default_geometry.width:
+  type: Int
+  default: 800
+  desc: Width of new windows.
+
+window.default_geometry.height:
+  type: Int
+  default: 600
+  desc: Height of new windows.
+
+window.default_geometry.x:
+  type: Int
+  default: 50
+  desc: X position of new windows.
+
+window.default_geometry.y:
+  type: Int
+  default: 50
+  desc: Y position of new windows.
+
 ## zoom
 
 zoom.default:

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -468,7 +468,10 @@ class MainWindow(QWidget):
 
     def _set_default_geometry(self):
         """Set some sensible default geometry."""
-        self.setGeometry(QRect(50, 50, 800, 600))
+        self.setGeometry(QRect(config.val.window.default_geometry.x,
+                               config.val.window.default_geometry.y,
+                               config.val.window.default_geometry.width,
+                               config.val.window.default_geometry.height))
 
     def _get_object(self, name):
         """Get an object for this window in the object registry."""


### PR DESCRIPTION
Added a few config options to control the geometry of new windows (the first window seems to remember its geometry from last session, but windows after that are fixed size). Tests mostly fail on my system for some reason, so going to see what CI says.