### PR TITLE
Suspender - Automatically discard background tabs

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -418,9 +418,8 @@ def _init_modules(*, args):
     cmdhistory.init()
     log.init.debug("Initializing sessions...")
     sessions.init(q_app)
-    if config.instance.get("content.suspender.enabled"):
-        log.init.debug("Initializing suspender...")
-        suspender.init()
+    log.init.debug("Initializing suspender...")
+    suspender.init()
 
     quitter.instance.shutting_down.connect(sessions.shutdown)
 

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -62,7 +62,7 @@ from qutebrowser.keyinput import macros, eventfilter
 from qutebrowser.mainwindow import mainwindow, prompt
 from qutebrowser.misc import (ipc, savemanager, sessions, crashsignal,
                               earlyinit, sql, cmdhistory, backendproblem,
-                              objects, quitter)
+                              objects, quitter, suspender)
 from qutebrowser.utils import (log, version, message, utils, urlutils, objreg,
                                usertypes, standarddir, error, qtutils)
 # pylint: disable=unused-import
@@ -418,6 +418,10 @@ def _init_modules(*, args):
     cmdhistory.init()
     log.init.debug("Initializing sessions...")
     sessions.init(q_app)
+    if config.instance.get("content.suspender.enabled"):
+        log.init.debug("Initializing suspender...")
+        suspender.init()
+
     quitter.instance.shutting_down.connect(sessions.shutdown)
 
     log.init.debug("Initializing websettings...")

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1270,7 +1270,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self._saved_zoom = None
         self._reload_url = None  # type: typing.Optional[QUrl]
         self._scripts.init()
-        self.inactive_time = 0
+        self.background_time = 0
         self.indicator_color_restore = None
 
     def get_tabwidget(self):
@@ -1292,7 +1292,7 @@ class WebEngineTab(browsertab.AbstractTab):
         tabwidget.set_tab_indicator_color(idx, color)
 
     def activate(self):
-        self.inactive_time = 0
+        self.background_time = 0
         """restore indicator state."""
         if self.indicator_color_restore:
             self.set_indicator_color(self.indicator_color_restore)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1304,19 +1304,18 @@ class WebEngineTab(browsertab.AbstractTab):
             self.set_indicator_color(self.indicator_color_restore)
 
     def discard_tab(self) -> None:
-        """discard an inactive tab
+        """Try to discard a tab.
 
         If the tab isn't discarded, the timer will try to discard the tab next
         time.
         """
         if suspender.suspender.discard(self):
-           self.stop_suspender_timer()
-           # change tab indicator color
-           self.indicator_color_restore = self.get_indicator_color()
-           self.set_indicator_color(config.instance.get(
-                                       "colors.suspender.discarded"))
-           log.webview.debug("Tab #{} discarded".format(repr(self.tab_id)))
-           print("Tab #{} discarded".format(repr(self.tab_id)))
+            self.stop_suspender_timer()
+            # change tab indicator color
+            self.indicator_color_restore = self.get_indicator_color()
+            self.set_indicator_color(config.instance.get(
+                "colors.suspender.discarded"))
+            log.webview.debug("Tab #{} discarded".format(repr(self.tab_id)))
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1270,7 +1270,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self._saved_zoom = None
         self._reload_url = None  # type: typing.Optional[QUrl]
         self._scripts.init()
-        self.discard_next_cycle = False
+        self.inactive_time = 0
         self.indicator_color_restore = None
 
     def get_tabwidget(self):
@@ -1292,6 +1292,7 @@ class WebEngineTab(browsertab.AbstractTab):
         tabwidget.set_tab_indicator_color(idx, color)
 
     def activate(self):
+        self.inactive_time = 0
         """restore indicator state."""
         if self.indicator_color_restore:
             self.set_indicator_color(self.indicator_color_restore)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1277,27 +1277,30 @@ class WebEngineTab(browsertab.AbstractTab):
             self.indicator_color_restore = None
 
     def start_suspender_timer(self):
-        if suspender.suspender is None:
-            return
-        self.suspender_timer.start(
-            config.instance.get("content.suspender.timeout") * 1000)
+        if suspender.suspender is not None:
+            self.suspender_timer.start(
+                config.instance.get("content.suspender.timeout") * 1000)
 
-    def _get_tabwidget(self):
+    def get_tabwidget(self):
+        """get TabWidget instance."""
         # somehow the parent became PyQt5.QtWidgets.QStackedWidget
         tabwidget = self.parent().parent()
         return tabwidget
 
     def get_indicator_color(self):
-        tabwidget = self._get_tabwidget()
+        """get tab's current indicator color."""
+        tabwidget = self.get_tabwidget()
         idx = tabwidget.indexOf(self)
