### PR TITLE
WIP: Use same hint for links or images with the same URL

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -1114,7 +1114,7 @@ class WordHinter:
         if (tag in ('a', 'img')):
             for e in existing:
                 cur_tag = e[1].tag_name()
-                if cur_tag = tag and (
+                if cur_tag == tag and (
                     (tag == 'a' and e[1]['href'] == elem['href']) or
                     (tag == 'img' and e[1]['src'] == elem['src'])):
                     return e[0]

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -99,7 +99,6 @@ class HintLabel(QLabel):
             matched: The part of the text which was typed.
             unmatched: The part of the text which was not typed yet.
         """
-        log.hints.debug('HintLabel.update_text({}, {})'.format(matched, unmatched))
         if (config.cache['hints.uppercase'] and
                 self._context.hint_mode in ['letter', 'word']):
             matched = html.escape(matched.upper())
@@ -119,7 +118,6 @@ class HintLabel(QLabel):
     @pyqtSlot()
     def _move_to_elem(self) -> None:
         """Reposition the label to its element."""
-        log.hints.debug('HintLabel._move_to_elem()')
         if not self.elem.has_frame():
             # This sometimes happens for some reason...
             log.hints.debug("Frame for {!r} vanished!".format(self))
@@ -131,7 +129,6 @@ class HintLabel(QLabel):
 
     def cleanup(self) -> None:
         """Clean up this element and hide it."""
-        log.hints.debug('HintLabel.cleanup()')
         self.hide()
         self.deleteLater()
 
@@ -184,7 +181,6 @@ class HintContext:
 
     def get_args(self, urlstr: str) -> typing.Sequence[str]:
         """Get the arguments, with {hint-url} replaced by the given URL."""
-        log.hints.debug('HintContext.get_args({})'.format(urlstr))
         args = []
         for arg in self.args:
             arg = arg.replace('{hint-url}', urlstr)
@@ -202,7 +198,6 @@ class HintActions:
     def click(self, elem: webelem.AbstractWebElement,
               context: HintContext) -> None:
         """Click an element."""
-        log.hints.debug('HintActions.click({}, {})'.format(elem, context))
         target_mapping = {
             Target.normal: usertypes.ClickTarget.normal,
             Target.current: usertypes.ClickTarget.normal,
@@ -234,7 +229,6 @@ class HintActions:
 
     def yank(self, url: QUrl, context: HintContext) -> None:
         """Yank an element to the clipboard or primary selection."""
-        log.hints.debug('HintActions.yank({}, {})'.format(url, context))
         sel = (context.target == Target.yank_primary and
                utils.supports_selection())
 
@@ -262,7 +256,6 @@ class HintActions:
 
     def run_cmd(self, url: QUrl, context: HintContext) -> None:
         """Run the command based on a hint URL."""
-        log.hints.debug('HintActions.run_cmd({}, {})'.format(url, context))
         urlstr = url.toString(QUrl.FullyEncoded)  # type: ignore
         args = context.get_args(urlstr)
         commandrunner = runners.CommandRunner(self._win_id)
@@ -270,7 +263,6 @@ class HintActions:
 
     def preset_cmd_text(self, url: QUrl, context: HintContext) -> None:
         """Preset a commandline text based on a hint URL."""
-        log.hints.debug('HintActions.preset_cmd_text({}, {})'.format(url, context))
         urlstr = url.toDisplayString(QUrl.FullyEncoded)  # type: ignore
         args = context.get_args(urlstr)
         text = ' '.join(args)
@@ -288,7 +280,6 @@ class HintActions:
             elem: The QWebElement to download.
             _context: The HintContext to use.
         """
-        log.hints.debug('HintActions.download({}, {})'.format(elem, context))
         url = elem.resolve_url(context.baseurl)
         if url is None:
             raise HintingError("No suitable link found for this element.")
@@ -308,7 +299,6 @@ class HintActions:
             elem: The QWebElement to use in the userscript.
             context: The HintContext to use.
         """
-        log.hints.debug('HintActions.call_userscript({}, {})'.format(elem, context))
         cmd = context.args[0]
         args = context.args[1:]
         env = {
@@ -328,7 +318,6 @@ class HintActions:
 
     def delete(self, elem: webelem.AbstractWebElement,
                _context: HintContext) -> None:
-        log.hints.debug('HintActions.delete({}, {})'.format(elem, context))
         elem.delete()
 
     def spawn(self, url: QUrl, context: HintContext) -> None:
@@ -338,7 +327,6 @@ class HintActions:
             url: The URL to open as a QUrl.
             context: The HintContext to use.
         """
-        log.hints.debug('HintActions.spawn({}, {})'.format(url, context))
         urlstr = url.toString(
             QUrl.FullyEncoded | QUrl.RemovePassword)  # type: ignore
         args = context.get_args(urlstr)
@@ -399,7 +387,6 @@ class HintManager(QObject):
 
     def _get_text(self) -> str:
         """Get a hint text based on the current context."""
-        log.hints.debug('HintManager.get_text()')
         assert self._context is not None
         text = self.HINT_TEXTS[self._context.target]
         if self._context.rapid:
@@ -409,7 +396,6 @@ class HintManager(QObject):
 
     def _cleanup(self) -> None:
         """Clean up after hinting."""
-        log.hints.debug('HintManager.cleanup()'.format())
         assert self._context is not None
         for label in self._context.all_labels:
             label.cleanup()
@@ -431,7 +417,6 @@ class HintManager(QObject):
         Return:
             A list of hint strings, in the same order as the elements.
         """
-        log.hints.debug('HintManager._hint_strings({})'.format(elems))
         if not elems:
             return []
 
@@ -463,7 +448,6 @@ class HintManager(QObject):
             chars: The alphabet to use for labels.
             elems: The elements to generate labels for.
         """
-        log.hints.debug('HintManager._hint_scattered({}, {}, {})'.format(min_chars, chars, elems))
         # Determine how many digits the link hints will require in the worst
         # case. Usually we do not need all of these digits for every link
         # single hint, so we can show shorter hints for a few of the links.
@@ -503,7 +487,6 @@ class HintManager(QObject):
             chars: The alphabet to use for labels.
             elems: The elements to generate labels for.
         """
-        log.hints.debug('HintManager._hint_linear({}, {}, {})'.format(min_chars, chars, elems))
         strings = []
         needed = max(min_chars, utils.ceil_log(len(elems), len(chars)))
         for i in range(len(elems)):
@@ -526,7 +509,6 @@ class HintManager(QObject):
         Return:
             A list of shuffled hint strings.
         """
-        log.hints.debug('HintManager._shuffle_hints({}, {})'.format(hints, length))
         buckets = [
             [] for i in range(length)
         ]  # type: typing.Sequence[_HintStringsType]
@@ -556,7 +538,6 @@ class HintManager(QObject):
         Return:
             A hint string.
         """
-        log.hints.debug('HintManager._number_to_hint_str({}, {}, {})'.format(number, chars, digits))
         base = len(chars)
         hintstr = []  # type: typing.MutableSequence[str]
         remainder = 0
@@ -579,7 +560,6 @@ class HintManager(QObject):
             target: A Target enum member.
             args: Arguments for userscript/download
         """
-        log.hints.debug('HintManager._check_args({}, ... {})'.format(target, args))
         if not isinstance(target, Target):
             raise TypeError("Target {} is no Target member!".format(target))
         if target in [Target.userscript, Target.spawn, Target.run,
@@ -595,7 +575,6 @@ class HintManager(QObject):
 
     def _filter_matches(self, filterstr: str, elemstr: str) -> bool:
         """Return True if `filterstr` matches `elemstr`."""
-        log.hints.debug('HintManager._filter_matches({}, {})'.format(filterstr, elemstr))
         # Empty string and None always match
         if not filterstr:
             return True
@@ -606,7 +585,6 @@ class HintManager(QObject):
 
     def _filter_matches_exactly(self, filterstr: str, elemstr: str) -> bool:
         """Return True if `filterstr` exactly matches `elemstr`."""
-        log.hints.debug('HintManager._filter_matches_exactly({}, {})'.format(filterstr, elemstr))
         # Empty string and None never match
         if not filterstr:
             return False
@@ -616,13 +594,11 @@ class HintManager(QObject):
 
     def _get_keyparser(self,
                        mode: usertypes.KeyMode) -> basekeyparser.BaseKeyParser:
-        log.hints.debug('HintManager._get_keyparser({})'.format(mode))
         mode_manager = modeman.instance(self._win_id)
         return mode_manager.parsers[mode]
 
     def _start_cb(self, elems: _ElemsType) -> None:
         """Initialize the elements and labels based on the context set."""
-        log.hints.debug('HintManager._start_cb({})'.format(elems))
         if self._context is None:
             log.hints.debug("In _start_cb without context!")
             return
@@ -679,7 +655,6 @@ class HintManager(QObject):
         for elem in elems:
             tag = elem.tag_name()
             if (tag in ('a', 'img')):
-                log.hints.debug(tag+': checking '+str(elem))
                 url = elem['href' if tag == 'a' else 'src']
                 if url in urls.keys():
                     urls[url].append(elem)
@@ -766,7 +741,6 @@ class HintManager(QObject):
                                 URL.
                 - With `run`: Same as `fill`.
         """
-        log.hints.debug('HintManager.start({}, {}, ... {}, {}, {}, {}, {})'.format(group, target, args, mode, add_history, rapid, first))
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=self._win_id)
         tab = tabbed_browser.widget.currentWidget()
@@ -819,7 +793,6 @@ class HintManager(QObject):
 
     def _get_hint_mode(self, mode: typing.Optional[str]) -> str:
         """Get the hinting mode to use based on a mode argument."""
-        log.hints.debug('HintManager._get_hint_mode({})'.format(mode))
         if mode is None:
             return config.val.hints.mode
 
@@ -832,7 +805,6 @@ class HintManager(QObject):
 
     def current_mode(self) -> typing.Optional[str]:
         """Return the currently active hinting mode (or None otherwise)."""
-        log.hints.debug('HintManager.current_mode()'.format())
         if self._context is None:
             return None
 
@@ -845,7 +817,6 @@ class HintManager(QObject):
             visible: typing.Mapping[str, HintLabel] = None
     ) -> None:
         """Handle the auto_follow option."""
-        log.hints.debug('HintManager._handle_auto_follow({}, {}, {})'.format(keystr, filterstr, visible))
         assert self._context is not None
 
         if visible is None:
@@ -883,7 +854,6 @@ class HintManager(QObject):
     @pyqtSlot(str)
     def handle_partial_key(self, keystr: str) -> None:
         """Handle a new partial keypress."""
-        log.hints.debug('HintManager.handle_partial_key({})'.format(keystr))
         if self._context is None:
             log.hints.debug("Got key without context!")
             return
@@ -916,7 +886,6 @@ class HintManager(QObject):
                        and `self._context.filterstr` are None, all hints are
                        shown.
         """
-        log.hints.debug('HintManager.filter_hints({})'.format(filterstr))
         assert self._context is not None
 
         if filterstr is None:
@@ -969,7 +938,6 @@ class HintManager(QObject):
         Args:
             keystr: The keychain string to follow.
         """
-        log.hints.debug('HintManager._fire({})'.format(keystr))
         assert self._context is not None
         # Handlers which take a QWebElement
         elem_handlers = {
@@ -1042,7 +1010,6 @@ class HintManager(QObject):
             select: Only select the given hint, don't necessarily follow it.
             keystring: The hint to follow, or None.
         """
-        log.hints.debug('HintManager.follow_hint({}, {})'.format(select, keystring))
         assert self._context is not None
         if keystring is None:
             if self._context.to_follow is None:
@@ -1061,7 +1028,6 @@ class HintManager(QObject):
     @pyqtSlot(usertypes.KeyMode)
     def on_mode_left(self, mode: usertypes.KeyMode) -> None:
         """Stop hinting when hinting mode was left."""
-        log.hints.debug('HintManager.on_mode_left({})'.format(mode))
         if mode != usertypes.KeyMode.hint or self._context is None:
             # We have one HintManager per tab, so when this gets called,
             # self._context might be None, because the current tab is not
@@ -1086,7 +1052,6 @@ class WordHinter:
 
     def ensure_initialized(self) -> None:
         """Generate the used words if yet uninitialized."""
-        log.hints.debug('WordHinter.ensure_initialized()')
         dictionary = config.val.hints.dictionary
         if not self.words or self.dictionary != dictionary:
             self.words.clear()
@@ -1116,7 +1081,6 @@ class WordHinter:
             self, elem: webelem.AbstractWebElement
     ) -> typing.Iterator[str]:
         """Extract tag words form the given element."""
-        log.hints.debug('WordHinter.extract_tag_words({})'.format(elem))
         _extractor_type = typing.Callable[[webelem.AbstractWebElement], str]
         attr_extractors = {
             "alt": lambda elem: elem["alt"],
@@ -1145,7 +1109,6 @@ class WordHinter:
             words: typing.Iterable[str]
     ) -> typing.Iterator[str]:
         """Take words and transform them to proper hints if possible."""
-        log.hints.debug('WordHinter.tag_words_to_hints({})'.format(words))
         for candidate in words:
             if not candidate:
                 continue
@@ -1156,7 +1119,6 @@ class WordHinter:
                 yield candidate[match.start():match.end()].lower()
 
     def any_prefix(self, hint: str, existing: typing.Iterable[str]) -> bool:
-        log.hints.debug('WordHinter.any_prefix({}, {})'.format(hint, existing))
         return any(hint.startswith(e) or e.startswith(hint) for e in existing)
 
     def filter_prefixes(
@@ -1165,28 +1127,12 @@ class WordHinter:
             existing: typing.Iterable[str]
     ) -> typing.Iterator[str]:
         """Filter hints which don't start with the given prefix."""
-        log.hints.debug('WordHinter.filter_prefixes({}, {})'.format(hints, existing))
         return (h for h in hints if not self.any_prefix(h, existing))
 
     def new_hint_for(self, elem: webelem.AbstractWebElement,
-                     existing: typing.Set[tuple],
+                     existing: typing.Iterable[str],
                      fallback: typing.Iterable[str]) -> typing.Optional[str]:
-        """Return a hint for elem, not conflicting with the existing except when the url is the same."""
-        log.hints.debug('WordHinter.new_hint_for({}, {}, {})'.format(elem, existing, fallback))
-        tag = elem.tag_name()
-        if (tag in ('a', 'img')):
-            log.hints.debug(tag+': checking '+str(existing))
-            for e in existing:
-                cur_tag = e[1].tag_name()
-                if cur_tag == tag:
-                    log.hints.debug('cur_tag == tag == '+str(tag))
-                if cur_tag == tag and (
-                    (tag == 'a' and e[1]['href'] == elem['href']) or
-                    (tag == 'img' and e[1]['src'] == elem['src'])):
-                    log.hints.debug('reusing tag '+str(e[0])+' for '+str(e[1]['href' if tag == 'a' else 'src']))
-                    return e[0]
-            # url not already hinted, generate new
-        
+        """Return a hint for elem, not conflicting with the existing."""
         new = self.tag_words_to_hints(self.extract_tag_words(elem))
         new_no_prefixes = self.filter_prefixes(new, existing)
         fallback_no_prefixes = self.filter_prefixes(fallback, existing)
@@ -1207,15 +1153,14 @@ class WordHinter:
         Return:
             A list of hint strings, in the same order as the elements.
         """
-        log.hints.debug('WordHinter.hint({})'.format(elems))
         self.ensure_initialized()
         hints = []
-        used_hints = set()  # type: typing.Set[tuple]
+        used_hints = set()  # type: typing.Set[str]
         words = iter(self.words)
         for elem in elems:
             hint = self.new_hint_for(elem, used_hints, words)
             if not hint:
                 raise HintingError("Not enough words in the dictionary.")
-            used_hints.add((hint, elem))
+            used_hints.add(hint)
             hints.append(hint)
         return hints


### PR DESCRIPTION
When hinting, don't just give every element a label, but check whether it is a link or an image and give elements with the same `href` or `src` the same label.

Which improvements does this make?

- links and images with the same URL will trigger the same action. It makes sense to communicate that to the user by showing the same label for those elements.
- on pages like YouTube or Twitch where there are multiple links semantically forming one "tile", this can reduce the number of unique labels and thus the maximum length of the labels dramatically, making navigation quicker.

Which disadvantages does this have?

- This keeps track of all the elements and the URLs in a separate object, which could slow this down for very big pages — I haven't tested this. I think it might be small enough to be lost in the noise, in the best case.

What is left to do?

- This is my first contribution to the project, I just poked around the bit — and I haven't gotten the tests to work right away using `tox`. I still need to figure ths out...
- I probably should make the crazy one-liner in `hints.py:627` easier to read...