### PR TITLE
Fix dark color preference with Qt 5.15.2

### DIFF
--- a/qutebrowser/browser/webengine/darkmode.py
+++ b/qutebrowser/browser/webengine/darkmode.py
@@ -264,6 +264,10 @@ def _variant() -> Variant:
 
 def settings() -> Iterator[Tuple[str, str]]:
     """Get necessary blink settings to configure dark mode for QtWebEngine."""
+    if (qtutils.version_check('5.15', compiled=False) and
+            config.val.colors.webpage.prefers_color_scheme_dark):
+        yield "preferredColorScheme", "1"
+
     if not config.val.colors.webpage.darkmode.enabled:
         return
 

--- a/qutebrowser/browser/webengine/darkmode.py
+++ b/qutebrowser/browser/webengine/darkmode.py
@@ -264,8 +264,10 @@ def _variant() -> Variant:
 
 def settings() -> Iterator[Tuple[str, str]]:
     """Get necessary blink settings to configure dark mode for QtWebEngine."""
-    if (qtutils.version_check('5.15', compiled=False) and
+    if (qtutils.version_check('5.15.2', compiled=False) and
             config.val.colors.webpage.prefers_color_scheme_dark):
+        # In future versions of 'blink', (> Qt 5.15.2) the enumeration has
+        # changed and this will need to be set to '0' instead.
         yield "preferredColorScheme", "1"
 
     if not config.val.colors.webpage.darkmode.enabled:

--- a/qutebrowser/config/qtargs.py
+++ b/qutebrowser/config/qtargs.py
@@ -204,10 +204,10 @@ def _qtwebengine_settings_args() -> Iterator[str]:
     }
 
     if (qtutils.version_check('5.14', compiled=False) and
-            not qtutils.version_check('5.15', compiled=False)):
-        # In Qt 5.14, `--force-dark-mode` is used to set the preferred
-        # colorscheme. In Qt 5.15, this is handled by a blink-setting
-        # instead.
+            not qtutils.version_check('5.15.2', compiled=False)):
+        # In Qt 5.14 to 5.15.1, `--force-dark-mode` is used to set the
+        # preferred colorscheme. In Qt 5.15.2, this is handled by a
+        # blink-setting instead.
         settings['colors.webpage.prefers_color_scheme_dark'] = {
             True: '--force-dark-mode',
             False: None,

--- a/qutebrowser/config/qtargs.py
+++ b/qutebrowser/config/qtargs.py
@@ -203,12 +203,18 @@ def _qtwebengine_settings_args() -> Iterator[str]:
         }
     }
 
-    referrer_setting = settings['content.headers.referer']
-    if qtutils.version_check('5.14', compiled=False):
+    if (qtutils.version_check('5.14', compiled=False) and
+            not qtutils.version_check('5.15', compiled=False)):
+        # In Qt 5.14, `--force-dark-mode` is used to set the preferred
+        # colorscheme. In Qt 5.15, this is handled by a blink-setting
+        # instead.
         settings['colors.webpage.prefers_color_scheme_dark'] = {
             True: '--force-dark-mode',
             False: None,
         }
+
+    referrer_setting = settings['content.headers.referer']
+    if qtutils.version_check('5.14', compiled=False):
         # Starting with Qt 5.14, this is handled via --enable-features
         referrer_setting['same-domain'] = None
     else:

--- a/tests/end2end/test_invocations.py
+++ b/tests/end2end/test_invocations.py
@@ -429,11 +429,6 @@ def test_preferred_colorscheme(request, quteproc_new):
     ]
     quteproc_new.start(args)
 