-        tabwidget.tab_indicator_color(idx)
+        return tabwidget.tab_indicator_color(idx)
 
     def set_indicator_color(self, color):
-        tabwidget = self._get_tabwidget()
+        """change tab's indicator color."""
+        tabwidget = self.get_tabwidget()
         idx = tabwidget.indexOf(self)
         tabwidget.set_tab_indicator_color(idx, color)
 
     def stop_suspender_timer(self):
+        """Stop the suspender timer and restore indicator state."""
         self.suspender_timer.stop()
         # restore indicator color
         if self.indicator_color_restore:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -38,7 +38,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            interceptor, webenginequtescheme,
                                            cookies, webenginedownloads,
                                            webenginesettings, certificateerror)
-from qutebrowser.misc import miscwidgets, objects, suspender
+from qutebrowser.misc import miscwidgets, objects
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
                                message, objreg, jinja, debug)
 from qutebrowser.qt import sip
@@ -1292,8 +1292,8 @@ class WebEngineTab(browsertab.AbstractTab):
         tabwidget.set_tab_indicator_color(idx, color)
 
     def activate(self):
+        """restore indicator state and reset background_time."""
         self.background_time = 0
-        """restore indicator state."""
         if self.indicator_color_restore:
             self.set_indicator_color(self.indicator_color_restore)
 
@@ -1309,8 +1309,8 @@ class WebEngineTab(browsertab.AbstractTab):
 
         Return False is the tab is not discarded.
 
