### PR TITLE
Open readability page next to original tab

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -66,6 +66,6 @@ JSDOM.fromFile(process.env.QUTE_HTML, domOpts).then(dom => {
             return 1;
         }
         // Success
-        qute.open(['-t', tmpFile]);
+        qute.open(['-t', '-r', tmpFile]);
     })
 });


### PR DESCRIPTION
 A baby change, but one that keeps your tabs nice and organized! Previously, the readability tab would go to the far-right. Now, it opens the tab next to the current page, so that they remain grouped together. 