### PR TITLE
Fix back-to-back tab deletions (:completion-item-del)

### DIFF
--- a/qutebrowser/completion/models/completionmodel.py
+++ b/qutebrowser/completion/models/completionmodel.py
@@ -232,8 +232,7 @@ class CompletionModel(QAbstractItemModel):
         if not cat.delete_func:
             raise cmdutils.CommandError("Cannot delete this item.")
 
-        data = [cat.data(cat.index(index.row(), i))
-                for i in range(cat.columnCount())]
+        data = ["{}/{}".format(parent.row(), index.row()+1)]
         cat.delete_func(data)
 
         self.beginRemoveRows(parent, index.row(), index.row())

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -84,6 +84,20 @@ Feature: Using completion
         Then the following tabs should be open:
             - data/hello.txt (active)
 
+    Scenario: Deleting muliple open tabs via the completion
+        Given I have a fresh instance
+        When I open data/hello.txt
+        And I open data/hello2.txt in a new tab
+        And I open data/hello3.txt in a new tab
+        And I run :set-cmd-text -s :buffer
+        And I wait for "Setting completion pattern ''" in the log
+        And I run :completion-item-focus next
+        And I wait for "setting text = ':buffer 0/1', *" in the log
+        And I run :completion-item-del
+        And I run :completion-item-del
+        Then the following tabs should be open:
+            - data/hello3.txt (active)
+
     Scenario: Go to tab after moving a tab
         Given I have a fresh instance
         When I open data/hello.txt


### PR DESCRIPTION
After deleting one tab using completion of the buffer command, deleting another sometimes deletes the wrong one. I was able to fix this by using the `currentIndex` from the `CompletionView` instead of the first column of the completion data. I tried fixing #2986 using the same principle, but it doesn't look like that will work.