-        If the tab isn't discarded, the suspender will try to discard the tab next
-        time.
+        If the tab isn't discarded, the suspender will try to
+        discard the tab next time.
         """
         page = self.get_page()
         page.setLifecycleState(page.LifecycleState.Discarded)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1303,9 +1303,18 @@ class WebEngineTab(browsertab.AbstractTab):
                 self.set_indicator_color(self.indicator_color_restore)
 
     def discard_tab(self) -> None:
-        page = self._widget.page()
-        if not page.isVisible():
-            suspender.suspender.discard(self)
+        """discard an inactive tab
+
+        If the tab isn't discarded, the timer will try to discard the tab next
+        time.
+        """
+        if suspender.suspender.discard(self):
+           self.stop_suspender_timer()
+           # change tab indicator color
+           self.indicator_color_restore = self.get_indicator_color()
+           self.set_indicator_color(config.instance.get(
+                                       "colors.suspender.discarded"))
+           log.webview.debug("Tab #{} discard".format(repr(self.tab_id)))
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -38,7 +38,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            interceptor, webenginequtescheme,
                                            cookies, webenginedownloads,
                                            webenginesettings, certificateerror)
-from qutebrowser.misc import miscwidgets, objects
+from qutebrowser.misc import miscwidgets, objects, suspender
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
                                message, objreg, jinja, debug)
 from qutebrowser.qt import sip
@@ -1305,13 +1305,7 @@ class WebEngineTab(browsertab.AbstractTab):
     def discard_tab(self) -> None:
         page = self._widget.page()
         if not page.isVisible():
-            page.setLifecycleState(page.LifecycleState.Discarded)
-            self.stop_suspender_timer()
-            # change tabbar icon
-            self.indicator_color_restore = self.get_indicator_color()
-            self.set_indicator_color(config.instance.get(
-                                        "colors.suspender.discarded"))
-            log.webview.debug("Tab #{} discard".format(repr(self.tab_id)))
+            suspender.suspender.discard(self)
 
     def _set_widget(self, widget):
         # pylint: disable=protected-access

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -634,7 +634,7 @@ content.suspender.timeout:
   default: 600
   type:
     name: Int
-    minval: 1
+    minval: 10
     maxval: maxint
   desc: Timeout (in seconds) for discarding inactive tabs.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2587,6 +2587,11 @@ colors.webpage.bg:
   desc: "Background color for webpages if unset (or empty to use the theme's
     color)."
 
+colors.suspender.discarded:
+  default: black
+  type: QtColor
+  desc: Color for the indicator of discarded tab.
+
 colors.webpage.force_dark_color_scheme:
   renamed: colors.webpage.prefers_color_scheme_dark
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -638,6 +638,14 @@ content.suspender.timeout:
     maxval: maxint
   desc: Timeout (in seconds) for discarding inactive tabs.
 
+content.suspender.max_active_tabs:
+  default: 6
+  type:
+    name: Int
+    minval: 1
+    maxval: maxint
+  desc: Max number of active tabs.
+
 content.hyperlink_auditing:
   default: false
   type: Bool

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -622,6 +622,22 @@ content.host_blocking.whitelist:
 
     Local domains are always exempt from hostblocking.
 
+content.suspender.enabled:
+  default: false
+  backend:
+    QtWebEngine: Qt 5.14
+    QtWebKit: true
+  type: Bool
+  desc: Enable automatically suspending tabs to reduce memory consumption.
+
+content.suspender.timeout:
+  default: 600
+  type:
+    name: Int
+    minval: 1
+    maxval: maxint
+  desc: Timeout (in seconds) for discarding inactive tabs.
+
 content.hyperlink_auditing:
   default: false
   type: Bool

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -646,6 +646,16 @@ content.suspender.max_active_tabs:
     maxval: maxint
   desc: Max number of active tabs.
 
+content.suspender.whitelist:
+  default: []
+  type:
+    name: List
+    valtype: UrlPattern
+    none_ok: true
+  desc: >-
+    A list of patterns that exempt a tab from being automatically
+    discarded by the suspender.
+
 content.hyperlink_auditing:
   default: false
   type: Bool

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -850,9 +850,7 @@ class TabbedBrowser(QWidget):
                         .format(current_mode.name, mode_on_change))
 
         if suspender.suspender:
-            suspender.suspender.stop_timer(tab)
-            if self._now_focused:
-                suspender.suspender.start_timer(self._now_focused)
+            tab.activate()
 
         self._now_focused = tab
         self.current_tab_changed.emit(tab)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -845,8 +845,22 @@ class TabbedBrowser(QWidget):
             modeman.enter(self._win_id, tab.data.input_mode, 'restore')
         if self._now_focused is not None:
             self.tab_deque.on_switch(self._now_focused)
+            # start suspender timer for previous focused tab
+            # only support QtWebEngine >= 5.14
+            try:
+                self._now_focused.start_suspender_timer()
+            except AttributeError:
+                pass
+
         log.modes.debug("Mode after tab change: {} (mode_on_change = {})"
                         .format(current_mode.name, mode_on_change))
+
+        # stop suspender timer for now focused tab
+        try:
+            tab.stop_suspender_timer()
+        except AttributeError:
+            pass
+
         self._now_focused = tab
         self.current_tab_changed.emit(tab)
         QTimer.singleShot(0, self._update_window_title)

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -852,7 +852,7 @@ class TabbedBrowser(QWidget):
         if suspender.suspender:
             suspender.suspender.stop_timer(tab)
             if self._now_focused:
-               suspender.suspender.start_timer(self._now_focused)
+                suspender.suspender.start_timer(self._now_focused)
 
         self._now_focused = tab
         self.current_tab_changed.emit(tab)

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -41,9 +41,27 @@ class Suspender:
     def __init__(self):
         self.check_timer = QTimer()
         self.check_timer.timeout.connect(self._check_discard_tabs)
+        self._set_timer()
+        # _set_timer_timemout calls the same function as _toggle_timer.
+        # But @config.change_filter doesn't support two options.
+        # Thus we need to repeat it.
+        config.instance.changed.connect(self._toggle_timer)
+        config.instance.changed.connect(self._set_timer_timemout)
+
+    @config.change_filter('content.suspender.enabled')
+    def _toggle_timer(self):
+        self._set_timer()
+
+    @config.change_filter('content.suspender.timeout')
+    def _set_timer_timemout(self):
+        self._set_timer()
+
+    def _set_timer(self):
         if config.instance.get("content.suspender.enabled"):
             self.check_timer.start(config.instance.get(
                 "content.suspender.timeout") * 1000)
+        else:
+            self.check_timer.stop()
 
     def _check_discard_tabs(self):
         """Iterate through all tabs and try to discard some

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -1,0 +1,75 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2020 Coiby Xu <coiby.xu@gmail.com>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <http://www.gnu.org/licenses/>.
+
+"""Management of tabs - suspend tab automatically."""
+
+import typing
+
+from qutebrowser.utils import objreg, log
+from qutebrowser.config import config
+
+
+suspender = typing.cast('Suspender', None)
+
+
+class Suspender:
+
+    def get_tab_page(self, tab):
+        return tab._widget.page()
+
+    def total_active_tabs(self):
+        count = 0
+        winlist = objreg.window_registry
+        for win_id in sorted(winlist):
+            tabbed_browser = objreg.get('tabbed-browser', scope='window',
+                                        window=win_id)
+            for tab in tabbed_browser.widgets():
+                page = self.get_tab_page(tab)
+                if page.lifecycleState() != page.LifecycleState.Discarded:
+                    count += 1
+
+        return count
+
+    def should_discard(self, tab):
+        return config.instance.get("content.suspender.max_active_tabs") > \
+                   self.total_active_tabs() \
+                and not tab.data.pinned \
+                and not tab.data.fullscreen \
+                and not tab.audio.is_recently_audible()
+
+    def discard(self, tab):
+        if self.should_discard(tab):
+            page = self.get_tab_page(tab)
+            page.setLifecycleState(page.LifecycleState.Discarded)
+            tab.stop_suspender_timer()
+            # change tabbar icon
+            tab.indicator_color_restore = tab.get_indicator_color()
+            tab.set_indicator_color(config.instance.get(
+                                        "colors.suspender.discarded"))
+            log.webview.debug("Tab #{} discard".format(repr(tab.tab_id)))
+
+def init():
+    """Initialize sessions.
+
+    Args:
+        parent: The parent to use for the SessionManager.
+    """
+
+    global suspender
+    suspender = Suspender()

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -100,6 +100,10 @@ class Suspender:
         max_active_tabs = config.instance.get(
             "content.suspender.max_active_tabs")
         left = active_count - max_active_tabs
