### PR TITLE
Replace pkg_resources.parse_version with one based QVersionNumber

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -367,7 +367,7 @@ def _open_special_pages(args):
          'qute://warning/webkit'),
 
         ('session-warning-shown',
-         qtutils.version_check('5.15', compiled=False),
+         utils.version_check('5.15', compiled=False),
          'qute://warning/sessions'),
     ]
 

--- a/qutebrowser/browser/eventfilter.py
+++ b/qutebrowser/browser/eventfilter.py
@@ -22,7 +22,7 @@
 from PyQt5.QtCore import QObject, QEvent, Qt, QTimer
 
 from qutebrowser.config import config
-from qutebrowser.utils import message, log, usertypes, qtutils
+from qutebrowser.utils import message, log, usertypes, utils
 from qutebrowser.misc import objects
 from qutebrowser.keyinput import modeman
 
@@ -182,7 +182,7 @@ class TabEventFilter(QObject):
             True if the event should be filtered, False otherwise.
         """
         return (e.isAutoRepeat() and
-                not qtutils.version_check('5.14', compiled=False) and
+                not utils.version_check('5.14', compiled=False) and
                 objects.backend == usertypes.Backend.QtWebEngine)
 
     def _mousepress_insertmode_cb(self, elem):

--- a/qutebrowser/browser/webengine/darkmode.py
+++ b/qutebrowser/browser/webengine/darkmode.py
@@ -83,7 +83,7 @@ except ImportError:  # pragma: no cover
     PYQT_WEBENGINE_VERSION = None  # type: ignore[assignment]
 
 from qutebrowser.config import config
-from qutebrowser.utils import usertypes, qtutils, utils, log
+from qutebrowser.utils import usertypes, utils, log
 
 
 class Variant(enum.Enum):
@@ -251,7 +251,7 @@ def _variant() -> Variant:
 
     # If we don't have PYQT_WEBENGINE_VERSION, we're on 5.12 (or older, but 5.12 is the
     # oldest supported version).
-    assert not qtutils.version_check(  # type: ignore[unreachable]
+    assert not utils.version_check(  # type: ignore[unreachable]
         '5.13', compiled=False)
 
     return Variant.qt_511_to_513

--- a/qutebrowser/browser/webengine/interceptor.py
+++ b/qutebrowser/browser/webengine/interceptor.py
@@ -27,7 +27,7 @@ from PyQt5.QtWebEngineCore import (QWebEngineUrlRequestInterceptor,
 
 from qutebrowser.config import websettings
 from qutebrowser.browser import shared
-from qutebrowser.utils import utils, log, debug, qtutils
+from qutebrowser.utils import utils, log, debug
 from qutebrowser.extensions import interceptors
 from qutebrowser.misc import objects
 
@@ -133,7 +133,7 @@ class RequestInterceptor(QWebEngineUrlRequestInterceptor):
             profile.setRequestInterceptor(self)
 
     # Gets called in the IO thread -> showing crash window will fail
-    @utils.prevent_exceptions(None, not qtutils.version_check('5.13'))
+    @utils.prevent_exceptions(None, not utils.version_check('5.13'))
     def interceptRequest(self, info):
         """Handle the given request.
 

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -34,7 +34,8 @@ from PyQt5.QtWebEngineWidgets import QWebEngineSettings, QWebEngineProfile
 from qutebrowser.browser.webengine import spell, webenginequtescheme
 from qutebrowser.config import config, websettings
 from qutebrowser.config.websettings import AttributeInfo as Attr
-from qutebrowser.utils import standarddir, qtutils, message, log, urlmatch, usertypes
+from qutebrowser.utils import (standarddir, qtutils, message, log, urlmatch,
+                               usertypes, utils)
 
 # The default QWebEngineProfile
 default_profile = cast(QWebEngineProfile, None)
@@ -299,7 +300,7 @@ def _update_settings(option):
 
     # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-75884
     # (note this isn't actually fixed properly before Qt 5.15)
