### PR TITLE
Add search.wrap configuration option

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -317,6 +317,7 @@ class AbstractSearch(QObject):
     def search(self, text: str, *,
                ignore_case: usertypes.IgnoreCase = usertypes.IgnoreCase.never,
                reverse: bool = False,
+               wrap: bool = True,
                result_cb: _Callback = None) -> None:
         """Find the given text on the page.
 
@@ -324,6 +325,7 @@ class AbstractSearch(QObject):
             text: The text to search for.
             ignore_case: Search case-insensitively.
             reverse: Reverse search direction.
+            wrap: Allow wrapping at the top or bottom of the page.
             result_cb: Called with a bool indicating whether a match was found.
         """
         raise NotImplementedError
@@ -332,23 +334,19 @@ class AbstractSearch(QObject):
         """Clear the current search."""
         raise NotImplementedError
 
-    def prev_result(self, *, result_cb: _Callback = None,
-                    nowrap: bool = False) -> None:
+    def prev_result(self, *, result_cb: _Callback = None) -> None:
         """Go to the previous result of the current search.
 
         Args:
             result_cb: Called with a bool indicating whether a match was found.
-            nowrap: Do not wrap at the top or bottom of the page.
         """
         raise NotImplementedError
 
-    def next_result(self, *, result_cb: _Callback = None,
-                    nowrap: bool = False) -> None:
+    def next_result(self, *, result_cb: _Callback = None) -> None:
         """Go to the next result of the current search.
 
         Args:
             result_cb: Called with a bool indicating whether a match was found.
-            nowrap: Do not wrap at the top or bottom of the page.
         """
         raise NotImplementedError
 

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -332,19 +332,23 @@ class AbstractSearch(QObject):
         """Clear the current search."""
         raise NotImplementedError
 
-    def prev_result(self, *, result_cb: _Callback = None) -> None:
+    def prev_result(self, *, result_cb: _Callback = None,
+                    nowrap: bool = False) -> None:
         """Go to the previous result of the current search.
 
         Args:
             result_cb: Called with a bool indicating whether a match was found.
+            nowrap: Do not wrap at the top or bottom of the page.
         """
         raise NotImplementedError
 
-    def next_result(self, *, result_cb: _Callback = None) -> None:
+    def next_result(self, *, result_cb: _Callback = None,
+                    nowrap: bool = False) -> None:
         """Go to the next result of the current search.
 
         Args:
             result_cb: Called with a bool indicating whether a match was found.
+            nowrap: Do not wrap at the top or bottom of the page.
         """
         raise NotImplementedError
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1503,6 +1503,7 @@ class CommandDispatcher:
         options = {
             'ignore_case': config.val.search.ignore_case,
             'reverse': reverse,
+            'wrap': config.val.search.wrap,
         }
 
         self._tabbed_browser.search_text = text
@@ -1518,13 +1519,11 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def search_next(self, count=1, nowrap=False):
+    def search_next(self, count=1):
         """Continue the search to the ([count]th) next term.
 
         Args:
             count: How many elements to ignore.
-            nowrap: Do not wrap when hitting the end of the page.
-                    With QtWebEngine, Qt >= 5.14 is required for this.
         """
         tab = self._current_widget()
         window_text = self._tabbed_browser.search_text
@@ -1549,18 +1548,16 @@ class CommandDispatcher:
                                prev=False)
 
         for _ in range(count - 1):
-            tab.search.next_result(nowrap=nowrap)
-        tab.search.next_result(result_cb=cb, nowrap=nowrap)
+            tab.search.next_result()
+        tab.search.next_result(result_cb=cb)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def search_prev(self, count=1, nowrap=False):
+    def search_prev(self, count=1):
         """Continue the search to the ([count]th) previous term.
 
         Args:
             count: How many elements to ignore.
-            nowrap: Do not wrap when hitting the end of the page.
-                    With QtWebEngine, Qt >= 5.14 is required for this.
         """
         tab = self._current_widget()
         window_text = self._tabbed_browser.search_text
@@ -1585,8 +1582,8 @@ class CommandDispatcher:
                                prev=True)
 
         for _ in range(count - 1):
