### PR TITLE
[RFC] Even lazier load - delay creating WebView/WebEngineView until the tab is focused on

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -629,6 +629,7 @@ class AbstractHistory:
         self._history = typing.cast(
             typing.Union['QWebHistory', 'QWebEngineHistory'], None)
         self.private_api = AbstractHistoryPrivate(tab)
+        self._to_load = []
 
     def __len__(self) -> int:
         raise NotImplementedError
@@ -1058,6 +1059,12 @@ class AbstractTab(QWidget):
 
     def load_status(self) -> usertypes.LoadStatus:
         return self._load_status
+
+    def load(self):
+        raise NotImplementedError
+
+    def load_history_entries(self, entries):
+        raise NotImplementedError
 
     def _load_url_prepare(self, url: QUrl, *,
                           emit_before_load_started: bool = True) -> None:

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -1160,12 +1160,6 @@ class AbstractTab(QWidget):
             page_template.render(title=self.title(), icon_url=icon_url),
             self._widget.url())
 
-    def setFocus(self):
-        """Load the tab when it gets focused."""
-        super().setFocus()
-        if self.history.load_on_focus:
-            self.history.load()
-
     def _load_url_prepare(self, url: QUrl, *,
                           emit_before_load_started: bool = True) -> None:
         qtutils.ensure_valid(url)
@@ -1249,3 +1243,15 @@ class AbstractTab(QWidget):
     def is_deleted(self) -> bool:
         assert self._widget is not None
         return sip.isdeleted(self._widget)
+
+    def showEvent(self, event):
+        """Load tab if unloaded.
+
+        Args:
+            event: QShowEvent
+        """
+        if event.spontaneous():
+            return
+
+        if self.history.load_on_focus:
+            self.load()

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -708,6 +708,9 @@ class AbstractHistory:
 
     def back(self, count: int = 1) -> None:
         """Go back in the tab's history."""
+        if not self.loaded:
+            self.load()
+
         self._check_count(count)
         idx = self.current_idx() - count
         if idx >= 0:
@@ -718,6 +721,9 @@ class AbstractHistory:
 
     def forward(self, count: int = 1) -> None:
         """Go forward in the tab's history."""
+        if not self.loaded:
+            self.load()
+
         self._check_count(count)
         idx = self.current_idx() + count
         if idx < len(self):
@@ -775,6 +781,7 @@ class AbstractHistory:
 
     def _go_to_item(self, item: TypeHistoryItem) -> None:
         self._tab.before_load_started.emit(item.url())
+        self._history.goToItem(item)
 
 
 class AbstractElements:

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -43,7 +43,7 @@ import pygments.formatters
 from qutebrowser.keyinput import modeman
 from qutebrowser.config import config
 from qutebrowser.utils import (utils, objreg, usertypes, log, qtutils,
-                               urlutils, message)
+                               urlutils, message, jinja)
 from qutebrowser.misc import miscwidgets, objects, sessions
 from qutebrowser.browser import eventfilter
 from qutebrowser.qt import sip
@@ -1139,28 +1139,25 @@ class AbstractTab(QWidget):
 
         self.history.unload()
 
-        # this would be a better way to do it if I could find a way to clear
-        # the page without the webview triggering the title and icon change
-        # signals
-
-        # title = self.title()
-        # icon = self.icon()
-        # self._widget.setHtml("", self._widget.url())
-        # self.title_changed.emit(title)
-        # self.icon_changed.emit(icon)
-
         try:
-            icon_url = \
-                self._widget.iconUrl().toDisplayString(QUrl.EncodeUnicode)
-            icon_tag = '<link rel="shortcut icon" href="{icon_url}"/>'.format(
-                icon_url=icon_url)
+            icon_url = self._widget.iconUrl().toDisplayString(
+                QUrl.EncodeUnicode
+            )
         except AttributeError:
             # QtWebkit doesn't have the iconUrl property
-            icon_tag = ''
+            icon_url = ''
+
+        page_template = jinja.environment.from_string(
+            '<html><head>'
+            '{% if icon_url %}'
+            '<link rel="shortcut icon" href="{{icon_url}}"/>'
+            '{% endif %}'
+            '<title>{{title}}</title>'
+            '</head></html>'
+        )
 
         self._widget.setHtml(
-            '<html><head>{icon_tag}<title>{title}</title></head></html>'
-            ''.format(title=self.title(), icon_tag=icon_tag),
+            page_template.render(title=self.title(), icon_url=icon_url),
             self._widget.url())
 
     def setFocus(self):

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -620,7 +620,7 @@ class AbstractHistoryPrivate:
         raise NotImplementedError
 
 
-class TabHistoryItem:
+class AbstractHistoryItem:
 
     """A single item in the tab history.
 
@@ -650,24 +650,7 @@ class TabHistoryItem:
 
     @classmethod
     def from_qt(cls, qt_item, active=False):
-        """Construct a TabHistoryItem from a Qt history item.
-
-        Args:
-            qt_item: a QWebEngineHistoryItem or QWebKitHistoryItem
-        """
-        qtutils.ensure_valid(qt_item)
-
-        try:
-            user_data = qt_item.userData()
-        except AttributeError:
-            user_data = None
-
-        return TabHistoryItem(
-            qt_item.url(),
-            qt_item.title(),
-            original_url=qt_item.originalUrl(),
-            active=active,
-            user_data=user_data)
+        raise NotImplementedError
 
 
 class AbstractHistory:
@@ -736,10 +719,10 @@ class AbstractHistory:
         self.load_on_focus = False
 
     def load_items(self, entries, lazy=True):
-        """Add a list of TabHistoryItems to the tab's history.
+        """Add a list of AbstractHistoryItems to the tab's history.
 
         Args:
-            entries: a list of TabHistoryItems
+            entries: a list of AbstractHistoryItem
             lazy: indicate if lazy history load
         """
         if lazy:
@@ -752,7 +735,7 @@ class AbstractHistory:
         self.to_load = []
         current_idx = self.current_idx()
         for idx, item in enumerate(self):
-            item = TabHistoryItem.from_qt(
+            item = self._tab.history_item_from_qt(
                 item, active=idx == current_idx)
             self.to_load.append(item)
 
@@ -1248,6 +1231,12 @@ class AbstractTab(QWidget):
         raise NotImplementedError
 
     def set_html(self, html: str, base_url: QUrl = QUrl()) -> None:
+        raise NotImplementedError
+
+    def history_item_from_qt(self, item):
+        raise NotImplementedError
+
+    def new_history_item(self, item):
         raise NotImplementedError
 
     def __repr__(self) -> str:

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -685,11 +685,13 @@ class AbstractHistory:
         if self.to_load:
             return iter(self.to_load)
 
-        return iter(
+        return iter([
             self._tab.history_item_from_qt(
                 item,
-                active=idx == self.current_idx())
-            for idx, item in enumerate(self._history.items()))
+                active=idx == self.current_idx()
+            )
+            for idx, item in enumerate(self._history.items())
+        ])
 
     def _check_count(self, count: int) -> None:
         """Check whether the count is positive."""
@@ -740,7 +742,10 @@ class AbstractHistory:
 
     def can_go_forward(self) -> bool:
         """Determine whether tab can be navigated forward."""
-        return self._history.canGoForward()
+        if self.loaded:
+            return self._history.canGoForward()
+
+        return self.current_idx() < len(self.to_load)
 
     def load(self) -> None:
         """Load the tab history."""

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -619,6 +619,7 @@ class AbstractHistoryPrivate:
         """Deserialize from a list of WebHistoryItems."""
         raise NotImplementedError
 