-    header_bug_fixed = qtutils.version_check('5.15', compiled=False)
+    header_bug_fixed = utils.version_check('5.15', compiled=False)
 
     if option in ['content.headers.user_agent',
                   'content.headers.accept_language'] and header_bug_fixed:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -166,7 +166,7 @@ class _WebEngineSearchWrapHandler:
         Args:
             page: The QtWebEnginePage to connect to this handler.
         """
-        if not qtutils.version_check("5.14"):
+        if not utils.version_check("5.14"):
             return
 
         try:
@@ -678,7 +678,7 @@ class WebEngineHistoryPrivate(browsertab.AbstractHistoryPrivate):
         self._tab.load_url(url)
 
     def load_items(self, items):
-        if qtutils.version_check('5.15', compiled=False):
+        if utils.version_check('5.15', compiled=False):
             self._load_items_workaround(items)
             return
 
@@ -845,7 +845,7 @@ class WebEngineAudio(browsertab.AbstractAudio):
         assert self._widget is not None
         page = self._widget.page()
         page.setAudioMuted(muted)
-        if was_muted != muted and qtutils.version_check('5.15'):
+        if was_muted != muted and utils.version_check('5.15'):
             # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-85118
             # so that the tab title at least updates the muted indicator
             self.muted_changed.emit(muted)
@@ -946,9 +946,9 @@ class _WebEnginePermissions(QObject):
 
         if not url.isValid():
             # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-85116
-            is_qtbug = (qtutils.version_check('5.15.0',
-                                              compiled=False,
-                                              exact=True) and
+            is_qtbug = (utils.version_check('5.15.0',
+                                            compiled=False,
+                                            exact=True) and
                         self._tab.is_private and
                         feature == QWebEnginePage.Notifications)
             logger = log.webview.debug if is_qtbug else log.webview.warning
@@ -966,8 +966,8 @@ class _WebEnginePermissions(QObject):
         if (
                 feature in [QWebEnginePage.DesktopVideoCapture,
                             QWebEnginePage.DesktopAudioVideoCapture] and
-                qtutils.version_check('5.13', compiled=False) and
-                not qtutils.version_check('5.13.2', compiled=False)
+                utils.version_check('5.13', compiled=False) and
+                not utils.version_check('5.13.2', compiled=False)
         ):
             # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-78016
             log.webview.warning("Ignoring desktop sharing request due to "
@@ -1194,7 +1194,7 @@ class _WebEngineScripts(QObject):
                 QWebEngineScript.ApplicationWorld,
             ),
         ]
-        if not qtutils.version_check('5.13'):
+        if not utils.version_check('5.13'):
             quirks.append(('globalthis_quirk',
                            QWebEngineScript.DocumentCreation,
                            QWebEngineScript.MainWorld))
@@ -1555,10 +1555,10 @@ class WebEngineTab(browsertab.AbstractTab):
                 # 5.13 before 5.13.2
                 # 5.12 before 5.12.6
                 # < 5.12 (which is unsupported)
-                (qtutils.version_check('5.13') and
-                 not qtutils.version_check('5.13.2')) or
-                (qtutils.version_check('5.12') and
-                 not qtutils.version_check('5.12.6'))
+                (utils.version_check('5.13') and
+                 not utils.version_check('5.13.2')) or
+                (utils.version_check('5.12') and
+                 not utils.version_check('5.12.6'))
             )
         )
 
@@ -1591,7 +1591,7 @@ class WebEngineTab(browsertab.AbstractTab):
         up doing it twice.
         """
         super()._on_url_changed(url)
-        if url.isValid() and qtutils.version_check('5.13'):
+        if url.isValid() and utils.version_check('5.13'):
             self.settings.update_for_url(url)
 
     @pyqtSlot(usertypes.NavigationRequest)

