### PR TITLE
Fix gopass 1.10.x deprecation in qute-pass userscript

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -142,7 +142,7 @@ def _run_pass(pass_arguments, encoding):
 
 
 def pass_(path, encoding):
-    return _run_pass([path], encoding)
+    return _run_pass(['show', path], encoding)
 
 
 def pass_otp(path, encoding):


### PR DESCRIPTION
Since gopass 1.10, reading secrets via "gopass <secret-name>" will yield a deprecation
warning which _run_pass() will stumble over. As it turns out - even "pass" can be called
with "pass show <secret-name>", so the fix will be compatible with both gopass and pass.

Refs #5690

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
