### PR TITLE
Visual line mode

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -427,13 +427,22 @@ class AbstractZoom(QObject):
         self._set_factor_internal(self._zoom_factor)
 
 
+class SelectionState(enum.IntEnum):
+
+    """Possible states of selection in Caret mode."""
+
+    none = 1
+    normal = 2
+    line = 3
+
+
 class AbstractCaret(QObject):
 
     """Attribute ``caret`` of AbstractTab for caret browsing."""
 
     #: Signal emitted when the selection was toggled.
     #: (argument - whether the selection is now active)
-    selection_toggled = pyqtSignal(bool)
+    selection_toggled = pyqtSignal(SelectionState)
     #: Emitted when a ``follow_selection`` action is done.
     follow_selected_done = pyqtSignal()
 
@@ -444,7 +453,7 @@ class AbstractCaret(QObject):
         super().__init__(parent)
         self._tab = tab
         self._widget = typing.cast(QWidget, None)
-        self.selection_enabled = False
+        self.selection_state = SelectionState.none
         self._mode_manager = mode_manager
         mode_manager.entered.connect(self._on_mode_entered)
         mode_manager.left.connect(self._on_mode_left)
@@ -500,7 +509,7 @@ class AbstractCaret(QObject):
     def move_to_end_of_document(self) -> None:
         raise NotImplementedError
 
-    def toggle_selection(self) -> None:
+    def toggle_selection(self, line: bool = False) -> None:
         raise NotImplementedError
 
     def drop_selection(self) -> None:
@@ -824,6 +833,15 @@ class AbstractTabPrivate:
         raise NotImplementedError
 
     def shutdown(self) -> None:
+        raise NotImplementedError
+
+    def run_js_sync(self, code: str) -> None:
+        """Run javascript sync.
+
+        Result will be returned when running JS is complete.
+        This is only implemented for QtWebKit.
+        For QtWebEngine, always raises UnsupportedOperationError.
+        """
         raise NotImplementedError
 
 

--- a/qutebrowser/components/caretcommands.py
+++ b/qutebrowser/components/caretcommands.py
@@ -185,9 +185,13 @@ def move_to_end_of_document(tab: apitypes.Tab) -> None:
 
 @cmdutils.register(modes=[cmdutils.KeyMode.caret])
 @cmdutils.argument('tab', value=cmdutils.Value.cur_tab)
-def toggle_selection(tab: apitypes.Tab) -> None:
-    """Toggle caret selection mode."""
-    tab.caret.toggle_selection()
+def toggle_selection(tab: apitypes.Tab, line: bool = False) -> None:
+    """Toggle caret selection mode.
+
+    Args:
+        line: Enables line-selection.
+    """
+    tab.caret.toggle_selection(line)
 
 
 @cmdutils.register(modes=[cmdutils.KeyMode.caret])

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3051,6 +3051,7 @@ bindings.default:
       <Escape>: leave-mode
     caret:
       v: toggle-selection
+      V: toggle-selection --line
       <Space>: toggle-selection
       <Ctrl-Space>: drop-selection
       c: enter-mode normal

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -1184,13 +1184,6 @@ window._qutebrowser.caret = (function() {
         }
     };
 
