### PR TITLE
Use QRegularExpression instead of QRegExp.

### DIFF
--- a/qutebrowser/completion/models/listcategory.py
+++ b/qutebrowser/completion/models/listcategory.py
@@ -22,7 +22,7 @@
 import re
 from typing import Iterable, Tuple
 
-from PyQt5.QtCore import Qt, QSortFilterProxyModel, QRegExp
+from PyQt5.QtCore import QSortFilterProxyModel, QRegularExpression
 from PyQt5.QtGui import QStandardItem, QStandardItemModel
 from PyQt5.QtWidgets import QWidget
 
@@ -63,9 +63,9 @@ class ListCategory(QSortFilterProxyModel):
         val = re.sub(r' +', r' ', val)  # See #1919
         val = re.escape(val)
         val = val.replace(r'\ ', '.*')
-        rx = QRegExp(val, Qt.CaseInsensitive)
+        rx = QRegularExpression(val, QRegularExpression.CaseInsensitiveOption)
         qtutils.ensure_valid(rx)
-        self.setFilterRegExp(rx)
+        self.setFilterRegularExpression(rx)
         self.invalidate()
         sortcol = 0
         self.sort(sortcol)


### PR DESCRIPTION
The latter is deprecated. See:
https://doc.qt.io/qt-5/qregularexpression.html#notes-for-qregexp-users

Fixes #5909.

Note:
The docs say:

> QRegExp by default does Unicode-aware matching, while
> QRegularExpression requires a separate option; see below for more
> details.

I don't think we need this option, as it only influence character
classes, which we arent using:

https://doc.qt.io/qt-5/qregularexpression.html#PatternOption-enum

> The meaning of the \w, \d, etc., character classes, as well as the
> meaning of their counterparts (\W, \D, etc.), is changed from matching
> ASCII characters only to matching any character with the corresponding
> Unicode property.


<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->