### PR TITLE
Document #AARRGGBB for QtColor and QssColor

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1053,7 +1053,7 @@ class QtColor(BaseType):
 
     A value can be in one of the following formats:
 
-    * `#RGB`/`#RRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
+    * `#RGB`/`#RRGGBB`/`#AARRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
     * An SVG color name as specified in
       http://www.w3.org/TR/SVG/types.html#ColorKeywords[the W3C specification].
     * transparent (no color)
@@ -1124,7 +1124,7 @@ class QssColor(BaseType):
 
     A value can be in one of the following formats:
 
-    * `#RGB`/`#RRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
+    * `#RGB`/`#RRGGBB`/`#AARRGGBB`/`#RRRGGGBBB`/`#RRRRGGGGBBBB`
     * An SVG color name as specified in
       http://www.w3.org/TR/SVG/types.html#ColorKeywords[the W3C specification].
     * transparent (no color)

--- a/tests/unit/config/test_configtypes.py
+++ b/tests/unit/config/test_configtypes.py
@@ -1287,6 +1287,7 @@ class TestQtColor:
     @pytest.mark.parametrize('val, expected', [
         ('#123', QColor('#123')),
         ('#112233', QColor('#112233')),
+        ('#44112233', QColor('#44112233')),
         ('#111222333', QColor('#111222333')),
         ('#111122223333', QColor('#111122223333')),
         ('red', QColor('red')),
@@ -1333,6 +1334,7 @@ class TestQssColor:
     @pytest.mark.parametrize('val', [
         '#123',
         '#112233',
+        '#44112233',
         '#111222333',
         '#111122223333',
         'red',


### PR DESCRIPTION
#5583 didn't pan out but in the process I learned that both QtColor and QssColor support #AARRGGBB via QColor, which isn't currently documented.