-    quteproc_new.open_path("qute://version")
-    quteproc_new.send_cmd(':jseval --world main '
+    quteproc_new.send_cmd(':jseval '
                           'matchMedia("(prefers-color-scheme: dark)").matches')
-    line = quteproc_new.wait_for(message='True')
-    line.expected = True
-
-    quteproc_new.send_cmd(':quit')
-    quteproc_new.wait_for_quit()
+    quteproc_new.wait_for(message='True')

--- a/tests/end2end/test_invocations.py
+++ b/tests/end2end/test_invocations.py
@@ -417,3 +417,23 @@ def test_referrer(quteproc_new, server, server2, request, value, expected):
             expected = expected.replace(key, str(val))
 
     assert headers.get('Referer') == expected
+
+
+@pytest.mark.qtwebkit_skip
+@utils.qt514
+def test_preferred_colorscheme(request, quteproc_new):
+    """Make sure the the preferred colorscheme is set."""
+    args = _base_args(request.config) + [
+        '--temp-basedir',
+        '-s', 'colors.webpage.prefers_color_scheme_dark', 'true',
+    ]
+    quteproc_new.start(args)
+
+    quteproc_new.open_path("qute://version")
+    quteproc_new.send_cmd(':jseval --world main '
+                          'matchMedia("(prefers-color-scheme: dark)").matches')
+    line = quteproc_new.wait_for(message='True')
+    line.expected = True
+
+    quteproc_new.send_cmd(':quit')
+    quteproc_new.wait_for_quit()

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -44,6 +44,9 @@ ON_CI = 'CI' in os.environ
 qt514 = pytest.mark.skipif(
     not qtutils.version_check('5.14'), reason="Needs Qt 5.14 or newer")
 
+qt515 = pytest.mark.skipif(
+    not qtutils.version_check('5.15'), reason="Needs Qt 5.15 or newer")
+
 
 class PartialCompareOutcome:
 

--- a/tests/helpers/utils.py
+++ b/tests/helpers/utils.py
@@ -44,9 +44,6 @@ ON_CI = 'CI' in os.environ
 qt514 = pytest.mark.skipif(
     not qtutils.version_check('5.14'), reason="Needs Qt 5.14 or newer")
 
-qt515 = pytest.mark.skipif(
-    not qtutils.version_check('5.15'), reason="Needs Qt 5.15 or newer")
-
 
 class PartialCompareOutcome:
 

--- a/tests/unit/browser/webengine/test_darkmode.py
+++ b/tests/unit/browser/webengine/test_darkmode.py
@@ -32,16 +32,23 @@ def patch_backend(monkeypatch):
     monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
 
 
-@pytest.mark.parametrize('enabled, expected', [
+@pytest.mark.parametrize('qversion, enabled, expected', [
     # Disabled or nothing set
-    (False, []),
+    ("5.14", False, []),
+    ("5.15.0", False, []),
+    ("5.15.1", False, []),
+    ("5.15.2", False, []),
 
     # Enabled in configuration
-    (True, [("preferredColorScheme", "1")]),
+    ("5.14", True, []),
+    ("5.15.0", True, []),
+    ("5.15.1", True, []),
+    ("5.15.2", True, [("preferredColorScheme", "1")]),
 ])
-@utils.qt515
-def test_colorscheme(config_stub, monkeypatch, enabled, expected):
-    config_stub.set_obj('colors.webpage.prefers_color_scheme_dark', enabled)
+@utils.qt514
+def test_colorscheme(config_stub, monkeypatch, qversion, enabled, expected):
+    monkeypatch.setattr(darkmode.qtutils, 'qVersion', lambda: qversion)
+    config_stub.val.colors.webpage.prefers_color_scheme_dark = enabled
     assert list(darkmode.settings()) == expected
 
 

--- a/tests/unit/browser/webengine/test_darkmode.py
+++ b/tests/unit/browser/webengine/test_darkmode.py
@@ -32,6 +32,19 @@ def patch_backend(monkeypatch):
     monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebEngine)
 
 
+@pytest.mark.parametrize('enabled, expected', [
+    # Disabled or nothing set
+    (False, []),
+
+    # Enabled in configuration
+    (True, [("preferredColorScheme", "1")]),
+])
+@utils.qt515
+def test_colorscheme(config_stub, monkeypatch, enabled, expected):
+    config_stub.set_obj('colors.webpage.prefers_color_scheme_dark', enabled)
+    assert list(darkmode.settings()) == expected
+
+
 @pytest.mark.parametrize('settings, expected', [
     # Disabled
     ({}, []),

--- a/tests/unit/config/test_qtargs.py
+++ b/tests/unit/config/test_qtargs.py
@@ -289,20 +289,20 @@ class TestQtArgs:
         else:
             assert arg in args
 
-    @pytest.mark.parametrize('dark, new_qt, added', [
-        (True, True, True),
-        (True, False, False),
-        (False, True, False),
-        (False, False, False),
+    @pytest.mark.parametrize('dark, qt_version, added', [
+        (True, "5.13", False),
+        (True, "5.14", True),
+        (True, "5.15", False),
+        (False, "5.13", False),
+        (False, "5.14", False),
+        (False, "5.15", False),
     ])
     @utils.qt514
     def test_prefers_color_scheme_dark(self, config_stub, monkeypatch, parser,
-                                       dark, new_qt, added):
+                                       dark, qt_version, added):
         monkeypatch.setattr(qtargs.objects, 'backend',
                             usertypes.Backend.QtWebEngine)
-        monkeypatch.setattr(qtargs.qtutils, 'version_check',
-                            lambda version, exact=False, compiled=True:
-                            new_qt)
+        monkeypatch.setattr(qtargs.qtutils, 'qVersion', lambda: qt_version)
 
         config_stub.val.colors.webpage.prefers_color_scheme_dark = dark
 

--- a/tests/unit/config/test_qtargs.py
+++ b/tests/unit/config/test_qtargs.py
@@ -292,10 +292,14 @@ class TestQtArgs:
     @pytest.mark.parametrize('dark, qt_version, added', [
         (True, "5.13", False),
         (True, "5.14", True),
-        (True, "5.15", False),
+        (True, "5.15.0", True),
+        (True, "5.15.1", True),
+        (True, "5.15.2", False),
         (False, "5.13", False),
         (False, "5.14", False),
-        (False, "5.15", False),
+        (False, "5.15.0", False),
+        (False, "5.15.1", False),
+        (False, "5.15.2", False),
     ])
     @utils.qt514
     def test_prefers_color_scheme_dark(self, config_stub, monkeypatch, parser,


### PR DESCRIPTION
QtWebEngine 5.15.2 doesn't toggle the preferred color-scheme media query
when using `--force-dark-mode`, instead a blink-specific setting needs
to be toggled.

Note: This same setting could probably be used on earlier versions as
well, but to avoid breaking anything that already works, only
QtWebEngine 5.15.2 and above will use this alternate setting.

Note 2: It's not clear that this is the correct value of
`preferredColorScheme`. According to the Chromium source, `kDark` is 0
and `kLight` is 1, but setting `preferredColorScheme` to 0 causes it to
use light mode.

Closes #5915 