### PR TITLE
mypy: use from-import for typing in `config`

### DIFF
--- a/qutebrowser/config/configcache.py
+++ b/qutebrowser/config/configcache.py
@@ -20,7 +20,7 @@
 
 """Implementation of a basic config cache."""
 
-import typing
+from typing import Any, Dict
 
 from qutebrowser.config import config
 
@@ -38,14 +38,14 @@ class ConfigCache:
     """
 
     def __init__(self) -> None:
-        self._cache = {}  # type: typing.Dict[str, typing.Any]
+        self._cache: Dict[str, Any] = {}
         config.instance.changed.connect(self._on_config_changed)
 
     def _on_config_changed(self, attr: str) -> None:
         if attr in self._cache:
             del self._cache[attr]
 
-    def __getitem__(self, attr: str) -> typing.Any:
+    def __getitem__(self, attr: str) -> Any:
         try:
             return self._cache[attr]
         except KeyError:

--- a/qutebrowser/config/configcommands.py
+++ b/qutebrowser/config/configcommands.py
@@ -19,9 +19,9 @@
 
 """Commands related to the configuration."""
 
-import typing
 import os.path
 import contextlib
+from typing import TYPE_CHECKING, Iterator, List, Optional
 
 from PyQt5.QtCore import QUrl
 
@@ -32,7 +32,7 @@ from qutebrowser.config import configtypes, configexc, configfiles, configdata
 from qutebrowser.misc import editor
 from qutebrowser.keyinput import keyutils
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from qutebrowser.config.config import Config, KeyConfig
 
 
@@ -47,17 +47,14 @@ class ConfigCommands:
         self._keyconfig = keyconfig
 
     @contextlib.contextmanager
-    def _handle_config_error(self) -> typing.Iterator[None]:
+    def _handle_config_error(self) -> Iterator[None]:
         """Catch errors in set_command and raise CommandError."""
         try:
             yield
         except configexc.Error as e:
             raise cmdutils.CommandError(str(e))
 
-    def _parse_pattern(
-            self,
-            pattern: typing.Optional[str]
-    ) -> typing.Optional[urlmatch.UrlPattern]:
+    def _parse_pattern(self, pattern: Optional[str]) -> Optional[urlmatch.UrlPattern]:
         """Parse a pattern string argument to a pattern."""
         if pattern is None:
             return None
@@ -75,8 +72,7 @@ class ConfigCommands:
         except keyutils.KeyParseError as e:
             raise cmdutils.CommandError(str(e))
 
-    def _print_value(self, option: str,
-                     pattern: typing.Optional[urlmatch.UrlPattern]) -> None:
+    def _print_value(self, option: str, pattern: Optional[urlmatch.UrlPattern]) -> None:
         """Print the value of the given option."""
         with self._handle_config_error():
             value = self._config.get_str(option, pattern=pattern)
@@ -468,7 +464,7 @@ class ConfigCommands:
             raise cmdutils.CommandError("{} already exists - use --force to "
                                         "overwrite!".format(filename))
 
-        options = []  # type: typing.List
+        options: List = []
         if defaults:
             options = [(None, opt, opt.default)
                        for _name, opt in sorted(configdata.DATA.items())]

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -24,8 +24,8 @@ Module attributes:
 DATA: A dict of Option objects after init() has been called.
 """
 
-import typing
-from typing import Optional
+from typing import (Any, Dict, Iterable, List, Mapping, MutableMapping, Optional,
+                    Sequence, Tuple, Union, cast)
 import functools
 
 import attr
@@ -33,10 +33,10 @@ from qutebrowser.config import configtypes
 from qutebrowser.utils import usertypes, qtutils, utils
 from qutebrowser.misc import debugcachestats
 
-DATA = typing.cast(typing.Mapping[str, 'Option'], None)
-MIGRATIONS = typing.cast('Migrations', None)
+DATA = cast(Mapping[str, 'Option'], None)
+MIGRATIONS = cast('Migrations', None)
 
-_BackendDict = typing.Mapping[str, typing.Union[str, bool]]
+_BackendDict = Mapping[str, Union[str, bool]]
 
 
 @attr.s
