### PR TITLE
More options for completion entries order

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -135,6 +135,7 @@
 |<<completion.use_best_match,completion.use_best_match>>|Execute the best-matching command on a partial match.
 |<<completion.web_history.exclude,completion.web_history.exclude>>|A list of patterns which should not be shown in the history.
 |<<completion.web_history.max_items,completion.web_history.max_items>>|Number of URLs to show in the web history.
+|<<completion.web_history.sort_criterion,completion.web_history.sort_criterion>>|How to sort URLs in the web history.
 |<<confirm_quit,confirm_quit>>|Require a confirmation before quitting the application.
 |<<content.autoplay,content.autoplay>>|Automatically start playing `<video>` elements.
 |<<content.cache.appcache,content.cache.appcache>>|Enable support for the HTML 5 web application cache feature.
@@ -1844,6 +1845,20 @@ Number of URLs to show in the web history.
 Type: <<types,Int>>
 
 Default: +pass:[-1]+
+
+[[completion.web_history.sort_criterion]]
+=== completion.web_history.sort_criterion
+How to sort URLs in the web history.
+
+Type: <<types,String>>
+
+Valid values:
+
+ * +recency+: Entries are sorted from most recently visited to least recently visited.
+ * +frequency+: Entries are sorted from most visited to least visited.
+ * +frecency+: Entries are sorted using a combination of recency and frequency.
+
+Default: +pass:[recency]+
 
 [[confirm_quit]]
 === confirm_quit

--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -115,7 +115,7 @@ class CompletionHistory(sql.SqlTable):
 
     FRECENCY_BONUS = 43200  # Seconds in 12 hours
 
-    def __init__(self, parent=None, recreate=False):
+    def __init__(self, parent=None, drop=False):
         super().__init__("CompletionHistory", ['url', 'title', 'last_atime',
                                                'visits', 'frecency'],
                          constraints={'url': 'PRIMARY KEY',
@@ -123,7 +123,7 @@ class CompletionHistory(sql.SqlTable):
                                       'last_atime': 'INTEGER NOT NULL',
                                       'visits': 'INTEGER NOT NULL',
                                       'frecency': 'INTEGER NOT NULL'},
-                         parent=parent, recreate=recreate)
+                         parent=parent, drop=drop)
         self.create_index('CompletionHistoryAtimeIndex', 'last_atime')
         self.create_index('CompletionHistoryVisitsIndex', 'visits')
         self.create_index('CompletionHistoryFrecencyIndex', 'frecency')
@@ -160,17 +160,17 @@ class WebHistory(sql.SqlTable):
         # Store the last saved url to avoid duplicate immediate saves.
         self._last_url = None
 
-        recreate_completion = False
+        drop_completion = False
 
         if sql.Query('pragma user_version').run().value() < _USER_VERSION:
-            recreate_completion = True
+            drop_completion = True
 
         self.metainfo = CompletionMetaInfo(parent=self)
         self.completion = CompletionHistory(parent=self,
-                                            recreate=recreate_completion)
+                                            drop=drop_completion)
         if self.metainfo['force_rebuild']:
             self.metainfo['force_rebuild'] = False
-            if not recreate_completion:
+            if not drop_completion:
                 self.completion.delete_all()
 
         if not self.completion:

--- a/qutebrowser/completion/models/histcategory.py
+++ b/qutebrowser/completion/models/histcategory.py
@@ -114,7 +114,7 @@ class HistoryCategory(QSqlQueryModel):
                     # need to tell SQL to treat '\' as an escape character
                     'WHERE ({})'.format(where_clause),
                     self._atime_expr(),
-                    "ORDER BY last_atime DESC",
+                    "ORDER BY frecency DESC",
                 ]), forward_only=False)
 
             with debug.log_time('sql', 'Running completion query'):

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1000,6 +1000,18 @@ completion.web_history.max_items:
 
     0: no history / -1: unlimited
 
