### PR TITLE
Fix completion.web_history.exclude not working when set in config.py

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -162,6 +162,7 @@ class WebHistory(sql.SqlTable):
         # Get a string of all patterns
         patterns = config.instance.get_str('completion.web_history.exclude')
 
+        # If patterns changed, update them in database and rebuild completion
         if self.metainfo['excluded_patterns'] != patterns:
             self.metainfo['excluded_patterns'] = patterns
             self.completion.delete_all()

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -475,12 +475,12 @@ class TestCompletionMetaInfo:
             metainfo['does_not_exist'] = 42
 
     def test_contains(self, metainfo):
-        assert 'force_rebuild' in metainfo
+        assert 'excluded_patterns' in metainfo
 
     def test_modify(self, metainfo):
-        assert not metainfo['force_rebuild']
-        metainfo['force_rebuild'] = True
-        assert metainfo['force_rebuild']
+        assert not metainfo['excluded_patterns']
+        metainfo['excluded_patterns'] = 'https://example.com/'
+        assert metainfo['excluded_patterns']
 
 
 class TestHistoryProgress:

--- a/tests/unit/browser/test_history.py
+++ b/tests/unit/browser/test_history.py
@@ -418,7 +418,7 @@ class TestRebuild:
         assert list(hist2.completion) == [('http://example.com', '', 1)]
 
     def test_pattern_change_rebuild(self, config_stub, web_history, stubs):
-        """Ensure that completion is regenerated when exclude patterns change"""
+        """Ensure that completion is rebuilt when exclude patterns change."""
         config_stub.val.completion.web_history.exclude = ['*.example.org']
 
         web_history.add_url(QUrl('http://example.com'),


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

The completion is now regenerated when `completion.web_history.exclude` is set or changed in `config.py`.

I tested this on both `config.py` and `autoconfig.yml` with the setting set, unset and modified, found no issues or crashes.

I think this could be used to replace the rebuild mechanism used exclusively by the `autoconfig.yml`, since it rebuilds any time the patterns change in the already loaded config. I'm not really sure since I'm not familiar enough with the codebase, yet. 

Closes #5868