-            tab.search.prev_result(nowrap=nowrap)
-        tab.search.prev_result(result_cb=cb, nowrap=nowrap)
+            tab.search.prev_result()
+        tab.search.prev_result(result_cb=cb)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_cmd_split=True)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1518,11 +1518,13 @@ class CommandDispatcher:
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def search_next(self, count=1):
+    def search_next(self, count=1, nowrap=False):
         """Continue the search to the ([count]th) next term.
 
         Args:
             count: How many elements to ignore.
+            nowrap: Do not wrap when hitting the end of the page.
+                    With QtWebEngine, Qt >= 5.14 is required for this.
         """
         tab = self._current_widget()
         window_text = self._tabbed_browser.search_text
@@ -1547,16 +1549,18 @@ class CommandDispatcher:
                                prev=False)
 
         for _ in range(count - 1):
-            tab.search.next_result()
-        tab.search.next_result(result_cb=cb)
+            tab.search.next_result(nowrap=nowrap)
+        tab.search.next_result(result_cb=cb, nowrap=nowrap)
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def search_prev(self, count=1):
+    def search_prev(self, count=1, nowrap=False):
         """Continue the search to the ([count]th) previous term.
 
         Args:
             count: How many elements to ignore.
+            nowrap: Do not wrap when hitting the end of the page.
+                    With QtWebEngine, Qt >= 5.14 is required for this.
         """
         tab = self._current_widget()
         window_text = self._tabbed_browser.search_text
@@ -1581,8 +1585,8 @@ class CommandDispatcher:
                                prev=True)
 
         for _ in range(count - 1):
-            tab.search.prev_result()
-        tab.search.prev_result(result_cb=cb)
+            tab.search.prev_result(nowrap=nowrap)
+        tab.search.prev_result(result_cb=cb, nowrap=nowrap)
 
     @cmdutils.register(instance='command-dispatcher', scope='window',
                        maxsplit=0, no_cmd_split=True)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -207,14 +207,7 @@ class _WebEngineSearchWrapHandler:
         self._active_match = 0
         self._total_matches = 0
 
-    def _message_wrap_prevented(self, top=True):
-        """Show a message informing the user that wrapping was prevented."""
-        if top:
-            message.info("Search hit TOP")
-        else:
-            message.info("Search hit BOTTOM")
-
-    def prevent_wrapping(self, going_up):
+    def prevent_wrapping(self, *, going_up):
         """Prevent wrapping if possible and required.
 
         Returns True if a wrap was prevented and False if not.
@@ -225,10 +218,10 @@ class _WebEngineSearchWrapHandler:
         if not self._nowrap_available or self.flag_wrap:
             return False
         elif going_up and self._active_match == 1:
-            self._message_wrap_prevented(True)
+            message.info("Search hit TOP")
             return True
         elif not going_up and self._active_match == self._total_matches:
-            self._message_wrap_prevented(False)
+            message.info("Search hit BOTTOM")
             return True
         else:
             return False

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -215,7 +215,8 @@ class _WebEngineSearchWrapHandler:
         Args:
             going_up: Whether the search would scroll the page up or down.
         """
-        if not self._nowrap_available or self.flag_wrap:
+        if (not self._nowrap_available or
+                self.flag_wrap or self._total_matches == 0):
             return False
         elif going_up and self._active_match == 1:
             message.info("Search hit TOP")

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -156,52 +156,83 @@ class WebEnginePrinting(browsertab.AbstractPrinting):
         self._widget.page().print(printer, callback)
 
 
