### PR TITLE
Correct qt devtools package name on Fedora

### DIFF
--- a/qutebrowser/browser/webengine/webengineinspector.py
+++ b/qutebrowser/browser/webengine/webengineinspector.py
@@ -118,7 +118,7 @@ class WebEngineInspector(inspector.AbstractWebInspector):
         pak = data_path / 'resources' / 'qtwebengine_devtools_resources.pak'
         if not pak.exists():
             raise inspector.Error("QtWebEngine devtools resources not found, "
-                                  "please install the qt5-webengine-devtools "
+                                  "please install the qt5-qtwebengine-devtools "
                                   "Fedora package.")
 
     def inspect(self, page: QWebEnginePage) -> None:  # type: ignore[override]


### PR DESCRIPTION
The package on fedora is called `qt5-qtwebengine-devtools`. While a minor issue it helps
pointing users to the needed package when trying to install.

This seems to be the case for all Fedora versions at least 30 or higher:
https://pkgs.org/download/qt5-qtwebengine-devtools

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
