### PR TITLE
Open PDF.js in the requested page if that page is empty

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -863,8 +863,8 @@ class AbstractDownloadManager(QObject):
             dl.stats.update_speed()
         self.data_changed.emit(-1)
 
-    @pyqtSlot(str, QUrl)
-    def _on_pdfjs_requested(self, filename: str, original_url: QUrl) -> None:
+    def _on_pdfjs_requested(self, filename: str, original_url: QUrl,
+                            download: AbstractDownloadItem) -> None:
         """Open PDF.js when a download requests it."""
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window='last-focused')
@@ -887,7 +887,8 @@ class AbstractDownloadManager(QObject):
         download.data_changed.connect(
             functools.partial(self._on_data_changed, download))
         download.error.connect(self._on_error)
-        download.pdfjs_requested.connect(self._on_pdfjs_requested)
+        download.pdfjs_requested.connect(functools.partial(
+            self._on_pdfjs_requested, download=download))
 
         download.basename = suggested_filename
         idx = len(self.downloads)


### PR DESCRIPTION
Closes #4588 .

Currently if it's opened in the old tab, it won't be switched to when the download completes (unlike the old/open in new tab behavior)

Useful tests:

* the tab/window is closed/defocused before the download completes.

(I used this command to quickly test the feature on the command-line: `qutebrowser -T ":set content.pdfjs true ;; open -t ;; open -t ;; later 500 open https://host.com/slow_to_load_file.pdf ;; later 1800 tab-(next|close)"`)