### PR TITLE
Fix qute-pass crash from wrong cache directory

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -177,7 +177,7 @@ def main(arguments):
         argument_parser.print_help()
         return ExitCodes.FAILURE
 
-    extractor = tldextract.TLDExtract(extra_suffixes=arguments.extra_url_suffixes.split(','))
+    extractor = tldextract.TLDExtract(extra_suffixes=arguments.extra_url_suffixes.split(','), cache_dir=os.environ['QUTE_DATA_DIR'])
     extract_result = extractor(arguments.url)
 
     # Try to find candidates using targets in the following order: fully-qualified domain name (includes subdomains),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

Owing to [this tldextract issue](https://github.com/john-kurkowski/tldextract/issues/209), the `qute-pass` userscript attempts to write cache data to a system directory, causing the script to crash with `PermissionDenied`. This fix tells `tldextract` to cache to `QUTE_DATA_DIR` instead (it creates a `.suffix_cache` file in that directory).