@@ -47,15 +47,15 @@ class Option:
     Note that this is just an option which exists, with no value associated.
     """
 
-    name = attr.ib()  # type: str
-    typ = attr.ib()  # type: configtypes.BaseType
-    default = attr.ib()  # type: typing.Any
-    backends = attr.ib()  # type: typing.Iterable[usertypes.Backend]
-    raw_backends = attr.ib()  # type: Optional[typing.Mapping[str, bool]]
-    description = attr.ib()  # type: str
-    supports_pattern = attr.ib(default=False)  # type: bool
-    restart = attr.ib(default=False)  # type: bool
-    no_autoconfig = attr.ib(default=False)  # type: bool
+    name: str = attr.ib()
+    typ: configtypes.BaseType = attr.ib()
+    default: Any = attr.ib()
+    backends: Iterable[usertypes.Backend] = attr.ib()
+    raw_backends: Optional[Mapping[str, bool]] = attr.ib()
+    description: str = attr.ib()
+    supports_pattern: bool = attr.ib(default=False)
+    restart: bool = attr.ib(default=False)
+    no_autoconfig: bool = attr.ib(default=False)
 
 
 @attr.s
@@ -68,13 +68,11 @@ class Migrations:
         deleted: A list of option names which have been removed.
     """
 
-    renamed = attr.ib(
-        default=attr.Factory(dict))  # type: typing.Dict[str, str]
-    deleted = attr.ib(
-        default=attr.Factory(list))  # type: typing.List[str]
+    renamed: Dict[str, str] = attr.ib(default=attr.Factory(dict))
+    deleted: List[str] = attr.ib(default=attr.Factory(list))
 
 
-def _raise_invalid_node(name: str, what: str, node: typing.Any) -> None:
+def _raise_invalid_node(name: str, what: str, node: Any) -> None:
     """Raise an exception for an invalid configdata YAML node.
 
     Args:
@@ -88,14 +86,14 @@ def _raise_invalid_node(name: str, what: str, node: typing.Any) -> None:
 
 def _parse_yaml_type(
         name: str,
-        node: typing.Union[str, typing.Mapping[str, typing.Any]],
+        node: Union[str, Mapping[str, Any]],
 ) -> configtypes.BaseType:
     if isinstance(node, str):
         # e.g:
         #   > type: Bool
         # -> create the type object without any arguments
         type_name = node
-        kwargs = {}  # type: typing.MutableMapping[str, typing.Any]
+        kwargs: MutableMapping[str, Any] = {}
     elif isinstance(node, dict):
         # e.g:
         #   > type:
@@ -136,7 +134,7 @@ def _parse_yaml_type(
 def _parse_yaml_backends_dict(
         name: str,
         node: _BackendDict,
-) -> typing.Sequence[usertypes.Backend]:
+) -> Sequence[usertypes.Backend]:
     """Parse a dict definition for backends.
 
     Example:
@@ -178,8 +176,8 @@ def _parse_yaml_backends_dict(
 
 def _parse_yaml_backends(
         name: str,
-        node: typing.Union[None, str, _BackendDict],
-) -> typing.Sequence[usertypes.Backend]:
+        node: Union[None, str, _BackendDict],
+) -> Sequence[usertypes.Backend]:
     """Parse a backend node in the yaml.
 
     It can have one of those four forms:
@@ -208,7 +206,7 @@ def _parse_yaml_backends(
 
 def _read_yaml(
         yaml_data: str,
-) -> typing.Tuple[typing.Mapping[str, Option], Migrations]:
+) -> Tuple[Mapping[str, Option], Migrations]:
     """Read config data from a YAML file.
 
     Args:

--- a/qutebrowser/config/configdiff.py
+++ b/qutebrowser/config/configdiff.py
@@ -19,9 +19,9 @@
 
 """Code to show a diff of the legacy config format."""
 
-import typing
 import difflib
 import os.path
+from typing import MutableSequence
 
 import pygments
 import pygments.lexers