+completion.web_history.sort_criterion:
+  default: recency
+  type:
+    name: String
+    valid_values:
+      - recency: Entries are sorted from most recently visited to least
+            recently visited.
+      - frequency: Entries are sorted from most visited to least visited.
+      - frecency: Entries are sorted using a combination of recency and
+            frequency.
+  desc: How to sort URLs in the web history.
+
 completion.delay:
   default: 0
   type:

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -380,25 +380,27 @@ class SqlTable(QObject):
             replace: If true, overwrite rows with a primary key match.
             ignore: If set, ignore conflicts.
         """
-        q = self._insert_query(values, replace)
+        q = self._insert_query(values, replace, ignore)
         q.run_batch(values)
         self.changed.emit()
 
     def update(self, update, where, escape=True):
         """Execute update rows statement.
+
         Args:
             update: column:value dict with new values to set
             where: column:value dict for filtering
             escape: enable new values SQL-escaping
         """
         if escape:
-            u = ', '.join(('{} = :{}'.format(k, k) for k in update.keys()))
+            u = ', '.join(('{k} = :{k}'.format(k=k) for k in update.keys()))
         else:
             u = ', '.join(('{} = {}'.format(k, v) for k, v in update.items()))
 
         s = 'UPDATE {} SET {}'.format(self._name, u)
         if where:
-            w = ' AND '.join(('{} = :w_{}'.format(f, f) for f in where.keys()))
+            w = ' AND '.join(
+                ('{f} = :w_{f}'.format(f=f) for f in where.keys()))
             s += ' WHERE {}'.format(w)
 
         p = update.copy()

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -273,7 +273,7 @@ class SqlTable(QObject):
     changed = pyqtSignal()
 
     def __init__(self, name, fields, constraints=None, parent=None,
-                 recreate=False):
+                 drop=False):
         """Create a new table in the SQL database.
 
         Does nothing if the table already exists.
@@ -282,12 +282,12 @@ class SqlTable(QObject):
             name: Name of the table.
             fields: A list of field names.
             constraints: A dict mapping field names to constraint strings.
-            recreate: Forces the re-creation of the table by dropping it first.
+            drop: Forces the re-creation of the table by dropping it first.
         """
         super().__init__(parent)
         self._name = name
 
-        if recreate:
+        if drop:
             Query("DROP TABLE IF EXISTS {}".format(self._name)).run()
 
         constraints = constraints or {}

--- a/tests/unit/misc/test_sql.py
+++ b/tests/unit/misc/test_sql.py
@@ -148,6 +148,24 @@ def test_insert_batch_replace(qtbot):
                             'lucky': [True, True]})
 
 
+def test_update(qtbot):
+    table = sql.SqlTable('Foo', ['a', 'b', 'c'])
+    table.insert({'a': 10, 'b': 10, 'c': 10})
+    table.insert({'a': 20, 'b': 20, 'c': 20})
+
+    with qtbot.waitSignal(table.changed):
+        table.update({'a': 11, 'b': 12, 'c': 13}, {'a': 10, 'b': 10})
+    with qtbot.waitSignal(table.changed):
+        table.update({'a': 21}, {'c': 20})
+
+    assert list(table) == [(11, 12, 13), (21, 20, 20)]
+
+    with qtbot.waitSignal(table.changed):
+        table.update({'a': 'a * a', 'b': 'b + 3'}, {'a': 11, 'b': 12}, False)
+
+    assert list(table) == [(121, 15, 13), (21, 20, 20)]
+
+
 def test_iter():
     table = sql.SqlTable('Foo', ['name', 'val', 'lucky'])
     table.insert({'name': 'one', 'val': 1, 'lucky': False})


### PR DESCRIPTION
This is based on the work of @vchimishuk in #4403. 

I started by reviewing that pull request and testing it, but I figured that if we used a simpler formula for frecency we wouldn't need the periodic calculation nor the threading stuff. So this approach uses the last visit timestamp plus a bonus for each visit as the frecency. This way the frecency doesn't depend on the current time and can be calculated just once when inserting (or updating) the record in `CompletionHistory`.

I also added `frequency` as an option as well since it was trivial. I will test this for a bit and add unit tests afterwards.

Fixes #601. 