+
+        # discard the tabs having been in the background for
+        # the longest time first
+        can_be_discarded.sort(key = lambda tab: tab.background_time)
         while left > 0 and can_be_discarded:
             tab = can_be_discarded.pop()
             if tab.discard():

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -86,9 +86,11 @@ class Suspender:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=win_id)
             current_tab = tabbed_browser.widget.currentWidget()
-            active_count += 1
+            # Rarely there could be no current widget.
+            if current_tab:
+                active_count += 1
             for tab in tabbed_browser.widgets():
-                if tab is not current_tab and not self.should_discard(tab):
+                if tab is current_tab or not self.should_discard(tab):
                     continue
                 page = tab.get_page()
                 if page.lifecycleState() != page.LifecycleState.Discarded:

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -30,6 +30,8 @@ suspender = typing.cast('Suspender', None)
 
 class Suspender:
 
+    """Automatically discard tabs."""
+
     def get_tab_page(self, tab):
         return tab._widget.page()
 
@@ -55,11 +57,11 @@ class Suspender:
 
     def should_discard(self, tab):
         return (config.instance.get("content.suspender.max_active_tabs") <
-                   self.total_active_tabs()
-                and not tab.data.pinned
-                and not tab.data.fullscreen
-                and not tab.audio.is_recently_audible()
-                and not self.in_whitelist(tab))
+                self.total_active_tabs() and not
+                tab.data.pinned and not
+                tab.data.fullscreen and not
+                tab.audio.is_recently_audible() and not
+                self.in_whitelist(tab))
 
     def start_timer(self, tab):
         if config.instance.get("content.suspender.enabled"):
@@ -77,8 +79,9 @@ class Suspender:
 
         return False
 
+
 def init():
-    """init suspender
+    """Initialize suspender.
 
     Suspender use the QWebEnginePage.LifecycleState API which is only
     supported by QtWebEngine >= 5.14.

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -46,12 +46,20 @@ class Suspender:
 
         return count
 
+    def in_whitelist(self, tab):
+        url = tab.url()
+        for pattern in config.instance.get("content.suspender.whitelist"):
+            if pattern.matches(url):
+                return True
+        return False
+
     def should_discard(self, tab):