+
 class TabHistoryItem:
 
     """A single item in the tab history.
@@ -657,7 +658,7 @@ class AbstractHistory:
         self._history = typing.cast(
             typing.Union['QWebHistory', 'QWebEngineHistory'], None)
         self.private_api = AbstractHistoryPrivate(tab)
-        self._to_load = []
+        self.to_load = []
 
     def __len__(self) -> int:
         raise NotImplementedError
@@ -1089,22 +1090,24 @@ class AbstractTab(QWidget):
         return self._load_status
 
     def load(self):
+        """Load the tab history."""
         if self.loaded:
             return
 
-        self.history.private_api.load_items(self.history._to_load)
-        self.history._to_load = []
+        self.history.private_api.load_items(self.history.to_load)
+        self.history.to_load = []
         self.loaded = True
         self.load_on_focus = False
 
     def unload(self):
+        """Unload the tab."""
         if not self.loaded:
             return
 
         self.loaded = False
         self.load_on_focus = True
 
-        _to_load = []
+        to_load = []
         for idx, item in enumerate(self.history):
             qtutils.ensure_valid(item)
             item = TabHistoryItem(
@@ -1113,23 +1116,29 @@ class AbstractTab(QWidget):
                 original_url=item.originalUrl(),
                 active=idx == self.history.current_idx(),
                 user_data=None)
-            _to_load.append(item)
-        self.history._to_load =_to_load
+            to_load.append(item)
+        self.history.to_load = to_load
 
         _title = self._widget.title()
         self._widget.setHtml('', self._widget.url())
         self.title_changed.emit(_title)
 
     def setFocus(self):
+        """Load the tab when it gets focused."""
         super().setFocus()
         if self.load_on_focus:
             self.load()
 
     def load_history_items(self, entries):
+        """Add a list of TabHistoryItems to the tab's history.
+
+        Args:
+            entries: a list of TabHistoryItems
+        """
         if self.loaded:
             self.history.private_api.load_items(entries)
         else:
-            self.history._to_load.extend(entries)
+            self.history.to_load.extend(entries)
 
     def _load_url_prepare(self, url: QUrl, *,
                           emit_before_load_started: bool = True) -> None:

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -619,6 +619,34 @@ class AbstractHistoryPrivate:
         """Deserialize from a list of WebHistoryItems."""
         raise NotImplementedError
 
+class TabHistoryItem:
+
+    """A single item in the tab history.
+
+    Attributes:
+        url: The QUrl of this item.
+        original_url: The QUrl of this item which was originally requested.
+        title: The title as string of this item.
+        active: Whether this item is the item currently navigated to.
+        user_data: The user data for this item.
+    """
+
+    def __init__(self, url, title, *, original_url=None, active=False,
+                 user_data=None):
+        self.url = url
+        if original_url is None:
+            self.original_url = url
+        else:
+            self.original_url = original_url
+        self.title = title
+        self.active = active
+        self.user_data = user_data
+
+    def __repr__(self):
+        return utils.get_repr(self, constructor=True, url=self.url,
+                              original_url=self.original_url, title=self.title,
+                              active=self.active, user_data=self.user_data)
+
 
 class AbstractHistory:
 
@@ -1061,6 +1089,9 @@ class AbstractTab(QWidget):
         return self._load_status
 
     def load(self):
+        raise NotImplementedError
+
+    def unload(self):
         raise NotImplementedError
 
     def load_history_entries(self, entries):

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1774,10 +1774,11 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
     def tab_load(self, count=None):
-        """
-        load the current tab
-        """
+        """Load the current tab.
 
+        Args:
+            count: The tab index to load, or None
+        """
         tab = self._cntwidget(count)
         if tab is None:
             return
@@ -1787,10 +1788,11 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)
     def tab_unload(self, count=None):
-        """
-        unload the current tab
-        """
+        """Unload the current tab.
 
+        Args:
+            count: The tab index to load, or None
+        """
         tab = self._cntwidget(count)
         if tab is None:
             return

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1776,6 +1776,9 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def tab_load(self, prev=False, next_=False, opposite=False,
                   force=False, count=None):
+        """
+        load the current tab
+        """
 
         # tabbar = self._tabbed_browser.widget.tabBar()
         tab = self._current_widget()
@@ -1784,5 +1787,8 @@ class CommandDispatcher:
     @cmdutils.register(instance='command-dispatcher', scope='window')
     def tab_unload(self, prev=False, next_=False, opposite=False,
                   force=False, count=None):
+        """
+        unload the current tab
+        """
         tab = self._current_widget()
         tab.unload()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1783,7 +1783,7 @@ class CommandDispatcher:
         if tab is None:
             return
 
-        tab.load()
+        tab.history.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -907,6 +907,8 @@ class CommandDispatcher:
         window.activateWindow()
         window.raise_()
         tabbed_browser.widget.setCurrentWidget(tab)
+        if not tab.loaded:
+            tab.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('index', choices=['last', 'stack-next', 'stack-prev'])

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1772,3 +1772,17 @@ class CommandDispatcher:
 
         log.misc.debug('state before fullscreen: {}'.format(
             debug.qflags_key(Qt, window.state_before_fullscreen)))
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def tab_load(self, prev=False, next_=False, opposite=False,
+                  force=False, count=None):
+
+        # tabbar = self._tabbed_browser.widget.tabBar()
+        tab = self._current_widget()
+        tab.load()
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def tab_unload(self, prev=False, next_=False, opposite=False,
+                  force=False, count=None):
+        tab = self._current_widget()
+        tab.unload()

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -907,8 +907,6 @@ class CommandDispatcher:
         window.activateWindow()
         window.raise_()
         tabbed_browser.widget.setCurrentWidget(tab)
-        if not tab.loaded:
-            tab.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
     @cmdutils.argument('index', choices=['last', 'stack-next', 'stack-prev'])
@@ -1774,21 +1772,27 @@ class CommandDispatcher:
             debug.qflags_key(Qt, window.state_before_fullscreen)))
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def tab_load(self, prev=False, next_=False, opposite=False,
-                  force=False, count=None):
+    @cmdutils.argument('count', value=cmdutils.Value.count)
+    def tab_load(self, count=None):
         """
         load the current tab
         """
 
-        # tabbar = self._tabbed_browser.widget.tabBar()
-        tab = self._current_widget()
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+
         tab.load()
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def tab_unload(self, prev=False, next_=False, opposite=False,
-                  force=False, count=None):
+    @cmdutils.argument('count', value=cmdutils.Value.count)
+    def tab_unload(self, count=None):
         """
         unload the current tab
         """
-        tab = self._current_widget()
+
+        tab = self._cntwidget(count)
+        if tab is None:
+            return
+
         tab.unload()

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -29,7 +29,6 @@ import json
 import os
 import time
 import textwrap
-import urllib
 import collections
 import base64
 import typing

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -482,7 +482,7 @@ def qute_back(url):
     """
     src = jinja.render(
         'back.html',
-        title='Suspended: ' + urllib.parse.unquote(url.fragment()))
+        title='~: ' + urllib.parse.unquote(url.fragment()))
     return 'text/html', src
 
 

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -474,18 +474,6 @@ def qute_bindings(_url):
     return 'text/html', src
 
 
-@add_handler('back')
-def qute_back(url):
-    """Handler for qute://back.
-
-    Simple page to free ram / lazy load a site, goes back on focusing the tab.
-    """
-    src = jinja.render(
-        'back.html',
-        title='~: ' + urllib.parse.unquote(url.fragment()))
-    return 'text/html', src
-
-
 @add_handler('configdiff')
 def qute_configdiff(url):
     """Handler for qute://configdiff."""

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -538,6 +538,24 @@ class WebEngineScroller(browsertab.AbstractScroller):
         return self._at_bottom
 
 
+class WebEngineHistoryItem(browsertab.AbstractHistoryItem):
+    @classmethod
+    def from_qt(cls, qt_item, active=False):
+        """Construct a WebEngineHistoryItem from a Qt history item.
+
+        Args:
+            qt_item: a QWebEngineHistoryItem
+        """
+        qtutils.ensure_valid(qt_item)
+
+        return cls(
+            qt_item.url(),
+            qt_item.title(),
+            original_url=qt_item.originalUrl(),
+            active=active,
+            user_data=None)
+
+
 class WebEngineHistoryPrivate(browsertab.AbstractHistoryPrivate):
 
     """History-related methods which are not part of the extension API."""
@@ -1284,6 +1302,18 @@ class WebEngineTab(browsertab.AbstractTab):
             title="Error loading page: {}".format(url_string),
             url=url_string, error=error)
         self.set_html(error_page)
+
+    def history_item_from_qt(self, qt_item, active=False):
+        return WebEngineHistoryItem.from_qt(qt_item, active)
+
+    def new_history_item(self, url, original_url, title, active, user_data):
+        return WebEngineHistoryItem(
+            url=url,
+            original_url=original_url,
+            title=title,
+            active=active,
+            user_data=user_data
+        )
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1194,38 +1194,6 @@ class WebEngineTab(browsertab.AbstractTab):
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
 
-    def unload(self):
-        if not self.loaded:
-            return
-
-        self.loaded = False
-        _to_load = []
-        for idx, item in enumerate(self.history):
-            qtutils.ensure_valid(item)
-            item = browsertab.TabHistoryItem(
-                item.url(),
-                item.title(),
-                original_url=item.originalUrl(),
-                active=idx == self.history.current_idx(),
-                user_data=None)
-            _to_load.append(item)
-        self.history._to_load =_to_load
-
-        _title = self._widget.title()
-        self._widget.setHtml('', self._widget.url())
-        self.title_changed.emit(_title)
-
-    def load(self):
-        self.history.load_items(self.history._to_load)
-        self.history._to_load = []
-        self.loaded = True
-
-    def load_history_items(self, entries):
-        if self.loaded:
-            self.history.private_api.load_items(entries)
-        else:
-            self.history._to_load.extend(entries)
-
     def load_url(self, url, *, emit_before_load_started=True):
         """Load the given URL in this tab.
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -589,21 +589,21 @@ class WebEngineHistory(browsertab.AbstractHistory):
         return len(self._history)
 
     def __iter__(self):
-        if self._to_load:
-            return iter(self._to_load)
+        if self.to_load:
+            return iter(self.to_load)
         else:
             return iter(self._history.items())
 
     def current_idx(self):
-        if self._to_load:
+        if self.to_load:
             idx = next(
-                (i for i, item in enumerate(self._to_load)
+                (i for i, item in enumerate(self.to_load)
                  if item.active
                 ),
                 None
             )
             if idx is None:
-                idx = len(self._to_load)-1
+                idx = len(self.to_load)-1
             return idx
         return self._history.currentItemIndex()
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -98,6 +98,7 @@ _JS_WORLD_MAP = {
 }
 
 
+
 class WebEngineAction(browsertab.AbstractAction):
 
     """QtWebEngine implementations related to web actions."""
@@ -1180,6 +1181,26 @@ class WebEngineTab(browsertab.AbstractTab):
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
 
+    def unload(self):
+        if not self.loaded:
+            return
+
+        self.loaded = False
+        self.history._to_load = []
+        for idx, item in enumerate(self.history):
+            qtutils.ensure_valid(item)
+            item = browsertab.TabHistoryItem(
+                item.url(),
+                item.title(),
+                original_url=item.originalUrl(),
+                active=idx == self.history.current_idx(),
+                user_data=None)
+            self.history._to_load.append(item)
+
+        _title = self._widget.title()
+        self._widget.setHtml('', self._widget.url())
+        self.title_changed.emit(_title)
+
     def load(self):
         self.history.load_items(self.history._to_load)
         self.history._to_load = []
@@ -1190,7 +1211,6 @@ class WebEngineTab(browsertab.AbstractTab):
             self.history.private_api.load_items(entries)
         else:
             self.history._to_load.extend(entries)
-            # self.entries_to_load.extend(entries)
 
     def load_url(self, url, *, emit_before_load_started=True):
         """Load the given URL in this tab.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1239,7 +1239,7 @@ class WebEngineTab(browsertab.AbstractTab):
 
     def reload(self, *, force=False):
         if not self.history.loaded:
-            self.load()
+            self.history.load()
             return
 
         if force:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -552,6 +552,12 @@ class WebEngineHistoryPrivate(browsertab.AbstractHistoryPrivate):
             scheme = self._tab.url().scheme()
             if scheme in ['view-source', 'chrome']:
                 raise browsertab.WebTabError("Can't serialize special URL!")
+
+        if self._tab.history.to_load:
+            _stream, data, _cur_data = tabhistory.serialize(
+                self._tab.history.to_load
+            )
+            return data
         return qtutils.serialize(self._history)
 
     def deserialize(self, data):
@@ -596,15 +602,11 @@ class WebEngineHistory(browsertab.AbstractHistory):
 
     def current_idx(self):
         if self.to_load:
-            idx = next(
-                (i for i, item in enumerate(self.to_load)
-                 if item.active
-                ),
-                None
-            )
-            if idx is None:
-                idx = len(self.to_load)-1
-            return idx
+            for i, item in enumerate(self.to_load):
+                if item.active:
+                    return i
+            return len(self.to_load) - 1
+
         return self._history.currentItemIndex()
 
     def can_go_back(self):
@@ -1209,6 +1211,10 @@ class WebEngineTab(browsertab.AbstractTab):
         self._widget.load(url)
 
     def url(self, *, requested=False):
+        if not self.loaded and self.history.to_load:
+            idx = self.history.current_idx()
+            return self.history.to_load[idx].url
+
         page = self._widget.page()
         if requested:
             return page.requestedUrl()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -31,6 +31,9 @@ from PyQt5.QtNetwork import QAuthenticator
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWebEngineWidgets import QWebEnginePage, QWebEngineScript
 
+if typing.TYPE_CHECKING:
+    from PyQt5.QtWebEngineWidgets import QWebEngineHistoryItem
+
 from qutebrowser.config import configdata, config
 from qutebrowser.browser import (browsertab, eventfilter, shared, webelem,
                                  history, greasemonkey)
@@ -539,6 +542,8 @@ class WebEngineScroller(browsertab.AbstractScroller):
 
 
 class WebEngineHistoryItem(browsertab.AbstractHistoryItem):
+    """History item data derived from QWebEngineHistoryItem."""
+
     @classmethod
     def from_qt(cls, qt_item, active=False):
         """Construct a WebEngineHistoryItem from a Qt history item.
@@ -1270,8 +1275,9 @@ class WebEngineTab(browsertab.AbstractTab):
             url=url_string, error=error)
         self.set_html(error_page)
 
-    def history_item_from_qt(self, qt_item, active=False):
-        return WebEngineHistoryItem.from_qt(qt_item, active)
+    def history_item_from_qt(self, item: browsertab.TypeHistoryItem,
+                             active: bool = False) -> WebEngineHistoryItem:
+        return WebEngineHistoryItem.from_qt(item, active)
 
     def new_history_item(self, url, original_url, title, active, user_data):
         return WebEngineHistoryItem(

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -590,7 +590,10 @@ class WebEngineHistory(browsertab.AbstractHistory):
         return len(self._history)
 
     def __iter__(self):
-        return iter(self._to_load or self._history.items())
+        if self._history is not None:
+            return iter(self._history.items())
+        else:
+            return iter(self._to_load)
 
     def current_idx(self):
         return self._history.currentItemIndex()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -98,7 +98,6 @@ _JS_WORLD_MAP = {
 }
 
 
-
 class WebEngineAction(browsertab.AbstractAction):
 
     """QtWebEngine implementations related to web actions."""
@@ -1167,7 +1166,6 @@ class WebEngineTab(browsertab.AbstractTab):
         self._saved_zoom = None
         self._reload_url = None  # type: typing.Optional[QUrl]
         self._scripts.init()
-        # self.entries_to_load = []
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1213,7 +1213,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self._widget.load(url)
 
     def url(self, *, requested=False):
-        if not self.loaded and self.history.to_load:
+        if not self.history.loaded and self.history.to_load:
             idx = self.history.current_idx()
             return self.history.to_load[idx].url
 
@@ -1248,7 +1248,7 @@ class WebEngineTab(browsertab.AbstractTab):
             self._widget.page().runJavaScript(code, world_id, callback)
 
     def reload(self, *, force=False):
-        if not self.loaded:
+        if not self.history.loaded:
             self.load()
             return
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -589,7 +589,7 @@ class WebEngineHistory(browsertab.AbstractHistory):
         return len(self._history)
 
     def __iter__(self):
-        return iter(self._history.items())
+        return iter(self._to_load or self._history.items())
 
     def current_idx(self):
         return self._history.currentItemIndex()
@@ -1153,6 +1153,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self._saved_zoom = None
         self._reload_url = None  # type: typing.Optional[QUrl]
         self._scripts.init()
+        # self.entries_to_load = []
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access
@@ -1178,6 +1179,18 @@ class WebEngineTab(browsertab.AbstractTab):
             return
         self.zoom.set_factor(self._saved_zoom)
         self._saved_zoom = None
+
+    def load(self):
+        self.history.load_items(self.history._to_load)
+        self.history._to_load = []
+        self.loaded = True
+
+    def load_history_items(self, entries):
+        if self.loaded:
+            self.history.private_api.load_items(entries)
+        else:
+            self.history._to_load.extend(entries)
+            # self.entries_to_load.extend(entries)
 
     def load_url(self, url, *, emit_before_load_started=True):
         """Load the given URL in this tab.
@@ -1227,6 +1240,10 @@ class WebEngineTab(browsertab.AbstractTab):
             self._widget.page().runJavaScript(code, world_id, callback)
 
     def reload(self, *, force=False):
+        if not self.loaded:
+            self.load()
+            return
+
         if force:
             action = QWebEnginePage.ReloadAndBypassCache
         else:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -609,39 +609,6 @@ class WebEngineHistory(browsertab.AbstractHistory):
         super().__init__(tab)
         self.private_api = WebEngineHistoryPrivate(tab)
 
-    def __len__(self):
-        return len(self._history)
-
-    def __iter__(self):
-        if self.to_load:
-            return iter(self.to_load)
-        else:
-            return iter(self._history.items())
-
-    def current_idx(self):
-        if self.to_load:
-            for i, item in enumerate(self.to_load):
-                if item.active:
-                    return i
-            return len(self.to_load) - 1
-
-        return self._history.currentItemIndex()
-
-    def can_go_back(self):
-        if self.to_load:
-            return self.current_idx() > 0
-        return self._history.canGoBack()
-
-    def can_go_forward(self):
-        return self._history.canGoForward()
-
-    def _item_at(self, i):
-        return self._history.itemAt(i)
-
-    def _go_to_item(self, item):
-        self._tab.before_load_started.emit(item.url())
-        self._history.goToItem(item)
-
 
 class WebEngineZoom(browsertab.AbstractZoom):
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -610,6 +610,8 @@ class WebEngineHistory(browsertab.AbstractHistory):
         return self._history.currentItemIndex()
 
     def can_go_back(self):
+        if self.to_load:
+            return self.current_idx() > 0
         return self._history.canGoBack()
 
     def can_go_forward(self):

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -59,7 +59,6 @@ class WebEngineView(QWebEngineView):
             sip.delete(self.layout())
             self._layout = miscwidgets.PseudoLayout(self)
 
-
     def render_widget(self):
         """Get the RenderWidgetHostViewQt for this view.
 

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -59,9 +59,6 @@ class WebEngineView(QWebEngineView):
             sip.delete(self.layout())
             self._layout = miscwidgets.PseudoLayout(self)
 
-    def focusInEvent(self, event):
-        super().focusInEvent(event)
-        print('focusIn', self)
 
     def render_widget(self):
         """Get the RenderWidgetHostViewQt for this view.

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -59,6 +59,10 @@ class WebEngineView(QWebEngineView):
             sip.delete(self.layout())
             self._layout = miscwidgets.PseudoLayout(self)
 
