### PR TITLE
URL and Title changes trigger history entry updates

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -25,6 +25,7 @@ import functools
 import dataclasses
 from typing import (cast, TYPE_CHECKING, Any, Callable, Iterable, List, Optional,
                     Sequence, Set, Type, Union)
+import time
 
 from PyQt5.QtCore import (pyqtSignal, pyqtSlot, QUrl, QObject, QSizeF, Qt,
                           QEvent, QPoint, QRect)
@@ -929,7 +930,12 @@ class AbstractTab(QWidget):
     # Signal emitted before shutting down
     shutting_down = pyqtSignal()
     # Signal emitted when a history item should be added
-    history_item_triggered = pyqtSignal(QUrl, QUrl, str)
+    # arg 0: Url accessed
+    # arg 1: Page title
+    # arg 2: Access time
+    # arg 3: Was this redirected to another url?
+    # arg 4: Is this an amendment to an existing entry?
+    history_item_triggered = pyqtSignal(QUrl, str, int, bool, bool)
     # Signal emitted when the underlying renderer process terminated.
     # arg 0: A TerminationStatus member.
     # arg 1: The exit code.
@@ -966,6 +972,11 @@ class AbstractTab(QWidget):
         self._tab_event_filter = eventfilter.TabEventFilter(
             self, parent=self)
         self.backend: Optional[usertypes.Backend] = None
+
+        self._last_history_url = None  # type: Optional[QUrl]
+        self._last_history_atime = None  # type: Optional[int]
+        self._last_history_title = None  # type: Optional[str]
+        self._last_history_requested_url = None  # type: Optional[QUrl]
 
         # If true, this tab has been requested to be removed (or is removed).
         self.pending_removal = False
@@ -1120,9 +1131,81 @@ class AbstractTab(QWidget):
         self._set_load_status(loadstatus)
 
     @pyqtSlot()
-    def _on_history_trigger(self) -> None:
-        """Emit history_item_triggered based on backend-specific signal."""
-        raise NotImplementedError
+    def _on_history_trigger(self, force_entry: bool = True) -> None:
+        """Add or update a history entry when required."""
+        try:
+            self._widget.page()
+        except RuntimeError:
+            # Looks like this slot can be triggered on destroyed tabs:
+            # https://crashes.qutebrowser.org/view/3abffbed (Qt 5.9.1)
+            # wrapped C/C++ object of type WebEngineView has been deleted
+            log.misc.debug("Ignoring history trigger for destroyed tab")
+            return
+
+        url = self.url()
+        requested_url = self.url(requested=True)
+
+        # Don't save the title if it's generated from the URL
+        title = self.title()
+        title_url = QUrl(url)
+        title_url.setScheme('')
+        title_url_str = title_url.toDisplayString(
+            QUrl.RemoveScheme)  # type: ignore[arg-type]
+        if title == title_url_str.strip('/'):
+            title = ""
+
+        # Don't add history entry if the URL is invalid anyways
+        if not url.isValid():
+            log.misc.debug("Ignoring invalid URL being added to history")
+            return
+
+        if url == self._last_history_url:
+            # Same page, but title might have changed
+            if title != self._last_history_title:
+                atime = self._last_history_atime
+                # redirect=False, update=True
+                self.history_item_triggered.emit(url, title, atime,
+                                                 False, True)
+                self._last_history_title = title
+
+            # Update this in case it changed.
+            self._last_history_requested_url = requested_url
+        elif force_entry or title != self._last_history_title:
+            # Don't add an entry if only the url has changed.
+            # This hopefully filters out unimportant url changes
+
+            atime = int(time.time())
+
+            no_formatting = cast(QUrl.FormattingOptions,
+                                        QUrl.UrlFormattingOption(0))
+            if any(u is not None and
+                   requested_url.matches(u, no_formatting)
+                   for u in (self._last_history_requested_url,
+                             self._last_history_url)):
+                # This isn't a new request, so get old atime and mark
+                # previous url as a redirect
+                atime = self._last_history_atime
+                # redirect=True, update=True
+                self.history_item_triggered.emit(self._last_history_url,
+                                                 title, atime, True, True)
+            elif requested_url.isValid() \
+                    and not requested_url.matches(url, no_formatting) \
+                    and not url.scheme() == 'view-source':
+                # If the url of the page is different than the url of the link
+                # originally clicked, save them both.
+                # Check for 'view-source' here because WebEngine sets
+                # requested_url to the url of the original page.
+                # redirect=True, update=False
+                self.history_item_triggered.emit(requested_url,
+                                                 title, atime, True, False)
+
+            # redirect=False, update=False
+            self.history_item_triggered.emit(url, title, atime, False, False)
+
+            self._last_history_atime = atime
+            self._last_history_requested_url = requested_url
+            self._last_history_url = url
+            self._last_history_title = title
 
     @pyqtSlot(int)
     def _on_load_progress(self, perc: int) -> None:

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -158,8 +158,6 @@ class WebHistory(sql.SqlTable):
                                       'redirect': 'NOT NULL'},
                          parent=parent)
         self._progress = progress
