### PR TITLE
Only quote search engine terms if requested

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1883,12 +1883,24 @@ url.searchengines:
       name: String
       forbidden: ' '
     valtype: SearchEngineUrl
-  desc: >-
+  desc: |
     Search engines which can be used via the address bar.
 
     Maps a search engine name (such as `DEFAULT`, or `ddg`) to a URL with a
     `{}` placeholder. The placeholder will be replaced by the search term, use
-    `{{` and `}}` for literal `{`/`}` signs.
+    `{{` and `}}` for literal `{`/`}` braces.
+
+    The following further placeholds are defined to configure how special
+    characters in the search terms are replaced by safe characters (called
+    'quoting'):
+
+    * `{}` and `{semiquoted}` quote everything except slashes; this is the most
+      sensible choice for almost all search engines (for the search term
+      `slash/and&amp` this placeholder expands to `slash/and%26amp`).
+    * `{quoted}` quotes all characters (for `slash/and&amp` this placeholder
+      expands to `slash%2Fand%26amp`).
+    * `{unquoted}` quotes nothing (for `slash/and&amp` this placeholder
+      expands to `slash/and&amp`).
 
     The search engine named `DEFAULT` is used when `url.auto_search` is turned
     on and something else than a URL was entered to be opened. Other search

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1760,11 +1760,16 @@ class SearchEngineUrl(BaseType):
         elif not value:
             return None
 
-        if not ('{}' in value or '{0}' in value):
+        if not re.search('{(|0|semiquoted|unquoted|quoted)}', value):
             raise configexc.ValidationError(value, "must contain \"{}\"")
 
         try:
-            value.format("")
+            format_keys = {
+                'quoted': "",
+                'unquoted': "",
+                'semiquoted': "",
+            }
+            value.format("", **format_keys)
         except (KeyError, IndexError):
             raise configexc.ValidationError(
                 value, "may not contain {...} (use {{ and }} for literal {/})")

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1776,11 +1776,6 @@ class SearchEngineUrl(BaseType):
         except ValueError as e:
             raise configexc.ValidationError(value, str(e))
 
-        url = QUrl(value.replace('{}', 'foobar'))
-        if not url.isValid():
-            raise configexc.ValidationError(
-                value, "invalid url, {}".format(url.errorString()))
-
         return value
 
 

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -116,8 +116,14 @@ def _get_search_url(txt: str) -> QUrl:
         engine = 'DEFAULT'
     if term:
         template = config.val.url.searchengines[engine]
+        semiquoted_term = urllib.parse.quote(term)
         quoted_term = urllib.parse.quote(term, safe='')
-        url = qurl_from_user_input(template.format(quoted_term))
+        format_keys = {
+            'unquoted': term,
+            'quoted': quoted_term,
+            'semiquoted': semiquoted_term,
+        }
+        url = qurl_from_user_input(template.format(semiquoted_term, **format_keys))
     else:
         url = qurl_from_user_input(config.val.url.searchengines[engine])
         url.setPath(None)  # type: ignore

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -123,7 +123,8 @@ def _get_search_url(txt: str) -> QUrl:
             'quoted': quoted_term,
             'semiquoted': semiquoted_term,
         }
-        url = qurl_from_user_input(template.format(semiquoted_term, **format_keys))
+        evaluated = template.format(semiquoted_term, **format_keys)
+        url = qurl_from_user_input(evaluated)
     else:
         url = qurl_from_user_input(config.val.url.searchengines[engine])
         url.setPath(None)  # type: ignore

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -194,10 +194,10 @@ Feature: Yanking and pasting.
             http://qutebrowser.org
             should not open
         And I run :open -t {clipboard}
-        And I wait until data/hello.txt?q=this%20url%3A%0Ahttp%3A%2F%2Fqutebrowser.org%0Ashould%20not%20open is loaded
+        And I wait until data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open is loaded
         Then the following tabs should be open:
             - about:blank
