### PR TITLE
Add ability to customise tab font based on selected status

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -214,7 +214,8 @@
 |<<fonts.messages.warning,fonts.messages.warning>>|Font used for warning messages.
 |<<fonts.prompts,fonts.prompts>>|Font used for prompts.
 |<<fonts.statusbar,fonts.statusbar>>|Font used in the statusbar.
-|<<fonts.tabs,fonts.tabs>>|Font used in the tab bar.
+|<<fonts.tabs.selected,fonts.tabs.selected>>|Font used in the tab bar for selected tabs.
+|<<fonts.tabs.unselected,fonts.tabs.unselected>>|Font used in the tab bar for unselected tabs.
 |<<fonts.web.family.cursive,fonts.web.family.cursive>>|Font family for cursive fonts.
 |<<fonts.web.family.fantasy,fonts.web.family.fantasy>>|Font family for fantasy fonts.
 |<<fonts.web.family.fixed,fonts.web.family.fixed>>|Font family for fixed fonts.
@@ -2785,11 +2786,19 @@ Type: <<types,Font>>
 
 Default: +pass:[default_size default_family]+
 
-[[fonts.tabs]]
-=== fonts.tabs
-Font used in the tab bar.
+[[fonts.tabs.selected]]
+=== fonts.tabs.selected
+Font used in the tab bar for selected tabs.
 
-Type: <<types,QtFont>>
+Type: <<types,Font>>
+
+Default: +pass:[default_size default_family]+
+
+[[fonts.tabs.unselected]]
+=== fonts.tabs.unselected
+Font used in the tab bar for unselected tabs.
+
+Type: <<types,Font>>
 
 Default: +pass:[default_size default_family]+
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2872,10 +2872,15 @@ fonts.statusbar:
   type: Font
   desc: Font used in the statusbar.
 
-fonts.tabs:
+fonts.tabs.selected:
   default: default_size default_family
-  type: QtFont
-  desc: Font used in the tab bar.
+  type: Font
+  desc: Font used in the tab bar for selected tabs.
+
+fonts.tabs.unselected:
+  default: default_size default_family
+  type: Font
+  desc: Font used in the tab bar for unselected tabs.
 
 fonts.web.family.standard:
   default: ''

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -340,6 +340,10 @@ class YamlMigrations(QObject):
                                        r'(?<!{)\{title\}(?!})',
                                        r'{current_title}')
 
+        self._migrate_to_multiple('fonts.tabs',
+                                  ('fonts.tabs.selected',
+                                   'fonts.tabs.unselected'))
+
         # content.headers.user_agent can't be empty to get the default anymore.
         setting = 'content.headers.user_agent'
         self._migrate_none(setting, configdata.DATA[setting].default)
@@ -445,6 +449,18 @@ class YamlMigrations(QObject):
             if val is None:
                 self._settings[name][scope] = value
                 self.changed.emit()
+
+    def _migrate_to_multiple(self, old_name: str, new_names: typing.Iterator[str]) -> None:
+        if old_name not in self._settings:
+            return
+
+        for new_name in new_names:
+            self._settings[new_name] = {}
+            for scope, val in self._settings[old_name].items():
+                self._settings[new_name][scope] = val
+
+        del self._settings[old_name]
+        self.changed.emit()
 
     def _migrate_string_value(self, name: str,
                               source: str,

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -385,7 +385,12 @@ class TabBar(QTabBar):
 
     STYLESHEET = """
         TabBar {
+            font: {{ conf.fonts.tabs.unselected }};
             background-color: {{ conf.colors.tabs.bar.bg }};
+        }
+
+        TabBar::tab:selected {
+            font: {{ conf.fonts.tabs.selected }};
         }
     """
 
@@ -395,8 +400,6 @@ class TabBar(QTabBar):
         super().__init__(parent)
         self._win_id = win_id
         self.setStyle(TabBarStyle())
-        self._set_font()
-        config.instance.changed.connect(self._on_config_changed)
         self.vertical = False
         self._auto_hide_timer = QTimer()
         self._auto_hide_timer.setSingleShot(True)
@@ -405,6 +408,9 @@ class TabBar(QTabBar):
         self.setAutoFillBackground(True)
         self.drag_in_progress = False
         stylesheet.set_register(self)
+        self.ensurePolished()
+        config.instance.changed.connect(self._on_config_changed)
+        self._set_icon_size()
         QTimer.singleShot(0, self.maybe_hide)
 
     def __repr__(self):
@@ -416,8 +422,10 @@ class TabBar(QTabBar):
 
     @pyqtSlot(str)
     def _on_config_changed(self, option: str) -> None:
-        if option == 'fonts.tabs':
-            self._set_font()
+        if option.startswith('fonts.tabs.'):
+            self.update()
+            self.ensurePolished()
+            self._set_icon_size()
         elif option == 'tabs.favicons.scale':
             self._set_icon_size()
         elif option == 'tabs.show_switching_delay':
@@ -433,7 +441,9 @@ class TabBar(QTabBar):
                       "tabs.padding",
                       "tabs.indicator.width",
                       "tabs.min_width",
-                      "tabs.pinned.shrink"]:
+                      "tabs.pinned.shrink",
+                      "fonts.tabs.selected",
+                      "fonts.tabs.unselected"]:
             self._minimum_tab_size_hint_helper.cache_clear()
             self._minimum_tab_height.cache_clear()
 
@@ -505,14 +515,6 @@ class TabBar(QTabBar):
         # This is a horrible hack, but we need to do this so the underlying Qt
         # code sets layoutDirty so it actually relayouts the tabs.
         self.setIconSize(self.iconSize())
-
-    def _set_font(self):
-        """Set the tab bar font."""
-        self.setFont(config.val.fonts.tabs)
-        self._set_icon_size()
-        # clear tab size cache
-        self._minimum_tab_size_hint_helper.cache_clear()
-        self._minimum_tab_height.cache_clear()
 
     def _set_icon_size(self):
         """Set the tab bar favicon size."""


### PR DESCRIPTION
Closes #5510 .
I have created two settings: `fonts.tabs.selected` and `fonts.tabs.unselected`. I did not create `{odd,even}` variants because I would probably have to mess with `paintEvent()`; Qt does not have `:nth-child` selectors AFAIK. In either case, I doubt that odd/even variants would be used by anyone. I could take a look at it though if you think otherwise @The-Compiler. 

Transitioning to `Font` was mostly painless. There aren't any more uses of QFont in `configdata.yml`, so I can work on #5511 after this.