### PR TITLE
Fix for #5550: qute-lastpass merge-candidate bugfix from @user202729

### DIFF
--- a/misc/userscripts/qute-lastpass
+++ b/misc/userscripts/qute-lastpass
@@ -115,6 +115,7 @@ def main(arguments):
     # the registered domain name and finally: the IPv4 address if that's what
     # the URL represents
     candidates = []
+    seen_id = set()
     for target in filter(None, [extract_result.fqdn, extract_result.registered_domain, extract_result.subdomain + extract_result.domain, extract_result.domain, extract_result.ipv4]):
         target_candidates, err = pass_(target, arguments.io_encoding)
         if err:
@@ -124,7 +125,10 @@ def main(arguments):
         if not target_candidates:
             continue
 
-        candidates = candidates + target_candidates
+        for candidate in target_candidates:
+            if candidate["id"] not in seen_id:
+                seen_id.add(candidate["id"])
+                candidates.append(candidate)
         if not arguments.merge_candidates:
             break
     else:


### PR DESCRIPTION
This is just @user202729 's fix. I tested it and it works properly. `qute-pass` doesn't have this issue because it is able to use a set as the candidate output seems to be scalar.

Sorry for the delay. I was trying to look into creating a unit test for the qute-lastpass script, but python isn't my native language and I ran into the following blockers below. Any suggestions would be helpful so I can open a PR in the future to fix.

1. `qute-lastpass` having a dash seems to violate import naming policy, using `importlib.import_module` as a workaround is not possible from the lack of a `.py` extension

2. Refactoring out parts to address the above into a separate python file that follows convention seems to violate the current userscripts convention where each script is atomic.

3. Opting for an integration test seems to push me down the route of what `test_userscripts` is doing, but this seems like overkill and it seems like I'd have to create a `lpass` program fake and do `PATH` env var shenanigans.

Thanks.