### PR TITLE
[readability-js] Increase visibility of certain elements under darkmode

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -57,7 +57,7 @@ const HEADER = `
         table,
         th,
         td {
-            border: 1px solid currentColor;
+            border: 1px solid grey;
             border-collapse: collapse;
             padding: 6px;
             vertical-align: top;
@@ -77,7 +77,7 @@ const HEADER = `
             background-color: #dddddd;
         }
         blockquote {
-            border-inline-start: 2px solid #333333 !important;
+            border-inline-start: 2px solid grey !important;
             padding: 0;
             padding-inline-start: 16px;
             margin-inline-start: 24px;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

I've noticed significant differences between Qt versions in the color output produced under darkmode (often improvements!). Per Qt 5.15.2, I noticed that lines/borders drawn in dark colors are  less visible on pages produced by `readability-js` (not entirely sure why — a lot of borders on other pages seem to stand out more). In fact, table borders are currently invisible, because they're drawn in black, which for some reason doesn't get inverted anymore. 

To rectifiy this, I decided to draw all borders/lines in grey, in line with  what chromium's (?) user agent stylesheet seems to be doing. Because a lot of borders on the web actually seem to be drawn in grayish colors (and not in pure black/white), I think this is a good permanent change (and not just a workaround for something in Qt 5.15.2).