@@ -730,8 +730,8 @@ scroll right
 
 def get_diff() -> str:
     """Get a HTML diff for the old config files."""
-    old_conf_lines = []  # type: typing.MutableSequence[str]
-    old_key_lines = []  # type: typing.MutableSequence[str]
+    old_conf_lines: MutableSequence[str] = []
+    old_key_lines: MutableSequence[str] = []
 
     for filename, dest in [('qutebrowser.conf', old_conf_lines),
                            ('keys.conf', old_key_lines)]:

--- a/qutebrowser/config/configexc.py
+++ b/qutebrowser/config/configexc.py
@@ -19,9 +19,9 @@
 
 """Exceptions related to config parsing."""
 
-import typing
-import attr
+from typing import Any, Mapping, Optional, Sequence, Union
 
+import attr
 from qutebrowser.utils import usertypes, log
 
 
@@ -46,7 +46,7 @@ class BackendError(Error):
     def __init__(
             self, name: str,
             backend: usertypes.Backend,
-            raw_backends: typing.Optional[typing.Mapping[str, bool]]
+            raw_backends: Optional[Mapping[str, bool]]
     ) -> None:
         if raw_backends is None or not raw_backends[backend.name]:
             msg = ("The {} setting is not available with the {} backend!"
@@ -76,8 +76,7 @@ class ValidationError(Error):
         msg: Additional error message.
     """
 
-    def __init__(self, value: typing.Any,
-                 msg: typing.Union[str, Exception]) -> None:
+    def __init__(self, value: Any, msg: Union[str, Exception]) -> None:
         super().__init__("Invalid value '{}' - {}".format(value, msg))
         self.option = None
 
@@ -117,9 +116,9 @@ class ConfigErrorDesc:
         traceback: The formatted traceback of the exception.
     """
 
-    text = attr.ib()  # type: str
-    exception = attr.ib()  # type: typing.Union[str, Exception]
-    traceback = attr.ib(None)  # type: str
+    text: str = attr.ib()
+    exception: Union[str, Exception] = attr.ib()
+    traceback: str = attr.ib(None)
 
     def __str__(self) -> str:
         if self.traceback:
@@ -141,7 +140,7 @@ class ConfigFileErrors(Error):
 
     def __init__(self,
                  basename: str,
-                 errors: typing.Sequence[ConfigErrorDesc], *,
+                 errors: Sequence[ConfigErrorDesc], *,
                  fatal: bool = False) -> None:
         super().__init__("Errors occurred while reading {}:\n{}".format(
             basename, '\n'.join('  {}'.format(e) for e in errors)))

--- a/qutebrowser/config/configfiles.py
+++ b/qutebrowser/config/configfiles.py
@@ -27,8 +27,9 @@ import textwrap
 import traceback
 import configparser
 import contextlib
-import typing
 import re
+from typing import (TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping,
+                    MutableMapping, Optional, cast)
 
 import yaml
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QObject, QSettings, qVersion
@@ -39,15 +40,15 @@ from qutebrowser.config import (configexc, config, configdata, configutils,
 from qutebrowser.keyinput import keyutils
 from qutebrowser.utils import standarddir, utils, qtutils, log, urlmatch
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from qutebrowser.misc import savemanager
 
 
 # The StateConfig instance
-state = typing.cast('StateConfig', None)
+state = cast('StateConfig', None)
 
 
-_SettingsType = typing.Dict[str, typing.Dict[str, typing.Any]]
+_SettingsType = Dict[str, Dict[str, Any]]
 
 
 class StateConfig(configparser.ConfigParser):
@@ -117,7 +118,7 @@ class YamlConfig(QObject):
                                       'autoconfig.yml')
         self._dirty = False
 
-        self._values = {}  # type: typing.Dict[str, configutils.Values]
+        self._values: Dict[str, configutils.Values] = {}
         for name, opt in configdata.DATA.items():
             self._values[name] = configutils.Values(opt)
 
@@ -130,7 +131,7 @@ class YamlConfig(QObject):
         """
         save_manager.add_saveable('yaml-config', self._save, self.changed)
 
-    def __iter__(self) -> typing.Iterator[configutils.Values]:
+    def __iter__(self) -> Iterator[configutils.Values]:
         """Iterate over configutils.Values items."""
         yield from self._values.values()
 
@@ -145,7 +146,7 @@ class YamlConfig(QObject):
         if not self._dirty:
             return
 
-        settings = {}  # type: _SettingsType
+        settings: _SettingsType = {}
         for name, values in sorted(self._values.items()):
             if not values:
                 continue
@@ -167,10 +168,7 @@ class YamlConfig(QObject):
             """.lstrip('\n')))
             utils.yaml_dump(data, f)
 
