### PR TITLE
Re-adding history to dmenu_qutebrowser userscript

### DIFF
--- a/misc/userscripts/dmenu_qutebrowser
+++ b/misc/userscripts/dmenu_qutebrowser
@@ -38,11 +38,13 @@
 #				(This is unnecessarily long. I use this rarely, feel free to make this script accept parameters.)
 #
 
-[ -z "$QUTE_URL" ] && QUTE_URL='http://google.com'
 
-url=$(echo "$QUTE_URL" | cat - "$QUTE_CONFIG_DIR/quickmarks" "$QUTE_DATA_DIR/history" | dmenu -l 15 -p qutebrowser)
+[ -z "$QUTE_URL" ] && QUTE_URL='https://duckduckgo.com'
+
+url=$(printf "%s\n%s" "$QUTE_URL" "$(sqlite3 "$QUTE_DATA_DIR/history.sqlite" 'select url from CompletionHistory')" | cat "$QUTE_CONFIG_DIR/quickmarks" - | dmenu -l 15 -p qutebrowser)
 url=$(echo "$url" | sed -E 's/[^ ]+ +//g' | grep -E "https?:" || echo "$url")
 
 [ -z "${url// }" ] && exit
 
 echo "open $url" >> "$QUTE_FIFO" || qutebrowser "$url"
+

--- a/misc/userscripts/dmenu_qutebrowser
+++ b/misc/userscripts/dmenu_qutebrowser
@@ -47,4 +47,3 @@ url=$(echo "$url" | sed -E 's/[^ ]+ +//g' | grep -E "https?:" || echo "$url")
 [ -z "${url// }" ] && exit
 
 echo "open $url" >> "$QUTE_FIFO" || qutebrowser "$url"
-

--- a/misc/userscripts/dmenu_qutebrowser
+++ b/misc/userscripts/dmenu_qutebrowser
@@ -41,7 +41,7 @@
 
 [ -z "$QUTE_URL" ] && QUTE_URL='https://duckduckgo.com'
 
-url=$(printf "%s\n%s" "$QUTE_URL" "$(sqlite3 "$QUTE_DATA_DIR/history.sqlite" 'select url from CompletionHistory')" | cat "$QUTE_CONFIG_DIR/quickmarks" - | dmenu -l 15 -p qutebrowser)
+url=$(printf "%s\n%s" "$QUTE_URL" "$(sqlite3 -separator ' ' "$QUTE_DATA_DIR/history.sqlite" 'select title, url from CompletionHistory')" | cat "$QUTE_CONFIG_DIR/quickmarks" - | dmenu -l 15 -p qutebrowser)
 url=$(echo "$url" | sed -E 's/[^ ]+ +//g' | grep -E "https?:" || echo "$url")
 
 [ -z "${url// }" ] && exit

--- a/misc/userscripts/qutedmenu
+++ b/misc/userscripts/qutedmenu
@@ -6,8 +6,9 @@
 
 # If you would like to set a custom colorscheme/font use these dirs.
 # https://github.com/halfwit/dotfiles/blob/master/.config/dmenu/bemenucolors
-readonly confdir=${XDG_CONFIG_HOME:-$HOME/.config}
 
+
+readonly confdir=${XDG_CONFIG_HOME:-$HOME/.config}
 readonly optsfile=$confdir/dmenu/bemenucolors
 
 create_menu() {
@@ -22,15 +23,13 @@ create_menu() {
     done < "$QUTE_CONFIG_DIR"/bookmarks/urls
 
     # Finally history
-    while read -r _ url; do
-        printf -- '%s\n' "$url"
-    done < "$QUTE_DATA_DIR"/history
+        printf -- '%s\n' "$(sqlite3 -separator ' ' "$QUTE_DATA_DIR/history.sqlite" 'select title, url from CompletionHistory')"
     }
 
 get_selection() {
     opts+=(-p qutebrowser)
-    #create_menu | dmenu -l 10 "${opts[@]}"
-    create_menu | bemenu -l 10 "${opts[@]}"
+    create_menu | dmenu -l 10 "${opts[@]}"
+    #create_menu | bemenu -l 10 "${opts[@]}"
 }
 
 # Main


### PR DESCRIPTION
As there is not a file called _history_ to cat from in $QUTE_DATA_DIR, but instead a sqlite file called history.sqlite.

So the changes I've made was to use sqlite3 and an inline query, to extract distinct urls from the History table, and appending them to the list piped into dmenu.

The rest works as it has always done.
Fixes #3091