-            - data/hello.txt?q=this%20url%3A%0Ahttp%3A%2F%2Fqutebrowser.org%0Ashould%20not%20open (active)
+            - data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open (active)
 
     Scenario: Pasting multiline whose first line looks like a URI
         When I set url.auto_search to naive

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -2003,7 +2003,6 @@ class TestSearchEngineUrl:
 
     @pytest.mark.parametrize('val', [
         'foo',  # no placeholder
-        ':{}',  # invalid URL
         'foo{bar}baz{}',  # {bar} format string variable
         '{1}{}',  # numbered format string variable
         '{{}',  # invalid format syntax

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -291,7 +291,6 @@ def test_special_urls(url, special):
     ('test/with/slashes', 'www.example.com', 'q=test/with/slashes'),
     ('test path-search', 'www.qutebrowser.org', 'q=path-search'),
     ('slash/and&amp', 'www.example.com', 'q=slash/and%26amp'),
-    ('quoted-path t/w/s', 'www.example.org', 't%26w%26s'),
     ('unquoted one=1&two=2', 'www.example.org', 'one=1&two=2'),
 ])
 def test_get_search_url(config_stub, url, host, query, open_base_url):
@@ -306,6 +305,25 @@ def test_get_search_url(config_stub, url, host, query, open_base_url):
     url = urlutils._get_search_url(url)
     assert url.host() == host
     assert url.query() == query
+
+
+@pytest.mark.parametrize('open_base_url', [True, False])
+@pytest.mark.parametrize('url, host, path', [
+    ('path-search t/w/s', 'www.example.org', 't/w/s'),
+    ('quoted-path t/w/s', 'www.example.org', 't%2Fw%2Fs'),
+])
+def test_get_search_url_for_path_search(config_stub, url, host, path, open_base_url):
+    """Test _get_search_url_for_path_search().
+
+    Args:
+        url: The "URL" to enter.
+        host: The expected search machine host.
+        path: The expected path on that host that is requested.
+    """
+    config_stub.val.url.open_base_url = open_base_url
+    url = urlutils._get_search_url(url)
+    assert url.host() == host
+    assert url.path(options=QUrl.PrettyDecoded) == '/' + path
 
 
 @pytest.mark.parametrize('url, host', [

--- a/tests/unit/utils/test_urlutils.py
+++ b/tests/unit/utils/test_urlutils.py
@@ -98,6 +98,8 @@ def init_config(config_stub):
         'test': 'http://www.qutebrowser.org/?q={}',
         'test-with-dash': 'http://www.example.org/?q={}',
         'path-search': 'http://www.example.org/{}',
+        'quoted-path': 'http://www.example.org/{quoted}',
+        'unquoted': 'http://www.example.org/?{unquoted}',
         'DEFAULT': 'http://www.example.com/?q={}',
     }
 
@@ -286,8 +288,11 @@ def test_special_urls(url, special):
     ('blub testfoo', 'www.example.com', 'q=blub testfoo'),
     ('stripped ', 'www.example.com', 'q=stripped'),
     ('test-with-dash testfoo', 'www.example.org', 'q=testfoo'),
-    ('test/with/slashes', 'www.example.com', 'q=test%2Fwith%2Fslashes'),
+    ('test/with/slashes', 'www.example.com', 'q=test/with/slashes'),
     ('test path-search', 'www.qutebrowser.org', 'q=path-search'),
+    ('slash/and&amp', 'www.example.com', 'q=slash/and%26amp'),
+    ('quoted-path t/w/s', 'www.example.org', 't%26w%26s'),
+    ('unquoted one=1&two=2', 'www.example.org', 'one=1&two=2'),
 ])
 def test_get_search_url(config_stub, url, host, query, open_base_url):
     """Test _get_search_url().


### PR DESCRIPTION
In the search engine url replacement, only quote the search term if the
search engine format explicitly requests this:

  - The placeholder {} inserts the plain search term without quotation
    like before of #4434. This seems to be the default for other
    browsers' search engines and to be supported by most websites. For
    example, https://en.wikipedia.org/wiki/AC/DC leads to the wikipedia
    article of AC/DC.
  - A new placeholder {quoted} inserts the quoted search term. For
    example, with

        c.url.searchengines['jpc'] = 'https://www.jpc.de/s/{quoted}'

    the command "jpc AC/DC" correctly redirects to https://www.jpc.de/s/AC%2FDC
    given results for "AC/DC". Here, the placeholder {quoted} is indeed
    necessary (as of March 2020), since  https://www.jpc.de/s/AC/DC only
    searches for "AC".

This addresses the issue #1772 and partially reverts #4434 (making the
there introduced behaviour configurable).