### PR TITLE
Yank as rich format

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -515,7 +515,8 @@ class AbstractCaret(QObject):
     def drop_selection(self) -> None:
         raise NotImplementedError
 
-    def selection(self, callback: typing.Callable[[str], None]) -> None:
+    def selection(self, callback: typing.Callable[[str], None],
+                  rich: bool = False) -> None:
         raise NotImplementedError
 
     def reverse_selection(self) -> None:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -674,7 +674,7 @@ class CommandDispatcher:
     @cmdutils.argument('what', choices=['selection', 'url', 'pretty-url',
                                         'title', 'domain', 'inline'])
     def yank(self, what='url', inline=None,
-             sel=False, keep=False, quiet=False):
+             sel=False, rich=False, keep=False, quiet=False):
         """Yank (copy) something to the clipboard or primary selection.
 
         Args:
@@ -711,24 +711,24 @@ class CommandDispatcher:
                 if not s and not quiet:
                     message.info("Nothing to yank")
                     return
-                self._yank_to_target(s, sel, what, keep, quiet)
+                self._yank_to_target(s, sel, what, keep, quiet, rich)
 
             caret = self._current_widget().caret
-            caret.selection(callback=_selection_callback)
+            caret.selection(callback=_selection_callback, rich=rich)
             return
         else:  # pragma: no cover
             raise ValueError("Invalid value {!r} for `what'.".format(what))
 
         self._yank_to_target(s, sel, what, keep, quiet)
 
-    def _yank_to_target(self, s, sel, what, keep, quiet):
+    def _yank_to_target(self, s, sel, what, keep, quiet, rich=False):
         if sel and utils.supports_selection():
             target = "primary selection"
         else:
             sel = False
             target = "clipboard"
 
-        utils.set_clipboard(s, selection=sel)
+        utils.set_clipboard(s, selection=sel, rich=rich)
         if what != 'selection':
             if not quiet:
                 message.info("Yanked {} to {}: {}".format(what, target, s))

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -460,12 +460,14 @@ class WebEngineCaret(browsertab.AbstractCaret):
     def drop_selection(self):
         self._js_call('dropSelection')
 
-    def selection(self, callback):
+    def selection(self, callback, rich=False):
         # Not using selectedText() as WORKAROUND for
         # https://bugreports.qt.io/browse/QTBUG-53134
         # Even on Qt 5.10 selectedText() seems to work poorly, see
         # https://github.com/qutebrowser/qutebrowser/issues/3523
-        self._tab.run_js_async(javascript.assemble('caret', 'getSelection'),
+        js_cmd = 'getSelectionHTML' if rich else 'getSelection'
+
+        self._tab.run_js_async(javascript.assemble('caret', js_cmd),
                                callback)
 
     def reverse_selection(self):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -405,8 +405,12 @@ class WebKitCaret(browsertab.AbstractCaret):
     def drop_selection(self):
         self._widget.triggerPageAction(QWebPage.MoveToNextChar)
 
-    def selection(self, callback):
-        callback(self._widget.selectedText())
+    def selection(self, callback, rich=False):
+        if rich:
+            callback(self._widget.selectedHtml())
+        else:
+            callback(self._widget.selectedText())
+
 
     def reverse_selection(self):
         self._tab.run_js_async("""{

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -411,7 +411,6 @@ class WebKitCaret(browsertab.AbstractCaret):
         else:
             callback(self._widget.selectedText())
 
-
     def reverse_selection(self):
         self._tab.run_js_async("""{
             const sel = window.getSelection();

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3103,8 +3103,10 @@ bindings.default:
       $: move-to-end-of-line
       gg: move-to-start-of-document
       G: move-to-end-of-document
-      Y: yank selection -s
-      y: yank selection
+      Yy: yank selection -s
+      yy: yank selection
+      Yh: yank selection -s --rich
+      yh: yank selection --rich
       <Return>: yank selection
       H: scroll left
       J: scroll down

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -37,7 +37,7 @@ import glob
 import mimetypes
 import typing
 
-from PyQt5.QtCore import QUrl
+from PyQt5.QtCore import QUrl, QMimeData
 from PyQt5.QtGui import QColor, QClipboard, QDesktopServices
 from PyQt5.QtWidgets import QApplication
 import pkg_resources
@@ -551,7 +551,7 @@ def sanitize_filename(name: str,
     return name
 
 
-def set_clipboard(data: str, selection: bool = False) -> None:
+def set_clipboard(data: str, selection: bool = False, rich: bool = False) -> None:
     """Set the clipboard to some given data."""
     global fake_clipboard
     if selection and not supports_selection():
@@ -562,8 +562,12 @@ def set_clipboard(data: str, selection: bool = False) -> None:
         fake_clipboard = data
     else:
         mode = QClipboard.Selection if selection else QClipboard.Clipboard
-        QApplication.clipboard().setText(data, mode=mode)
-
+        if not rich:
+            QApplication.clipboard().setText(data, mode=mode)
+        else:
+            mime_data = QMimeData()
+            mime_data.setHtml(data)
+            QApplication.clipboard().setMimeData(mime_data, mode=mode)
 
 def get_clipboard(selection: bool = False, fallback: bool = False) -> str:
     """Get data from the clipboard.

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -551,7 +551,8 @@ def sanitize_filename(name: str,
     return name
 
 
-def set_clipboard(data: str, selection: bool = False, rich: bool = False) -> None:
+def set_clipboard(data: str, selection: bool = False,
+                  rich: bool = False) -> None:
     """Set the clipboard to some given data."""
     global fake_clipboard
     if selection and not supports_selection():
@@ -568,6 +569,7 @@ def set_clipboard(data: str, selection: bool = False, rich: bool = False) -> Non
             mime_data = QMimeData()
             mime_data.setHtml(data)
             QApplication.clipboard().setMimeData(mime_data, mode=mode)
+
 
 def get_clipboard(selection: bool = False, fallback: bool = False) -> str:
     """Get data from the clipboard.


### PR DESCRIPTION
This PR will allow qutebrowser to copy rich format to clipboard via `yh` command in caret mode #5382 .

This feature is implemented in different ways depending on which backend is used. For webengine backend, converting selection to HTML is done in caret.js whereas for webkit backend, there is a native API [`selectedHtml`](https://doc.qt.io/archives/qt-4.8/qwebview.html#selectedHtml-prop). 

This difference in ways of implemention also lead to slightly different behaviour. For example,
 1. Webkit's `selectedHTML` doesn't convert a.href and img.src to absolute links thus image coping is not supported for webkit backend
 2. The selected HTML sometimes is slightly different.

So I don't add a test to `tests/unit/browser/test_caret.py`. Take `end2end/data/caret.html` as an example,
 - for webengine, the selected HTML is
```html
'<a href="qute:///data/hello.txt">one</a> two three<br>eins zwei drei'
```
 - for webkit, the selecte HTML is
```html
'<a href="/data/hello.txt">one</a><span style="display: inline !important; float: none;"> two three</span>'
```