### PR TITLE
If "tabs.tabs_are_windows" is set, "tab-close" should map to "close"

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -418,9 +418,10 @@ class TabbedBrowser(QWidget):
             new_undo: Whether the undo entry should be a new item in the stack.
         """
         last_close = config.val.tabs.last_close
+        tabs_are_windows = config.val.tabs.tabs_are_windows
         count = self.widget.count()
 
-        if last_close == 'ignore' and count == 1:
+        if last_close == 'ignore' and count == 1 and not tabs_are_windows:
             return
 
         self._remove_tab(tab, add_undo=add_undo, new_undo=new_undo)


### PR DESCRIPTION
The code should be self explainatory, but i'm basically overriding the default behaviour of the `tab_close` of the last tab if `last_close` is set to `ignore`..  One could also create another label that does this more directly. Feedback is welcome.
fixes #5695

I have not been able to run the tests locally.

Also would it be possible to tag the repo or this PR as a hacktober-friendly application? If not that is fine as well - I've primarily wanted to give back to qutebrowser because I've been using it for a long time.