### PR TITLE
Like Chromium, support --app-id arg to set Wayland app_id

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -94,7 +94,8 @@ def run(args):
     q_app = Application(args)
     q_app.setOrganizationName("qutebrowser")
     q_app.setApplicationName("qutebrowser")
-    q_app.setDesktopFileName("org.qutebrowser.qutebrowser")
+    # Default DesktopFileName is org.qutebrowser.qutebrowser, set in `get_argparser()`
+    q_app.setDesktopFileName(args.desktop_file_name)
     q_app.setApplicationVersion(qutebrowser.__version__)
 
     if args.version:

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -93,6 +93,11 @@ def get_argparser():
 
     parser.add_argument('--json-args', help=argparse.SUPPRESS)
     parser.add_argument('--temp-basedir-restarted', help=argparse.SUPPRESS)
+    parser.add_argument('--desktop-file-name',
+                        default="org.qutebrowser.qutebrowser",
+                        help="Set the base name of the desktop entry for this "
+                        "application. Used to set the app_id under Wayland. See "
+                        "https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop")
 
     debug = parser.add_argument_group('debug arguments')
     debug.add_argument('-l', '--loglevel', dest='loglevel',


### PR DESCRIPTION
This adds support an --desktop-file-name CLI option which will set the app_id property under Wayland.

The option is used on Linux to support creating "single site browsers" that function as independent apps-- the window manager will recognize them as independent apps to launch and switch to.

For example, you could treat Gmail as an independent app from "Qutebrowser"

In Chromium, these feature is exposed through the GUI menu as "More tools... > Create Shortcut "Open as window".

The result is a `.desktop` file located in `~/.local/share/application` with lines that looks like this:

```
Exec=/usr/bin/chromium "--profile-directory=Profile 1" --app-id=aebhdehjpceoxxxyyymkchpgbnngobd
StartupWMClass=crx_aebhdehjpceoxxxyyymkchpgbnngobd
```

Qutebrowser already supports `--basedir` as a custom profile directory option, so all that's missing is to add support for setting Wayland's app_id

When `--desktop-file-name` is supplied to `qutebrowser`, it will set the "DesktopFileName" through QT:

https://doc.qt.io/qt-5/qguiapplication.html#desktopFileName-prop

Testing on Wayland confirms that if the `--desktop-file-name` is not passed the "app_id" Wayland property is set as "org.qutebrowser.qutebrowser" as before. If `--desktop-file-name` is provided the Wayland "app_id" property is set to the provided string.

Once this feature is merged, users can create single site browsers by creating `.desktop` files manually that match this value

This work could further built on by having a way to generate `.desktop` files for sites automatically as `Chromium` does to assist in creating single-site-browsers.

Fixes #5245