-    def _pop_object(self,
-                    yaml_data: typing.Any,
-                    key: str,
-                    typ: type) -> typing.Any:
+    def _pop_object(self, yaml_data: Any, key: str, typ: type) -> Any:
         """Get a global object from the given data."""
         if not isinstance(yaml_data, dict):
             desc = configexc.ConfigErrorDesc("While loading data",
@@ -227,19 +225,18 @@ class YamlConfig(QObject):
         self._validate_names(settings)
         self._build_values(settings)
 
-    def _load_settings_object(self, yaml_data: typing.Any) -> '_SettingsType':
+    def _load_settings_object(self, yaml_data: Any) -> '_SettingsType':
         """Load the settings from the settings: key."""
         return self._pop_object(yaml_data, 'settings', dict)
 
-    def _load_legacy_settings_object(self,
-                                     yaml_data: typing.Any) -> '_SettingsType':
+    def _load_legacy_settings_object(self, yaml_data: Any) -> '_SettingsType':
         data = self._pop_object(yaml_data, 'global', dict)
         settings = {}
         for name, value in data.items():
             settings[name] = {'global': value}
         return settings
 
-    def _build_values(self, settings: typing.Mapping) -> None:
+    def _build_values(self, settings: Mapping) -> None:
         """Build up self._values from the values in the given dict."""
         errors = []
         for name, yaml_values in settings.items():
@@ -285,7 +282,7 @@ class YamlConfig(QObject):
                       for e in sorted(unknown)]
             raise configexc.ConfigFileErrors('autoconfig.yml', errors)
 