--- a/qutebrowser/config/configdata.py
+++ b/qutebrowser/config/configdata.py
@@ -30,7 +30,7 @@ import functools
 
 import attr
 from qutebrowser.config import configtypes
-from qutebrowser.utils import usertypes, qtutils, utils
+from qutebrowser.utils import usertypes, utils
 from qutebrowser.misc import debugcachestats
 
 DATA = cast(Mapping[str, 'Option'], None)
@@ -158,9 +158,9 @@ def _parse_yaml_backends_dict(
     conditionals = {
         True: True,
         False: False,
-        'Qt 5.13': qtutils.version_check('5.13'),
-        'Qt 5.14': qtutils.version_check('5.14'),
-        'Qt 5.15': qtutils.version_check('5.15'),
+        'Qt 5.13': utils.version_check('5.13'),
+        'Qt 5.14': utils.version_check('5.14'),
+        'Qt 5.15': utils.version_check('5.15'),
     }
     for key in sorted(node.keys()):
         if conditionals[node[key]]:

--- a/qutebrowser/config/qtargs.py
+++ b/qutebrowser/config/qtargs.py
@@ -26,7 +26,7 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence
 
 from qutebrowser.config import config
 from qutebrowser.misc import objects
-from qutebrowser.utils import usertypes, qtutils, utils
+from qutebrowser.utils import usertypes, utils
 
 
 def qt_args(namespace: argparse.Namespace) -> List[str]:
@@ -73,7 +73,7 @@ def _qtwebengine_enabled_features(feature_flags: Sequence[str]) -> Iterator[str]
         flag = flag[len(prefix):]
         yield from iter(flag.split(','))
 
-    if qtutils.version_check('5.15', compiled=False) and utils.is_linux:
+    if utils.version_check('5.15', compiled=False) and utils.is_linux:
         # Enable WebRTC PipeWire for screen capturing on Wayland.
         #
         # This is disabled in Chromium by default because of the "dialog hell":
@@ -115,8 +115,8 @@ def _qtwebengine_args(
         feature_flags: Sequence[str],
 ) -> Iterator[str]:
     """Get the QtWebEngine arguments to use based on the config."""
-    is_qt_514 = (qtutils.version_check('5.14', compiled=False) and
-                 not qtutils.version_check('5.15', compiled=False))
+    is_qt_514 = (utils.version_check('5.14', compiled=False) and
+                 not utils.version_check('5.15', compiled=False))
 
     if is_qt_514:
         # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-82105
@@ -126,7 +126,7 @@ def _qtwebengine_args(
     # https://codereview.qt-project.org/c/qt/qtwebengine/+/256786
     # also see:
     # https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/265753
-    if qtutils.version_check('5.12.3', compiled=False):
+    if utils.version_check('5.12.3', compiled=False):
         if 'stack' in namespace.debug_flags:
             # Only actually available in Qt 5.12.5, but let's save another
             # check, as passing the option won't hurt.
@@ -196,7 +196,7 @@ def _qtwebengine_settings_args() -> Iterator[str]:
         }
     }
 