+    def focusInEvent(self, event):
+        super().focusInEvent(event)
+        print('focusIn', self)
+
     def render_widget(self):
         """Get the RenderWidgetHostViewQt for this view.
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -576,37 +576,6 @@ class WebKitHistory(browsertab.AbstractHistory):
         super().__init__(tab)
         self.private_api = WebKitHistoryPrivate(tab)
 
-    def __len__(self):
-        return len(self._history)
-
-    def __iter__(self):
-        if self.to_load:
-            return iter(self.to_load)
-        else:
-            return iter(self._history.items())
-
-    def current_idx(self):
-        if self.to_load:
-            for i, item in enumerate(self.to_load):
-                if item.active:
-                    return i
-            return len(self.to_load) - 1
-
-        return self._history.currentItemIndex()
-
-    def can_go_back(self):
-        return self._history.canGoBack()
-
-    def can_go_forward(self):
-        return self._history.canGoForward()
-
-    def _item_at(self, i):
-        return self._history.itemAt(i)
-
-    def _go_to_item(self, item):
-        self._tab.before_load_started.emit(item.url())
-        self._history.goToItem(item)
-
 
 class WebKitElements(browsertab.AbstractElements):
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -557,10 +557,10 @@ class WebKitHistory(browsertab.AbstractHistory):
         return len(self._history)
 
     def __iter__(self):
-        if self._history is not None:
-            return iter(self._history.items())
-        else:
+        if self._to_load:
             return iter(self._to_load)
+        else:
+            return iter(self._history.items())
 
     def current_idx(self):
         return self._history.currentItemIndex()

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -557,8 +557,8 @@ class WebKitHistory(browsertab.AbstractHistory):
         return len(self._history)
 
     def __iter__(self):
-        if self._to_load:
-            return iter(self._to_load)
+        if self.to_load:
+            return iter(self.to_load)
         else:
             return iter(self._history.items())
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -522,6 +522,11 @@ class WebKitHistoryPrivate(browsertab.AbstractHistoryPrivate):
     """History-related methods which are not part of the extension API."""
 
     def serialize(self):
+        if self._tab.history.to_load:
+            _stream, data, _cur_data = tabhistory.serialize(
+                self._tab.history.to_load
+            )
+            return data
         return qtutils.serialize(self._history)
 
     def deserialize(self, data):
@@ -563,6 +568,12 @@ class WebKitHistory(browsertab.AbstractHistory):
             return iter(self._history.items())
 
     def current_idx(self):
+        if self.to_load:
+            for i, item in enumerate(self.to_load):
+                if item.active:
+                    return i
+            return len(self.to_load) - 1
+
         return self._history.currentItemIndex()
 
     def can_go_back(self):
@@ -736,6 +747,10 @@ class WebKitTab(browsertab.AbstractTab):
         self._widget.load(url)
 
     def url(self, *, requested=False):
+        if not self.loaded and self.history.to_load:
+            idx = self.history.current_idx()
+            return self.history.to_load[idx].url
+
         frame = self._widget.page().mainFrame()
         if requested:
             return frame.requestedUrl()

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -730,18 +730,6 @@ class WebKitTab(browsertab.AbstractTab):
         settings = widget.settings()
         settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, True)
 
-    def load(self):
-        if not self.loaded:
-            self.history.load_items(self.history._to_load)
-            self.history._to_load = []
-            self.loaded = True
-
-    def load_history_items(self, entries):
-        if self.loaded:
-            self.history.load_items(entries)
-        else:
-            self.history._to_load.extend(entries)
-
     def load_url(self, url, *, emit_before_load_started=True):
         self._load_url_prepare(
             url, emit_before_load_started=emit_before_load_started)
@@ -773,6 +761,10 @@ class WebKitTab(browsertab.AbstractTab):
         return self._widget.icon()
 
     def reload(self, *, force=False):
+        if not self.loaded:
+            self.load()
+            return
+
         if force:
             action = QWebPage.ReloadAndBypassCache
         else:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -747,7 +747,7 @@ class WebKitTab(browsertab.AbstractTab):
         self._widget.load(url)
 
     def url(self, *, requested=False):
-        if not self.loaded and self.history.to_load:
+        if not self.history.loaded and self.history.to_load:
             idx = self.history.current_idx()
             return self.history.to_load[idx].url
 
@@ -776,7 +776,7 @@ class WebKitTab(browsertab.AbstractTab):
         return self._widget.icon()
 
     def reload(self, *, force=False):
-        if not self.loaded:
+        if not self.history.loaded:
             self.load()
             return
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -557,7 +557,10 @@ class WebKitHistory(browsertab.AbstractHistory):
         return len(self._history)
 
     def __iter__(self):
-        return iter(self._history.items())
+        if self._history is not None:
+            return iter(self._history.items())
+        else:
+            return iter(self._to_load)
 
     def current_idx(self):
         return self._history.currentItemIndex()
@@ -726,6 +729,18 @@ class WebKitTab(browsertab.AbstractTab):
     def _make_private(self, widget):
         settings = widget.settings()
         settings.setAttribute(QWebSettings.PrivateBrowsingEnabled, True)
+
+    def load(self):
+        if not self.loaded:
+            self.history.load_items(self.history._to_load)
+            self.history._to_load = []
+            self.loaded = True
+
+    def load_history_items(self, entries):
+        if self.loaded:
+            self.history.load_items(entries)
+        else:
+            self.history._to_load.extend(entries)
 
     def load_url(self, url, *, emit_before_load_started=True):
         self._load_url_prepare(

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -517,6 +517,24 @@ class WebKitScroller(browsertab.AbstractScroller):
         return self.pos_px().y() >= frame.scrollBarMaximum(Qt.Vertical)
 
 
+class WebKitHistoryItem(browsertab.AbstractHistoryItem):
+    @classmethod
+    def from_qt(cls, qt_item, active=False):
+        """Construct a WebKitHistoryItem from a Qt history item.
+
+        Args:
+            qt_item: a QWebKitHistoryItem
+        """
+        qtutils.ensure_valid(qt_item)
+
+        return cls(
+            qt_item.url(),
+            qt_item.title(),
+            original_url=qt_item.originalUrl(),
+            active=active,
+            user_data=qt_item.userData())
+
+
 class WebKitHistoryPrivate(browsertab.AbstractHistoryPrivate):
 
     """History-related methods which are not part of the extension API."""
@@ -791,6 +809,18 @@ class WebKitTab(browsertab.AbstractTab):
 
     def title(self):
         return self._widget.title()
+
+    def history_item_from_qt(self, qt_item, active=False):
+        return WebKitHistoryItem.from_qt(qt_item, active)
+
+    def new_history_item(self, url, original_url, title, active, user_data):
+        return WebKitHistoryItem(
+            url=url,
+            original_url=original_url,
+            title=title,
+            active=active,
+            user_data=user_data
+        )
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -21,6 +21,7 @@
 
 import re
 import functools
+import typing
 import xml.etree.ElementTree
 
 from PyQt5.QtCore import pyqtSlot, Qt, QUrl, QPoint, QTimer, QSizeF, QSize
@@ -28,6 +29,9 @@ from PyQt5.QtGui import QIcon
 from PyQt5.QtWebKitWidgets import QWebPage, QWebFrame
 from PyQt5.QtWebKit import QWebSettings
 from PyQt5.QtPrintSupport import QPrinter
+
+if typing.TYPE_CHECKING:
+    from PyQt5.QtWebKit import QWebHistoryItem
 
 from qutebrowser.browser import browsertab, shared
 from qutebrowser.browser.webkit import (webview, tabhistory, webkitelem,
@@ -518,6 +522,8 @@ class WebKitScroller(browsertab.AbstractScroller):
 
 
 class WebKitHistoryItem(browsertab.AbstractHistoryItem):
+    """History item data derived from QWebHistoryItem."""
+
     @classmethod
     def from_qt(cls, qt_item, active=False):
         """Construct a WebKitHistoryItem from a Qt history item.
@@ -779,10 +785,14 @@ class WebKitTab(browsertab.AbstractTab):
     def title(self):
         return self._widget.title()
 
-    def history_item_from_qt(self, qt_item, active=False):
-        return WebKitHistoryItem.from_qt(qt_item, active)
+    def history_item_from_qt(self, item: browsertab.TypeHistoryItem,
+                             active: bool = False) -> WebKitHistoryItem:
+        return WebKitHistoryItem.from_qt(item, active)
 
