### PR TITLE
Allow non-decimal args to QColor converters 

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1063,7 +1063,7 @@ class QtColor(BaseType):
 
     def _parse_value(self, kind: str, val: str) -> int:
         try:
-            return int(val)
+            return int(val, base=0)
         except ValueError:
             pass
 

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1057,8 +1057,8 @@ class QtColor(BaseType):
     * An SVG color name as specified in
       http://www.w3.org/TR/SVG/types.html#ColorKeywords[the W3C specification].
     * transparent (no color)
-    * `rgb(r, g, b)` / `rgba(r, g, b, a)` (values 0-255 or percentages)
-    * `hsv(h, s, v)` / `hsva(h, s, v, a)` (values 0-255, hue 0-359)
+    * `rgb(r, g, b)` / `rgba(r, g, b, a)` (values 0-255, 0x0-0xff, or percentages)
+    * `hsv(h, s, v)` / `hsva(h, s, v, a)` (values 0-255, 0x0-0xff, hue 0-359)
     """
 
     def _parse_value(self, kind: str, val: str) -> int:

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1053,7 +1053,8 @@ class QtColor(BaseType):
 
     A value can be in one of the following formats:
 
-    * `#RGB`/`#RRGGBB`/`#AARRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
+    * `#RGB`/`#RRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
+    * `#AARRGGBB`
     * An SVG color name as specified in
       http://www.w3.org/TR/SVG/types.html#ColorKeywords[the W3C specification].
     * transparent (no color)

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1053,7 +1053,7 @@ class QtColor(BaseType):
 
     A value can be in one of the following formats:
 
-    * `#RGB`/`#RRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
+    * `#RGB`/`#RRGGBB`/`#AARRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
     * An SVG color name as specified in
       http://www.w3.org/TR/SVG/types.html#ColorKeywords[the W3C specification].
     * transparent (no color)

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1295,6 +1295,7 @@ class TestQtColor:
         ('rgb(0,0,0)', QColor.fromRgb(0, 0, 0)),
 
         ('rgba(255, 255, 255, 1.0)', QColor.fromRgb(255, 255, 255, 255)),
+        ('rgba(0xff, 0xff, 0xFF, 1.0)', QColor.fromRgb(255, 255, 255, 255)),
 
         ('hsv(10%,10%,10%)', QColor.fromHsv(35, 25, 25)),
         ('hsva(10%,20%,30%,40%)', QColor.fromHsv(35, 51, 76, 102)),


### PR DESCRIPTION
I can't figure out how to run QB from source on my mac, so I'm marking this as a draft until I can get back to my dev machine and test it. That said, I'm pretty confident it will work.

I also added #AARRGGBB, which has been supported by QColor since 5.2, to the docs.