-    def set_obj(self, name: str, value: typing.Any, *,
+    def set_obj(self, name: str, value: Any, *,
                 pattern: urlmatch.UrlPattern = None) -> None:
         """Set the given setting to the given value."""
         self._values[name].add(value, pattern)
@@ -477,8 +474,7 @@ class YamlMigrations(QObject):
                 self._settings[name][scope] = value
                 self.changed.emit()
 
-    def _migrate_to_multiple(self, old_name: str,
-                             new_names: typing.Iterable[str]) -> None:
+    def _migrate_to_multiple(self, old_name: str, new_names: Iterable[str]) -> None:
         if old_name not in self._settings:
             return
 
@@ -541,12 +537,12 @@ class ConfigAPI:
     def __init__(self, conf: config.Config, keyconfig: config.KeyConfig):
         self._config = conf
         self._keyconfig = keyconfig
-        self.errors = []  # type: typing.List[configexc.ConfigErrorDesc]
+        self.errors: List[configexc.ConfigErrorDesc] = []
         self.configdir = pathlib.Path(standarddir.config())
         self.datadir = pathlib.Path(standarddir.data())
 
     @contextlib.contextmanager
-    def _handle_error(self, action: str, name: str) -> typing.Iterator[None]:
+    def _handle_error(self, action: str, name: str) -> Iterator[None]:
         """Catch config-related exceptions and save them in self.errors."""
         try:
             yield
@@ -582,21 +578,19 @@ class ConfigAPI:
             with self._handle_error('reading', 'autoconfig.yml'):
                 read_autoconfig()
 
-    def get(self, name: str, pattern: str = None) -> typing.Any:
+    def get(self, name: str, pattern: str = None) -> Any:
         """Get a setting value from the config, optionally with a pattern."""
         with self._handle_error('getting', name):
             urlpattern = urlmatch.UrlPattern(pattern) if pattern else None
             return self._config.get_mutable_obj(name, pattern=urlpattern)
 
-    def set(self, name: str, value: typing.Any, pattern: str = None) -> None:
+    def set(self, name: str, value: Any, pattern: str = None) -> None:
         """Set a setting value in the config, optionally with a pattern."""
         with self._handle_error('setting', name):
             urlpattern = urlmatch.UrlPattern(pattern) if pattern else None
             self._config.set_obj(name, value, pattern=urlpattern)
 
-    def bind(self, key: str,
-             command: typing.Optional[str],
-             mode: str = 'normal') -> None:
+    def bind(self, key: str, command: Optional[str], mode: str = 'normal') -> None:
         """Bind a key to a command, with an optional key mode."""
         with self._handle_error('binding', key):
             seq = keyutils.KeySequence.parse(key)
@@ -625,7 +619,7 @@ class ConfigAPI:
             self.errors += e.errors
 
     @contextlib.contextmanager
-    def pattern(self, pattern: str) -> typing.Iterator[config.ConfigContainer]:
+    def pattern(self, pattern: str) -> Iterator[config.ConfigContainer]:
         """Get a ConfigContainer for the given pattern."""
         # We need to propagate the exception so we don't need to return
         # something.
@@ -641,9 +635,8 @@ class ConfigPyWriter:
 
     def __init__(
             self,
-            options: typing.List,
-            bindings: typing.MutableMapping[
-                str, typing.Mapping[str, typing.Optional[str]]],
+            options: List,
+            bindings: MutableMapping[str, Mapping[str, Optional[str]]],
             *, commented: bool) -> None:
         self._options = options
         self._bindings = bindings
@@ -664,7 +657,7 @@ class ConfigPyWriter:
         else:
             return line
 
-    def _gen_lines(self) -> typing.Iterator[str]:
+    def _gen_lines(self) -> Iterator[str]:
         """Generate a config.py with the given settings/bindings.
 
         Yields individual lines.
@@ -673,7 +666,7 @@ class ConfigPyWriter:
         yield from self._gen_options()
         yield from self._gen_bindings()
 
-    def _gen_header(self) -> typing.Iterator[str]:
+    def _gen_header(self) -> Iterator[str]:
         """Generate the initial header of the config."""
         yield self._line("# Autogenerated config.py")
         yield self._line("#")
@@ -706,7 +699,7 @@ class ConfigPyWriter:
             yield self._line("config.load_autoconfig(False)")
             yield ''
 
-    def _gen_options(self) -> typing.Iterator[str]:
+    def _gen_options(self) -> Iterator[str]:
         """Generate the options part of the config."""
         for pattern, opt, value in self._options:
             if opt.name in ['bindings.commands', 'bindings.default']:
@@ -734,7 +727,7 @@ class ConfigPyWriter:
                     opt.name, value, str(pattern)))
             yield ''
 
-    def _gen_bindings(self) -> typing.Iterator[str]:
+    def _gen_bindings(self) -> Iterator[str]:
         """Generate the bindings part of the config."""
         normal_bindings = self._bindings.pop('normal', {})
         if normal_bindings:
@@ -835,7 +828,7 @@ def read_autoconfig() -> None:
 
 
 @contextlib.contextmanager
-def saved_sys_properties() -> typing.Iterator[None]:
+def saved_sys_properties() -> Iterator[None]:
     """Save various sys properties such as sys.path and sys.modules."""
     old_path = sys.path.copy()
     old_modules = sys.modules.copy()

--- a/qutebrowser/config/configutils.py
+++ b/qutebrowser/config/configutils.py
@@ -21,21 +21,22 @@
 """Utilities and data structures used by various config code."""
 
 
-import typing
 import collections
 import itertools
 import operator
+from typing import (
+    TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Optional, Sequence, Set, Union)
 
 from PyQt5.QtCore import QUrl
 
 from qutebrowser.utils import utils, urlmatch, usertypes, qtutils
 from qutebrowser.config import configexc
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from qutebrowser.config import configdata
 
 
-def _widened_hostnames(hostname: str) -> typing.Iterable[str]:
+def _widened_hostnames(hostname: str) -> Iterable[str]:
     """A generator for widening string hostnames.
 
     Ex: a.c.foo -> [a.c.foo, c.foo, foo]"""
@@ -56,8 +57,8 @@ class ScopedValue:
 
     id_gen = itertools.count(0)
 
-    def __init__(self, value: typing.Any,
-                 pattern: typing.Optional[urlmatch.UrlPattern],
+    def __init__(self, value: Any,
+                 pattern: Optional[urlmatch.UrlPattern],
                  hide_userconfig: bool = False) -> None:
         self.value = value
         self.pattern = pattern
@@ -90,17 +91,18 @@ class Values:
         _domain_map: A mapping from hostnames to all associated ScopedValues.
     """
 
-    _VmapKeyType = typing.Optional[urlmatch.UrlPattern]
+    _VmapKeyType = Optional[urlmatch.UrlPattern]
 
     def __init__(self,
                  opt: 'configdata.Option',
-                 values: typing.Sequence[ScopedValue] = ()) -> None:
+                 values: Sequence[ScopedValue] = ()) -> None:
         self.opt = opt
