### PR TITLE
Add smarthide property to hide status only on normal mode

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1564,6 +1564,13 @@ statusbar.hide:
   default: false
   desc: Hide the statusbar unless a message is shown.
 
+statusbar.smarthide:
+  type: Bool
+  default: false
+  desc: >-
+    If statusbar.hide is true, only hide the statusbar in normal mode, and show
+    it in other modes.
+
 statusbar.padding:
   type: Padding
   default:


### PR DESCRIPTION
The option statusbar.hide is very nice aesthetically, but it prevents the user from seeing the current mode. This pull request adds the ability to make the statusbar hide only when in normal mode, and show in all other modes. This is done by introducing an option statusbar.smarthide, which should be enabled in conjunction with statusbar.hide.