### PR TITLE
Don't allow page to be scrolled while hinting

### DIFF
--- a/qutebrowser/browser/eventfilter.py
+++ b/qutebrowser/browser/eventfilter.py
@@ -162,6 +162,12 @@ class TabEventFilter(QObject):
             # See https://github.com/qutebrowser/qutebrowser/issues/395
             self._ignore_wheel_event = False
             return True
+
+        # Don't allow scrolling while hinting
+        mode = modeman.instance(self._tab.win_id).mode
+        if mode == usertypes.KeyMode.hint:
+            return True
+
         elif e.modifiers() & Qt.ControlModifier:
             mode = modeman.instance(self._tab.win_id).mode
             if mode == usertypes.KeyMode.passthrough:

--- a/qutebrowser/browser/eventfilter.py
+++ b/qutebrowser/browser/eventfilter.py
@@ -169,7 +169,6 @@ class TabEventFilter(QObject):
             return True
 
         elif e.modifiers() & Qt.ControlModifier:
-            mode = modeman.instance(self._tab.win_id).mode
             if mode == usertypes.KeyMode.passthrough:
                 return False
 


### PR DESCRIPTION
Currently while in hint mode, if the user scrolls with the mouse, the hint labels are left on the screen at the original position when the user started hinting at.
This makes it a little hard to follow a hint accurately if you accidentally scroll.

For instance, my touchpad is extremely sensitive and picks up accidental scroll events from time to time when my palm touches the edge. This makes hinting extremely frustrating at times because I have to restart the hint sequence after scrolling back to the position I originally started hinting at.

If this is not the best place to implement this change, let me know.