### PR TITLE
Allow the usage of insert-text in command mode

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1222,7 +1222,7 @@ If the option name ends with '?' or no value is provided, the value of the optio
 
 [[set-cmd-text]]
 === set-cmd-text
-Syntax: +:set-cmd-text [*--space*] [*--append*] [*--run-on-count*] 'text'+
+Syntax: +:set-cmd-text [*--space*] [*--append*] [*--insert*] [*--run-on-count*] 'text'+
 
 Preset the statusbar to some text.
 
@@ -1232,6 +1232,8 @@ Preset the statusbar to some text.
 ==== optional arguments
 * +*-s*+, +*--space*+: If given, a space is added to the end.
 * +*-a*+, +*--append*+: If given, the text is appended to the current text.
+* +*-i*+, +*--insert*+: If given, the text is inserted in the current text at cursor position. This cannot be used with append
+
 * +*-r*+, +*--run-on-count*+: If given with a count, the command is run with the given count rather than setting the command text.
 
 


### PR DESCRIPTION
The use-case behind this one is to be able to bind something else than ctrl-v to paste the clipboard in the command prompt.

Implementation wise:
The callback returning None, had to put the QLineEdit insert fallback within the callback.
Don't know if the widget call should be try…except scoped.