### PR TITLE
Remove cssutils dependency

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -36,10 +36,6 @@ ignore_missing_imports = True
 # https://bitbucket.org/birkenfeld/pygments-main/issues/1485/type-hints
 ignore_missing_imports = True
 
-[mypy-cssutils]
-# Pretty much inactive currently
-ignore_missing_imports = True
-
 [mypy-pypeg2]
 # Pretty much inactive currently
 ignore_missing_imports = True

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -134,8 +134,6 @@ The following software and libraries are required to run qutebrowser:
 
 The following libraries are optional:
 
-* http://cthedot.de/cssutils/[cssutils] (for an improved `:download --mhtml`
-  with QtWebKit).
 * On Windows, https://pypi.python.org/pypi/colorama/[colorama] for colored log
   output.
 * http://asciidoc.org/[asciidoc] to generate the documentation for the `:help`

--- a/misc/requirements/requirements-dev.txt
+++ b/misc/requirements/requirements-dev.txt
@@ -6,7 +6,6 @@ cffi==1.14.3
 chardet==3.0.4
 colorama==0.4.4
 cryptography==3.2.1
-cssutils==1.0.2
 github3.py==1.3.0
 hunter==3.3.1
 idna==2.10

--- a/misc/requirements/requirements-dev.txt-raw
+++ b/misc/requirements/requirements-dev.txt-raw
@@ -1,5 +1,4 @@
 hunter
-cssutils
 pympler
 github3.py
 bump2version

--- a/misc/requirements/requirements-qutebrowser.txt-raw
+++ b/misc/requirements/requirements-qutebrowser.txt-raw
@@ -3,5 +3,4 @@ Pygments
 pyPEG2
 PyYAML
 colorama
-cssutils
 attrs

--- a/misc/requirements/requirements-tests-git.txt
+++ b/misc/requirements/requirements-tests-git.txt
@@ -27,7 +27,6 @@ git+https://github.com/pallets/werkzeug.git
 ## qutebrowser dependencies
 
 git+https://github.com/tartley/colorama.git
-hg+https://bitbucket.org/cthedot/cssutils
 git+https://github.com/pallets/jinja.git
 git+https://github.com/pallets/markupsafe.git
 hg+http://bitbucket.org/birkenfeld/pygments-main

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -263,7 +263,6 @@ def _module_versions() -> Sequence[str]:
         ('jinja2', ['__version__']),
         ('pygments', ['__version__']),
         ('yaml', ['__version__']),
-        ('cssutils', ['__version__']),
         ('attr', ['__version__']),
         ('PyQt5.QtWebEngineWidgets', []),
         ('PyQt5.QtWebEngine', ['PYQT_WEBENGINE_VERSION_STR']),

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,6 @@
 
 attrs==20.3.0
 colorama==0.4.4
-cssutils==1.0.2
 Jinja2==2.11.2
 MarkupSafe==1.1.1
 Pygments==2.7.2