-    if qtutils.version_check('5.14'):
+    if utils.version_check('5.14'):
         settings['colors.webpage.prefers_color_scheme_dark'] = {
             True: '--force-dark-mode',
             False: None,
@@ -231,6 +231,6 @@ def init_envvars() -> None:
 
     if config.val.qt.highdpi:
         env_var = ('QT_ENABLE_HIGHDPI_SCALING'
-                   if qtutils.version_check('5.14', compiled=False)
+                   if utils.version_check('5.14', compiled=False)
                    else 'QT_AUTO_SCREEN_SCALE_FACTOR')
         os.environ[env_var] = '1'

--- a/qutebrowser/misc/backendproblem.py
+++ b/qutebrowser/misc/backendproblem.py
@@ -241,9 +241,9 @@ class _BackendProblemChecker:
             return
 
         # Only Qt 5.14 should be affected
-        if not qtutils.version_check('5.14', compiled=False):
+        if not utils.version_check('5.14', compiled=False):
             return
-        if qtutils.version_check('5.15', compiled=False):
+        if utils.version_check('5.15', compiled=False):
             return
 
         # Newer graphic hardware isn't affected
@@ -318,7 +318,7 @@ class _BackendProblemChecker:
         if QSslSocket.supportsSsl():
             return
 
-        if qtutils.version_check('5.12.4'):
+        if utils.version_check('5.12.4'):
             version_text = ("If you use OpenSSL 1.0 with a PyQt package from "
                             "PyPI (e.g. on Ubuntu 16.04), you will need to "
                             "build OpenSSL 1.1 from sources and set "
@@ -401,7 +401,7 @@ class _BackendProblemChecker:
         # It seems these issues started with Qt 5.12.
         # They should be fixed with Qt 5.12.5:
         # https://codereview.qt-project.org/c/qt/qtwebengine-chromium/+/265408
-        if qtutils.version_check('5.12.5', compiled=False):
+        if utils.version_check('5.12.5', compiled=False):
             return
 
         log.init.info("Qt version changed, nuking QtWebEngine cache")
@@ -417,7 +417,7 @@ class _BackendProblemChecker:
         https://bugreports.qt.io/browse/QTBUG-82105
         """
         if ('serviceworker_workaround' not in configfiles.state['general'] and
-                qtutils.version_check('5.14', compiled=False)):
+                utils.version_check('5.14', compiled=False)):
             # Nuke the service worker directory once for every install with Qt
             # 5.14, given that it seems to cause a variety of segfaults.
             configfiles.state['general']['serviceworker_workaround'] = '514'

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -30,7 +30,6 @@ import datetime
 import enum
 from typing import List, Tuple
 
-import pkg_resources
 from PyQt5.QtCore import pyqtSlot, Qt, QSize
 from PyQt5.QtWidgets import (QDialog, QLabel, QTextEdit, QPushButton,
                              QVBoxLayout, QHBoxLayout, QCheckBox,
@@ -361,8 +360,8 @@ class _CrashDialog(QDialog):
         Args:
             newest: The newest version as a string.
         """
-        new_version = pkg_resources.parse_version(newest)
-        cur_version = pkg_resources.parse_version(qutebrowser.__version__)
+        new_version = utils.parse_version(newest)
+        cur_version = utils.parse_version(qutebrowser.__version__)
         lines = ['The report has been sent successfully. Thanks!']
         if new_version > cur_version:
             lines.append("<b>Note:</b> The newest available version is v{}, "

--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -175,7 +175,7 @@ def check_qt_version():
 
     try:
         from PyQt5.QtCore import QVersionNumber, QLibraryInfo
-        recent_qt_runtime = QLibraryInfo.version().normalized() >= QVersionNumber(5, 12)
+        recent_qt_runtime = QLibraryInfo.version().normalized() >= QVersionNumber(5, 12).normalized()
     except (ImportError, AttributeError):
         # QVersionNumber was added in Qt 5.6, QLibraryInfo.version() in 5.8
         recent_qt_runtime = False

--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -172,7 +172,18 @@ def check_qt_version():
     """Check if the Qt version is recent enough."""
     from PyQt5.QtCore import (qVersion, QT_VERSION, PYQT_VERSION,
                               PYQT_VERSION_STR)
-    from pkg_resources import parse_version
+
+    try:
+        from PyQt5.QtCore import QVersionNumber, QLibraryInfo
+        recent_qt_runtime = QLibraryInfo.version().normalized() >= QVersionNumber(5, 12)
+    except (ImportError, AttributeError):
+        # QVersionNumber was added in Qt 5.6, QLibraryInfo.version() in 5.8
+        recent_qt_runtime = False
+
+    if QT_VERSION < 0x050C00 or PYQT_VERSION < 0x050C00 or not recent_qt_runtime:
+        from pkg_resources import parse_version
+    else:
+        from qutebrowser.utils.utils import parse_version
     parsed_qversion = parse_version(qVersion())
 
     if (QT_VERSION < 0x050C00 or PYQT_VERSION < 0x050C00 or

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -66,7 +66,7 @@ def init(parent=None):
     backup_path = os.path.join(base_path, 'before-qt-515')
     if (os.path.exists(base_path) and
             not os.path.exists(backup_path) and
-            qtutils.version_check('5.15', compiled=False)):
+            utils.version_check('5.15', compiled=False)):
         os.mkdir(backup_path)
         for filename in glob.glob(os.path.join(base_path, '*.yml')):
             shutil.copy(filename, backup_path)

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -29,14 +29,12 @@ Module attributes:
 
 
 import io
-import operator
 import contextlib
 from typing import TYPE_CHECKING, BinaryIO, IO, Iterator, Optional, Union, cast
 
 import pkg_resources
-from PyQt5.QtCore import (qVersion, QEventLoop, QDataStream, QByteArray,
-                          QIODevice, QFileDevice, QSaveFile, QT_VERSION_STR,
-                          PYQT_VERSION_STR, QObject, QUrl)
+from PyQt5.QtCore import (QEventLoop, QDataStream, QByteArray, QIODevice,
+                          QFileDevice, QSaveFile, QObject, QUrl)
 from PyQt5.QtGui import QColor
 from PyQt5.QtWidgets import QApplication
 try:
@@ -85,31 +83,6 @@ class QtOSError(OSError):
         filename = dev.fileName()
         msg += ": {!r}".format(filename)
         return msg
-
-
-def version_check(version: str,
-                  exact: bool = False,
-                  compiled: bool = True) -> bool:
-    """Check if the Qt runtime version is the version supplied or newer.
-
-    Args:
-        version: The version to check against.
-        exact: if given, check with == instead of >=
-        compiled: Set to False to not check the compiled version.
-    """
-    if compiled and exact:
-        raise ValueError("Can't use compiled=True with exact=True!")
-
-    parsed = pkg_resources.parse_version(version)
-    op = operator.eq if exact else operator.ge
-    result = op(pkg_resources.parse_version(qVersion()), parsed)
-    if compiled and result:
-        # qVersion() ==/>= parsed, now check if QT_VERSION_STR ==/>= parsed.
-        result = op(pkg_resources.parse_version(QT_VERSION_STR), parsed)
-    if compiled and result:
-        # Finally, check PYQT_VERSION_STR as well.
-        result = op(pkg_resources.parse_version(PYQT_VERSION_STR), parsed)
-    return result
 
 
 MAX_WORLD_ID = 256

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -212,7 +212,7 @@ def resource_filename(filename: str) -> str:
     return pkg_resources.resource_filename(qutebrowser.__name__, filename)
 
 
-def parse_version(version):
+def parse_version(version: str) -> QVersionNumber:
     """Parse version string.
 
     This is a replacement of pkg_resources.parse_version

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -39,7 +39,7 @@ from end2end.fixtures.webserver import server, server_per_test, ssl_server
 from end2end.fixtures.quteprocess import (quteproc_process, quteproc,
                                           quteproc_new)
 from end2end.fixtures.testprocess import pytest_runtest_makereport
-from qutebrowser.utils import qtutils, utils
+from qutebrowser.utils import utils
 from qutebrowser.browser.webengine import spell
 
 
@@ -84,11 +84,11 @@ def _get_version_tag(tag):
     if package == 'qt':
         op = match.group('operator')
         do_skip = {
-            '==': not qtutils.version_check(version, exact=True,
-                                            compiled=False),
-            '>=': not qtutils.version_check(version, compiled=False),
-            '<': qtutils.version_check(version, compiled=False),
-            '!=': qtutils.version_check(version, exact=True, compiled=False),
+            '==': not utils.version_check(version, exact=True,
+                                          compiled=False),
+            '>=': not utils.version_check(version, compiled=False),
+            '<': utils.version_check(version, compiled=False),
+            '!=': utils.version_check(version, exact=True, compiled=False),
         }
         return pytest.mark.skipif(do_skip[op], reason='Needs ' + tag)
     elif package == 'pyqt':
@@ -140,7 +140,7 @@ def pytest_collection_modifyitems(config, items):
     """Apply @qtwebengine_* markers; skip unittests with QUTE_BDD_WEBENGINE."""
     # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-75884
     # (note this isn't actually fixed properly before Qt 5.15)
-    header_bug_fixed = qtutils.version_check('5.15', compiled=False)
+    header_bug_fixed = utils.version_check('5.15', compiled=False)
 
     lib_path = pathlib.Path(QCoreApplication.libraryPaths()[0])
     qpdf_image_plugin = lib_path / 'imageformats' / 'libqpdf.so'
@@ -153,7 +153,7 @@ def pytest_collection_modifyitems(config, items):
         ('qtwebengine_notifications',
          'Skipped with QtWebEngine < 5.13',
          pytest.mark.skipif,
-         config.webengine and not qtutils.version_check('5.13')),
+         config.webengine and not utils.version_check('5.13')),
         ('qtwebkit_skip', 'Skipped with QtWebKit', pytest.mark.skipif,
          not config.webengine),
         ('qtwebengine_flaky', 'Flaky with QtWebEngine', pytest.mark.skipif,

--- a/tests/end2end/features/test_qutescheme_bdd.py
+++ b/tests/end2end/features/test_qutescheme_bdd.py
@@ -19,7 +19,7 @@
 
 import pytest_bdd as bdd
 
-from qutebrowser.utils import qtutils
+from qutebrowser.utils import utils
 
 
 bdd.scenarios('qutescheme.feature')
@@ -56,7 +56,7 @@ def request_blocked(request, quteproc, kind):
             'redirect': [blocking_set_msg, blocked_request_msg],
             'form': [blocking_js_msg],
         }
-        if qtutils.version_check('5.15', compiled=False):
+        if utils.version_check('5.15', compiled=False):
             # On Qt 5.15, Chromium blocks the redirect as ERR_UNSAFE_REDIRECT
             # instead.
             expected_messages['redirect'] = [unsafe_redirect_msg]

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -37,12 +37,12 @@ try:
 except ImportError:
     PYQT_WEBENGINE_VERSION_STR = None
 
-from qutebrowser.utils import qtutils, log
+from qutebrowser.utils import utils, log
 
 ON_CI = 'CI' in os.environ
 
 qt514 = pytest.mark.skipif(
-    not qtutils.version_check('5.14'), reason="Needs Qt 5.14 or newer")
+    not utils.version_check('5.14'), reason="Needs Qt 5.14 or newer")
 
 
 class PartialCompareOutcome:

--- a/tests/unit/browser/webengine/test_darkmode.py
+++ b/tests/unit/browser/webengine/test_darkmode.py
@@ -101,7 +101,7 @@ QT_515_2_SETTINGS = [
     ('5.15.2', QT_515_2_SETTINGS),
 ])
 def test_qt_version_differences(config_stub, monkeypatch, qversion, expected):
-    monkeypatch.setattr(darkmode.qtutils, 'qVersion', lambda: qversion)
+    monkeypatch.setattr(darkmode.utils, 'qVersion', lambda: qversion)
 
     major, minor, patch = [int(part) for part in qversion.split('.')]
     hexversion = major << 16 | minor << 8 | patch
@@ -164,7 +164,7 @@ def test_customization(config_stub, monkeypatch, setting, value, exp_key, exp_va
     (None, 0x060000, darkmode.Variant.qt_515_2),  # Qt 6
 ])
 def test_variant(monkeypatch, qversion, webengine_version, expected):
-    monkeypatch.setattr(darkmode.qtutils, 'qVersion', lambda: qversion)
+    monkeypatch.setattr(darkmode.utils, 'qVersion', lambda: qversion)
     monkeypatch.setattr(darkmode, 'PYQT_WEBENGINE_VERSION', webengine_version)
     assert darkmode._variant() == expected
 

--- a/tests/unit/config/test_configdata.py
+++ b/tests/unit/config/test_configdata.py
@@ -291,7 +291,7 @@ class TestParseYamlBackend:
               QtWebKit: {}
               QtWebEngine: Qt 5.15
         """.format('true' if webkit else 'false'))
-        monkeypatch.setattr(configdata.qtutils, 'version_check',
+        monkeypatch.setattr(configdata.utils, 'version_check',
                             lambda v: has_new_version)
         backends = configdata._parse_yaml_backends('test', data)
         assert backends == expected

--- a/tests/unit/config/test_qtargs.py
+++ b/tests/unit/config/test_qtargs.py
@@ -42,7 +42,7 @@ class TestQtArgs:
     @pytest.fixture(autouse=True)
     def reduce_args(self, monkeypatch, config_stub):
         """Make sure no --disable-shared-workers/referer argument get added."""
-        monkeypatch.setattr(qtargs.qtutils, 'qVersion', lambda: '5.15.0')
+        monkeypatch.setattr(qtargs.utils, 'qVersion', lambda: '5.15.0')
         config_stub.val.content.headers.referer = 'always'
 
     @pytest.mark.parametrize('args, expected', [
@@ -94,7 +94,7 @@ class TestQtArgs:
     ])
     def test_shared_workers(self, config_stub, monkeypatch, parser,
                             backend, expected):
-        monkeypatch.setattr(qtargs.qtutils, 'qVersion', lambda: '5.14.0')
+        monkeypatch.setattr(qtargs.utils, 'qVersion', lambda: '5.14.0')
         monkeypatch.setattr(qtargs.objects, 'backend', backend)
         parsed = parser.parse_args([])
         args = qtargs.qt_args(parsed)
@@ -115,7 +115,7 @@ class TestQtArgs:
     ])
     def test_in_process_stack_traces(self, monkeypatch, parser, backend,
                                      version_check, debug_flag, expected):
-        monkeypatch.setattr(qtargs.qtutils, 'version_check',
+        monkeypatch.setattr(qtargs.utils, 'version_check',
                             lambda version, compiled=False: version_check)
         monkeypatch.setattr(qtargs.objects, 'backend', backend)
         parsed = parser.parse_args(['--debug-flag', 'stack'] if debug_flag
@@ -282,7 +282,7 @@ class TestQtArgs:
                                        dark, new_qt, added):
         monkeypatch.setattr(qtargs.objects, 'backend',
                             usertypes.Backend.QtWebEngine)
-        monkeypatch.setattr(qtargs.qtutils, 'version_check',
+        monkeypatch.setattr(qtargs.utils, 'version_check',
                             lambda version, exact=False, compiled=True:
                             new_qt)
 
@@ -336,7 +336,7 @@ class TestQtArgs:
         """If enable-features is already specified, we should combine both."""
         monkeypatch.setattr(qtargs.objects, 'backend',
                             usertypes.Backend.QtWebEngine)
-        monkeypatch.setattr(qtargs.qtutils, 'version_check',
+        monkeypatch.setattr(qtargs.utils, 'version_check',
                             lambda version, exact=False, compiled=True:
                             True)
         monkeypatch.setattr(qtargs.utils, 'is_mac', False)
@@ -417,7 +417,7 @@ class TestEnvVars:
 
         monkeypatch.setattr(qtargs.objects, 'backend',
                             usertypes.Backend.QtWebEngine)
-        monkeypatch.setattr(qtargs.qtutils, 'version_check',
+        monkeypatch.setattr(qtargs.utils, 'version_check',
                             lambda version, exact=False, compiled=True:
                             new_qt)
 

--- a/tests/unit/utils/test_qtutils.py
+++ b/tests/unit/utils/test_qtutils.py
@@ -49,59 +49,6 @@ else:
     test_file = None
 
 
-# pylint: disable=bad-continuation
-@pytest.mark.parametrize(['qversion', 'compiled', 'pyqt', 'version', 'exact',
-                          'expected'], [
-    # equal versions
-    ('5.4.0', None, None, '5.4.0', False, True),
-    ('5.4.0', None, None, '5.4.0', True, True),  # exact=True
-    ('5.4.0', None, None, '5.4', True, True),  # without trailing 0
-    # newer version installed
-    ('5.4.1', None, None, '5.4', False, True),
-    ('5.4.1', None, None, '5.4', True, False),  # exact=True
-    # older version installed
-    ('5.3.2', None, None, '5.4', False, False),
-    ('5.3.0', None, None, '5.3.2', False, False),
-    ('5.3.0', None, None, '5.3.2', True, False),  # exact=True
-    # compiled=True
-    # new Qt runtime, but compiled against older version
-    ('5.4.0', '5.3.0', '5.4.0', '5.4.0', False, False),
-    # new Qt runtime, compiled against new version, but old PyQt
-    ('5.4.0', '5.4.0', '5.3.0', '5.4.0', False, False),
-    # all up-to-date
-    ('5.4.0', '5.4.0', '5.4.0', '5.4.0', False, True),
-])
-# pylint: enable=bad-continuation
-def test_version_check(monkeypatch, qversion, compiled, pyqt, version, exact,
-                       expected):
-    """Test for version_check().
-
-    Args:
-        monkeypatch: The pytest monkeypatch fixture.
-        qversion: The version to set as fake qVersion().
-        compiled: The value for QT_VERSION_STR (set compiled=False)
-        pyqt: The value for PYQT_VERSION_STR (set compiled=False)
-        version: The version to compare with.
-        exact: Use exact comparing (==)
-        expected: The expected result.
-    """
-    monkeypatch.setattr(qtutils, 'qVersion', lambda: qversion)
-    if compiled is not None:
-        monkeypatch.setattr(qtutils, 'QT_VERSION_STR', compiled)
-        monkeypatch.setattr(qtutils, 'PYQT_VERSION_STR', pyqt)
-        compiled_arg = True
-    else:
-        compiled_arg = False
-
-    actual = qtutils.version_check(version, exact, compiled=compiled_arg)
-    assert actual == expected
-
-
-def test_version_check_compiled_and_exact():
-    with pytest.raises(ValueError):
-        qtutils.version_check('1.2.3', exact=True, compiled=True)
-
-
 @pytest.mark.parametrize('version, is_new', [
     ('537.21', False),  # QtWebKit 5.1
     ('538.1', False),   # Qt 5.8

--- a/tests/unit/utils/test_standarddir.py
+++ b/tests/unit/utils/test_standarddir.py
@@ -31,7 +31,7 @@ import subprocess
 from PyQt5.QtCore import QStandardPaths
 import pytest
 
-from qutebrowser.utils import standarddir, utils, qtutils
+from qutebrowser.utils import standarddir, utils
 
 
 # Use a different application name for tests to make sure we don't change real
@@ -186,7 +186,7 @@ class TestStandardDir:
     @pytest.mark.linux
     @pytest.mark.qt_log_ignore(r'^QStandardPaths: ')
     @pytest.mark.skipif(
-        qtutils.version_check('5.14', compiled=False),
+        utils.version_check('5.14', compiled=False),
         reason="Qt 5.14 automatically creates missing runtime dirs")
     def test_linux_invalid_runtimedir(self, monkeypatch, tmpdir):
         """With invalid XDG_RUNTIME_DIR, fall back to TempLocation."""


### PR DESCRIPTION
qtutils.version_check is moved to utils.version_check as well.
This partially fixes #4467.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
