### PR TITLE
Align tab index

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -3978,6 +3978,7 @@ The following placeholders are defined:
 * `{current_title}`: Title of the current web page.
 * `{title_sep}`: The string ` - ` if a title is set, empty otherwise.
 * `{index}`: Index of this tab.
+* `{aligned_index}`: Index of this tab padded with spaces to have the same width.
 * `{id}`: Internal tab ID of this tab.
 * `{scroll_pos}`: Page scroll position.
 * `{host}`: Host of the current web page.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1782,6 +1782,7 @@ tabs.title.format:
       - current_title
       - title_sep
       - index
+      - aligned_index
       - id
       - scroll_pos
       - host
@@ -1799,6 +1800,7 @@ tabs.title.format:
     * `{current_title}`: Title of the current web page.
     * `{title_sep}`: The string ` - ` if a title is set, empty otherwise.
     * `{index}`: Index of this tab.
+    * `{aligned_index}`: Index of this tab padded with spaces to have the same width.
     * `{id}`: Internal tab ID of this tab.
     * `{scroll_pos}`: Page scroll position.
     * `{host}`: Host of the current web page.
@@ -1818,6 +1820,7 @@ tabs.title.format_pinned:
       - current_title
       - title_sep
       - index
+      - aligned_index
       - id
       - scroll_pos
       - host

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -151,7 +151,8 @@ class TabWidget(QTabWidget):
 
         fields = self.get_tab_fields(idx)
         fields['current_title'] = fields['current_title'].replace('&', '&&')
-        fields['index'] = str(idx + 1).rjust(2)
+        fields['index'] = idx + 1
+        fields['aligned_index'] = str(idx + 1).rjust(len(str(self.count())))
 
         title = '' if fmt is None else fmt.format(**fields)
         tabbar = self.tabBar()

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -151,7 +151,7 @@ class TabWidget(QTabWidget):
 
         fields = self.get_tab_fields(idx)
         fields['current_title'] = fields['current_title'].replace('&', '&&')
-        fields['index'] = idx + 1
+        fields['index'] = str(idx + 1).rjust(2)
 
         title = '' if fmt is None else fmt.format(**fields)
         tabbar = self.tabBar()


### PR DESCRIPTION
A small and potentially controversial proposal 😄 Currently when you have more than 9 tabs open and you are using vertical tabs, alignment is off by one character and this makes it very unaesthetic 😁  

![image](https://user-images.githubusercontent.com/1177900/85933260-67f6e500-b8d5-11ea-8d94-e5b43bf5310c.png)

But if we pad this with a space character, it becomes much more pleasant to look at with up to 99 tabs 😄 

![image](https://user-images.githubusercontent.com/1177900/85933263-793ff180-b8d5-11ea-8cd9-6d9fe23e32b9.png)

This patch isn't particularly noticeable with horizontal tabs:

![image](https://user-images.githubusercontent.com/1177900/85933274-94126600-b8d5-11ea-9524-2df142eb82be.png)

What do you think?