-        self._vmap = collections.OrderedDict()  \
-            # type: collections.OrderedDict[Values._VmapKeyType, ScopedValue]
+        self._vmap: 'collections.OrderedDict[Values._VmapKeyType, ScopedValue]' = (
+            collections.OrderedDict()
+        )
         # A map from domain parts to rules that fall under them.
-        self._domain_map = collections.defaultdict(set)  \
-            # type: typing.Dict[typing.Optional[str], typing.Set[ScopedValue]]
+        self._domain_map: Dict[
+            Optional[str], Set[ScopedValue]] = collections.defaultdict(set)
 
         for scoped in values:
             self._add_scoped(scoped)
@@ -117,7 +119,7 @@ class Values:
             return '\n'.join(lines)
         return '{}: <unchanged>'.format(self.opt.name)
 
-    def dump(self, include_hidden: bool = False) -> typing.Sequence[str]:
+    def dump(self, include_hidden: bool = False) -> Sequence[str]:
         """Dump all customizations for this value.
 
         Arguments:
@@ -138,7 +140,7 @@ class Values:
 
         return lines
 
-    def __iter__(self) -> typing.Iterator['ScopedValue']:
+    def __iter__(self) -> Iterator['ScopedValue']:
         """Yield ScopedValue elements.
 
         This yields in "normal" order, i.e. global and then first-set settings
@@ -151,12 +153,12 @@ class Values:
         return bool(self._vmap)
 
     def _check_pattern_support(
-            self, arg: typing.Union[urlmatch.UrlPattern, QUrl, None]) -> None:
+            self, arg: Union[urlmatch.UrlPattern, QUrl, None]) -> None:
         """Make sure patterns are supported if one was given."""
         if arg is not None and not self.opt.supports_pattern:
             raise configexc.NoPatternError(self.opt.name)
 