--- a/scripts/dev/recompile_requirements.py
+++ b/scripts/dev/recompile_requirements.py
@@ -164,7 +164,6 @@ CHANGELOG_URLS = {
     'yamllint': 'https://github.com/adrienverge/yamllint/blob/master/CHANGELOG.rst',
     'pathspec': 'https://github.com/cpburnz/python-path-specification/blob/master/CHANGES.rst',
     'filelock': 'https://github.com/benediktschmitt/py-filelock/commits/master',
-    'cssutils': 'https://pythonhosted.org/cssutils/CHANGELOG.html',
     'github3.py': 'https://github3py.readthedocs.io/en/master/release-notes/index.html',
     'manhole': 'https://github3py.readthedocs.io/en/master/release-notes/index.html',
     'pycparser': 'https://github.com/eliben/pycparser/blob/master/CHANGES',

--- a/tests/unit/browser/webkit/test_mhtml.py
+++ b/tests/unit/browser/webkit/test_mhtml.py
@@ -28,12 +28,6 @@ import pytest
 mhtml = pytest.importorskip('qutebrowser.browser.webkit.mhtml')
 
 
-try:
-    import cssutils
-except ImportError:
-    cssutils = None
-
-
 @pytest.fixture(autouse=True)
 def patch_uuid(monkeypatch):
     monkeypatch.setattr(uuid, "uuid4", lambda: "UUID")
@@ -255,34 +249,25 @@ def test_empty_content_type(checker):
         """)
 
 
-@pytest.mark.parametrize('has_cssutils', [
-    pytest.param(True, marks=pytest.mark.skipif(
-        cssutils is None, reason="requires cssutils"), id='with_cssutils'),
-    pytest.param(False, id='no_cssutils'),
-])
-@pytest.mark.parametrize('inline, style, expected_urls', [
-    pytest.param(False, "@import 'default.css'", ['default.css'],
+@pytest.mark.parametrize('style, expected_urls', [
+    pytest.param("@import 'default.css'", ['default.css'],
                  id='import with apostrophe'),
-    pytest.param(False, '@import "default.css"', ['default.css'],
+    pytest.param('@import "default.css"', ['default.css'],
                  id='import with quote'),
-    pytest.param(False, "@import \t 'tabbed.css'", ['tabbed.css'],
+    pytest.param("@import \t 'tabbed.css'", ['tabbed.css'],
                  id='import with tab'),
-    pytest.param(False, "@import url('default.css')", ['default.css'],
+    pytest.param("@import url('default.css')", ['default.css'],
                  id='import with url()'),
-    pytest.param(False, """body {
+    pytest.param("""body {
     background: url("/bg-img.png")
     }""", ['/bg-img.png'], id='background with body'),
-    pytest.param(True, 'background: url(folder/file.png) no-repeat',
+    pytest.param('background: url(folder/file.png) no-repeat',
                  ['folder/file.png'], id='background'),
-    pytest.param(True, 'content: url()', [], id='content'),
+    pytest.param('content: url()', [], id='content'),
 ])
-def test_css_url_scanner(monkeypatch, has_cssutils, inline, style,
-                         expected_urls):
-    if not has_cssutils:
-        monkeypatch.setattr(mhtml, '_get_css_imports_cssutils',
-                            lambda data, inline=False: None)
+def test_css_url_scanner(monkeypatch, style, expected_urls):
     expected_urls.sort()
-    urls = mhtml._get_css_imports(style, inline=inline)
+    urls = mhtml._get_css_imports(style)
     urls.sort()
     assert urls == expected_urls
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -561,7 +561,6 @@ class ImportFake:
             ('jinja2', True),
             ('pygments', True),
             ('yaml', True),
-            ('cssutils', True),
             ('attr', True),
             ('PyQt5.QtWebEngineWidgets', True),
             ('PyQt5.QtWebEngine', True),
@@ -637,7 +636,6 @@ class TestModuleVersions:
 
     @pytest.mark.parametrize('module, idx, expected', [
         ('colorama', 1, 'colorama: no'),
-        ('cssutils', 6, 'cssutils: no'),
     ])
     def test_missing_module(self, module, idx, expected, import_fake):
         """Test with a module missing.
@@ -681,7 +679,6 @@ class TestModuleVersions:
         ('jinja2', True),
         ('pygments', True),
         ('yaml', True),
-        ('cssutils', True),
         ('attr', True),
     ])
     def test_existing_attributes(self, name, has_version):
@@ -694,8 +691,6 @@ class TestModuleVersions:
             name: The name of the module to check.
             has_version: Whether a __version__ attribute is expected.
         """
-        if name == 'cssutils':
-            pytest.importorskip(name)
         module = importlib.import_module(name)
         assert hasattr(module, '__version__') == has_version
 


### PR DESCRIPTION
Closes #5878

This PR does the following things:
 - Removes cssutils dependent code from ```mhtml.py```
 - Removes cssutils tests from ```test_mhtml.py``` and ```test_version.py```
 - Remove everything related to cssutils (readme, requirments, .mypy.ini)

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