-        # Store the last saved url to avoid duplicate immediate saves.
-        self._last_url = None
 
         self.completion = CompletionHistory(parent=self)
         self.metainfo = CompletionMetaInfo(parent=self)
@@ -341,7 +339,6 @@ class WebHistory(sql.SqlTable):
             self.delete_all()
             self.completion.delete_all()
         self.history_cleared.emit()
-        self._last_url = None
 
     def delete_url(self, url):
         """Remove all history entries with the given url.
@@ -353,37 +350,30 @@ class WebHistory(sql.SqlTable):
         qtutils.ensure_valid(qurl)
         self.delete('url', self._format_url(qurl))
         self.completion.delete('url', self._format_completion_url(qurl))
-        if self._last_url == url:
-            self._last_url = None
         self.url_cleared.emit(qurl)
 
-    @pyqtSlot(QUrl, QUrl, str)
-    def add_from_tab(self, url, requested_url, title):
+    @pyqtSlot(QUrl, str, int, bool, bool)
+    def add_from_tab(self, url, title, atime=None, redirect=False,
+                     update=False):
         """Add a new history entry as slot, called from a BrowserTab."""
-        if self._is_excluded_entirely(url) or self._is_excluded_entirely(requested_url):
+        if self._is_excluded_entirely(url):
             return
         if url.isEmpty():
             # things set via setHtml
             return
+        self.add_url(url, title, atime, redirect=redirect, update=update)
 
-        no_formatting = QUrl.UrlFormattingOption(0)
-        if (requested_url.isValid() and
-                not requested_url.matches(url, no_formatting)):
-            # If the url of the page is different than the url of the link
-            # originally clicked, save them both.
-            self.add_url(requested_url, title, redirect=True)
-        if url != self._last_url:
-            self.add_url(url, title)
-            self._last_url = url
-
-    def add_url(self, url, title="", *, redirect=False, atime=None):
+    def add_url(self, url, title="", atime=None, *, redirect=False,
+                update=False):
         """Called via add_from_tab when a URL should be added to the history.
 
         Args:
             url: A url (as QUrl) to add to the history.
+            title: The title of the referenced page.
+            atime: Override the atime used to add the entry
             redirect: Whether the entry was redirected to another URL
                       (hidden in completion)