-    def add(self, value: typing.Any,
+    def add(self, value: Any,
             pattern: urlmatch.UrlPattern = None, *,
             hide_userconfig: bool = False) -> None:
         """Add a value with the given pattern to the list of values.
@@ -201,7 +203,7 @@ class Values:
         self._vmap.clear()
         self._domain_map.clear()
 
-    def _get_fallback(self, fallback: bool) -> typing.Any:
+    def _get_fallback(self, fallback: bool) -> Any:
         """Get the fallback global/default value."""
         if None in self._vmap:
             return self._vmap[None].value
@@ -211,8 +213,7 @@ class Values:
         else:
             return usertypes.UNSET
 
-    def get_for_url(self, url: QUrl = None, *,
-                    fallback: bool = True) -> typing.Any:
+    def get_for_url(self, url: QUrl = None, *, fallback: bool = True) -> Any:
         """Get a config value, falling back when needed.
 
         This first tries to find a value matching the URL (if given).
@@ -225,7 +226,7 @@ class Values:
             return self._get_fallback(fallback)
         qtutils.ensure_valid(url)
 
-        candidates = []  # type: typing.List[ScopedValue]
+        candidates: List[ScopedValue] = []
         # Urls trailing with '.' are equivalent to non-trailing types.
         # urlutils strips them, so in order to match we will need to as well.
         widened_hosts = _widened_hostnames(url.host().rstrip('.'))
@@ -247,8 +248,8 @@ class Values:
         return self._get_fallback(fallback)
 
     def get_for_pattern(self,
-                        pattern: typing.Optional[urlmatch.UrlPattern], *,
-                        fallback: bool = True) -> typing.Any:
+                        pattern: Optional[urlmatch.UrlPattern], *,
+                        fallback: bool = True) -> Any:
         """Get a value only if it's been overridden for the given pattern.
 
         This is useful when showing values to the user.
@@ -272,11 +273,11 @@ class FontFamilies:
 
     """A list of font family names."""
 
-    def __init__(self, families: typing.Sequence[str]) -> None:
+    def __init__(self, families: Sequence[str]) -> None:
         self._families = families
         self.family = families[0] if families else None
 
-    def __iter__(self) -> typing.Iterator[str]:
+    def __iter__(self) -> Iterator[str]:
         yield from self._families
 
     def __repr__(self) -> str:
@@ -285,7 +286,7 @@ class FontFamilies:
     def __str__(self) -> str:
         return self.to_str()
 
-    def _quoted_families(self) -> typing.Iterator[str]:
+    def _quoted_families(self) -> Iterator[str]:
         for f in self._families:
             needs_quoting = any(c in f for c in ', ')
             yield '"{}"'.format(f) if needs_quoting else f

--- a/qutebrowser/config/qtargs.py
+++ b/qutebrowser/config/qtargs.py
@@ -21,15 +21,15 @@
 
 import os
 import sys
-import typing
 import argparse
+from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 from qutebrowser.config import config
 from qutebrowser.misc import objects
 from qutebrowser.utils import usertypes, qtutils, utils
 
 
-def qt_args(namespace: argparse.Namespace) -> typing.List[str]:
+def qt_args(namespace: argparse.Namespace) -> List[str]:
     """Get the Qt QApplication arguments based on an argparse namespace.
 
     Args:
@@ -61,9 +61,7 @@ def qt_args(namespace: argparse.Namespace) -> typing.List[str]:
     return argv
 
 
