### PR TITLE
WIP: Disable logging if cmdline starts with "@".

### DIFF
--- a/qutebrowser/commands/userscripts.py
+++ b/qutebrowser/commands/userscripts.py
@@ -397,7 +397,6 @@ def _lookup_path(cmd):
 
     raise NotFoundError(cmd, directories)
 
-
 def run_async(tab, cmd, *args, win_id, env, verbose=False):
     """Run a userscript after dumping page html/source.
 
@@ -426,8 +425,11 @@ def run_async(tab, cmd, *args, win_id, env, verbose=False):
         raise UnsupportedError
 
     runner.got_cmd.connect(
-        lambda cmd:
-        log.commands.debug("Got userscript command: {}".format(cmd)))
+        lambda cmd: (
+            commandrunner.is_silent(cmd) or
+            log.commands.debug("Got userscript command: {}".format(cmd))
+        )
+    )
     runner.got_cmd.connect(commandrunner.run_safely)
 
     env['QUTE_USER_AGENT'] = websettings.user_agent()

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -257,6 +257,18 @@ def ignore_py_warnings(**kwargs: typing.Any) -> typing.Iterator[None]:
         _init_py_warnings()
 
 
+@contextlib.contextmanager
+def silent() -> typing.Iterator[None]:
+    """Contextmanager which temporarily disables the Qt message handler."""
+    logging.info("Disabling logs")
+    logging.disable()
+    try:
+        yield
+    finally:
+        logging.disable(logging.NOTSET)
+        logging.info("Re-enabling logs")
+
+
 def _init_handlers(
         level: int,
         color: bool,

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -305,6 +305,15 @@ def test_ignore_py_warnings(caplog):
     assert msg.endswith("UserWarning: not hidden")
 
 
+def test_silent(logger, caplog):
+    with caplog.at_level(logging.DEBUG):
+        with log.silent():
+            logger.error("This is terrible")
+            logger.info("This is ok")
+            logger.debug("This is noisy")
+    assert caplog.messages == ["Disabling logs", "Re-enabling logs"]
+
+
 class TestQtMessageHandler:
 
     @attr.s


### PR DESCRIPTION
Hi! Long time no see ;)
I've wanted to use the `pass` userscript for a while but #938 scared me away. 
I'm not looking for a full review yet, but more of a discussion on whether this approach is feasible.

Disabling logs is tricky, as a commandlines coming from userscripts (which is the main usecase for this, I think) can arrive at any point and would disable logging for the duration of the command. Maybe we don't care if we lose some unrelated logs? I'm not sure. It is better than setting `--loglines 0` at least.

--- commit message below ---

If a commandline starts with the "@" character, all logging is disabled
during the execution of this commandline. This is useful for running
sensitive commands whose text should not appear in the logs. For
example, a password manager userscript might use:

```
echo "@insert-text $PASSWORD" >> "$QUTE_FIFO"
```

This contributes to #938, though a few issues are unadressed:

- Should this be disabled for async commands? Which commands are async?
- Does the async nature of userscripts mean this could potentially
  conceal logging for things unrelated to the command?
- Should live command completion ignore the `@`? Or should `@` be
  completely disabled for live commands, if possible? It would be a
  false sense of security for live commands, as your command will show
  up in all the completion logging as you type it. We might be able to
  disable completion logging as soon as we see a `@` though ...

Note: I initially tried adding a `:silent` command with a syntax similar
to `:later` (e.g. `:silent insert-text foo`), but the whole command line
will get logged before it is actually executed, i.e. the `silent` bit
doesn't kick in soon enough if it is a regular command.