### PR TITLE
Open a downloaded item's directory via a context-menu option

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -469,7 +469,7 @@ The index of the download to delete.
 
 [[download-open]]
 === download-open
-Syntax: +:download-open ['cmdline']+
+Syntax: +:download-open [*--dir*] ['cmdline']+
 
 Open the last/[count]th download.
 
@@ -480,6 +480,8 @@ If no specific command is given, this will use the system's default application 
  present, the filename is automatically appended to the
  cmdline.
 
+==== optional arguments
+* +*-d*+, +*--dir*+: Open the file's directory instead
 
 ==== count
 The index of the download to open.

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1121,7 +1121,7 @@ class DownloadModel(QAbstractListModel):
                 count = len(self)
             raise cmdutils.CommandError("Download {} is not done!"
                                         .format(count))
-        download.open_file(cmdline, open_dir=True)
+        download.open_file(cmdline, open_dir=dir_)
 
     @cmdutils.register(instance='download-model', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -640,6 +640,27 @@ class AbstractDownloadItem(QObject):
         # (see issue #2296)
         QTimer.singleShot(0, lambda: utils.open_file(filename, cmdline))
 
+    @pyqtSlot()
+    def open_file_dir(self, cmdline=None):
+        """Open the downloaded file's directory.
+
+        Args:
+            cmdline: The command to use as string. A `{}` is expanded to the
+                     filename. None means to use the system's default
+                     application or `downloads.open_dispatcher` if set. If no
+                     `{}` is found, the filename is appended to the cmdline.
+        """
+        assert self.successful
+        filename = (os.path.sep).join(self._get_open_filename().split(os.path.sep)[0:-1])
+        if filename is None:  # pragma: no cover
+            log.downloads.error("No filename to open the download's directory!")
+            return
+        # By using a singleshot timer, we ensure that we return fast. This
+        # is important on systems where process creation takes long, as
+        # otherwise the prompt might hang around and cause bugs
+        # (see issue #2296)
+        QTimer.singleShot(0, lambda: utils.open_file(filename, cmdline))
+
     def _ensure_can_set_filename(self, filename):
         """Make sure we can still set a filename."""
         raise NotImplementedError

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -628,7 +628,7 @@ class AbstractDownloadItem(QObject):
                      filename. None means to use the system's default
                      application or `downloads.open_dispatcher` if set. If no
                      `{}` is found, the filename is appended to the cmdline.
-            open_dir: Specify whether to open the file's directory instead
+            open_dir: Specify whether to open the file's directory instead.
         """
         assert self.successful
         filename = self._get_open_filename()

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1097,8 +1097,8 @@ class DownloadModel(QAbstractListModel):
 
     @cmdutils.register(instance='download-model', scope='window', maxsplit=0)
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    @cmdutils.argument('dir', flag='d')
-    def download_open(self, cmdline: str = None, count: int = 0, dir_: bool = False) -> None:
+    def download_open(self, cmdline: str = None, count: int = 0,
+                      dir_: bool = False) -> None:
         """Open the last/[count]th download.
 
         If no specific command is given, this will use the system's default
@@ -1110,7 +1110,7 @@ class DownloadModel(QAbstractListModel):
                      present, the filename is automatically appended to the
                      cmdline.
             count: The index of the download to open.
-            dir: Whether to open the file's directory instead
+            dir_: Whether to open the file's directory instead.
         """
         try:
             download = self[count - 1]
@@ -1121,10 +1121,7 @@ class DownloadModel(QAbstractListModel):
                 count = len(self)
             raise cmdutils.CommandError("Download {} is not done!"
                                         .format(count))
-        if dir:
-            download.open_file(cmdline, open_dir=True)
-        else:
-            download.open_file(cmdline)
+        download.open_file(cmdline, open_dir=True)
 
     @cmdutils.register(instance='download-model', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -620,7 +620,7 @@ class AbstractDownloadItem(QObject):
         raise NotImplementedError
 
     @pyqtSlot()
-    def open_file(self, cmdline=None):
+    def open_file(self, cmdline=None, open_dir=False):
         """Open the downloaded file.
 
         Args:
@@ -628,39 +628,20 @@ class AbstractDownloadItem(QObject):
                      filename. None means to use the system's default
                      application or `downloads.open_dispatcher` if set. If no
                      `{}` is found, the filename is appended to the cmdline.
+            open_dir: Specify whether to open the file's directory instead
         """
         assert self.successful
         filename = self._get_open_filename()
         if filename is None:  # pragma: no cover
             log.downloads.error("No filename to open the download!")
             return
+        if open_dir:
+            filename = os.path.dirname(filename)
         # By using a singleshot timer, we ensure that we return fast. This
         # is important on systems where process creation takes long, as
         # otherwise the prompt might hang around and cause bugs
         # (see issue #2296)
         QTimer.singleShot(0, lambda: utils.open_file(filename, cmdline))
-
-    @pyqtSlot()
-    def open_file_dir(self, cmdline=None):
-        """Open the downloaded file's directory.
-
-        Args:
-            cmdline: The command to use as string. A `{}` is expanded to the
-                     filename. None means to use the system's default
-                     application or `downloads.open_dispatcher` if set. If no
-                     `{}` is found, the filename is appended to the cmdline.
-        """
-        assert self.successful
-        filename = self._get_open_filename()
-        if filename is None:  # pragma: no cover
-            log.downloads.error("No filename to open the download's directory!")
-            return
-        dirname = os.path.dirname(filename)
-        # By using a singleshot timer, we ensure that we return fast. This
-        # is important on systems where process creation takes long, as
-        # otherwise the prompt might hang around and cause bugs
-        # (see issue #2296)
-        QTimer.singleShot(0, lambda: utils.open_file(dirname, cmdline))
 
     def _ensure_can_set_filename(self, filename):
         """Make sure we can still set a filename."""

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1097,7 +1097,8 @@ class DownloadModel(QAbstractListModel):
 
     @cmdutils.register(instance='download-model', scope='window', maxsplit=0)
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def download_open(self, cmdline: str = None, count: int = 0) -> None:
+    @cmdutils.argument('dir', flag='d')
+    def download_open(self, cmdline: str = None, count: int = 0, dir: bool = False) -> None:
         """Open the last/[count]th download.
 
         If no specific command is given, this will use the system's default
@@ -1109,6 +1110,7 @@ class DownloadModel(QAbstractListModel):
                      present, the filename is automatically appended to the
                      cmdline.
             count: The index of the download to open.
+            dir: Whether to open the file's directory instead
         """
         try:
             download = self[count - 1]
@@ -1119,7 +1121,10 @@ class DownloadModel(QAbstractListModel):
                 count = len(self)
             raise cmdutils.CommandError("Download {} is not done!"
                                         .format(count))
-        download.open_file(cmdline)
+        if dir:
+            download.open_file(cmdline, open_dir=True)
+        else:
+            download.open_file(cmdline)
 
     @cmdutils.register(instance='download-model', scope='window')
     @cmdutils.argument('count', value=cmdutils.Value.count)

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -651,15 +651,16 @@ class AbstractDownloadItem(QObject):
                      `{}` is found, the filename is appended to the cmdline.
         """
         assert self.successful
-        filename = (os.path.sep).join(self._get_open_filename().split(os.path.sep)[0:-1])
+        filename = self._get_open_filename()
         if filename is None:  # pragma: no cover
             log.downloads.error("No filename to open the download's directory!")
             return
+        dirname = os.path.dirname(filename)
         # By using a singleshot timer, we ensure that we return fast. This
         # is important on systems where process creation takes long, as
         # otherwise the prompt might hang around and cause bugs
         # (see issue #2296)
-        QTimer.singleShot(0, lambda: utils.open_file(filename, cmdline))
+        QTimer.singleShot(0, lambda: utils.open_file(dirname, cmdline))
 
     def _ensure_can_set_filename(self, filename):
         """Make sure we can still set a filename."""

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1098,7 +1098,7 @@ class DownloadModel(QAbstractListModel):
     @cmdutils.register(instance='download-model', scope='window', maxsplit=0)
     @cmdutils.argument('count', value=cmdutils.Value.count)
     @cmdutils.argument('dir', flag='d')
-    def download_open(self, cmdline: str = None, count: int = 0, dir: bool = False) -> None:
+    def download_open(self, cmdline: str = None, count: int = 0, dir_: bool = False) -> None:
         """Open the last/[count]th download.
 
         If no specific command is given, this will use the system's default

--- a/qutebrowser/browser/downloadview.py
+++ b/qutebrowser/browser/downloadview.py
@@ -148,7 +148,9 @@ class DownloadView(QListView):
         elif item.done:
             if item.successful:
                 actions.append(("Open", item.open_file))
-                actions.append(("Open directory", functools.partial(item.open_file, open_dir=True)))
+                actions.append(("Open directory",
+                                functools.partial(item.open_file,
+                                                  open_dir=True, cmdline=None)))
             else:
                 actions.append(("Retry", item.try_retry))
             actions.append(("Remove", item.remove))

--- a/qutebrowser/browser/downloadview.py
+++ b/qutebrowser/browser/downloadview.py
@@ -148,6 +148,7 @@ class DownloadView(QListView):
         elif item.done:
             if item.successful:
                 actions.append(("Open", item.open_file))
+                actions.append(("Open directory", item.open_file_dir))
             else:
                 actions.append(("Retry", item.try_retry))
             actions.append(("Remove", item.remove))

--- a/qutebrowser/browser/downloadview.py
+++ b/qutebrowser/browser/downloadview.py
@@ -148,7 +148,7 @@ class DownloadView(QListView):
         elif item.done:
             if item.successful:
                 actions.append(("Open", item.open_file))
-                actions.append(("Open directory", item.open_file_dir))
+                actions.append(("Open directory", functools.partial(item.open_file, open_dir=True)))
             else:
                 actions.append(("Retry", item.try_retry))
             actions.append(("Remove", item.remove))


### PR DESCRIPTION
This one adds a right click context menu option to open a downloaded file's directory.
Instead of just opening the file, which may be dangerous / wanting to inspect or operate on it first,
a right click context menu option of `Open directory` lets one open the file's directory. This is akin 
to the main big browsers who has a similar option. i.e. `Show in folder`

Caveats:
- Platform agnostic. uses `os.path.sep`
- Uses the same [utils.py open_file()](https://github.com/qutebrowser/qutebrowser/blob/f3000da73446dfb43f4ef6056ecf61bc4f53ef1c/qutebrowser/utils/utils.py#L653-L709) and [downloads.py open_file()](https://github.com/elig0n/qutebrowser/blob/5bc142a7dbbb171e9fdb931a6f6aa23a5d210b6d/qutebrowser/browser/downloads.py#L623-L641) mechanisms which for most of the cases means utilizing the system's default/MIME handler and also going through the same sanity checks.
- It was my experience that most Linux file managers will open parameters which comprise of complete paths + filenames as the directories themselves with the filename selected in them without having to use any special argument but sometimes will try to execute the file itself handing it to MIME handlers. [Windows explorer has /select](https://stackoverflow.com/a/13680458/9205341). Since those are uncertain "bets" that can lead to mistakes, I have chosen to go with the directory itself passed as the executable name.

Improvements and comments are welcome.