-def _qtwebengine_enabled_features(
-        feature_flags: typing.Sequence[str],
-) -> typing.Iterator[str]:
+def _qtwebengine_enabled_features(feature_flags: Sequence[str]) -> Iterator[str]:
     """Get --enable-features flags for QtWebEngine.
 
     Args:
@@ -114,8 +112,8 @@ def _qtwebengine_enabled_features(
 
 def _qtwebengine_args(
         namespace: argparse.Namespace,
-        feature_flags: typing.Sequence[str],
-) -> typing.Iterator[str]:
+        feature_flags: Sequence[str],
+) -> Iterator[str]:
     """Get the QtWebEngine arguments to use based on the config."""
     is_qt_514 = (qtutils.version_check('5.14', compiled=False) and
                  not qtutils.version_check('5.15', compiled=False))
@@ -162,8 +160,8 @@ def _qtwebengine_args(
     yield from _qtwebengine_settings_args()
 
 
-def _qtwebengine_settings_args() -> typing.Iterator[str]:
-    settings = {
+def _qtwebengine_settings_args() -> Iterator[str]:
+    settings: Dict[str, Dict[Any, Optional[str]]] = {
         'qt.force_software_rendering': {
             'software-opengl': None,
             'qt-quick': None,
@@ -201,7 +199,7 @@ def _qtwebengine_settings_args() -> typing.Iterator[str]:
             'never': '--no-referrers',
             'same-domain': '--reduced-referrer-granularity',
         }
-    }  # type: typing.Dict[str, typing.Dict[typing.Any, typing.Optional[str]]]
+    }
 
     if not qtutils.version_check('5.11'):
         # On Qt 5.11, we can control this via QWebEngineSettings

--- a/qutebrowser/config/websettings.py
+++ b/qutebrowser/config/websettings.py
@@ -20,9 +20,9 @@
 """Bridge from QWeb(Engine)Settings to our own settings."""
 
 import re
-import typing
 import argparse
 import functools
+from typing import Any, Callable, Dict, Optional, Set
 
 import attr
 from PyQt5.QtCore import QUrl, pyqtSlot, qVersion
@@ -41,11 +41,11 @@ class UserAgent:
 
     """A parsed user agent."""
 
-    os_info = attr.ib()  # type: str
-    webkit_version = attr.ib()  # type: str
-    upstream_browser_key = attr.ib()  # type: str
-    upstream_browser_version = attr.ib()  # type: str
-    qt_key = attr.ib()  # type: str
+    os_info: str = attr.ib()
+    webkit_version: str = attr.ib()
+    upstream_browser_key: str = attr.ib()
+    upstream_browser_version: str = attr.ib()
+    qt_key: str = attr.ib()
 
     @classmethod
     def parse(cls, ua: str) -> 'UserAgent':
@@ -82,8 +82,7 @@ class AttributeInfo:
 
     """Info about a settings attribute."""
 
-    def __init__(self, *attributes: typing.Any,
-                 converter: typing.Callable = None) -> None:
+    def __init__(self, *attributes: Any, converter: Callable = None) -> None:
         self.attributes = attributes
         if converter is None:
             self.converter = lambda val: val
@@ -95,18 +94,18 @@ class AbstractSettings:
 
     """Abstract base class for settings set via QWeb(Engine)Settings."""
 
-    _ATTRIBUTES = {}  # type: typing.Dict[str, AttributeInfo]
-    _FONT_SIZES = {}  # type: typing.Dict[str, typing.Any]
-    _FONT_FAMILIES = {}  # type: typing.Dict[str, typing.Any]
-    _FONT_TO_QFONT = {}  # type: typing.Dict[typing.Any, QFont.StyleHint]
+    _ATTRIBUTES: Dict[str, AttributeInfo] = {}
+    _FONT_SIZES: Dict[str, Any] = {}
+    _FONT_FAMILIES: Dict[str, Any] = {}
+    _FONT_TO_QFONT: Dict[Any, QFont.StyleHint] = {}
 
-    def __init__(self, settings: typing.Any) -> None:
+    def __init__(self, settings: Any) -> None:
         self._settings = settings
 
-    def _assert_not_unset(self, value: typing.Any) -> None:
+    def _assert_not_unset(self, value: Any) -> None:
         assert value is not usertypes.UNSET
 
-    def set_attribute(self, name: str, value: typing.Any) -> bool:
+    def set_attribute(self, name: str, value: Any) -> bool:
         """Set the given QWebSettings/QWebEngineSettings attribute.
 
         If the value is usertypes.UNSET, the value is reset instead.
@@ -148,7 +147,7 @@ class AbstractSettings:
         self._settings.setFontSize(family, value)
         return old_value != value
 
-    def set_font_family(self, name: str, value: typing.Optional[str]) -> bool:
+    def set_font_family(self, name: str, value: Optional[str]) -> bool:
         """Set the given QWebSettings/QWebEngineSettings font family.
 
         With None (the default), QFont is used to get the default font for the
@@ -180,7 +179,7 @@ class AbstractSettings:
         self._settings.setDefaultTextEncoding(encoding)
         return old_value != encoding
 
-    def _update_setting(self, setting: str, value: typing.Any) -> bool:
+    def _update_setting(self, setting: str, value: Any) -> bool:
         """Update the given setting/value.
 
         Unknown settings are ignored.
@@ -203,7 +202,7 @@ class AbstractSettings:
         value = config.instance.get(setting)
         self._update_setting(setting, value)
 
-    def update_for_url(self, url: QUrl) -> typing.Set[str]:
+    def update_for_url(self, url: QUrl) -> Set[str]:
         """Update settings customized for the given tab.
 
         Return:


### PR DESCRIPTION
`configtypes.py` is large enough by itself that I'll create a separate PR for it.

See #5396 