+class _WebEngineSearchWrapHandler():
+
+    """QtWebEngine implementations related to wrapping when searching.
+
+    Attributes:
+        flag_wrap: An additional flag indicating whether the last search
+                   used wrapping.
+        active_match: The 1-based index of the currently active matc
+                      on the page.
+        total_matches: The total number of search matches on the page.
+        store_match_data_connected: Whether the store_match_data method
+                                    has already been connected to the
+                                    findTextFinished signal.
+    """
+
+    def __init__(self):
+        self.active_match = 0
+        self.total_matches = 0
+        self.store_match_data_connected = False
+        self.flag_wrap = True
+
+    def store_match_data(self, result):
+        """Store information on the last match.
+
+        The information will be checked against when wrapping is turned off.
+
+        Args:
+            result: A FindTextResult passed by the findTextFinished signal.
+        """
+        self.active_match = result.activeMatch()
+        self.total_matches = result.numberOfMatches()
+        log.webview.debug("Active search match: {}/{}"
+                          .format(self.active_match, self.total_matches))
+
+    def reset_match_data(self):
+        """Reset match information.
+
+        Stale information could lead to next_result or prev_result misbehaving.
+        """
+        self.active_match = 0
+        self.total_matches = 0
+
+    def message_wrap_prevented(self, top=True):
+        """Show a message informing the user that wrapping was prevented."""
+        if top:
+            message.info("Search hit TOP")
+        else:
+            message.info("Search hit BOTTOM")
+
+
 class WebEngineSearch(browsertab.AbstractSearch):
 
     """QtWebEngine implementations related to searching on the page.
 
     Attributes:
         _flags: The QWebEnginePage.FindFlags of the last search.
-        _flag_wrap: An additional flag indicating whether the last search
-                    used wrapping.
         _pending_searches: How many searches have been started but not called
                            back yet.
-        _nowrap_available: Whether the nowrap functionality is available.
-        _active_match: The 1-based index of the currently active matc
-                       on the page.
-        _total_matches: The total number of search matches on the page.
     """
 
     def __init__(self, tab, parent=None):
         super().__init__(tab, parent)
         self._flags = QWebEnginePage.FindFlags(0)  # type: ignore
-        self._flag_wrap = True
         self._pending_searches = 0
         # The API necessary to stop wrapping was added in this version
         if qtutils.version_check("5.14"):
-            self._active_match = 0
-            self._total_matches = 0
-            self._nowrap_available = True
-            self._store_match_data_connected = False
+            self._wrap_handler = _WebEngineSearchWrapHandler()
         else:
-            self._nowrap_available = False
-
-    def _store_match_data(self, result):
-        self._active_match = result.activeMatch()
-        self._total_matches = result.numberOfMatches()
-        log.webview.debug("active match: number {0} of {1}"
-                          .format(self._active_match, self._total_matches))
-
-    def _reset_match_data(self):
-        self._active_match = 0
-        self._total_matches = 0
+            self._wrap_handler = None
 
     def _find(self, text, flags, callback, caller):
         """Call findText on the widget."""
-        if self._nowrap_available and not self._store_match_data_connected:
+        if (self._wrap_handler is not None and
+                not self._wrap_handler.store_match_data_connected):
             self._widget.page().findTextFinished.connect(
-                self._store_match_data)
-            self._store_match_data_connected = True
+                self._wrap_handler.store_match_data)
+            self._wrap_handler.store_match_data_connected = True
         self.search_displayed = True
         self._pending_searches += 1
 
@@ -248,9 +279,9 @@ class WebEngineSearch(browsertab.AbstractSearch):
 
         self.text = text
         self._flags = QWebEnginePage.FindFlags(0)  # type: ignore
-        if self._nowrap_available:
-            self._reset_match_data()
-            self._flag_wrap = wrap
+        if self._wrap_handler is not None:
+            self._wrap_handler.reset_match_data()
+            self._wrap_handler.flag_wrap = wrap
         if self._is_case_sensitive(ignore_case):
             self._flags |= QWebEnginePage.FindCaseSensitively
         if reverse:
@@ -262,41 +293,38 @@ class WebEngineSearch(browsertab.AbstractSearch):
         if self.search_displayed:
             self.cleared.emit()
         self.search_displayed = False
-        if self._nowrap_available:
-            self._reset_match_data()
+        if self._wrap_handler is not None:
+            self._wrap_handler.reset_match_data()
         self._widget.findText('')
-
-    def _message_wrap_prevented(self, top=True):
-        if top:
-            message.info("Search hit TOP")
-        else:
-            message.info("Search hit BOTTOM")
 
     def prev_result(self, *, result_cb=None):
         # The int() here makes sure we get a copy of the flags.
         flags = QWebEnginePage.FindFlags(int(self._flags))  # type: ignore
-        nowrap = self._nowrap_available and not self._flag_wrap
+        nowrap = (self._wrap_handler is not None and
+                  not self._wrap_handler.flag_wrap)
         if flags & QWebEnginePage.FindBackward:
-            if nowrap and self._active_match == self._total_matches:
-                self._message_wrap_prevented(top=False)
+            if (nowrap and self._wrap_handler.active_match ==
+                    self._wrap_handler.total_matches):
+                self._wrap_handler.message_wrap_prevented(top=False)
                 return
             flags &= ~QWebEnginePage.FindBackward
         else:
-            if nowrap and self._active_match == 1:
-                self._message_wrap_prevented(top=True)
+            if nowrap and self._wrap_handler.active_match == 1:
+                self._wrap_handler.message_wrap_prevented(top=True)
                 return
             flags |= QWebEnginePage.FindBackward
         self._find(self.text, flags, result_cb, 'prev_result')
 
     def next_result(self, *, result_cb=None):
-        if self._nowrap_available and not self._flag_wrap:
+        if self._wrap_handler is not None and not self._wrap_handler.flag_wrap:
             going_up = self._flags & QWebEnginePage.FindBackward
 
-            if going_up and self._active_match == 1:
-                self._message_wrap_prevented(top=True)
+            if going_up and self._wrap_handler.active_match == 1:
+                self._wrap_handler.message_wrap_prevented(top=True)
                 return
-            elif not going_up and self._active_match == self._total_matches:
-                self._message_wrap_prevented(top=False)
+            elif (not going_up and self._wrap_handler.active_match ==
+                  self._wrap_handler.total_matches):
+                self._wrap_handler.message_wrap_prevented(top=False)
                 return
         self._find(self.text, self._flags, result_cb, 'next_result')
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -180,6 +180,8 @@ class WebEngineSearch(browsertab.AbstractSearch):
             self._total_matches = 0
             self._nowrap_enabled = True
             self._store_match_data_connected = False
+        else:
+            self._nowrap_enabled = False
 
     def _store_match_data(self, result):
         self._active_match = result.activeMatch()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -176,14 +176,14 @@ class _WebEngineSearchWrapHandler:
         self.flag_wrap = True
         self._nowrap_available = False
 
-    def connect_signal(self, signal):
-        """Connect the given findTextFinished signal to the internal handler.
+    def connect_signal(self, page):
+        """Connect to the findTextFinished signal of the page.
 
         Args:
-            signal: A findTextFinished signal to connect to.
+            page: The QtWebEnginePage to connect to this handler.
         """
         if qtutils.version_check("5.14"):
-            signal.connect(self._store_match_data)
+            page.findTextFinished.connect(self._store_match_data)
             self._nowrap_available = True
 
     def _store_match_data(self, result):
@@ -252,7 +252,7 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._wrap_handler = _WebEngineSearchWrapHandler()
 
     def connect_signals(self):
-        self._wrap_handler.connect_signal(self._widget.page().findTextFinished)
+        self._wrap_handler.connect_signal(self._widget.page())
 
     def _find(self, text, flags, callback, caller):
         """Call findText on the widget."""

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -149,12 +149,16 @@ class WebKitSearch(browsertab.AbstractSearch):
                               self._flags | QWebPage.HighlightAllOccurrences)
         self._call_cb(result_cb, found, text, self._flags, 'search')
 
-    def next_result(self, *, result_cb=None):
+    def next_result(self, *, result_cb=None, nowrap=False):
         self.search_displayed = True
-        found = self._widget.findText(self.text, self._flags)
-        self._call_cb(result_cb, found, self.text, self._flags, 'next_result')
+        # The int() here makes sure we get a copy of the flags.
+        flags = QWebPage.FindFlags(int(self._flags))  # type: ignore
+        if nowrap:
+            flags &= ~QWebPage.FindWrapsAroundDocument
+        found = self._widget.findText(self.text, flags)
+        self._call_cb(result_cb, found, self.text, flags, 'next_result')
 
-    def prev_result(self, *, result_cb=None):
+    def prev_result(self, *, result_cb=None, nowrap=False):
         self.search_displayed = True
         # The int() here makes sure we get a copy of the flags.
         flags = QWebPage.FindFlags(int(self._flags))  # type: ignore
@@ -162,6 +166,8 @@ class WebKitSearch(browsertab.AbstractSearch):
             flags &= ~QWebPage.FindBackward
         else:
             flags |= QWebPage.FindBackward
+        if nowrap:
+            flags &= ~QWebPage.FindWrapsAroundDocument
         found = self._widget.findText(self.text, flags)
         self._call_cb(result_cb, found, self.text, flags, 'prev_result')
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -137,7 +137,7 @@ class WebKitSearch(browsertab.AbstractSearch):
 
         self.text = text
         self.search_displayed = True
-        self._flags = QWebPage.FindFlags(0)
+        self._flags = QWebPage.FindFlags(0)  # type: ignore
         if self._is_case_sensitive(ignore_case):
             self._flags |= QWebPage.FindCaseSensitively
         if reverse:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -137,7 +137,7 @@ class WebKitSearch(browsertab.AbstractSearch):
 
         self.text = text
         self.search_displayed = True
-        self._flags = 0
+        self._flags = QWebPage.FindFlags(0)
         if self._is_case_sensitive(ignore_case):
             self._flags |= QWebPage.FindCaseSensitively
         if reverse:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -125,7 +125,7 @@ class WebKitSearch(browsertab.AbstractSearch):
         self._widget.findText('', QWebPage.HighlightAllOccurrences)
 
     def search(self, text, *, ignore_case=usertypes.IgnoreCase.never,
-               reverse=False, result_cb=None):
+               reverse=False, wrap=True, result_cb=None):
         # Don't go to next entry on duplicate search
         if self.text == text and self.search_displayed:
             log.webview.debug("Ignoring duplicate search request"
@@ -137,11 +137,13 @@ class WebKitSearch(browsertab.AbstractSearch):
 
         self.text = text
         self.search_displayed = True
-        self._flags = QWebPage.FindWrapsAroundDocument
+        self._flags = 0
         if self._is_case_sensitive(ignore_case):
             self._flags |= QWebPage.FindCaseSensitively
         if reverse:
             self._flags |= QWebPage.FindBackward
+        if wrap:
+            self._flags |= QWebPage.FindWrapsAroundDocument
         # We actually search *twice* - once to highlight everything, then again
         # to get a mark so we can navigate.
         found = self._widget.findText(text, self._flags)
@@ -149,16 +151,12 @@ class WebKitSearch(browsertab.AbstractSearch):
                               self._flags | QWebPage.HighlightAllOccurrences)
         self._call_cb(result_cb, found, text, self._flags, 'search')
 
-    def next_result(self, *, result_cb=None, nowrap=False):
+    def next_result(self, *, result_cb=None):
         self.search_displayed = True
-        # The int() here makes sure we get a copy of the flags.
-        flags = QWebPage.FindFlags(int(self._flags))  # type: ignore
-        if nowrap:
-            flags &= ~QWebPage.FindWrapsAroundDocument
-        found = self._widget.findText(self.text, flags)
-        self._call_cb(result_cb, found, self.text, flags, 'next_result')
+        found = self._widget.findText(self.text, self._flags)
+        self._call_cb(result_cb, found, self.text, self._flags, 'next_result')
 
-    def prev_result(self, *, result_cb=None, nowrap=False):
+    def prev_result(self, *, result_cb=None):
         self.search_displayed = True
         # The int() here makes sure we get a copy of the flags.
         flags = QWebPage.FindFlags(int(self._flags))  # type: ignore
@@ -166,8 +164,6 @@ class WebKitSearch(browsertab.AbstractSearch):
             flags &= ~QWebPage.FindBackward
         else:
             flags |= QWebPage.FindBackward
-        if nowrap:
-            flags &= ~QWebPage.FindWrapsAroundDocument
         found = self._widget.findText(self.text, flags)
         self._call_cb(result_cb, found, self.text, flags, 'prev_result')
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -51,11 +51,12 @@ search.incremental:
 search.wrap:
   type: Bool
   default: True
+  backend:
+    QtWebEngine: Qt 5.14
+    QtWebKit: true
   desc: >-
     Wrap around at the top and bottom of the page when advancing through text matches
     using `:search-next` and `:search-prev`.
-
-    When using QtWebEngine, Qt>=5.14 is required to disable wrapping.
 
 new_instance_open_target:
   type:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -48,6 +48,15 @@ search.incremental:
   default: True
   desc: Find text on a page incrementally, renewing the search for each typed character.
 
+search.wrap:
+  type: Bool
+  default: True
+  desc: >-
+    Wrap around at the top and bottom of the page when advancing through text matches
+    using `:search-next` and `:search-prev`.
+
+    When using QtWebEngine, Qt>=5.14 is required to disable wrapping.
+
 new_instance_open_target:
   type:
     name: String

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -248,8 +248,8 @@ Feature: Searching on a page
         And I run :search-next
         And I wait for "next_result found foo with flags FindBackward" in the log
         And I run :search-next
-        And I wait for "next_result found foo with flags FindBackward" in the log
-        Then "foo" should be found
+        And I wait for "next_result didn't find foo with flags FindBackward" in the log
+        Then the warning "Text 'foo' not found on page!" should be shown
 
     @qtwebengine_skip
     Scenario: Preventing wrapping at the bottom of the page with QtWebKit
@@ -260,8 +260,8 @@ Feature: Searching on a page
         And I run :search-next
         And I wait for "next_result found foo" in the log
         And I run :search-next
-        And I wait for "next_result found foo" in the log
-        Then "Foo" should be found
+        And I wait for "next_result didn't find foo" in the log
+        Then the warning "Text 'foo' not found on page!" should be shown
 
     ## follow searched links
     @skip  # Too flaky

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -213,6 +213,56 @@ Feature: Searching on a page
     # TODO: wrapping message with scrolling
     # TODO: wrapping message without scrolling
 
+    ## wrapping prevented
+
+    @qtwebkit_skip @qt>=5.14
+    Scenario: Preventing wrapping at the top of the page with QtWebEngine
+        When I set search.ignore_case to always
+        And I set search.wrap to false
+        And I run :search --reverse foo
+        And I wait for "search found foo with flags FindBackward" in the log
+        And I run :search-next
+        And I wait for "next_result found foo with flags FindBackward" in the log
+        And I run :search-next
+        And I wait for "Search hit TOP" in the log
+        Then "foo" should be found
+
+    @qtwebkit_skip @qt>=5.14
+    Scenario: Preventing wrapping at the bottom of the page with QtWebEngine
+        When I set search.ignore_case to always
+        And I set search.wrap to false
+        And I run :search foo
+        And I wait for "search found foo" in the log
+        And I run :search-next
+        And I wait for "next_result found foo" in the log
+        And I run :search-next
+        And I wait for "Search hit BOTTOM" in the log
+        Then "Foo" should be found
+
+    @qtwebengine_skip
+    Scenario: Preventing wrapping at the top of the page with QtWebKit
+        When I set search.ignore_case to always
+        And I set search.wrap to false
+        And I run :search --reverse foo
+        And I wait for "search found foo with flags FindBackward" in the log
+        And I run :search-next
+        And I wait for "next_result found foo with flags FindBackward" in the log
+        And I run :search-next
+        And I wait for "next_result found foo with flags FindBackward" in the log
+        Then "foo" should be found
+
+    @qtwebengine_skip
+    Scenario: Preventing wrapping at the bottom of the page with QtWebKit
+        When I set search.ignore_case to always
+        And I set search.wrap to false
+        And I run :search foo
+        And I wait for "search found foo" in the log
+        And I run :search-next
+        And I wait for "next_result found foo" in the log
+        And I run :search-next
+        And I wait for "next_result found foo" in the log
+        Then "Foo" should be found
+
     ## follow searched links
     @skip  # Too flaky
     Scenario: Follow a searched link


### PR DESCRIPTION
Closes #5136.

With QtWebEngine, the API does not support the necessary flags to stop
wrapping, so the implementation via checking which match the search is
currently on is required. (The new functionality is disabled on Qt < 5.14)

It is not possible to display a message with QtWebKit since there is no
feedback from the search function.

This pull request is still WIP, as I have not yet created tests and am not completely certain of the stability of the solution.

### To do

- [x] Make tests for the introduced behavior

And probably more.

### Comments

I had to change the `findText` call from the `QWebEngineView` object to its `page()`, since only `QWebEnginePage` supports the new API for some reason. (Another good question would be why QWebEngine is lacking QWebKit functionality even though it's supposed to be its successor). The WebEngine solution is obviously stateful and thus potentially prone to breaking in all kinds of fascinating ways; I am currently still unsure whether connecting `_store_match_data` to the `QWebEnginePage` once will work consistently - more testing required.