### PR TITLE
Fix misaligned completion highlighting after UTF-16 surrogate pairs

### DIFF
--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -26,7 +26,7 @@ import re
 import html
 
 from PyQt5.QtWidgets import QStyle, QStyleOptionViewItem, QStyledItemDelegate
-from PyQt5.QtCore import QRectF, QSize, Qt
+from PyQt5.QtCore import QRectF, QRegularExpression, QSize, Qt
 from PyQt5.QtGui import (QIcon, QPalette, QTextDocument, QTextOption,
                          QAbstractTextDocumentLayout, QSyntaxHighlighter,
                          QTextCharFormat)
@@ -41,14 +41,21 @@ class _Highlighter(QSyntaxHighlighter):
         super().__init__(doc)
         self._format = QTextCharFormat()
         self._format.setForeground(color)
-        self._pattern = pattern
+        self._expression = QRegularExpression(
+            pattern,
+            QRegularExpression.CaseInsensitiveOption
+        )
 
     def highlightBlock(self, text):
         """Override highlightBlock for custom highlighting."""
-        for match in re.finditer(self._pattern, text, re.IGNORECASE):
-            start, end = match.span()
-            length = end - start
-            self.setFormat(start, length, self._format)
+        match_iterator = self._expression.globalMatch(text)
+        while match_iterator.hasNext():
+            match = match_iterator.next()
+            self.setFormat(
+                match.capturedStart(),
+                match.capturedLength(),
+                self._format
+            )
 
 
 class CompletionItemDelegate(QStyledItemDelegate):

--- a/qutebrowser/completion/completiondelegate.py
+++ b/qutebrowser/completion/completiondelegate.py
@@ -41,9 +41,11 @@ class _Highlighter(QSyntaxHighlighter):
         super().__init__(doc)
         self._format = QTextCharFormat()
         self._format.setForeground(color)
+        words = pattern.split()
+        words.sort(key=len, reverse=True)
+        pat = "|".join(re.escape(word) for word in words)
         self._expression = QRegularExpression(
-            pattern,
-            QRegularExpression.CaseInsensitiveOption
+            pat, QRegularExpression.CaseInsensitiveOption
         )
 
     def highlightBlock(self, text):
@@ -233,12 +235,11 @@ class CompletionItemDelegate(QStyledItemDelegate):
             pattern = view.pattern
             columns_to_filter = index.model().columns_to_filter(index)
             if index.column() in columns_to_filter and pattern:
-                pat = re.escape(pattern).replace(r'\ ', r'|')
                 if self._opt.state & QStyle.State_Selected:
                     color = config.val.colors.completion.item.selected.match.fg
                 else:
                     color = config.val.colors.completion.match.fg
-                _Highlighter(self._doc, pat, color)
+                _Highlighter(self._doc, pattern, color)
             self._doc.setPlainText(self._opt.text)
         else:
             self._doc.setHtml(

--- a/tests/unit/completion/test_completiondelegate.py
+++ b/tests/unit/completion/test_completiondelegate.py
@@ -34,7 +34,7 @@ from qutebrowser.completion import completiondelegate
     ('foo', 'barfoobaz', [(3, 3)]),
     ('foo', 'barfoobazfoo', [(3, 3), (9, 3)]),
     ('foo', 'foofoo', [(0, 3), (3, 3)]),
-    ('a|b', 'cadb', [(1, 1), (3, 1)]),
+    ('a b', 'cadb', [(1, 1), (3, 1)]),
     ('foo', '<foo>', [(1, 3)]),
     ('<a>', "<a>bc", [(0, 3)]),
 

--- a/tests/unit/completion/test_completiondelegate.py
+++ b/tests/unit/completion/test_completiondelegate.py
@@ -42,6 +42,10 @@ from qutebrowser.completion import completiondelegate
     ('foo', "'foo'", [(1, 3)]),
     ('x', "'x'", [(1, 1)]),
     ('lt', "<lt", [(1, 2)]),
+
+    # See https://github.com/qutebrowser/qutebrowser/pull/5111
+    ('bar', '\U0001d65b\U0001d664\U0001d664bar', [(6, 3)]),
+    ('an anomaly', 'an anomaly', [(0, 2), (3, 7)]),
 ])
 def test_highlight(pat, txt, segments):
     doc = QTextDocument(txt)


### PR DESCRIPTION
QStrings use UTF-16, which means characters with Unicode code points above FFFF are represented by a surrogate pair. Python strings represent these code points as a single character. This means that character indices might differ between the two different representations of a string, so if we're using Qt functionality to highlight matches, then we have to get UTF-16 indices (e.g. by using Qt search functionality).

This seems like the sort of issue that might also be causing bugs elsewhere.