### PR TITLE
Add loglevel config settings.

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -379,6 +379,8 @@ def _init_modules(*, args):
     Args:
         args: The argparse namespace.
     """
+    log.init.debug("Initializing logging from config...")
+    log.init_from_config(config.val)
     log.init.debug("Initializing save manager...")
     save_manager = savemanager.SaveManager(q_app)
     objreg.register('save-manager', save_manager)

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3194,3 +3194,26 @@ bindings.commands:
 
     * register: Entered when qutebrowser is waiting for a register name/key for
       commands like `:set-mark`.
+
+## logging
+
+logging.level.ram:
+  default: null
+  type:
+    name: String
+    none_ok: true
+    # levels match those in qutebrowser/utils/log.py
+    valid_values: ['VDEBUG', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+  desc:
+    Level for in-memory logs.
+
+logging.level.console:
+  default: null
+  type:
+    name: String
+    none_ok: true
+    # levels match those in qutebrowser/utils/log.py
+    valid_values: ['VDEBUG', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
+  desc:  >-
+    Level for console (stdout/stderr) logs.
+    Ignored if the --loglevel or --debug CLI flags are used.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3200,20 +3200,16 @@ bindings.commands:
 logging.level.ram:
   default: null
   type:
-    name: String
+    name: LogLevel
     none_ok: true
-    # levels match those in qutebrowser/utils/log.py
-    valid_values: ['VDEBUG', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
   desc:
     Level for in-memory logs.
 
 logging.level.console:
   default: null
   type:
-    name: String
+    name: LogLevel
     none_ok: true
-    # levels match those in qutebrowser/utils/log.py
-    valid_values: ['VDEBUG', 'DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL']
   desc:  >-
     Level for console (stdout/stderr) logs.
     Ignored if the --loglevel or --debug CLI flags are used.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3210,4 +3210,4 @@ logging.level.console:
     name: LogLevel
   desc:  >-
     Level for console (stdout/stderr) logs.
-    Ignored if the --loglevel or --debug CLI flags are used.
+    Ignored if the `--loglevel` or `--debug` CLI flags are used.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3198,18 +3198,16 @@ bindings.commands:
 ## logging
 
 logging.level.ram:
-  default: null
+  default: debug
   type:
     name: LogLevel
-    none_ok: true
   desc:
     Level for in-memory logs.
 
 logging.level.console:
-  default: null
+  default: info
   type:
     name: LogLevel
-    none_ok: true
   desc:  >-
     Level for console (stdout/stderr) logs.
     Ignored if the --loglevel or --debug CLI flags are used.

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -2021,7 +2021,7 @@ class LogLevel(String):
     def __init__(self, none_ok: bool = False) -> None:
         super().__init__(none_ok=none_ok)
         self.valid_values = ValidValues(*[level.lower()
-                                        for level in log.LOG_LEVELS])
+                                          for level in log.LOG_LEVELS])
 
 
 class Key(BaseType):

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -2020,7 +2020,8 @@ class LogLevel(String):
 
     def __init__(self, none_ok: bool = False) -> None:
         super().__init__(none_ok=none_ok)
-        self.valid_values = ValidValues(*log.LOG_LEVELS.keys())
+        self.valid_values = ValidValues(*[level.lower()
+                                        for level in log.LOG_LEVELS])
 
 
 class Key(BaseType):

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -63,7 +63,7 @@ from PyQt5.QtNetwork import QNetworkProxy
 from qutebrowser.misc import objects, debugcachestats
 from qutebrowser.config import configexc, configutils
 from qutebrowser.utils import (standarddir, utils, qtutils, urlutils, urlmatch,
-                               usertypes)
+                               usertypes, log)
 from qutebrowser.keyinput import keyutils
 from qutebrowser.browser.network import pac
 
@@ -2012,6 +2012,15 @@ class NewTabPosition(String):
             ('next', "After the current tab."),
             ('first', "At the beginning."),
             ('last', "At the end."))
+
+
+class LogLevel(String):
+
+    """Log level."""
+
+    def __init__(self, none_ok: bool = False) -> None:
+        super().__init__(none_ok=none_ok)
+        self.valid_values = ValidValues(*log.LOG_LEVELS.keys())
 
 
 class Key(BaseType):

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -2016,7 +2016,7 @@ class NewTabPosition(String):
 
 class LogLevel(String):
 
-    """Log level."""
+    """A logging level."""
 
     def __init__(self, none_ok: bool = False) -> None:
         super().__init__(none_ok=none_ok)

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -96,7 +96,7 @@ def get_argparser():
 
     debug = parser.add_argument_group('debug arguments')
     debug.add_argument('-l', '--loglevel', dest='loglevel',
-                       help="Set loglevel", default='info',
+                       help="Override the configured console loglevel",
                        choices=['critical', 'error', 'warning', 'info',
                                 'debug', 'vdebug'])
     debug.add_argument('--logfilter', type=logfilter_error,

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -41,6 +41,9 @@ try:
 except ImportError:
     colorama = None
 
+if typing.TYPE_CHECKING:
+    from qutebrowser.config import config as configmodule
+
 _log_inited = False
 _args = None
 
@@ -526,7 +529,7 @@ def hide_qt_warning(pattern: str, logger: str = 'qt') -> typing.Iterator[None]:
         logger_obj.removeFilter(log_filter)
 
 
-def init_from_config(conf: typing.Any) -> None:
+def init_from_config(conf: 'configmodule.ConfigContainer') -> None:
     """Initialize logging settings from the config.
 
     init_log is called before the config module is initialized, so config-based
