### PR TITLE
[readability-js] When hinting, use the URL selected via hints

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -97,13 +97,24 @@ const HEADER = `
 </head>`;
 const scriptsDir = path.join(process.env.QUTE_DATA_DIR, 'userscripts');
 const tmpFile = path.join(scriptsDir, '/readability.html');
-const domOpts = {url: process.env.QUTE_URL, contentType: "text/html; charset=utf-8"};
 
-if (!fs.existsSync(scriptsDir)){
+if (!fs.existsSync(scriptsDir)) {
     fs.mkdirSync(scriptsDir);
 }
 
-JSDOM.fromFile(process.env.QUTE_HTML, domOpts).then(dom => {
+// When hinting, use the selected hint instead of the current page
+if (process.env.QUTE_MODE === 'hints') {
+    var getDOM = JSDOM.fromURL;
+    var domOpts = {};
+    var target = process.env.QUTE_URL;
+}
+else {
+    var getDOM = JSDOM.fromFile;
+    var domOpts = {url: process.env.QUTE_URL, contentType: "text/html; charset=utf-8"};
+    var target = process.env.QUTE_HTML;
+}
+
+getDOM(target, domOpts).then(dom => {
     let reader = new Readability(dom.window.document);
     let article = reader.parse();
     let content = util.format(HEADER, article.title) + article.content;

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -106,7 +106,6 @@ let getDOM, domOpts, target;
 // When hinting, use the selected hint instead of the current page
 if (process.env.QUTE_MODE === 'hints') {
     getDOM = JSDOM.fromURL;
-    domOpts = {};
     target = process.env.QUTE_URL;
 }
 else {

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -102,16 +102,17 @@ if (!fs.existsSync(scriptsDir)) {
     fs.mkdirSync(scriptsDir);
 }
 
+let getDOM, domOpts, target;
 // When hinting, use the selected hint instead of the current page
 if (process.env.QUTE_MODE === 'hints') {
-    var getDOM = JSDOM.fromURL;
-    var domOpts = {};
-    var target = process.env.QUTE_URL;
+    getDOM = JSDOM.fromURL;
+    domOpts = {};
+    target = process.env.QUTE_URL;
 }
 else {
-    var getDOM = JSDOM.fromFile;
-    var domOpts = {url: process.env.QUTE_URL, contentType: "text/html; charset=utf-8"};
-    var target = process.env.QUTE_HTML;
+    getDOM = JSDOM.fromFile;
+    domOpts = {url: process.env.QUTE_URL, contentType: "text/html; charset=utf-8"};
+    target = process.env.QUTE_HTML;
 }
 
 getDOM(target, domOpts).then(dom => {


### PR DESCRIPTION
Previously, this userscript always assumed the user wanted to parse the current page. However, this meant that something like `:hint all userscript readability-js` wouldn't work. To fix this, the script now checks if qutebrowser is in hinting mode, and sets the target page accordingly.

An alternative solution would be to rewrite this script to rely on `QUTE_URL`+`JSDOM.fromURL` accross the board. However, using `QUTE_HTML` when the target page is already loaded seems faster, uses less data, and works offline.