### PR TITLE
reduce use of pkg_resources by not extracting a file to find its filename

### DIFF
--- a/qutebrowser/utils/jinja.py
+++ b/qutebrowser/utils/jinja.py
@@ -118,8 +118,7 @@ class Environment(jinja2.Environment):
     def _data_url(self, path: str) -> str:
         """Get a data: url for the broken qutebrowser logo."""
         data = utils.read_file(path, binary=True)
-        filename = utils.resource_filename(path)
-        mimetype = utils.guess_mimetype(filename)
+        mimetype = utils.guess_mimetype(path)
         return urlutils.data_url(mimetype, data).toString()
 
     def getattr(self, obj: Any, attribute: str) -> Any:


### PR DESCRIPTION
Further progress on #4467

guess_mimetype is quite happy with a string and doesn't need to extract temp files that may or may not ever be cleaned up anyway.