-            atime: Override the atime used to add the entry
+            update: Whether this is an update to a previous history entry
         """
         if not url.isValid():
             log.misc.warning("Ignoring invalid URL being added to history")
@@ -395,10 +385,37 @@ class WebHistory(sql.SqlTable):
         atime = int(atime) if (atime is not None) else int(time.time())
 
         with self._handle_sql_errors():
-            self.insert({'url': self._format_url(url),
-                         'title': title,
-                         'atime': atime,
-                         'redirect': redirect})
+            if update:
+                self.update({'url': self._format_url(url), 'atime': atime},
+                            {'title': title, 'redirect': redirect})
+            else:
+                self.insert({'url': self._format_url(url),
+                             'title': title,
+                             'atime': atime,
+                             'redirect': redirect})
+
+            if redirect and update:
+                try:
+                    self.completion.delete(
+                        'url', self._format_completion_url(url))
+                except KeyError:
+                    # This is fine - probably it was deleted by another tab.
+                    pass
+                else:
+                    # Check if we've over-writtent a non-redirected entry
+                    previous = self.select(
+                        sort_by='atime',
+                        sort_order='desc',
+                        limit=1,
+                        filter_values={"url": self._format_url(url),
+                                       "redirect": 0})
+                    for entry in previous:
+                        # This runs either 0 or 1 times
+                        self.completion.insert({
+                            'url': self._format_completion_url(url),
+                            'title': entry.title,
+                            'last_atime': entry.atime
+                        }, replace=True)
 
             if redirect or self._is_excluded_from_completion(url):
                 return

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1360,36 +1360,6 @@ class WebEngineTab(browsertab.AbstractTab):
             url=url_string, error=error)
         self.set_html(error_page)
 
-    @pyqtSlot()
-    def _on_history_trigger(self):
-        try:
-            self._widget.page()
-        except RuntimeError:
-            # Looks like this slot can be triggered on destroyed tabs:
-            # https://crashes.qutebrowser.org/view/3abffbed (Qt 5.9.1)
-            # wrapped C/C++ object of type WebEngineView has been deleted
-            log.misc.debug("Ignoring history trigger for destroyed tab")
-            return
-
-        url = self.url()
-        requested_url = self.url(requested=True)
-
-        # Don't save the title if it's generated from the URL
-        title = self.title()
-        title_url = QUrl(url)
-        title_url.setScheme('')
-        title_url_str = title_url.toDisplayString(
-            QUrl.RemoveScheme)  # type: ignore[arg-type]
-        if title == title_url_str.strip('/'):
-            title = ""
-
-        # Don't add history entry if the URL is invalid anyways
-        if not url.isValid():
-            log.misc.debug("Ignoring invalid URL being added to history")
-            return
-
-        self.history_item_triggered.emit(url, requested_url, title)
-
     @pyqtSlot(QUrl, 'QAuthenticator*', 'QString')
     def _on_proxy_authentication_required(self, url, authenticator,
                                           proxy_host):
@@ -1642,7 +1612,11 @@ class WebEngineTab(browsertab.AbstractTab):
                 self._on_select_client_certificate)
 
         view.titleChanged.connect(self.title_changed)
+        view.titleChanged.connect(
+            functools.partial(self._on_history_trigger, False))
         view.urlChanged.connect(self._on_url_changed)
+        view.urlChanged.connect(
+            functools.partial(self._on_history_trigger, False))
         view.renderProcessTerminated.connect(
             self._on_render_process_terminated)
         view.iconChanged.connect(self.icon_changed)

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -894,12 +894,6 @@ class WebKitTab(browsertab.AbstractTab):
     def renderer_process_pid(self) -> Optional[int]:
         return None
 
-    @pyqtSlot()
-    def _on_history_trigger(self):
-        url = self.url()
-        requested_url = self.url(requested=True)
-        self.history_item_triggered.emit(url, requested_url, self.title())
-
     def set_html(self, html, base_url=QUrl()):
         self._widget.setHtml(html, base_url)
 
@@ -985,7 +979,11 @@ class WebKitTab(browsertab.AbstractTab):
         frame.loadStarted.connect(self._on_load_started)
         view.scroll_pos_changed.connect(self.scroller.perc_changed)
         view.titleChanged.connect(self.title_changed)
+        view.titleChanged.connect(
+            functools.partial(self._on_history_trigger, False))
         view.urlChanged.connect(self._on_url_changed)
+        view.urlChanged.connect(
+            functools.partial(self._on_history_trigger, False))
         view.shutting_down.connect(self.shutting_down)
         page.networkAccessManager().sslErrors.connect(self._on_ssl_errors)
         frame.loadFinished.connect(self._on_frame_load_finished)

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -454,12 +454,39 @@ class SqlTable(QObject):
         q.run_batch(values)
         self.changed.emit()
 
+    def _update_query(self, filter_values, new_values):
+        assignments = ', '.join(
+            '{key} = :new{key}'.format(key=key) for key in new_values)
+        tests = ' AND '.join(
+            '{key} = :filter{key}'.format(key=key) for key in filter_values)
+        return Query("UPDATE {table} SET {assignments} "
+                     "WHERE {tests}".format(
+                         table=self._name,
+                         assignments=assignments,
+                         tests=tests))
+
+    def update(self, filter_values, new_values):
+        """Append a row to the table.
+
+        Args:
+            filter_values: A dict of (field name : value) pairs to filter by.
+            new_values: A dict of (filed name : value) pairs to update.
+            replace: If set, replace existing values.
+        """
+        q = self._update_query(filter_values, new_values)
+        values = {
+            "filter" + key: value for (key, value) in filter_values.items()}
+        values.update({
+            "new"+key: value for (key, value) in new_values.items()})
+        q.run(**values)
+        self.changed.emit()
+
     def delete_all(self):
         """Remove all rows from the table."""
         Query("DELETE FROM {table}".format(table=self._name)).run()
         self.changed.emit()
 
-    def select(self, sort_by, sort_order, limit=-1):
+    def select(self, sort_by, sort_order, limit=-1, filter_values=None):
         """Prepare, run, and return a select statement on this table.
 
         Args:
@@ -469,9 +496,17 @@ class SqlTable(QObject):
 
         Return: A prepared and executed select query.
         """
-        q = Query("SELECT * FROM {table} ORDER BY {sort_by} {sort_order} "
-                  "LIMIT :limit"
-                  .format(table=self._name, sort_by=sort_by,
+        where = ""
+        values = {"limitparam": limit}
+
+        if filter_values is not None:
+            where = " WHERE " + " AND ".join(
+                '{key} = :{key}'.format(key=key) for key in filter_values)
+            values.update(filter_values)
+
+        q = Query("SELECT * FROM {table}{where} "
+                  "ORDER BY {sort_by} {sort_order} LIMIT :limitparam"
+                  .format(table=self._name, where=where, sort_by=sort_by,
                           sort_order=sort_order))
-        q.run(limit=limit)
+        q.run(**values)
         return q

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -20,11 +20,11 @@ Feature: Page history
             http://localhost:(port)/data/title.html Test title
 
     Scenario: History item with redirect
-        When I open redirect-to?url=data/title.html without waiting
-        And I wait until data/title.html is loaded
+        When I open redirect-to?url=data/hello.txt without waiting
+        And I wait until data/hello.txt is loaded
         Then the history should contain:
-            r http://localhost:(port)/redirect-to?url=data/title.html Test title
-            http://localhost:(port)/data/title.html Test title
+            r http://localhost:(port)/redirect-to?url=data/hello.txt
+            http://localhost:(port)/data/hello.txt
 
     Scenario: History item with spaces in URL
         When I open data/title with spaces.html

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -205,70 +205,86 @@ class TestAdd:
             with pytest.raises(sql.BugError):
                 web_history.add_url(QUrl('https://www.example.org/'))
 
-    @pytest.mark.parametrize('level, url, req_url, expected', [
-        (logging.DEBUG, 'a.com', 'a.com', [('a.com', 'title', 12345, False)]),
-        (logging.DEBUG, 'a.com', 'b.com', [('a.com', 'title', 12345, False),
-                                           ('b.com', 'title', 12345, True)]),
-        (logging.WARNING, 'a.com', '', [('a.com', 'title', 12345, False)]),
-
-        (logging.WARNING, '', '', []),
-
-        (logging.WARNING, 'data:foo', '', []),
-        (logging.WARNING, 'a.com', 'data:foo', []),
-
-        (logging.WARNING, 'view-source:foo', '', []),
-        (logging.WARNING, 'a.com', 'view-source:foo', []),
-
-        (logging.WARNING, 'qute://back', '', []),
-        (logging.WARNING, 'a.com', 'qute://back', []),
-
-        (logging.WARNING, 'qute://pdfjs/', '', []),
-        (logging.WARNING, 'a.com', 'qute://pdfjs/', []),
+    @pytest.mark.parametrize('level, url, expected', [
+        (logging.DEBUG, 'a.com', [('a.com', 'title', 12345, False)]),
+        (logging.WARNING, '', []),
+        (logging.WARNING, 'data:foo', []),
+        (logging.WARNING, 'view-source:foo', []),
+        (logging.WARNING, 'qute://back', []),
+        (logging.WARNING, 'qute://pdfjs/', []),
     ])
     def test_from_tab(self, web_history, caplog, mock_time,
-                      level, url, req_url, expected):
+                      level, url, expected):
         with caplog.at_level(level):
-            web_history.add_from_tab(QUrl(url), QUrl(req_url), 'title')
+            web_history.add_from_tab(QUrl(url), 'title',)
         assert set(web_history) == set(expected)
 
     def test_exclude(self, web_history, config_stub):
         """Excluded URLs should be in the history but not completion."""
         config_stub.val.completion.web_history.exclude = ['*.example.org']
         url = QUrl('http://www.example.org/')
-        web_history.add_from_tab(url, url, 'title')
+        web_history.add_from_tab(url, 'title')
         assert list(web_history)
         assert not list(web_history.completion)
 
-    def test_no_immedate_duplicates(self, web_history, mock_time):
-        url = QUrl("http://example.com")
-        url2 = QUrl("http://example2.com")
-        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
-        hist = list(web_history)
-        assert hist
-        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
-        assert list(web_history) == hist
-        web_history.add_from_tab(QUrl(url2), QUrl(url2), 'title')
-        assert list(web_history) != hist
-
     def test_delete_add_tab(self, web_history, mock_time):
         url = QUrl("http://example.com")
-        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
+        web_history.add_from_tab(QUrl(url), 'title')
         hist = list(web_history)
         assert hist
         web_history.delete_url(QUrl(url))
         assert len(web_history) == 0
-        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
+        web_history.add_from_tab(QUrl(url), 'title')
         assert list(web_history) == hist
 
     def test_clear_add_tab(self, web_history, mock_time):
         url = QUrl("http://example.com")
-        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
+        web_history.add_from_tab(QUrl(url), 'title')
         hist = list(web_history)
         assert hist
         history.history_clear(force=True)
         assert len(web_history) == 0
-        web_history.add_from_tab(QUrl(url), QUrl(url), 'title')
+        web_history.add_from_tab(QUrl(url), 'title')
         assert list(web_history) == hist
+
+    def test_update_title(self, web_history):
+        url = QUrl("http://example.com")
+        web_history.add_from_tab(QUrl(url), 'title', 12345, False, False)
+        expected = [("http://example.com", 'title', 12345, False)]
+        assert list(web_history) == expected
+        assert list(web_history.completion)
+        web_history.add_from_tab(QUrl(url), 'title2', 12345, False, True)
+        expected = [("http://example.com", 'title2', 12345, False)]
+        assert list(web_history) == expected
+        assert len(web_history.completion) == 1
+
+    def test_update_redirect(self, web_history):
+        url = QUrl("http://example.com")
+        web_history.add_from_tab(QUrl(url), 'title', 12345, False, False)
+        expected = [("http://example.com", 'title', 12345, False)]
+        assert list(web_history) == expected
+        assert list(web_history.completion)
+        web_history.add_from_tab(QUrl(url), 'title', 12345, True, True)
+        expected = [("http://example.com", 'title', 12345, True)]
+        assert list(web_history) == expected
+        assert not list(web_history.completion)
+
+    def test_add_interleaved_redirects(self, web_history):
+        url = QUrl("http://example.com")
+        web_history.add_from_tab(url, 'title', 12345, False, False)
+        web_history.add_from_tab(url, 'title', 12345, False, False)
+        web_history.add_from_tab(url, 'title', 12345, True, True)
+        web_history.add_from_tab(url, 'title', 12345, True, True)
+        assert not list(web_history.completion)
+
+    def test_redirect_restores_old_completion(self, web_history):
+        url = QUrl("http://example.com")
+        web_history.add_from_tab(url, 'title1', 12345, False, False)
+        web_history.add_from_tab(url, 'title2', 12346, False, False)
+        web_history.add_from_tab(url, 'title3', 12347, False, False)
+        web_history.add_from_tab(url, 'title4', 12347, True, True)
+        expected = [("http://example.com", 'title2', 12346)]
+        assert list(web_history.completion) == expected
 
 
 class TestHistoryInterface:


### PR DESCRIPTION
This is a change to the way that history entries are generated, to fix known issues where the history is incomplete (#5012 and #2835) or has incorrect page titles. Both forms of misbehaviour can currently be observed on YouTube (when clicking through several different videos).

This replaces the existing (different) algorithms for webengine and webkit with a common (almost) algorithm, which works roughly as follows. Whenever the page title changes and the page url does not, then the new title is saved in the history entry in place of the old one. A new history entry is created whenever the url changes and either the title also changes, or a `loadFinished` (webengine) or `initialLayoutCompleted` (webkit) signal is received. (These different signals are the ones currently used; I don't see any reason for this not to be unified). There are also some subtleties concerning recognising redirects.

To implement this change it is necessary to amend history entries after initially adding them to the database. (Having logged the signals emitted when browsing YouTube, this retrospective editing of history seems to be unavoidable). This has two consequences. Firstly, updates to history entries assume that the pair (atime, url) is sufficiently unique that it is safe to update all entries with the same atime and url simultaneously. There are some convoluted edge-cases in which this would leave history entries with an inaccurate title, but I don't think we should worry about those.

The second consequence is that more of the history entry processing has to be undertaken on a per-tab basis. This required some refactoring of the code, including changing the signature of add_url. As a consequence, several of the tests are now broken. I haven't yet attempted to fix them, as I thought it would be better to first have a discussion/review of the main code changes. The refactoring also entirely replaces the changes made in #4699, where consecutive history entries were deduplicated on a global basis. I think it is more appropriate to carry out this deduplication on a per-tab basis, as I have done here.


Some questions/considerations for futher development:
1. There are some cases in which it would be desirable to save a new history entry even without a loadFinished signal or a change in the page title. One such example would be when viewing consecutively two YouTube videos with the same title. On the other hand, without the signal or title change check there would be a lot of history entries created when panning many common online maps (including Google Maps). I think the first situation is sufficiently unusual that it is ok to miss the entry there, when weighed against the benefit of not having an excessive quantity of map history entries, but I'd be interested to hear any other opinions.

2. Should reloading a page create a new entry? Currently the behaviour depends on whether there have been any page loads in other tabs. With this change, reloading would never create a new entry. There's an argument to be made that it should at least sometimes create a new entry - either at all times, or whenever the url has changed since the last history entry (from that tab). Either of these would help mitigate the issue in the first question.

3. A more technical question. The `_on_history_trigger` method for webengine previously tried calling `self._widget.page()`, apparently to check whether the tab had been destroyed. I don't see why this would be necessary, and have removed that check while refactoring; is that likely to reintroduce some subtle bug, or was that guard no longer necessary?