### PR TITLE
[readbility-js] Apply css styling to images

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -44,6 +44,16 @@ const HEADER = `
         h1, h2, h3 {
             line-height: 1.2;
         }
+        img {
+            max-width:100%;
+            height:auto;
+        }
+        p > img:only-child,
+        p > a:only-child > img:only-child,
+        .wp-caption img,
+        figure img {
+            display: block;
+        }
     </style>
     <!-- This icon is licensed under the Mozilla Public License 2.0 (available at: https://www.mozilla.org/en-US/MPL/2.0/).
     The original icon can be found here: https://dxr.mozilla.org/mozilla-central/source/browser/themes/shared/reader/readerMode.svg -->


### PR DESCRIPTION
Currently, the `readability-js` userscript leaves images untouched, while mozilla's firefox applies at least two  css attributes to them (I checked the html generated by their readability extention to verify this). 

## Change 1: shrink image if too big ##

Mozilla's approach seems better: in qutebrowser's `readability-js`, every image is displayed in its original size. For really big images, this can look really odd, and it moreover makes their contents hard to grasp at a glance.

* Example without css styling (note how both images are cut-off):
![2020-09-17-1600337419](https://user-images.githubusercontent.com/10417027/93461161-a6a0a800-f8e4-11ea-8c73-4f78b85e408a.jpg)


* Example with css styling, such that images are proportionally shrunk in size in case they're wider than the body-text (achieved by `max-width:100%; height:auto`):

![2020-09-17-1600337502](https://user-images.githubusercontent.com/10417027/93461194-b4eec400-f8e4-11ea-9e84-f6178e630bce.jpg)


Mozilla does this slighlty differently (I think they center large images, and then make them slightly less wide than the body-text). My approach will do for now, as it maximizes the image size (i.e. visibility) without sacrificing image quality.

## Change 2: Display some images as blocks ##

Additionally, this PR displays some images as blocks. This ensures that they're not inlined with the rest of the text when inappropiate (I got this code straight from the mozilla project).

Btw, I tested these changes on a bunch of websites, and they seem to never degrade the quality of resulting the document, and only potentially improve it.

Oh and, I thought of applying more css from their readability implementation (for example, they set some fonts that are nice for reading, when available). Not sure if you're okay with adding more css.