-    def new_history_item(self, url, original_url, title, active, user_data):
+    def new_history_item(
+            self, url: QUrl, original_url: QUrl,
+            title: str, active: bool,
+            user_data: typing.Dict[str, typing.Any]) -> WebKitHistoryItem:
         return WebKitHistoryItem(
             url=url,
             original_url=original_url,

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -556,6 +556,7 @@ class TabbedBrowser(QWidget):
             background: bool = None,
             related: bool = True,
             idx: int = None,
+            from_session: bool = False,
     ) -> browsertab.AbstractTab:
         """Open a new tab with a given URL.
 
@@ -592,12 +593,15 @@ class TabbedBrowser(QWidget):
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=window.win_id)
             return tabbed_browser.tabopen(url=url, background=background,
-                                          related=related)
+                                          related=related,
+                                          from_session=from_session)
 
         tab = browsertab.create(win_id=self._win_id,
                                 private=self.is_private,
-                                parent=self.widget)
-        self._connect_tab_signals(tab)
+                                parent=self.widget, from_session=from_session)
+
+        if not from_session:
+            self._connect_tab_signals(tab)
 
         if idx is None:
             idx = self._get_new_tab_idx(related)

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -81,7 +81,7 @@ class TabWidget(QTabWidget):
         """
         super().setCurrentIndex(idx)
         tab = self.widget(idx)
-        if tab.load_on_focus:
+        if tab.history.load_on_focus:
             tab.load()
 
     @config.change_filter('tabs')

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -73,17 +73,6 @@ class TabWidget(QTabWidget):
         self._init_config()
         config.instance.changed.connect(self._init_config)
 
-    def setCurrentIndex(self, idx):
-        """Set the focus to the tab at index idx and load it.
-
-        Args:
-            idx index of the tab to focus
-        """
-        super().setCurrentIndex(idx)
-        tab = self.widget(idx)
-        if tab.history.load_on_focus:
-            tab.load()
-
     @config.change_filter('tabs')
     def _init_config(self):
         """Initialize attributes based on the config."""

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -559,7 +559,6 @@ class TabBar(QTabBar):
                     idx = self.count() - 1
             self.tabCloseRequested.emit(idx)  # type: ignore
             return
-
         super().mousePressEvent(e)
 
     def minimumTabSizeHint(self, index: int, ellipsis: bool = True) -> QSize:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -416,18 +416,6 @@ class TabBar(QTabBar):
         stylesheet.set_register(self)
         QTimer.singleShot(0, self.maybe_hide)
 
-    def setCurrentIndex(self, idx):
-        """Set the focus to the tab at index idx and load it.
-
-        Args:
-            idx index of the tab to focus
-        """
-        super().setCurrentIndex(idx)
-
-        tab = self.widget(idx)
-        if not tab.loaded:
-            tab.load()
-
     def __repr__(self):
         return utils.get_repr(self, count=self.count())
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -138,6 +138,9 @@ class TabWidget(QTabWidget):
                    is only set if the given field is in the template.
         """
         tab = self.widget(idx)
+        # TODO Deal with the case of webkit
+        if not tab._webview_loaded:
+            return
         if tab.data.pinned:
             fmt = config.cache['tabs.title.format_pinned']
         else:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -73,6 +73,20 @@ class TabWidget(QTabWidget):
         self._init_config()
         config.instance.changed.connect(self._init_config)
 
+    def setCurrentIndex(self, idx):
+        super().setCurrentIndex(idx)
+        self.load_tab_at_index(idx)
+
+    # def setCurrentWidget(self, tabWidget):
+    #     super().setCurrentWidget(tabWidget)
+    #     if not tabWidget.loaded:
+    #         tabWidget.load()
+
+    def load_tab_at_index(self, idx):
+        tab = self.widget(idx)
+        if not tab.loaded:
+            tab.load()
+
     @config.change_filter('tabs')
     def _init_config(self):
         """Initialize attributes based on the config."""
@@ -405,6 +419,14 @@ class TabBar(QTabBar):
         stylesheet.set_register(self)
         QTimer.singleShot(0, self.maybe_hide)
 
+    def setCurrentIndex(self, idx):
+        super().setCurrentIndex(idx)
+
+        print('tabBar setIndex', idx)
+        tab = self.widget(idx)
+        if not tab.loaded:
+            tab.load()
+
     def __repr__(self):
         return utils.get_repr(self, count=self.count())
 
@@ -546,7 +568,11 @@ class TabBar(QTabBar):
                     idx = self.count() - 1
             self.tabCloseRequested.emit(idx)  # type: ignore
             return
+
+        prevIdx = self.currentIndex()
         super().mousePressEvent(e)
+        if prevIdx != self.currentIndex():
+            self.parent().load_tab_at_index(self.currentIndex())
 
     def minimumTabSizeHint(self, index: int, ellipsis: bool = True) -> QSize:
         """Set the minimum tab size to indicator/icon/... text.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -75,16 +75,8 @@ class TabWidget(QTabWidget):
 
     def setCurrentIndex(self, idx):
         super().setCurrentIndex(idx)
-        self.load_tab_at_index(idx)
-
-    # def setCurrentWidget(self, tabWidget):
-    #     super().setCurrentWidget(tabWidget)
-    #     if not tabWidget.loaded:
-    #         tabWidget.load()
-
-    def load_tab_at_index(self, idx):
         tab = self.widget(idx)
-        if not tab.loaded:
+        if tab.load_on_focus:
             tab.load()
 
     @config.change_filter('tabs')
@@ -568,10 +560,7 @@ class TabBar(QTabBar):
             self.tabCloseRequested.emit(idx)  # type: ignore
             return
 
-        prevIdx = self.currentIndex()
         super().mousePressEvent(e)
