### PR TITLE
[readability-js] Add css styling to more html elements

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -74,7 +74,7 @@ const HEADER = `
         code { 
             padding: .2em .4em;
             margin: 0;
-            background-color: ##dddddd;
+            background-color: #dddddd;
         }
         blockquote {
             border-inline-start: 2px solid #333333 !important;

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -76,6 +76,13 @@ const HEADER = `
             margin: 0;
             background-color: ##dddddd;
         }
+        blockquote {
+            border-inline-start: 2px solid #333333 !important;
+            padding: 0;
+            padding-inline-start: 16px;
+            margin-inline-start: 24px;
+            border-radius: 5px;
+        }
     </style>
     <!-- This icon is licensed under the Mozilla Public License 2.0 (available at: https://www.mozilla.org/en-US/MPL/2.0/).
     The original icon can be found here: https://dxr.mozilla.org/mozilla-central/source/browser/themes/shared/reader/readerMode.svg -->

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -54,6 +54,28 @@ const HEADER = `
         figure img {
             display: block;
         }
+        table,
+        th,
+        td {
+            border: 1px solid currentColor;
+            border-collapse: collapse;
+            padding: 6px;
+            vertical-align: top;
+        }
+        table {
+            margin: 5px;
+        }
+        pre {
+            padding: 16px;
+            overflow: auto;
+            line-height: 1.45;
+            background-color: #dddddd;
+        }
+        code { 
+            padding: .2em .4em;
+            margin: 0;
+            background-color: ##dddddd;
+        }
     </style>
     <!-- This icon is licensed under the Mozilla Public License 2.0 (available at: https://www.mozilla.org/en-US/MPL/2.0/).
     The original icon can be found here: https://dxr.mozilla.org/mozilla-central/source/browser/themes/shared/reader/readerMode.svg -->


### PR DESCRIPTION
After looking at mozilla's readability script some more, I noticed a couple changes they make to css elements in order to make them easier to visually differentiate from other html elements, and arguably more readable in general. I generally just copied over their css code.  Some of these changes are of a more aesthetic nature, but I would argue that they also have a functional component. 

Btw: I don't think there's much css styling to add after this PR, so don't worry about this script becoming enormous. 

### Tables and codeblocks ###

Tables and codeblock elements (`<code>` and `<pre>` tags) now visually standout more. Also note how   the different table cells are the easier to distinguish.  Codeblocks are not really styled in mozilla's readability script, so I copied over the way Github styles them and changed the background color to the gray qutebrowser.org uses for codeblocks.  Giving codeblocks a background is also very much in line with modern web design, and allows users to tell apart code from other elements at a glance.  While mozilla doesn't do this, I imagine qutebrowser's userbase reads a lot more technical documents.


Left is the arch wiki before css-styling, right is after: 
![xorg-combine](https://user-images.githubusercontent.com/10417027/94015343-05ff2c00-fdad-11ea-848c-ca5721cc74bc.jpg)

Wikipedia articles also really benefit from having more defined tables:
![arch](https://user-images.githubusercontent.com/10417027/94015401-17e0cf00-fdad-11ea-939c-b3cc58160e82.png)


### blockquotes ###

The styling for blockqoutes was copied over from mozilla, and aside from the slight  indentation, gives users a clear, visually recognizable way to tell they're reading a blockquote.


![plato](https://user-images.githubusercontent.com/10417027/94015776-99d0f800-fdad-11ea-8a0b-54c65020bc0f.png)
