### PR TITLE
#5227 Make fullscreen notification overlay timeout configurable 

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -136,6 +136,8 @@
 |<<content.desktop_capture,content.desktop_capture>>|Allow websites to share screen content.
 |<<content.dns_prefetch,content.dns_prefetch>>|Try to pre-fetch DNS entries to speed up browsing.
 |<<content.frame_flattening,content.frame_flattening>>|Expand each subframe to its contents.
+|<<content.fullscreen.overlay_timeout,content.fullscreen.overlay_timeout>>|Set fullscreen notification overlay timeout in milliseconds.
+|<<content.fullscreen.window,content.fullscreen.window>>|Limit fullscreen to the browser window (does not expand to fill the screen).
 |<<content.geolocation,content.geolocation>>|Allow websites to request geolocations.
 |<<content.headers.accept_language,content.headers.accept_language>>|Value to send in the `Accept-Language` header.
 |<<content.headers.custom,content.headers.custom>>|Custom headers for qutebrowser HTTP requests.
@@ -176,7 +178,6 @@
 |<<content.user_stylesheets,content.user_stylesheets>>|List of user stylesheet filenames to use.
 |<<content.webgl,content.webgl>>|Enable WebGL.
 |<<content.webrtc_ip_handling_policy,content.webrtc_ip_handling_policy>>|Which interfaces to expose via WebRTC.
-|<<content.windowed_fullscreen,content.windowed_fullscreen>>|Limit fullscreen to the browser window (does not expand to fill the screen).
 |<<content.xss_auditing,content.xss_auditing>>|Monitor load requests for cross-site scripting attempts.
 |<<downloads.location.directory,downloads.location.directory>>|Directory to save downloads to.
 |<<downloads.location.prompt,downloads.location.prompt>>|Prompt the user for the download location.
@@ -1809,6 +1810,23 @@ Default: +pass:[false]+
 
 This setting is only available with the QtWebKit backend.
 
+[[content.fullscreen.overlay_timeout]]
+=== content.fullscreen.overlay_timeout
+Set fullscreen notification overlay timeout in milliseconds.
+If set to 0, no overlay will be displayed.
+
+Type: <<types,Int>>
+
+Default: +pass:[3000]+
+
+[[content.fullscreen.window]]
+=== content.fullscreen.window
+Limit fullscreen to the browser window (does not expand to fill the screen).
+
+Type: <<types,Bool>>
+
+Default: +pass:[false]+
+
 [[content.geolocation]]
 === content.geolocation
 Allow websites to request geolocations.
@@ -2321,14 +2339,6 @@ Default: +pass:[all-interfaces]+
 On QtWebEngine, this setting requires Qt 5.9.2 or newer.
 
 On QtWebKit, this setting is unavailable.
-
-[[content.windowed_fullscreen]]
-=== content.windowed_fullscreen
-Limit fullscreen to the browser window (does not expand to fill the screen).
-
-Type: <<types,Bool>>
-
-Default: +pass:[false]+
 
 [[content.xss_auditing]]
 === content.xss_auditing

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -815,9 +815,11 @@ class _WebEnginePermissions(QObject):
         self._tab.data.fullscreen = on
         self._tab.fullscreen_requested.emit(on)
         if on:
-            notification = miscwidgets.FullscreenNotification(self._widget)
-            notification.show()
-            notification.set_timeout(3000)
+            timeout = config.instance.get('content.fullscreen.overlay_timeout')
+            if timeout !=  0:
+                notification = miscwidgets.FullscreenNotification(self._widget)
+                notification.set_timeout(timeout)
+                notification.show()
 
     @pyqtSlot(QUrl, 'QWebEnginePage::Feature')
     def _on_feature_permission_requested(self, url, feature):

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -371,6 +371,9 @@ content.default_encoding:
     _iso-8859-1_, etc.
 
 content.windowed_fullscreen:
+  renamed: content.fullscreen.window
+
+content.fullscreen.window:
   type: Bool
   default: false
   desc: >-

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -376,6 +376,17 @@ content.windowed_fullscreen:
   desc: >-
     Limit fullscreen to the browser window (does not expand to fill the screen).
 
+content.fullscreen.overlay_timeout:
+  type:
+    name: Int
+    minval: 0
+    maxval: maxint
+  default: 3000
+  desc: >-
+    Set fullscreen notification overlay timeout in milliseconds.
+
+    If set to 0, no overlay will be displayed.
+
 content.desktop_capture:
   type: BoolAsk
   default: ask

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -577,7 +577,7 @@ class MainWindow(QWidget):
 
     @pyqtSlot(bool)
     def _on_fullscreen_requested(self, on):
-        if not config.val.content.windowed_fullscreen:
+        if not config.val.content.fullscreen.window:
             if on:
                 self.state_before_fullscreen = self.windowState()
                 self.setWindowState(Qt.WindowFullScreen |  # type: ignore

--- a/qutebrowser/misc/miscwidgets.py
+++ b/qutebrowser/misc/miscwidgets.py
@@ -326,7 +326,7 @@ class FullscreenNotification(QLabel):
             self.setText("Page is now fullscreen.")
 
         self.resize(self.sizeHint())
-        if config.val.content.windowed_fullscreen:
+        if config.val.content.fullscreen.window:
             geom = self.parentWidget().geometry()
         else:
             geom = QApplication.desktop().screenGeometry(self)


### PR DESCRIPTION
#5297 This pull request introduces new :set option "content.fullscreen.overlay_timeout", with which can be configured timeout for fullsceen notification. 
It also renames "content.windowed_fullscreen" for "content.fullscreen.window" to keep names united. 
The documentation about these two settings have been updated too.