@@ -537,13 +540,16 @@ def init_from_config(conf: typing.Any) -> None:
               This is passed rather than accessed via the module to avoid a
               cyclic import.
     """
+    assert ram_handler is not None
+    assert console_handler is not None
+    assert _args is not None
     ramlevel = conf.logging.level.ram
     consolelevel = conf.logging.level.console
-    if ramlevel and ram_handler:
+    if ramlevel:
         init.info("Configuring RAM loglevel to %s", ramlevel)
         ram_handler.setLevel(LOG_LEVELS[ramlevel])
-    if consolelevel and console_handler:
-        if _args and _args.loglevel:
+    if consolelevel:
+        if _args.loglevel:
             init.info("--loglevel flag overrides logging.level.console")
         else:
             init.info("Configuring console loglevel to %s", consolelevel)

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -296,7 +296,7 @@ def _init_handlers(
         ram_handler = None
     else:
         ram_handler = RAMHandler(capacity=ram_capacity)
-        ram_handler.setLevel(logging.NOTSET)
+        ram_handler.setLevel(logging.DEBUG)
         ram_handler.setFormatter(ram_fmt)
         ram_handler.html_formatter = html_fmt
 
@@ -629,9 +629,7 @@ class RAMHandler(logging.Handler):
             self._data = collections.deque()
 
     def emit(self, record: logging.LogRecord) -> None:
-        if record.levelno >= logging.DEBUG:
-            # We don't log VDEBUG to RAM.
-            self._data.append(record)
+        self._data.append(record)
 
     def dump_log(self, html: bool = False, level: str = 'vdebug') -> str:
         """Dump the complete formatted log data as string.

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -540,15 +540,13 @@ def init_from_config(conf: 'configmodule.ConfigContainer') -> None:
               This is passed rather than accessed via the module to avoid a
               cyclic import.
     """
-    assert ram_handler is not None
-    assert console_handler is not None
     assert _args is not None
     ramlevel = conf.logging.level.ram
     consolelevel = conf.logging.level.console
-    if ramlevel:
+    if ram_handler and ramlevel:
         init.info("Configuring RAM loglevel to %s", ramlevel)
         ram_handler.setLevel(LOG_LEVELS[ramlevel])
-    if consolelevel:
+    if console_handler and consolelevel:
         if _args.loglevel:
             init.info("--loglevel flag overrides logging.level.console")
         else:

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -545,13 +545,13 @@ def init_from_config(conf: 'configmodule.ConfigContainer') -> None:
     consolelevel = conf.logging.level.console
     if ram_handler and ramlevel:
         init.info("Configuring RAM loglevel to %s", ramlevel)
-        ram_handler.setLevel(LOG_LEVELS[ramlevel])
+        ram_handler.setLevel(LOG_LEVELS[ramlevel].upper())
     if console_handler and consolelevel:
         if _args.loglevel:
             init.info("--loglevel flag overrides logging.level.console")
         else:
             init.info("Configuring console loglevel to %s", consolelevel)
-            console_handler.setLevel(LOG_LEVELS[consolelevel])
+            console_handler.setLevel(LOG_LEVELS[consolelevel].upper())
 
 
 class QtWarningFilter(logging.Filter):

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -541,17 +541,17 @@ def init_from_config(conf: 'configmodule.ConfigContainer') -> None:
               cyclic import.
     """
     assert _args is not None
