### PR TITLE
Move error pages to qute://error URL

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -196,6 +196,19 @@ def qute_bookmarks(_url: QUrl) -> _HandlerRet:
     return 'text/html', src
 
 
+@add_handler('error')
+def qute_error(error_url: QUrl) -> _HandlerRet:
+    """Handler for qute://error. Display an error page."""
+    queries = QUrlQuery(error_url)
+    url_string = queries.queryItemValue("u")
+    error = queries.queryItemValue("e")
+    error_page = jinja.render(
+        'error.html',
+        title="Error loading page: {}".format(url_string),
+        url=url_string, error=error)
+    return 'text/html', error_page
+
+
 @add_handler('tabs')
 def qute_tabs(_url: QUrl) -> _HandlerRet:
     """Handler for qute://tabs. Display information about all open tabs."""

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -26,7 +26,7 @@ import html as html_utils
 import typing
 
 from PyQt5.QtCore import (pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QUrl,
-                          QTimer, QObject)
+                          QTimer, QObject, QUrlQuery)
 from PyQt5.QtNetwork import QAuthenticator
 from PyQt5.QtWidgets import QApplication, QWidget
 from PyQt5.QtWebEngineWidgets import QWebEnginePage, QWebEngineScript, QWebEngineHistory
@@ -40,7 +40,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            webenginesettings, certificateerror)
 from qutebrowser.misc import miscwidgets, objects, quitter
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
-                               message, objreg, jinja, debug)
+                               message, objreg, debug)
 from qutebrowser.keyinput import modeman
 from qutebrowser.qt import sip
 
@@ -1492,15 +1492,14 @@ class WebEngineTab(browsertab.AbstractTab):
         # percent encoded content is 2 megabytes minus 30 bytes.
         self._widget.setHtml(html, base_url)
 
-    def _show_error_page(self, url, error):
+    def _show_error_page(self, url: QUrl, error: str):
         """Show an error page in the tab."""
         log.misc.debug("Showing error page for {}".format(error))
-        url_string = url.toDisplayString()
-        error_page = jinja.render(
-            'error.html',
-            title="Error loading page: {}".format(url_string),
-            url=url_string, error=error)
-        self.set_html(error_page)
+        error_url = QUrl("qute://error")
+        queries = QUrlQuery()
+        queries.setQueryItems([["u", url.toDisplayString()], ["e", error]])
+        error_url.setQuery(queries)
+        self.load_url(error_url)
 
     @pyqtSlot()
     def _on_history_trigger(self):

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -25,7 +25,7 @@ import typing
 import contextlib
 
 import attr
-from PyQt5.QtCore import pyqtSlot, QUrl, QObject
+from PyQt5.QtCore import pyqtSlot, QUrl, QObject, QUrlQuery
 
 from qutebrowser.api import cmdutils
 from qutebrowser.config import config
@@ -52,10 +52,15 @@ class ParseResult:
     cmdline = attr.ib()
 
 
-def _url(tabbed_browser):
+def _url(tabbed_browser) -> QUrl:
     """Convenience method to get the current url."""
     try:
-        return tabbed_browser.current_url()
+        url = tabbed_browser.current_url()
+        if url.scheme() == "qute" and url.host() == "error":
+            real_url = QUrl(QUrlQuery(url).queryItemValue("u"))
+            if real_url.isValid():
+                return real_url
+        return url
     except qtutils.QtValueError as e:
         msg = "Current URL is invalid"
         if e.reason:


### PR DESCRIPTION
Related: #3918 

TODO:

* Should the function that extracts error URL be moved somewhere else (instead of having it duplicated)?
* `:reload`?
* `{url:raw}`?
* Display the real URL on the status bar?
* What's the proper way to handle invalid error URLs such as `qute://error/?u=:/@$`? (normally this would not happen)
* This will make it much less likely to get double OOM, but should the page be simply reloaded instead of double-errorred if it's killed/crashes again?