### PR TITLE
Enable configuring loglevel at runtime.

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -373,6 +373,13 @@ def open_desktopservices_url(url):
     tabbed_browser.tabopen(url)
 
 
+# This is effectively a @config.change_filter
+# Howerver, logging is initialized too early to use that annotation
+def _on_config_changed(name: str) -> None:
+    if name.startswith('logging.'):
+        log.init_from_config(config.val)
+
+
 def _init_modules(*, args):
     """Initialize all 'modules' which need to be initialized.
 
@@ -381,6 +388,8 @@ def _init_modules(*, args):
     """
     log.init.debug("Initializing logging from config...")
     log.init_from_config(config.val)
+    config.instance.changed.connect(_on_config_changed)
+
     log.init.debug("Initializing save manager...")
     save_manager = savemanager.SaveManager(q_app)
     objreg.register('save-manager', save_manager)

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -224,7 +224,7 @@ def log_capacity(capacity: int) -> None:
     log.ram_handler.change_log_capacity(capacity)
 
 
-@cmdutils.register(debug=True)
+@cmdutils.register(debug=True, deprecated="Use `:set log.level.console`")
 @cmdutils.argument('level', choices=sorted(
     (level.lower() for level in log.LOG_LEVELS),
     key=lambda e: log.LOG_LEVELS[e.upper()]))


### PR DESCRIPTION
Now `:set logging.level.{ram,console}` will work after qutebrowser has
started. This allows us to derecate debug-set-loglevel.

Logging is initialized too early for `config.change_filter` to work, so I
had to hack it.