### PR TITLE
replace pkg_resources.parse_version everywhere with the packaging module

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -127,6 +127,7 @@ The following software and libraries are required to run qutebrowser:
 * https://www.riverbankcomputing.com/software/pyqt/intro[PyQt] 5.7.0 or newer
   (5.14 recommended, support for < 5.11 will be dropped soon) for Python 3
 * https://pypi.python.org/pypi/setuptools/[pkg_resources/setuptools]
+* https://pypi.python.org/pypi/packaging/[packaging]
 * https://fdik.org/pyPEG/[pyPEG2]
 * http://jinja.pocoo.org/[jinja2]
 * http://pygments.org/[pygments]

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -30,7 +30,7 @@ import datetime
 import enum
 import typing
 
-import pkg_resources
+import packaging
 from PyQt5.QtCore import pyqtSlot, Qt, QSize
 from PyQt5.QtWidgets import (QDialog, QLabel, QTextEdit, QPushButton,
                              QVBoxLayout, QHBoxLayout, QCheckBox,
@@ -361,8 +361,8 @@ class _CrashDialog(QDialog):
         Args:
             newest: The newest version as a string.
         """
-        new_version = pkg_resources.parse_version(newest)
-        cur_version = pkg_resources.parse_version(qutebrowser.__version__)
+        new_version = packaging.version.parse(newest)
+        cur_version = packaging.version.parse(qutebrowser.__version__)
         lines = ['The report has been sent successfully. Thanks!']
         if new_version > cur_version:
             lines.append("<b>Note:</b> The newest available version is v{}, "

--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -172,12 +172,12 @@ def check_qt_version():
     """Check if the Qt version is recent enough."""
     from PyQt5.QtCore import (qVersion, QT_VERSION, PYQT_VERSION,
                               PYQT_VERSION_STR)
-    from pkg_resources import parse_version
+    import packaging
     from qutebrowser.utils import log
-    parsed_qversion = parse_version(qVersion())
+    parsed_qversion = packaging.version.parse(qVersion())
 
     if (QT_VERSION < 0x050701 or PYQT_VERSION < 0x050700 or
-            parsed_qversion < parse_version('5.7.1')):
+            parsed_qversion < packaging.version.parse('5.7.1')):
         text = ("Fatal error: Qt >= 5.7.1 and PyQt >= 5.7 are required, "
                 "but Qt {} / PyQt {} is installed.".format(qt_version(),
                                                            PYQT_VERSION_STR))
@@ -230,6 +230,7 @@ def check_libraries():
     """Check if all needed Python libraries are installed."""
     modules = {
         'pkg_resources': _missing_str("pkg_resources/setuptools"),
+        'packaging': _missing_str("packaging")
         'pypeg2': _missing_str("pypeg2"),
         'jinja2': _missing_str("jinja2"),
         'pygments': _missing_str("pygments"),

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -33,7 +33,7 @@ import operator
 import contextlib
 import typing
 
-import pkg_resources
+import packaging
 from PyQt5.QtCore import (qVersion, QEventLoop, QDataStream, QByteArray,
                           QIODevice, QFileDevice, QSaveFile, QT_VERSION_STR,
                           PYQT_VERSION_STR, QObject, QUrl)
@@ -100,15 +100,15 @@ def version_check(version: str,
     if compiled and exact:
         raise ValueError("Can't use compiled=True with exact=True!")
 
-    parsed = pkg_resources.parse_version(version)
+    parsed = packaging.version.parse(version)
     op = operator.eq if exact else operator.ge
-    result = op(pkg_resources.parse_version(qVersion()), parsed)
+    result = op(packaging.version.parse(qVersion()), parsed)
     if compiled and result:
         # qVersion() ==/>= parsed, now check if QT_VERSION_STR ==/>= parsed.
-        result = op(pkg_resources.parse_version(QT_VERSION_STR), parsed)
+        result = op(packaging.version.parse(QT_VERSION_STR), parsed)
     if compiled and result:
         # Finally, check PYQT_VERSION_STR as well.
-        result = op(pkg_resources.parse_version(PYQT_VERSION_STR), parsed)
+        result = op(packaging.version.parse(PYQT_VERSION_STR), parsed)
     return result
 
 
@@ -119,8 +119,8 @@ MAX_WORLD_ID = 256 if version_check('5.11.2') else 11
 def is_new_qtwebkit() -> bool:
     """Check if the given version is a new QtWebKit."""
     assert qWebKitVersion is not None
-    return (pkg_resources.parse_version(qWebKitVersion()) >
-            pkg_resources.parse_version('538.1'))
+    return (packaging.version.parse(qWebKitVersion()) >
+            packaging.version.parse('538.1'))
 
 
 def is_single_process() -> bool:

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -34,7 +34,7 @@ import typing
 import functools
 
 import attr
-import pkg_resources
+import packaging
 from PyQt5.QtCore import PYQT_VERSION_STR, QLibraryInfo
 from PyQt5.QtNetwork import QSslSocket
 from PyQt5.QtGui import (QOpenGLContext, QOpenGLVersionProfile,
@@ -123,7 +123,7 @@ def distribution() -> typing.Optional[DistributionInfo]:
     assert pretty is not None
 
     if 'VERSION_ID' in info:
-        dist_version = pkg_resources.parse_version(
+        dist_version = packaging.version.parse(
             info['VERSION_ID']
         )  # type: typing.Optional[typing.Tuple[str, ...]]
     else:

--- a/setup.py
+++ b/setup.py
@@ -71,7 +71,7 @@ try:
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},
         zip_safe=True,
-        install_requires=['pypeg2', 'jinja2', 'pygments', 'PyYAML', 'attrs'],
+        install_requires=['pypeg2', 'jinja2', 'pygments', 'PyYAML', 'attrs', 'packaging'],
         python_requires='>=3.5',
         name='qutebrowser',
         version=_get_constant('version'),

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -33,7 +33,7 @@ import textwrap
 import datetime
 
 import attr
-import pkg_resources
+import packaging
 import pytest
 import hypothesis
 import hypothesis.strategies
@@ -77,7 +77,7 @@ from qutebrowser.browser import pdfjs
      """,
      version.DistributionInfo(
          id='ubuntu', parsed=version.Distribution.ubuntu,
-         version=pkg_resources.parse_version('14.4'),
+         version=packaging.version.parse('14.4'),
          pretty='Ubuntu 14.04.5 LTS')),
     # Ubuntu 17.04
     ("""
@@ -90,7 +90,7 @@ from qutebrowser.browser import pdfjs
      """,
      version.DistributionInfo(
          id='ubuntu', parsed=version.Distribution.ubuntu,
-         version=pkg_resources.parse_version('17.4'),
+         version=packaging.version.parse('17.4'),
          pretty='Ubuntu 17.04')),
     # Debian Jessie
     ("""
@@ -102,7 +102,7 @@ from qutebrowser.browser import pdfjs
      """,
      version.DistributionInfo(
          id='debian', parsed=version.Distribution.debian,
-         version=pkg_resources.parse_version('8'),
+         version=packaging.version.parse('8'),
          pretty='Debian GNU/Linux 8 (jessie)')),
     # Void Linux
     ("""
@@ -133,7 +133,7 @@ from qutebrowser.browser import pdfjs
      """,
      version.DistributionInfo(
          id='fedora', parsed=version.Distribution.fedora,
-         version=pkg_resources.parse_version('25'),
+         version=packaging.version.parse('25'),
          pretty='Fedora 25 (Twenty Five)')),
     # OpenSUSE
     ("""
@@ -146,7 +146,7 @@ from qutebrowser.browser import pdfjs
      """,
      version.DistributionInfo(
          id='opensuse', parsed=version.Distribution.opensuse,
-         version=pkg_resources.parse_version('42.2'),
+         version=packaging.version.parse('42.2'),
          pretty='openSUSE Leap 42.2')),
     # Linux Mint
     ("""
@@ -159,7 +159,7 @@ from qutebrowser.browser import pdfjs
      """,
      version.DistributionInfo(
          id='linuxmint', parsed=version.Distribution.linuxmint,
-         version=pkg_resources.parse_version('18.1'),
+         version=packaging.version.parse('18.1'),
          pretty='Linux Mint 18.1')),
     # Manjaro
     ("""
@@ -188,7 +188,7 @@ from qutebrowser.browser import pdfjs
     """,
      version.DistributionInfo(
          id='org.kde.Platform', parsed=version.Distribution.kde_flatpak,
-         version=pkg_resources.parse_version('5.12'),
+         version=packaging.version.parse('5.12'),
          pretty='KDE')),
     # No PRETTY_NAME
     ("""
@@ -221,7 +221,7 @@ def test_distribution(tmpdir, monkeypatch, os_release, expected):
     (None, False),
     (version.DistributionInfo(
         id='org.kde.Platform', parsed=version.Distribution.kde_flatpak,
-        version=pkg_resources.parse_version('5.12'),
+        version=packaging.version.parse('5.12'),
         pretty='Unknown'), True),
     (version.DistributionInfo(
         id='arch', parsed=version.Distribution.arch, version=None,


### PR DESCRIPTION
Under the hood, it's just a redirection wrapper for its vendored copy of packaging.version (`parse()`, `Version`, `LegacyVersion`) anyway.

In addition to removing indirection, this results in faster import times. pkg_resources is really slow to load, since it does way too many things. Although qutebrowser still imports pkg_resources for other functions, this greatly reduces the number of problematic calls.

Partial fix for #4467
