### PR TITLE
update .gitignore for temporary vim files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,15 @@
 __pycache__
 *.py~
 *.pyc
-*.swp
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+[._]*.un~
+Session.vim
+Sessionx.vim
+*~
 /build
 /dist
 /qutebrowser.egg-info


### PR DESCRIPTION
Do not add vim undofiles by default.
Also, after .swp comes .swo etc., so added those as well.

For hacktober :+1: 