-        return config.instance.get("content.suspender.max_active_tabs") < \
-                   self.total_active_tabs() \
-                and not tab.data.pinned \
-                and not tab.data.fullscreen \
+        return (config.instance.get("content.suspender.max_active_tabs") <
+                   self.total_active_tabs()
+                and not tab.data.pinned
+                and not tab.data.fullscreen
                 and not tab.audio.is_recently_audible()
+                and not self.in_whitelist(tab))
 
     def start_timer(self, tab):
         if config.instance.get("content.suspender.enabled"):

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -71,7 +71,7 @@ class Suspender:
             self.check_timer.stop()
 
     def _check_discard_tabs(self):
-        """Iterate through all tabs and try to discard some
+        """Iterate through all tabs and try to discard some tabs.
 
         Only discard a tab if,
           - there are more than content.suspender.max_active_tabs tabs

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -57,12 +57,9 @@ class Suspender:
         if self.should_discard(tab):
             page = self.get_tab_page(tab)
             page.setLifecycleState(page.LifecycleState.Discarded)
-            tab.stop_suspender_timer()
-            # change tabbar icon
-            tab.indicator_color_restore = tab.get_indicator_color()
-            tab.set_indicator_color(config.instance.get(
-                                        "colors.suspender.discarded"))
-            log.webview.debug("Tab #{} discard".format(repr(tab.tab_id)))
+            return page.lifecycleState() == page.LifecycleState.Discarded
+
+        return False
 
 def init():
     """Initialize sessions.

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -47,7 +47,7 @@ class Suspender:
         return count
 
     def should_discard(self, tab):
-        return config.instance.get("content.suspender.max_active_tabs") > \
+        return config.instance.get("content.suspender.max_active_tabs") < \
                    self.total_active_tabs() \
                 and not tab.data.pinned \
                 and not tab.data.fullscreen \

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -88,12 +88,13 @@ class Suspender:
             current_tab = tabbed_browser.widget.currentWidget()
             active_count += 1
             for tab in tabbed_browser.widgets():
-                if tab is not current_tab:
-                    page = tab.get_page()
-                    if page.lifecycleState() != page.LifecycleState.Discarded:
-                        tab.background_time += self.timer_period
-                        if tab.background_time > self._tab_timeout:
-                            can_be_discarded.append(tab)
+                if tab is not current_tab and not self.should_discard(tab):
+                    continue
+                page = tab.get_page()
+                if page.lifecycleState() != page.LifecycleState.Discarded:
+                    tab.background_time += self.timer_period
+                    if tab.background_time > self._tab_timeout:
+                        can_be_discarded.append(tab)
                         active_count += 1
 
         max_active_tabs = config.instance.get(
@@ -101,7 +102,7 @@ class Suspender:
         left = active_count - max_active_tabs
         while left > 0 and can_be_discarded:
             tab = can_be_discarded.pop()
-            if self.should_discard(tab) and tab.discard():
+            if tab.discard():
                 left -= 1
                 tab.background_time = 0
 

--- a/qutebrowser/misc/suspender.py
+++ b/qutebrowser/misc/suspender.py
@@ -91,8 +91,8 @@ class Suspender:
                 if tab is not current_tab:
                     page = tab.get_page()
                     if page.lifecycleState() != page.LifecycleState.Discarded:
-                        tab.inactive_time += self.timer_period
-                        if tab.inactive_time > self._tab_timeout:
+                        tab.background_time += self.timer_period
+                        if tab.background_time > self._tab_timeout:
                             can_be_discarded.append(tab)
                         active_count += 1
 
@@ -103,7 +103,7 @@ class Suspender:
             tab = can_be_discarded.pop()
             if self.should_discard(tab) and tab.discard():
                 left -= 1
-                tab.inactive_time = 0
+                tab.background_time = 0
 
     def in_whitelist(self, tab):
         """check if a tab is whitelisted."""


### PR DESCRIPTION
The suspender will periodically check all tabs to try to discard them if certain conditions are met,

  - there are more than content.suspender.max_active_tabs tabs
  - the tab is not playing audio
  - the tab is not pinned
  - the tab in fullscreen mode

It makes use of the [Page Lifecycle API](https://doc.qt.io/qt-5/qtwebengine-features.html#page-lifecycle-api) introduced in Qt 5.14.0 to discard a tab. However, for now, after a tab is discard, it will be blank the first time it's being focused on because there is [an issue in qtwebengine](https://bugreports.qt.io/browse/QTBUG-83641) which may be caused by a chromium bug according to a Qt developer. This bug has been fixed by Chromium update. I can confirm in Qt 5.15 this issue has disappeared. But I don't know when the bug fix will be backported to Qt 5.14.
