### PR TITLE
Fix bad formatting in tabs.title.format docs

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -4046,14 +4046,14 @@ The following placeholders are defined:
 * `{perc}`: Percentage as a string like `[10%]`.
 * `{perc_raw}`: Raw percentage, e.g. `10`.
 * `{current_title}`: Title of the current web page.
-* `{title_sep}`: The string ` - ` if a title is set, empty otherwise.
+* `{title_sep}`: The string `" - "` if a title is set, empty otherwise.
 * `{index}`: Index of this tab.
 * `{aligned_index}`: Index of this tab padded with spaces to have the same
   width.
 * `{id}`: Internal tab ID of this tab.
 * `{scroll_pos}`: Page scroll position.
 * `{host}`: Host of the current web page.
-* `{backend}`: Either ''webkit'' or ''webengine''
+* `{backend}`: Either `webkit` or `webengine`
 * `{private}`: Indicates when private mode is enabled.
 * `{current_url}`: URL of the current web page.
 * `{protocol}`: Protocol (http/https/...) of the current web page.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1827,14 +1827,14 @@ tabs.title.format:
     * `{perc}`: Percentage as a string like `[10%]`.
     * `{perc_raw}`: Raw percentage, e.g. `10`.
     * `{current_title}`: Title of the current web page.
-    * `{title_sep}`: The string ` - ` if a title is set, empty otherwise.
+    * `{title_sep}`: The string `" - "` if a title is set, empty otherwise.
     * `{index}`: Index of this tab.
     * `{aligned_index}`: Index of this tab padded with spaces to have the same
       width.
     * `{id}`: Internal tab ID of this tab.
     * `{scroll_pos}`: Page scroll position.
     * `{host}`: Host of the current web page.
-    * `{backend}`: Either ''webkit'' or ''webengine''
+    * `{backend}`: Either `webkit` or `webengine`
     * `{private}`: Indicates when private mode is enabled.
     * `{current_url}`: URL of the current web page.
     * `{protocol}`: Protocol (http/https/...) of the current web page.


### PR DESCRIPTION
Hi! It's that time of the year again. Now that all the drama with "spamtoberfest" has ended (although I see that qutebrowser was fortunately not affected) I'll be sending some small PRs to fix issues here and there.

I noticed that there is something wrong with the way the documentation for the `tabs.title.format` setting is rendered. It seems to be related with the double single-quotes around `webkit` and `webengine`, so I replaced those with back quotes. The ``` - ``` in
`{title_step}` also looked weird so I changed that too. I'm attaching a screenshot of how it looked:
![screenshot](https://user-images.githubusercontent.com/7890579/95799008-c485e080-0cc9-11eb-94e7-8f8ac45798e6.png)