-        if prevIdx != self.currentIndex():
-            self.parent().load_tab_at_index(self.currentIndex())
 
     def minimumTabSizeHint(self, index: int, ellipsis: bool = True) -> QSize:
         """Set the minimum tab size to indicator/icon/... text.

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -422,7 +422,6 @@ class TabBar(QTabBar):
     def setCurrentIndex(self, idx):
         super().setCurrentIndex(idx)
 
-        print('tabBar setIndex', idx)
         tab = self.widget(idx)
         if not tab.loaded:
             tab.load()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -74,6 +74,11 @@ class TabWidget(QTabWidget):
         config.instance.changed.connect(self._init_config)
 
     def setCurrentIndex(self, idx):
+        """Set the focus to the tab at index idx and load it.
+
+        Args:
+            idx index of the tab to focus
+        """
         super().setCurrentIndex(idx)
         tab = self.widget(idx)
         if tab.load_on_focus:
@@ -412,6 +417,11 @@ class TabBar(QTabBar):
         QTimer.singleShot(0, self.maybe_hide)
 
     def setCurrentIndex(self, idx):
+        """Set the focus to the tab at index idx and load it.
+
+        Args:
+            idx index of the tab to focus
+        """
         super().setCurrentIndex(idx)
 
         tab = self.widget(idx)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -210,8 +210,9 @@ class SessionManager(QObject):
             data['history'].append(item_data)
 
         # check active
-        if data['history'] and not any(i.get('active') for i in data['history']):
-            log.session.warning('no active item for', tab)
+        if (data['history'] and not
+                any(i.get('active') for i in data['history'])):
+            log.sessions.warning('no active item for {}'.format(tab))
             data['history'][-1]['active'] = True
 
         return data
@@ -247,7 +248,9 @@ class SessionManager(QObject):
                 win_data['private'] = True
 
             for i, tab in enumerate(tabbed_browser.widgets()):
-                log.sessions.debug("saving tab {} with history {}...".format(tab, list(tab.history)))
+                log.sessions.debug(
+                    "saving tab {} with history {}...".format(
+                        tab, list(tab.history)))
                 active = i == tabbed_browser.widget.currentIndex()
                 win_data['tabs'].append(self._save_tab(tab, active))
             data['windows'].append(win_data)
@@ -375,16 +378,21 @@ class SessionManager(QObject):
                     histentry['original-url'].encode('ascii'))
             else:
                 orig_url = url
-            entry = browsertab.TabHistoryItem(url=url, original_url=orig_url,
-                                   title=histentry['title'], active=active,
-                                   user_data=user_data)
-            entries.append(entry)
+
+            entry = browsertab.TabHistoryItem(
+                url=url,
+                original_url=orig_url,
+                title=histentry['title'],
+                active=active,
+                user_data=user_data)
+            history_items.append(entry)
+
             if active:
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
             new_tab.loaded = False
-            new_tab.load_history_items(entries)
+            new_tab.load_history_items(history_items)
         except ValueError as e:
             raise SessionError(e)
 
@@ -444,8 +452,7 @@ class SessionManager(QObject):
         for win in data['windows']:
             self._load_window(win)
 
-        if data['windows']:
-            self.did_load = True
+        self.did_load = bool(data['windows'])
         if not name.startswith('_') and not temp:
             self.current = name
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -134,7 +134,7 @@ class SessionManager(QObject):
         Args:
             tab: The tab to save.
             idx: The index of the current history item.
-            item: TheHistoryItem.
+            item: The TabHistoryItem.
 
         Return:
             A dict with the saved data for this item.
@@ -310,7 +310,6 @@ class SessionManager(QObject):
 
     def save_autosave(self):
         """Save the autosave session."""
-        return
         try:
             self.save('_autosave')
         except SessionError as e:

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -321,18 +321,8 @@ class SessionManager(QObject):
     def _load_tab(self, new_tab, data):
         """Load yaml data into a newly opened tab."""
         entries = []
-        lazy_load = []  # type: typing.MutableSequence[_JsonType]
-        # use len(data['history'])
-        # -> dropwhile empty if not session.lazy_session
-        lazy_index = len(data['history'])
-        gen = itertools.chain(
-            itertools.takewhile(lambda _: not lazy_load,
-                                enumerate(data['history'])),
-            enumerate(lazy_load),
-            itertools.dropwhile(lambda i: i[0] < lazy_index,
-                                enumerate(data['history'])))
 
-        for i, histentry in gen:
+        for i, histentry in enumerate(data['history']):
             user_data = {}
 
             if 'zoom' in data:
@@ -370,14 +360,14 @@ class SessionManager(QObject):
                 title=histentry['title'],
                 active=active,
                 user_data=user_data)
-            history_items.append(entry)
+            entries.append(entry)
 
             if active:
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
             new_tab.loaded = False
-            new_tab.load_history_items(history_items)
+            new_tab.load_history_items(entries)
         except ValueError as e:
             raise SessionError(e)
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -19,24 +19,22 @@
 
 """Management of sessions - saved tabs/windows."""
 
+import itertools
 import os
 import os.path
-import itertools
-import urllib
 import typing
+import urllib
 
-from PyQt5.QtCore import QUrl, QObject, QPoint, QTimer, pyqtSlot
-from PyQt5.QtWidgets import QApplication
 import yaml
+from PyQt5.QtCore import QObject, QPoint, QTimer, QUrl, pyqtSlot
+from PyQt5.QtWidgets import QApplication
 
-from qutebrowser.utils import (standarddir, objreg, qtutils, log, message,
-                               utils)
 from qutebrowser.api import cmdutils
-from qutebrowser.config import config, configfiles
 from qutebrowser.completion.models import miscmodels
+from qutebrowser.config import config, configfiles
 from qutebrowser.mainwindow import mainwindow
 from qutebrowser.qt import sip
-
+from qutebrowser.utils import log, message, objreg, qtutils, standarddir, utils
 
 _JsonType = typing.MutableMapping[str, typing.Any]
 
@@ -164,7 +162,7 @@ class SessionManager(QObject):
         Args:
             tab: The tab to save.
             idx: The index of the current history item.
-            item: The history item.
+            item: TheHistoryItem.
 
         Return:
             A dict with the saved data for this item.
@@ -173,8 +171,8 @@ class SessionManager(QObject):
             'url': bytes(item.url().toEncoded()).decode('ascii'),
         }  # type: _JsonType
 
-        if item.title():
-            data['title'] = item.title()
+        if item.title:
+            data['title'] = item.title
         else:
             # https://github.com/qutebrowser/qutebrowser/issues/879
             if tab.history.current_idx() == idx:
@@ -182,15 +180,15 @@ class SessionManager(QObject):
             else:
                 data['title'] = data['url']
 
-        if item.originalUrl() != item.url():
-            encoded = item.originalUrl().toEncoded()
+        if item.original_url != item.url:
+            encoded = item.original_url.toEncoded()
             data['original-url'] = bytes(encoded).decode('ascii')
 
         if tab.history.current_idx() == idx:
             data['active'] = True
 
         try:
-            user_data = item.userData()
+            user_data = item.user_data
         except AttributeError:
             # QtWebEngine
             user_data = None
@@ -221,15 +219,26 @@ class SessionManager(QObject):
         if active:
             data['active'] = True
         for idx, item in enumerate(tab.history):
-            qtutils.ensure_valid(item)
+            if not isinstance(item, TabHistoryItem):
+                qtutils.ensure_valid(item)
+                item = TabHistoryItem(
+                    item.url(),
+                    item.title(),
+                    original_url=item.originalUrl(),
+                    active=active,
+                    user_data=None)
             item_data = self._save_tab_item(tab, idx, item)
-            if item.url().scheme() == 'qute' and item.url().host() == 'back':
+            if item.url.scheme() == 'qute' and item.url.host() == 'back':
                 # don't add qute://back to the session file
                 if item_data.get('active', False) and data['history']:
                     # mark entry before qute://back as active
                     data['history'][-1]['active'] = True
             else:
                 data['history'].append(item_data)
+        # check active
+        if not any(i.get('active') for i in data['history']):
+            data['history'][-1]['active'] = True
+
         return data
 
     def _save_all(self, *, only_window=None, with_private=False):
@@ -261,6 +270,8 @@ class SessionManager(QObject):
             win_data['tabs'] = []
             if tabbed_browser.is_private:
                 win_data['private'] = True
+
+            # import pdb; pdb.set_trace()
             for i, tab in enumerate(tabbed_browser.widgets()):
                 active = i == tabbed_browser.widget.currentIndex()
                 win_data['tabs'].append(self._save_tab(tab, active))
@@ -324,6 +335,7 @@ class SessionManager(QObject):
 
     def save_autosave(self):
         """Save the autosave session."""
+        return
         try:
             self.save('_autosave')
         except SessionError as e:
@@ -382,19 +394,19 @@ class SessionManager(QObject):
             if 'pinned' in histentry:
                 new_tab.data.pinned = histentry['pinned']
 
-            if (config.val.session.lazy_restore and
-                    histentry.get('active', False) and
-                    not histentry['url'].startswith('qute://back')):
-                # remove "active" mark and insert back page marked as active
-                lazy_index = i + 1
-                lazy_load.append({
-                    'title': histentry['title'],
-                    'url':
-                        'qute://back#' +
-                        urllib.parse.quote(histentry['title']),
-                    'active': True
-                })
-                histentry['active'] = False
+            # if (config.val.session.lazy_restore and
+            #         histentry.get('active', False) and
+            #         not histentry['url'].startswith('qute://back')):
+            #     # remove "active" mark and insert back page marked as active
+            #     lazy_index = i + 1
+            #     lazy_load.append({
+            #         'title': histentry['title'],
+            #         'url':
+            #             'qute://back#' +
+            #             urllib.parse.quote(histentry['title']),
+            #         'active': True
+            #     })
+            #     histentry['active'] = False
 
             active = histentry.get('active', False)
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))
@@ -411,7 +423,8 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            new_tab.history.private_api.load_items(entries)
+            new_tab.load_history_items(entries)
+            # new_tab.history.load_items(entries)
         except ValueError as e:
             raise SessionError(e)
 
@@ -443,6 +456,7 @@ class SessionManager(QObject):
             name: The name of the session to load.
             temp: If given, don't set the current session.
         """
+        print('loading session')
         path = self._get_session_path(name, check_exists=True)
         try:
             with open(path, encoding='utf-8') as f:
@@ -466,6 +480,8 @@ class SessionManager(QObject):
             self.did_load = True
         if not name.startswith('_') and not temp:
             self.current = name
+
+        print('session loaded')
 
     def delete(self, name):
         """Delete a session."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -192,19 +192,7 @@ class SessionManager(QObject):
             data['active'] = True
         for idx, item in enumerate(tab.history):
             if not isinstance(item, browsertab.TabHistoryItem):
-                qtutils.ensure_valid(item)
-
-                try:
-                    user_data = item.userData()
-                except AttributeError:
-                    user_data = None
-
-                item = browsertab.TabHistoryItem(
-                    item.url(),
-                    item.title(),
-                    original_url=item.originalUrl(),
-                    active=active,
-                    user_data=user_data)
+                item = browsertab.TabHistoryItem.from_qt(item, active=active)
 
             item_data = self._save_tab_item(tab, idx, item)
             data['history'].append(item_data)
@@ -248,9 +236,6 @@ class SessionManager(QObject):
                 win_data['private'] = True
 
             for i, tab in enumerate(tabbed_browser.widgets()):
-                log.sessions.debug(
-                    "saving tab {} with history {}...".format(
-                        tab, list(tab.history)))
                 active = i == tabbed_browser.widget.currentIndex()
                 win_data['tabs'].append(self._save_tab(tab, active))
             data['windows'].append(win_data)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -140,7 +140,7 @@ class SessionManager(QObject):
             A dict with the saved data for this item.
         """
         data = {
-            'url': bytes(item.url().toEncoded()).decode('ascii'),
+            'url': bytes(item.url.toEncoded()).decode('ascii'),
         }  # type: _JsonType
 
         if item.title:

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -240,6 +240,7 @@ class SessionManager(QObject):
 
         # check active
         if data['history'] and not any(i.get('active') for i in data['history']):
+            log.session.warning('no active item for', tab)
             data['history'][-1]['active'] = True
 
         return data

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -19,18 +19,15 @@
 
 """Management of sessions - saved tabs/windows."""
 
-import itertools
 import os
 import os.path
 import typing
-import urllib
 
 import yaml
 from PyQt5.QtCore import QObject, QPoint, QTimer, QUrl, pyqtSlot
 from PyQt5.QtWidgets import QApplication
 
 from qutebrowser.api import cmdutils
-from qutebrowser.browser import browsertab
 from qutebrowser.completion.models import miscmodels
 from qutebrowser.config import config, configfiles
 from qutebrowser.mainwindow import mainwindow
@@ -319,7 +316,7 @@ class SessionManager(QObject):
         """Load yaml data into a newly opened tab."""
         entries = []
 