-    ramlevel = conf.logging.level.ram
-    consolelevel = conf.logging.level.console
-    if ram_handler and ramlevel:
+    if ram_handler:
+        ramlevel = conf.logging.level.ram
         init.info("Configuring RAM loglevel to %s", ramlevel)
-        ram_handler.setLevel(LOG_LEVELS[ramlevel].upper())
-    if console_handler and consolelevel:
+        ram_handler.setLevel(LOG_LEVELS[ramlevel.upper()])
+    if console_handler:
+        consolelevel = conf.logging.level.console
         if _args.loglevel:
             init.info("--loglevel flag overrides logging.level.console")
         else:
             init.info("Configuring console loglevel to %s", consolelevel)
-            console_handler.setLevel(LOG_LEVELS[consolelevel].upper())
+            console_handler.setLevel(LOG_LEVELS[consolelevel.upper()])
 
 
 class QtWarningFilter(logging.Filter):

--- a/qutebrowser/utils/log.py
+++ b/qutebrowser/utils/log.py
@@ -541,6 +541,9 @@ def init_from_config(conf: 'configmodule.ConfigContainer') -> None:
               cyclic import.
     """
     assert _args is not None
+    if _args.debug:
+        init.info("--debug flag overrides log configs")
+        return
     if ram_handler:
         ramlevel = conf.logging.level.ram
         init.info("Configuring RAM loglevel to %s", ramlevel)

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -257,11 +257,11 @@ class TestInitLog:
     @pytest.mark.parametrize(
         'console_cli, console_conf, console_expected, ram_conf, ram_expected',
         [
-            (None, None, logging.INFO, None, logging.NOTSET),
-            (None, None, logging.INFO, 'CRITICAL', logging.CRITICAL),
-            (None, 'WARNING', logging.WARNING, 'INFO', logging.INFO),
-            ('INFO', 'WARNING', logging.INFO, 'VDEBUG', logging.VDEBUG),
-            ('WARNING', 'INFO', logging.WARNING, 'CRITICAL', logging.CRITICAL),
+            (None, 'info', logging.INFO, 'debug', logging.DEBUG),
+            (None, 'info', logging.INFO, 'critical', logging.CRITICAL),
+            (None, 'warning', logging.WARNING, 'info', logging.INFO),
+            ('info', 'warning', logging.INFO, 'vdebug', logging.VDEBUG),
+            ('warning', 'info', logging.WARNING, 'critical', logging.CRITICAL),
         ])
     def test_init_from_config(self, console_cli, console_conf,
                               console_expected, ram_conf, ram_expected, args,

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -255,6 +255,30 @@ class TestInitLog:
             warnings.warn("test warning", PendingDeprecationWarning)
 
 
+@pytest.mark.parametrize(
+    'console_cli,console_conf,console_expected,ram_conf,ram_expected',
+    [
+        (None, None, logging.INFO, None, logging.NOTSET),
+        (None, None, logging.INFO, 'CRITICAL', logging.CRITICAL),
+        (None, 'WARNING', logging.WARNING, 'INFO', logging.INFO),
+        ('INFO', 'WARNING', logging.INFO, 'VDEBUG', logging.VDEBUG),
+        ('WARNING', 'INFO', logging.WARNING, 'CRITICAL', logging.CRITICAL),
+    ])
+def test_init_from_config(mocker, console_cli, console_conf, console_expected,
+                          ram_conf, ram_expected):
+    args = argparse.Namespace(debug=False, loglevel=console_cli, color=True,
+                              loglines=10, logfilter="", force_color=False,
+                              json_logging=False, debug_flags=set())
+    log.init_log(args)
+
+    conf = mocker.Mock()
+    conf.logging.level.ram = ram_conf
+    conf.logging.level.console = console_conf
+    log.init_from_config(conf)
+    assert log.ram_handler.level == ram_expected
+    assert log.console_handler.level == console_expected
+
+
 class TestHideQtWarning:
 
     """Tests for hide_qt_warning/QtWarningFilter."""

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -30,6 +30,7 @@ import pytest
 import _pytest.logging
 from PyQt5 import QtCore
 
+from qutebrowser import qutebrowser
 from qutebrowser.utils import log
 from qutebrowser.misc import utilcmds
 
@@ -285,6 +286,19 @@ class TestInitLog:
         config_stub.val.logging.level.ram = conf
         log.init_from_config(config_stub.val)
         assert log.ram_handler.level == expected
+
+    def test_init_from_config_consistent_default(self, config_stub):
+        """Ensure config defaults are consistent with the builtin defaults"""
+        args = qutebrowser.get_argparser().parse_args([])
+        log.init_log(args)
+
+        assert log.ram_handler.level == logging.DEBUG
+        assert log.console_handler.level == logging.INFO
+
+        log.init_from_config(config_stub.val)
+
+        assert log.ram_handler.level == logging.DEBUG
+        assert log.console_handler.level == logging.INFO
 
 
 class TestHideQtWarning:

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -254,27 +254,37 @@ class TestInitLog:
         with pytest.raises(PendingDeprecationWarning):
             warnings.warn("test warning", PendingDeprecationWarning)
 
-    @pytest.mark.parametrize(
-        'console_cli, console_conf, console_expected, ram_conf, ram_expected',
+    @pytest.mark.parametrize('cli, conf, expected',
         [
-            (None, 'info', logging.INFO, 'debug', logging.DEBUG),
-            (None, 'info', logging.INFO, 'critical', logging.CRITICAL),
-            (None, 'warning', logging.WARNING, 'info', logging.INFO),
-            ('info', 'warning', logging.INFO, 'vdebug', logging.VDEBUG),
-            ('warning', 'info', logging.WARNING, 'critical', logging.CRITICAL),
+            (None, 'info', logging.INFO),
+            (None, 'warning', logging.WARNING),
+            ('info', 'warning', logging.INFO),
+            ('warning', 'info', logging.WARNING),
         ])
-    def test_init_from_config(self, console_cli, console_conf,
-                              console_expected, ram_conf, ram_expected, args,
-                              config_stub):
+    def test_init_from_config_console(self, cli, conf, expected, args,
+                                      config_stub):
         args.debug = False
-        args.loglevel = console_cli
+        args.loglevel = cli
         log.init_log(args)
 
-        config_stub.val.logging.level.ram = ram_conf
-        config_stub.val.logging.level.console = console_conf
+        config_stub.val.logging.level.console = conf
         log.init_from_config(config_stub.val)
-        assert log.ram_handler.level == ram_expected
-        assert log.console_handler.level == console_expected
+        assert log.console_handler.level == expected
+
+    @pytest.mark.parametrize('conf, expected',
+        [
+            ('vdebug', logging.VDEBUG),
+            ('debug', logging.DEBUG),
+            ('info', logging.INFO),
+            ('critical', logging.CRITICAL),
+        ])
+    def test_init_from_config_ram(self, conf, expected, args, config_stub):
+        args.debug = False
+        log.init_log(args)
+
+        config_stub.val.logging.level.ram = conf
+        log.init_from_config(config_stub.val)
+        assert log.ram_handler.level == expected
 
 
 class TestHideQtWarning:

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -263,7 +263,7 @@ class TestInitLog:
             ('INFO', 'WARNING', logging.INFO, 'VDEBUG', logging.VDEBUG),
             ('WARNING', 'INFO', logging.WARNING, 'CRITICAL', logging.CRITICAL),
         ])
-    def test_init_from_config(self, mocker, console_cli, console_conf,
+    def test_init_from_config(self, console_cli, console_conf,
                               console_expected, ram_conf, ram_expected, args,
                               config_stub):
         args.debug = False

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -254,29 +254,27 @@ class TestInitLog:
         with pytest.raises(PendingDeprecationWarning):
             warnings.warn("test warning", PendingDeprecationWarning)
 
+    @pytest.mark.parametrize(
+        'console_cli, console_conf, console_expected, ram_conf, ram_expected',
+        [
+            (None, None, logging.INFO, None, logging.NOTSET),
+            (None, None, logging.INFO, 'CRITICAL', logging.CRITICAL),
+            (None, 'WARNING', logging.WARNING, 'INFO', logging.INFO),
+            ('INFO', 'WARNING', logging.INFO, 'VDEBUG', logging.VDEBUG),
+            ('WARNING', 'INFO', logging.WARNING, 'CRITICAL', logging.CRITICAL),
+        ])
+    def test_init_from_config(self, mocker, console_cli, console_conf,
+                              console_expected, ram_conf, ram_expected, args,
+                              config_stub):
+        args.debug = False
+        args.loglevel = console_cli
+        log.init_log(args)
 
-@pytest.mark.parametrize(
-    'console_cli,console_conf,console_expected,ram_conf,ram_expected',
-    [
-        (None, None, logging.INFO, None, logging.NOTSET),
-        (None, None, logging.INFO, 'CRITICAL', logging.CRITICAL),
-        (None, 'WARNING', logging.WARNING, 'INFO', logging.INFO),
-        ('INFO', 'WARNING', logging.INFO, 'VDEBUG', logging.VDEBUG),
-        ('WARNING', 'INFO', logging.WARNING, 'CRITICAL', logging.CRITICAL),
-    ])
-def test_init_from_config(mocker, console_cli, console_conf, console_expected,
-                          ram_conf, ram_expected):
-    args = argparse.Namespace(debug=False, loglevel=console_cli, color=True,
-                              loglines=10, logfilter="", force_color=False,
-                              json_logging=False, debug_flags=set())
-    log.init_log(args)
-
-    conf = mocker.Mock()
-    conf.logging.level.ram = ram_conf
-    conf.logging.level.console = console_conf
-    log.init_from_config(conf)
-    assert log.ram_handler.level == ram_expected
-    assert log.console_handler.level == console_expected
+        config_stub.val.logging.level.ram = ram_conf
+        config_stub.val.logging.level.console = console_conf
+        log.init_from_config(config_stub.val)
+        assert log.ram_handler.level == ram_expected
+        assert log.console_handler.level == console_expected
 
 
 class TestHideQtWarning:

--- a/tests/unit/utils/test_log.py
+++ b/tests/unit/utils/test_log.py
@@ -255,13 +255,12 @@ class TestInitLog:
         with pytest.raises(PendingDeprecationWarning):
             warnings.warn("test warning", PendingDeprecationWarning)
 
-    @pytest.mark.parametrize('cli, conf, expected',
-        [
-            (None, 'info', logging.INFO),
-            (None, 'warning', logging.WARNING),
-            ('info', 'warning', logging.INFO),
-            ('warning', 'info', logging.WARNING),
-        ])
+    @pytest.mark.parametrize('cli, conf, expected', [
+        (None, 'info', logging.INFO),
+        (None, 'warning', logging.WARNING),
+        ('info', 'warning', logging.INFO),
+        ('warning', 'info', logging.WARNING),
+    ])
     def test_init_from_config_console(self, cli, conf, expected, args,
                                       config_stub):
         args.debug = False
@@ -272,13 +271,12 @@ class TestInitLog:
         log.init_from_config(config_stub.val)
         assert log.console_handler.level == expected
 
-    @pytest.mark.parametrize('conf, expected',
-        [
-            ('vdebug', logging.VDEBUG),
-            ('debug', logging.DEBUG),
-            ('info', logging.INFO),
-            ('critical', logging.CRITICAL),
-        ])
+    @pytest.mark.parametrize('conf, expected', [
+        ('vdebug', logging.VDEBUG),
+        ('debug', logging.DEBUG),
+        ('info', logging.INFO),
+        ('critical', logging.CRITICAL),
+    ])
     def test_init_from_config_ram(self, conf, expected, args, config_stub):
         args.debug = False
         log.init_log(args)
@@ -288,7 +286,7 @@ class TestInitLog:
         assert log.ram_handler.level == expected
 
     def test_init_from_config_consistent_default(self, config_stub):
-        """Ensure config defaults are consistent with the builtin defaults"""
+        """Ensure config defaults are consistent with the builtin defaults."""
         args = qutebrowser.get_argparser().parse_args([])
         log.init_log(args)
 


### PR DESCRIPTION
Log levels can now be configured in config.py by setting
loggin.level.console (for stdout/stderr) and logging.level.ram (for
:messages).

This is of interest for users who would like password-manager
integration that uses `fake-key` to send sensitive strings to websites.
The default 'debug' ram logging would store various logs containing the
sensitive data.

Previously the loglevel was only configurable through CLI flags, and
those only affected the console loglevel. We felt a config value would
be nicer than just adding another flag for RAM loglevel, requiring you
to create an alias for qutebrowser and ensure _that_ alias gets used
anywhere qutebrowser might be invoked.

Logging is initialized before the config is loaded, so configuration-set
loglevels have to be loaded in a second, later stage. However, this
stage will only set the console loglevel if it wasn't set on the CLI, as
a CLI flag feels like a more explicit action that should override a
config.

Fixes #5286.