### PR TITLE
Let open_url_in_instance.sh complain if socat is not installed.

### DIFF
--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -12,4 +12,4 @@ printf '{"args": ["%s"], "target_arg": null, "version": "%s", "protocol_version"
        "${_url}" \
        "${_qb_version}" \
        "${_proto_version}" \
-       "${PWD}" | socat - UNIX-CONNECT:"${_ipc_socket}" 2>/dev/null || "$_qute_bin" "$@" &
+       "${PWD}" | socat -lf /dev/null - UNIX-CONNECT:"${_ipc_socket}" || "$_qute_bin" "$@" &


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

I have had a bit of hard time debugging `open_url_in_instance.sh` to find out why isn't it faster than just `/bin/qutebrowser` anymore. Turns out I uninstalled `socat` somewhere in the past and the script silently fell back to running `/bin/qutebrowser`. I believe that outputting an error message here doesn't harm. Errors of `socat` are still silenced by the `-lf /dev/null` flag i.e. the script won't complain if there is no socket yet.