-        for i, histentry in enumerate(data['history']):
+        for histentry in data['history']:
             user_data = {}
 
             if 'zoom' in data:
@@ -363,7 +360,8 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            new_tab.history.load_items(entries, lazy=not data.get('active', False))
+            new_tab.history.load_items(entries,
+                                       lazy=not data.get('active', False))
         except ValueError as e:
             raise SessionError(e)
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -222,22 +222,24 @@ class SessionManager(QObject):
         for idx, item in enumerate(tab.history):
             if not isinstance(item, browsertab.TabHistoryItem):
                 qtutils.ensure_valid(item)
+
+                try:
+                    user_data = item.userData()
+                except AttributeError:
+                    user_data = None
+
                 item = browsertab.TabHistoryItem(
                     item.url(),
                     item.title(),
                     original_url=item.originalUrl(),
                     active=active,
-                    user_data=None)
+                    user_data=user_data)
+
             item_data = self._save_tab_item(tab, idx, item)
-            if item.url.scheme() == 'qute' and item.url.host() == 'back':
-                # don't add qute://back to the session file
-                if item_data.get('active', False) and data['history']:
-                    # mark entry before qute://back as active
-                    data['history'][-1]['active'] = True
-            else:
-                data['history'].append(item_data)
+            data['history'].append(item_data)
+
         # check active
-        if not any(i.get('active') for i in data['history']):
+        if data['history'] and not any(i.get('active') for i in data['history']):
             data['history'][-1]['active'] = True
 
         return data
@@ -272,8 +274,8 @@ class SessionManager(QObject):
             if tabbed_browser.is_private:
                 win_data['private'] = True
 
-            # import pdb; pdb.set_trace()
             for i, tab in enumerate(tabbed_browser.widgets()):
+                log.sessions.debug("saving tab {} with history {}...".format(tab, list(tab.history)))
                 active = i == tabbed_browser.widget.currentIndex()
                 win_data['tabs'].append(self._save_tab(tab, active))
             data['windows'].append(win_data)
@@ -424,8 +426,11 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            new_tab.load_history_items(entries)
-            # new_tab.history.load_items(entries)
+            if config.val.session.lazy_restore:
+                new_tab.loaded = False
+                new_tab.load_history_items(entries)
+            else:
+                new_tab.history.load_items(entries)
         except ValueError as e:
             raise SessionError(e)
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -82,35 +82,6 @@ class SessionNotFoundError(SessionError):
     """Exception raised when a session to be loaded was not found."""
 
 
-# class TabHistoryItem:
-
-#     """A single item in the tab history.
-
-#     Attributes:
-#         url: The QUrl of this item.
-#         original_url: The QUrl of this item which was originally requested.
-#         title: The title as string of this item.
-#         active: Whether this item is the item currently navigated to.
-#         user_data: The user data for this item.
-#     """
-
-#     def __init__(self, url, title, *, original_url=None, active=False,
-#                  user_data=None):
-#         self.url = url
-#         if original_url is None:
-#             self.original_url = url
-#         else:
-#             self.original_url = original_url
-#         self.title = title
-#         self.active = active
-#         self.user_data = user_data
-
-#     def __repr__(self):
-#         return utils.get_repr(self, constructor=True, url=self.url,
-#                               original_url=self.original_url, title=self.title,
-#                               active=self.active, user_data=self.user_data)
-
-
 class SessionManager(QObject):
 
     """Manager for sessions.
@@ -398,20 +369,6 @@ class SessionManager(QObject):
             if 'pinned' in histentry:
                 new_tab.data.pinned = histentry['pinned']
 
-            # if (config.val.session.lazy_restore and
-            #         histentry.get('active', False) and
-            #         not histentry['url'].startswith('qute://back')):
-            #     # remove "active" mark and insert back page marked as active
-            #     lazy_index = i + 1
-            #     lazy_load.append({
-            #         'title': histentry['title'],
-            #         'url':
-            #             'qute://back#' +
-            #             urllib.parse.quote(histentry['title']),
-            #         'active': True
-            #     })
-            #     histentry['active'] = False
-
             active = histentry.get('active', False)
             url = QUrl.fromEncoded(histentry['url'].encode('ascii'))
             if 'original-url' in histentry:
@@ -427,32 +384,38 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            if config.val.session.lazy_restore:
-                new_tab.loaded = False
-                new_tab.load_history_items(entries)
-            else:
-                new_tab.history.load_items(entries)
+            new_tab.loaded = False
+            new_tab.load_history_items(entries)
         except ValueError as e:
             raise SessionError(e)
 
     def _load_window(self, win):
         """Turn yaml data into windows."""
         window = mainwindow.MainWindow(geometry=win['geometry'],
-                                       private=win.get('private', None))
+                                           private=win.get('private', None))
         window.show()
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=window.win_id)
         tab_to_focus = None
+        new_tabs = []
         for i, tab in enumerate(win['tabs']):
             new_tab = tabbed_browser.tabopen(background=False)
+            new_tabs.append(new_tab)
             self._load_tab(new_tab, tab)
             if tab.get('active', False):
                 tab_to_focus = i
             if new_tab.data.pinned:
                 tabbed_browser.widget.set_tab_pinned(new_tab,
                                                      new_tab.data.pinned)
+
+        for tab in new_tabs:
+            tab.load_on_focus = True
+            if not config.val.session.lazy_restore:
+                tab.load()
+
         if tab_to_focus is not None:
             tabbed_browser.widget.setCurrentIndex(tab_to_focus)
+
         if win.get('active', False):
             QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -30,6 +30,7 @@ from PyQt5.QtCore import QObject, QPoint, QTimer, QUrl, pyqtSlot
 from PyQt5.QtWidgets import QApplication
 
 from qutebrowser.api import cmdutils
+from qutebrowser.browser import browsertab
 from qutebrowser.completion.models import miscmodels
 from qutebrowser.config import config, configfiles
 from qutebrowser.mainwindow import mainwindow
@@ -81,33 +82,33 @@ class SessionNotFoundError(SessionError):
     """Exception raised when a session to be loaded was not found."""
 
 
-class TabHistoryItem:
+# class TabHistoryItem:
 
-    """A single item in the tab history.
+#     """A single item in the tab history.
 
-    Attributes:
-        url: The QUrl of this item.
-        original_url: The QUrl of this item which was originally requested.
-        title: The title as string of this item.
-        active: Whether this item is the item currently navigated to.
-        user_data: The user data for this item.
-    """
+#     Attributes:
+#         url: The QUrl of this item.
+#         original_url: The QUrl of this item which was originally requested.
+#         title: The title as string of this item.
+#         active: Whether this item is the item currently navigated to.
+#         user_data: The user data for this item.
+#     """
 
-    def __init__(self, url, title, *, original_url=None, active=False,
-                 user_data=None):
-        self.url = url
-        if original_url is None:
-            self.original_url = url
-        else:
-            self.original_url = original_url
-        self.title = title
-        self.active = active
-        self.user_data = user_data
+#     def __init__(self, url, title, *, original_url=None, active=False,
+#                  user_data=None):
+#         self.url = url
+#         if original_url is None:
+#             self.original_url = url
+#         else:
+#             self.original_url = original_url
+#         self.title = title
+#         self.active = active
+#         self.user_data = user_data
 
-    def __repr__(self):
-        return utils.get_repr(self, constructor=True, url=self.url,
-                              original_url=self.original_url, title=self.title,
-                              active=self.active, user_data=self.user_data)
+#     def __repr__(self):
+#         return utils.get_repr(self, constructor=True, url=self.url,
+#                               original_url=self.original_url, title=self.title,
+#                               active=self.active, user_data=self.user_data)
 
 
 class SessionManager(QObject):
@@ -219,9 +220,9 @@ class SessionManager(QObject):
         if active:
             data['active'] = True
         for idx, item in enumerate(tab.history):
-            if not isinstance(item, TabHistoryItem):
+            if not isinstance(item, browsertab.TabHistoryItem):
                 qtutils.ensure_valid(item)
-                item = TabHistoryItem(
+                item = browsertab.TabHistoryItem(
                     item.url(),
                     item.title(),
                     original_url=item.originalUrl(),
@@ -415,7 +416,7 @@ class SessionManager(QObject):
                     histentry['original-url'].encode('ascii'))
             else:
                 orig_url = url
-            entry = TabHistoryItem(url=url, original_url=orig_url,
+            entry = browsertab.TabHistoryItem(url=url, original_url=orig_url,
                                    title=histentry['title'], active=active,
                                    user_data=user_data)
             entries.append(entry)
@@ -456,7 +457,6 @@ class SessionManager(QObject):
             name: The name of the session to load.
             temp: If given, don't set the current session.
         """
-        print('loading session')
         path = self._get_session_path(name, check_exists=True)
         try:
             with open(path, encoding='utf-8') as f:
@@ -480,8 +480,6 @@ class SessionManager(QObject):
             self.did_load = True
         if not name.startswith('_') and not temp:
             self.current = name
-
-        print('session loaded')
 
     def delete(self, name):
         """Delete a session."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -367,14 +367,14 @@ class SessionManager(QObject):
 
         try:
             new_tab.loaded = False
-            new_tab.load_history_items(entries)
+            new_tab.history.load_items(entries, lazy=not data.get('active', False))
         except ValueError as e:
             raise SessionError(e)
 
     def _load_window(self, win):
         """Turn yaml data into windows."""
         window = mainwindow.MainWindow(geometry=win['geometry'],
-                                           private=win.get('private', None))
+                                       private=win.get('private', None))
         window.show()
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=window.win_id)
@@ -393,7 +393,7 @@ class SessionManager(QObject):
         for tab in new_tabs:
             tab.load_on_focus = True
             if not config.val.session.lazy_restore:
-                tab.load()
+                tab.history.load()
 
         if tab_to_focus is not None:
             tabbed_browser.widget.setCurrentIndex(tab_to_focus)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -191,9 +191,6 @@ class SessionManager(QObject):
         if active:
             data['active'] = True
         for idx, item in enumerate(tab.history):
-            if not isinstance(item, browsertab.AbstractHistoryItem):
-                item = tab.history_item_from_qt(item, active=active)
-
             item_data = self._save_tab_item(tab, idx, item)
             data['history'].append(item_data)
 
@@ -366,7 +363,6 @@ class SessionManager(QObject):
                 new_tab.title_changed.emit(histentry['title'])
 
         try:
-            new_tab.loaded = False
             new_tab.history.load_items(entries, lazy=not data.get('active', False))
         except ValueError as e:
             raise SessionError(e)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -134,7 +134,7 @@ class SessionManager(QObject):
         Args:
             tab: The tab to save.
             idx: The index of the current history item.
-            item: The TabHistoryItem.
+            item: The AbstractHistoryItem.
 
         Return:
             A dict with the saved data for this item.
@@ -191,8 +191,8 @@ class SessionManager(QObject):
         if active:
             data['active'] = True
         for idx, item in enumerate(tab.history):
-            if not isinstance(item, browsertab.TabHistoryItem):
-                item = browsertab.TabHistoryItem.from_qt(item, active=active)
+            if not isinstance(item, browsertab.AbstractHistoryItem):
+                item = tab.history_item_from_qt(item, active=active)
 
             item_data = self._save_tab_item(tab, idx, item)
             data['history'].append(item_data)
@@ -354,7 +354,7 @@ class SessionManager(QObject):
             else:
                 orig_url = url
 
-            entry = browsertab.TabHistoryItem(
+            entry = new_tab.new_history_item(
                 url=url,
                 original_url=orig_url,
                 title=histentry['title'],

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -365,7 +365,8 @@ class SessionManager(QObject):
         tab_to_focus = None
         new_tabs = []
         for i, tab in enumerate(win['tabs']):
-            new_tab = tabbed_browser.tabopen(background=False)
+            new_tab = tabbed_browser.tabopen(background=False,
+                                             from_session=True)
             new_tabs.append(new_tab)
             self._load_tab(new_tab, tab)
             if tab.get('active', False):

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -156,11 +156,7 @@ class SessionManager(QObject):
         if tab.history.current_idx() == idx:
             data['active'] = True
 
-        try:
-            user_data = item.user_data
-        except AttributeError:
-            # QtWebEngine
-            user_data = None
+        user_data = item.user_data
 
         if tab.history.current_idx() == idx:
             pos = tab.scroller.pos_px()
@@ -190,12 +186,6 @@ class SessionManager(QObject):
         for idx, item in enumerate(tab.history):
             item_data = self._save_tab_item(tab, idx, item)
             data['history'].append(item_data)
-
-        # check active
-        if (data['history'] and not
-                any(i.get('active') for i in data['history'])):
-            log.sessions.warning('no active item for {}'.format(tab))
-            data['history'][-1]['active'] = True
 
         return data
 

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1490,3 +1490,71 @@ Feature: Tab management
         And I open data/hello.txt in a new tab
         And I run :fake-key -g hello-world<enter>
         Then the message "hello-world" should be shown
+
+    Scenario: Simple tab unload
+        When I open data/numbers/1.txt
+        And I run :tab-only
+        And I run :tab-unload
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+
+    Scenario: Simple tab unload / load
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-unload
+        And I run :tab-load
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+                  active: true
+
+    Scenario: Simple tab unload then go backward to a new background tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt
+        And I run :tab-unload
+        And I run :back -b
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+                - url: http://localhost:*/data/numbers/3.txt
+                  active: true
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+                  active: true
+                - url: http://localhost:*/data/numbers/3.txt
+
+    Scenario: Simple tab unload then go forward to a new background tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new tab
+        And I open data/numbers/3.txt
+        And I run :back
+        And I run :tab-unload
+        And I run :forward -b
+        Then the session should look like:
+            windows:
+            - tabs:
+              - history:
+                - url: about:blank
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+                  active: true
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+                - url: http://localhost:*/data/numbers/3.txt
+                  active: true

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -215,6 +215,11 @@ class FakeWebTabScroller(browsertab.AbstractScroller):
         return self._pos_perc
 
 
+class FakeWebTabHistoryPrivate(browsertab.AbstractHistoryPrivate):
+    def load_items(self, items):
+        pass
+
+
 class FakeWebTabHistory(browsertab.AbstractHistory):
 
     """Fake for Web{Kit,Engine}History."""
@@ -223,6 +228,7 @@ class FakeWebTabHistory(browsertab.AbstractHistory):
         super().__init__(tab)
         self._can_go_back = can_go_back
         self._can_go_forward = can_go_forward
+        self.private_api = FakeWebTabHistoryPrivate(tab)
 
     def can_go_back(self):
         assert self._can_go_back is not None

--- a/tests/unit/browser/webkit/test_tabhistory.py
+++ b/tests/unit/browser/webkit/test_tabhistory.py
@@ -24,7 +24,7 @@ from PyQt5.QtCore import QUrl, QPoint
 import pytest
 
 tabhistory = pytest.importorskip('qutebrowser.browser.webkit.tabhistory')
-from qutebrowser.misc.sessions import TabHistoryItem as Item
+from qutebrowser.browser.browsertab import TabHistoryItem as Item
 from qutebrowser.utils import qtutils
 
 

--- a/tests/unit/browser/webkit/test_tabhistory.py
+++ b/tests/unit/browser/webkit/test_tabhistory.py
@@ -20,12 +20,13 @@
 """Tests for webelement.tabhistory."""
 
 import attr
-from PyQt5.QtCore import QUrl, QPoint
 import pytest
+from PyQt5.QtCore import QPoint, QUrl
+
+from qutebrowser.browser.browsertab import AbstractHistoryItem as Item
+from qutebrowser.utils import qtutils
 
 tabhistory = pytest.importorskip('qutebrowser.browser.webkit.tabhistory')
-from qutebrowser.browser.browsertab import TabHistoryItem as Item
-from qutebrowser.utils import qtutils
 
 
 pytestmark = pytest.mark.qt_log_ignore('QIODevice::read.*: device not open')

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -27,7 +27,7 @@ from PyQt5.QtCore import QUrl, QPoint, QByteArray, QObject
 QWebView = pytest.importorskip('PyQt5.QtWebKitWidgets').QWebView
 
 from qutebrowser.misc import sessions
-from qutebrowser.misc.sessions import TabHistoryItem as Item
+from qutebrowser.browser.browsertab import TabHistoryItem as Item
 from qutebrowser.utils import objreg, qtutils
 from qutebrowser.browser.webkit import tabhistory
 

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -32,8 +32,6 @@ from qutebrowser.utils import objreg, qtutils
 
 QWebView = pytest.importorskip('PyQt5.QtWebKitWidgets').QWebView
 
-
-
 pytestmark = pytest.mark.qt_log_ignore('QIODevice::read.*: device not open')
 
 webengine_refactoring_xfail = pytest.mark.xfail(

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -23,13 +23,15 @@ import logging
 
 import pytest
 import yaml
-from PyQt5.QtCore import QUrl, QPoint, QByteArray, QObject
+from PyQt5.QtCore import QByteArray, QObject, QPoint, QUrl
+
+from qutebrowser.browser.browsertab import AbstractHistoryItem as Item
+from qutebrowser.browser.webkit import tabhistory
+from qutebrowser.misc import sessions
+from qutebrowser.utils import objreg, qtutils
+
 QWebView = pytest.importorskip('PyQt5.QtWebKitWidgets').QWebView
 
-from qutebrowser.misc import sessions
-from qutebrowser.browser.browsertab import TabHistoryItem as Item
-from qutebrowser.utils import objreg, qtutils
-from qutebrowser.browser.webkit import tabhistory
 
 
 pytestmark = pytest.mark.qt_log_ignore('QIODevice::read.*: device not open')


### PR DESCRIPTION
Hi,

This yet another attempt at solving #67 which is based on the work #4037 done by @phmongeau,

> It would probably be possible to avoid creating the webview untill the tab is loaded, but I haven't looked into that yet.

It will not create WebView/WebEngineView until the tab is focused on thus no QtWebEngineProcess/QtWebProcess will be spawned initally.

If it's worthwile to do lazy load in this way, I'll fix the test failures introduced by the commit soon.

Any comment is welcome!

Thank you!