-    CaretBrowsing.selectionEnabled = function() {
-        if (CaretBrowsing.selectionState === CaretBrowsing.SelectionState.NONE) {
-            return false;
-        }
-        return true;
-    };
-
     CaretBrowsing.move = function(direction, granularity, count = 1) {
         let action = "move";
         if (CaretBrowsing.selectionState !== CaretBrowsing.SelectionState.NONE) {
@@ -1348,14 +1341,14 @@ window._qutebrowser.caret = (function() {
     funcs.setInitialCursor = () => {
         if (!CaretBrowsing.initiated) {
             CaretBrowsing.setInitialCursor();
-            return CaretBrowsing.selectionEnabled();
+            return CaretBrowsing.selectionState !== CaretBrowsing.SelectionState.NONE;
         }
 
         if (window.getSelection().toString().length === 0) {
             positionCaret();
         }
         CaretBrowsing.toggle();
-        return CaretBrowsing.selectionEnabled();
+        return CaretBrowsing.selectionState !== CaretBrowsing.SelectionState.NONE;
     };
 
     funcs.setFlags = (flags) => {

--- a/qutebrowser/javascript/caret.js
+++ b/qutebrowser/javascript/caret.js
@@ -706,6 +706,16 @@ window._qutebrowser.caret = (function() {
     CaretBrowsing.isCaretVisible = false;
 
     /**
+     * selection modes
+     * @type {enum}
+     */
+    CaretBrowsing.SelectionState = {
+        "NONE": 1,
+        "NORMAL": 2,
+        "LINE": 3,
+    };
+
+    /**
      * The actual caret element, an absolute-positioned flashing line.
      * @type {Element}
      */
@@ -887,7 +897,11 @@ window._qutebrowser.caret = (function() {
         CaretBrowsing.injectCaretStyles();
         CaretBrowsing.toggle();
         CaretBrowsing.initiated = true;
-        CaretBrowsing.selectionEnabled = selectionRange > 0;
+        if (selectionRange > 0) {
+            CaretBrowsing.selectionState = CaretBrowsing.SelectionState.NORMAL;
+        } else {
+            CaretBrowsing.selectionState = CaretBrowsing.SelectionState.NONE;
+        }
     };
 
     /**
@@ -1145,16 +1159,52 @@ window._qutebrowser.caret = (function() {
             }
         };
 
+    CaretBrowsing.reverseSelection = () => {
+        const sel = window.getSelection();
+        sel.setBaseAndExtent(
+            sel.extentNode, sel.extentOffset, sel.baseNode,
+            sel.baseOffset
+        );
+    };
+
+    CaretBrowsing.selectLine = function() {
+        const sel = window.getSelection();
+        sel.modify("extend", "right", "lineboundary");
+        CaretBrowsing.reverseSelection();
+        sel.modify("extend", "left", "lineboundary");
+        CaretBrowsing.reverseSelection();
+    };
+
+    CaretBrowsing.updateLineSelection = function(direction, granularity) {
+        if (!(granularity === "character") && !(granularity === "word")) {
+            window.
+                getSelection().
+                modify("extend", direction, granularity);
+            CaretBrowsing.selectLine();
+        }
+    };
+
+    CaretBrowsing.selectionEnabled = function() {
+        if (CaretBrowsing.selectionState === CaretBrowsing.SelectionState.NONE) {
+            return false;
+        }
+        return true;
+    };
+
     CaretBrowsing.move = function(direction, granularity, count = 1) {
         let action = "move";
-        if (CaretBrowsing.selectionEnabled) {
+        if (CaretBrowsing.selectionState !== CaretBrowsing.SelectionState.NONE) {
             action = "extend";
         }
 
         for (let i = 0; i < count; i++) {
-            window.
-                getSelection().
-                modify(action, direction, granularity);
+            if (CaretBrowsing.selectionState === CaretBrowsing.SelectionState.LINE) {
+                CaretBrowsing.updateLineSelection(direction, granularity);
+            } else {
+                window.
+                    getSelection().
+                    modify(action, direction, granularity);
+            }
         }
 
         if (CaretBrowsing.isWindows &&
@@ -1174,7 +1224,7 @@ window._qutebrowser.caret = (function() {
 
     CaretBrowsing.moveToBlock = function(paragraph, boundary, count = 1) {
         let action = "move";
-        if (CaretBrowsing.selectionEnabled) {
+        if (CaretBrowsing.selectionState !== CaretBrowsing.SelectionState.NONE) {
             action = "extend";
         }
         for (let i = 0; i < count; i++) {
@@ -1185,6 +1235,10 @@ window._qutebrowser.caret = (function() {
             window.
                 getSelection().
                 modify(action, boundary, "paragraphboundary");
+
+            if (CaretBrowsing.selectionState === CaretBrowsing.SelectionState.LINE) {
+                CaretBrowsing.selectLine();
+            }
         }
     };
 
@@ -1294,14 +1348,14 @@ window._qutebrowser.caret = (function() {
     funcs.setInitialCursor = () => {
         if (!CaretBrowsing.initiated) {
             CaretBrowsing.setInitialCursor();
-            return CaretBrowsing.selectionEnabled;
+            return CaretBrowsing.selectionEnabled();
         }
 
         if (window.getSelection().toString().length === 0) {
             positionCaret();
         }
         CaretBrowsing.toggle();
-        return CaretBrowsing.selectionEnabled;
+        return CaretBrowsing.selectionEnabled();
     };
 
     funcs.setFlags = (flags) => {
@@ -1399,17 +1453,22 @@ window._qutebrowser.caret = (function() {
 
     funcs.getSelection = () => window.getSelection().toString();
 
-    funcs.toggleSelection = () => {
-        CaretBrowsing.selectionEnabled = !CaretBrowsing.selectionEnabled;
-        return CaretBrowsing.selectionEnabled;
+    funcs.toggleSelection = (line) => {
+        if (line) {
+            CaretBrowsing.selectionState =
+                CaretBrowsing.SelectionState.LINE;
+            CaretBrowsing.selectLine();
+            CaretBrowsing.finishMove();
+        } else if (CaretBrowsing.selectionState === CaretBrowsing.SelectionState.NONE) {
+            CaretBrowsing.selectionState = CaretBrowsing.SelectionState.NORMAL;
+        } else {
+            CaretBrowsing.selectionState = CaretBrowsing.SelectionState.NONE;
+        }
+        return CaretBrowsing.selectionState;
     };
 
     funcs.reverseSelection = () => {
-        const sel = window.getSelection();
-        sel.setBaseAndExtent(
-            sel.extentNode, sel.extentOffset, sel.baseNode,
-            sel.baseOffset
-        );
+        CaretBrowsing.reverseSelection();
     };
 
     return funcs;

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -372,12 +372,16 @@ class StatusBar(QWidget):
         self.maybe_hide()
         assert tab.is_private == self._color_flags.private
 
-    @pyqtSlot(bool)
-    def on_caret_selection_toggled(self, selection):
+    @pyqtSlot(browsertab.SelectionState)
+    def on_caret_selection_toggled(self, selection_state):
         """Update the statusbar when entering/leaving caret selection mode."""
-        log.statusbar.debug("Setting caret selection {}".format(selection))
-        if selection:
+        log.statusbar.debug("Setting caret selection {}"
+                            .format(selection_state))
+        if selection_state is browsertab.SelectionState.normal:
             self._set_mode_text("caret selection")
+            self._color_flags.caret = ColorFlags.CaretMode.selection
+        elif selection_state is browsertab.SelectionState.line:
+            self._set_mode_text("caret line selection")
             self._color_flags.caret = ColorFlags.CaretMode.selection
         else:
             self._set_mode_text("caret")

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -189,7 +189,7 @@ class TabbedBrowser(QWidget):
     cur_scroll_perc_changed = pyqtSignal(int, int)
     cur_load_status_changed = pyqtSignal(usertypes.LoadStatus)
     cur_fullscreen_requested = pyqtSignal(bool)
-    cur_caret_selection_toggled = pyqtSignal(bool)
+    cur_caret_selection_toggled = pyqtSignal(browsertab.SelectionState)
     close_window = pyqtSignal()
     resized = pyqtSignal('QRect')
     current_tab_changed = pyqtSignal(browsertab.AbstractTab)

--- a/tests/unit/browser/test_caret.py
+++ b/tests/unit/browser/test_caret.py
@@ -24,7 +24,7 @@ import textwrap
 import pytest
 from PyQt5.QtCore import QUrl
 
-from qutebrowser.utils import utils, qtutils, usertypes
+from qutebrowser.utils import usertypes
 
 
 @pytest.fixture
@@ -73,9 +73,9 @@ class Selection:
     def check_multiline(self, expected, *, strip=False):
         self.check(textwrap.dedent(expected).strip(), strip=strip)
 
-    def toggle(self):
+    def toggle(self, line=False):
         with self._qtbot.wait_signal(self._caret.selection_toggled):
-            self._caret.toggle_selection()
+            self._caret.toggle_selection(line=line)
 
 
 @pytest.fixture
@@ -390,4 +390,91 @@ class TestReverse:
         selection.check("ne two three")
         caret.reverse_selection()
         caret.move_to_start_of_line()
+        selection.check("one two three")
+
+
+class TestLineSelection:
+
+    def test_toggle(self, caret, selection):
+        selection.toggle(True)
+        selection.check("one two three")
+
+    def test_toggle_untoggle(self, caret, selection):
+        selection.toggle()
+        selection.check("")
+        selection.toggle(True)
+        selection.check("one two three")
+        selection.toggle()
+        selection.check("one two three")
+
+    def test_from_center(self, caret, selection):
+        caret.move_to_next_char(4)
+        selection.toggle(True)
+        selection.check("one two three")
+
+    def test_more_lines(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_next_line(2)
+        selection.check_multiline("""
+            one two three
+            eins zwei drei
+
+            four five six
+        """, strip=True)
+
+    def test_not_selecting_char(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_next_char()
+        selection.check("one two three")
+        caret.move_to_prev_char()
+        selection.check("one two three")
+
+    def test_selecting_prev_next_word(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_next_word()
+        selection.check("one two three")
+        caret.move_to_prev_word()
+        selection.check("one two three")
+
+    def test_selecting_end_word(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_end_of_word()
+        selection.check("one two three")
+
+    def test_selecting_prev_next_line(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_next_line()
+        selection.check_multiline("""
+            one two three
+            eins zwei drei
+        """, strip=True)
+        caret.move_to_prev_line()
+        selection.check("one two three")
+
+    def test_not_selecting_start_end_line(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_end_of_line()
+        selection.check("one two three")
+        caret.move_to_start_of_line()
+        selection.check("one two three")
+
+    def test_selecting_block(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_end_of_next_block()
+        selection.check_multiline("""
+            one two three
+            eins zwei drei
+        """, strip=True)
+
+    def test_selecting_start_end_document(self, caret, selection):
+        selection.toggle(True)
+        caret.move_to_end_of_document()
+        selection.check_multiline("""
+            one two three
+            eins zwei drei
+
+            four five six
+            vier fünf sechs
+        """, strip=True)
+        caret.move_to_start_of_document()
         selection.check("one two three")


### PR DESCRIPTION
This PR introduces visual mode line for both webengine and webkit backends. It follows the behaviour of visual line mode in Vim, except for commands move-to-next-word, move-to-prev-word and move-to-end-of-word. It is because in browser is not possible to have cursor even under selection, thus the functionality then will be very similar to move-to-next-line and move-to-prev-line.
Please correct me if otherwise.
In this PR also unit tests are implemented, please let me know me, if more tests are needed.