### PR TITLE
Add fedora debugging info

### DIFF
--- a/doc/stacktrace.asciidoc
+++ b/doc/stacktrace.asciidoc
@@ -52,7 +52,7 @@ Or:
 Then install the needed debuginfo packages:
 
 ----
-# debuginfo-install python3 qt5-qtwebengine python3-qt5-webengine python3-qt5-base python-qt5 python3-qt5 python3-qt5-webkit-debuginfo
+# debuginfo-install python3 qt5-qtwebengine python3-qt5-webengine python3-qt5-base python-qt5 python3-qt5 python3-qt5-webkit
 ----
 
 Archlinux


### PR DESCRIPTION
I've added the instructions on how to install the debug symbols on Fedora.
The list of packages should be fine, everything missing should be pulled as dependency.