### PR TITLE
Don't filter completion models until a completion is requested

### DIFF
--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -310,6 +310,11 @@ class CompletionView(QTreeView):
         if not self._active:
             return
 
+        if config.val.completion.show != 'always':
+            with debug.log_time(log.completion, 'Set pattern {}'.format(self.pattern)):
+                self.model().set_pattern(self.pattern)
+                self._maybe_update_geometry()
+
         selmodel = self.selectionModel()
         indices = {
             'next': lambda: self._next_idx(upwards=False),
@@ -379,11 +384,16 @@ class CompletionView(QTreeView):
                 "Ignoring pattern set request as pattern has not changed.")
             return
         self.pattern = pattern
-        with debug.log_time(log.completion, 'Set pattern {}'.format(pattern)):
-            self.model().set_pattern(pattern)
-            self.selectionModel().clear()
-            self._maybe_update_geometry()
-            self._maybe_show()
+        self.selectionModel().clear()
+        if config.val.completion.show == 'always':
+            with debug.log_time(log.completion, 'Set pattern {}'.format(pattern)):
+                self.model().set_pattern(pattern)
+                self._maybe_update_geometry()
+                self._maybe_show()
+        else:
+            log.completion.debug(
+                "Ignoring pattern set request as completion.show is {}.".format(
+                    config.val.completion.show))
 
     def _maybe_show(self):
         if (config.val.completion.show == 'always' and

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -45,6 +45,7 @@ class CompletionView(QTreeView):
 
     Attributes:
         pattern: Current filter pattern, used for highlighting.
+        _model_pattern: Pattern currently set in the underlying model.
         _win_id: The ID of the window this CompletionView is associated with.
         _height: The height to use for the CompletionView.
         _height_perc: Either None or a percentage if height should be relative.
@@ -116,6 +117,7 @@ class CompletionView(QTreeView):
                  parent: QWidget = None) -> None:
         super().__init__(parent)
         self.pattern = None  # type: typing.Optional[str]
+        self._model_pattern = None  # type: typing.Optional[str]
         self._win_id = win_id
         self._cmd = cmd
         self._active = False
@@ -310,9 +312,14 @@ class CompletionView(QTreeView):
         if not self._active:
             return
 
-        if config.val.completion.show != 'always':
+        if (
+                config.val.completion.show != 'always'
+                and self.pattern is not None
+                and self.pattern != self._model_pattern
+        ):
             with debug.log_time(log.completion, 'Set pattern {}'.format(self.pattern)):
                 self.model().set_pattern(self.pattern)
+                self._model_pattern = self.pattern
                 self._maybe_update_geometry()
 
         selmodel = self.selectionModel()
@@ -388,6 +395,7 @@ class CompletionView(QTreeView):
         if config.val.completion.show == 'always':
             with debug.log_time(log.completion, 'Set pattern {}'.format(pattern)):
                 self.model().set_pattern(pattern)
+                self._model_pattern = pattern
                 self._maybe_update_geometry()
                 self._maybe_show()
         else:


### PR DESCRIPTION
I moved the responsibility of setting the pattern in the underlying model from `set_pattern` to `completion_item_focus` when `completion.show` is not `always`, as suggested in #4794. To avoid setting the same pattern over and over again when hitting `<Tab>` inside the completion widget I needed to record the last pattern actually set in the model in `self._model_pattern`. Maybe it would be better to have `CompletionModel` expose its current pattern so the completion widget doesn't need to remember this?

Fixes #4794.