### PR TITLE
Time units added to :later command

### DIFF
--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -49,9 +49,10 @@ def later(duration: str, command: str, win_id: int) -> None:
         duration: Duration to wait in format XhYmZs or number for seconds.
         command: The command to run, with optional args.
     """
-    ms = utils.parse_duration(duration)
-    if ms < 0:
-        raise cmdutils.CommandError("Wrong format, expected XhYmZs or Number.")
+    try:
+        ms = utils.parse_duration(duration)
+    except ValueError as e:
+        raise cmdutils.CommandError(e)
     commandrunner = runners.CommandRunner(win_id)
     timer = usertypes.Timer(name='later', parent=QApplication.instance())
     try:

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -46,7 +46,7 @@ def later(duration: str, command: str, win_id: int) -> None:
     """Execute a command after some time.
 
     Args:
-        duration: Duration to wait in format XhYmZs or number for seconds.
+        duration: Duration to wait in format XhYmZs or a number for milliseconds.
         command: The command to run, with optional args.
     """
     try:

--- a/qutebrowser/misc/utilcmds.py
+++ b/qutebrowser/misc/utilcmds.py
@@ -42,15 +42,16 @@ from qutebrowser.qt import sip
 
 @cmdutils.register(maxsplit=1, no_cmd_split=True, no_replace_variables=True)
 @cmdutils.argument('win_id', value=cmdutils.Value.win_id)
-def later(ms: int, command: str, win_id: int) -> None:
+def later(duration: str, command: str, win_id: int) -> None:
     """Execute a command after some time.
 
     Args:
-        ms: How many milliseconds to wait.
+        duration: Duration to wait in format XhYmZs or number for seconds.
         command: The command to run, with optional args.
     """
+    ms = utils.parse_duration(duration)
     if ms < 0:
-        raise cmdutils.CommandError("I can't run something in the past!")
+        raise cmdutils.CommandError("Wrong format, expected XhYmZs or Number.")
     commandrunner = runners.CommandRunner(win_id)
     timer = usertypes.Timer(name='later', parent=QApplication.instance())
     try:

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -781,18 +781,17 @@ def parse_duration(duration: str) -> int:
         # For backward compatibility return milliseconds
         return int(duration)
 
-    match = re.search(
-        r'^(?P<hours>[0-9]+(\.[0-9])*h)?\s*'
-        r'(?P<minutes>[0-9]+(\.[0-9])*m)?\s*'
-        r'(?P<seconds>[0-9]+(\.[0-9])*s)?$',
+    match = re.fullmatch(
+        r'(?P<hours>[0-9]+(\.[0-9])?h)?\s*'
+        r'(?P<minutes>[0-9]+(\.[0-9])?m)?\s*'
+        r'(?P<seconds>[0-9]+(\.[0-9])?s)?',
         duration
     )
-    if not match:
+    if not match or not match.group(0):
         raise ValueError(
             f"Invalid duration: {duration} - "
             "expected XhYmZs or a number of milliseconds"
         )
-
     seconds_string = match.group('seconds') if match.group('seconds') else '0'
     seconds = float(seconds_string.rstrip('s'))
     minutes_string = match.group('minutes') if match.group('minutes') else '0'

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -773,3 +773,20 @@ def libgl_workaround() -> None:
     libgl = ctypes.util.find_library("GL")
     if libgl is not None:  # pragma: no branch
         ctypes.CDLL(libgl, mode=ctypes.RTLD_GLOBAL)
+
+
+def parse_duration(duration: str) -> int:
+    """Parse duration in format XhYmZs into milliseconds duration."""
+    has_only_valid_chars = re.match("^([0-9]+[shm]?){1,3}$", duration)
+    if not has_only_valid_chars:
+        return -1
+    if re.match("^[0-9]+$", duration):
+        seconds = int(duration)
+    else:
+        match = re.search("([0-9]+)s", duration)
+        seconds = match.group(1) if match else 0
+    match = re.search("([0-9]+)m", duration)
+    minutes = match.group(1) if match else 0
+    match = re.search("([0-9]+)h", duration)
+    hours = match.group(1) if match else 0
+    return (int(seconds) + int(minutes) * 60 + int(hours) * 3600) * 1000

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -820,24 +820,42 @@ def test_libgl_workaround(monkeypatch, skip):
     utils.libgl_workaround()  # Just make sure it doesn't crash.
 
 
-@pytest.mark.parametrize('durations, out', [
-    ("-1s", -1),  # No sense to wait for negative seconds
-    ("-1", -1),
-    ("34ss", -1),
+@pytest.mark.parametrize('duration, out', [
     ("0", 0),
     ("0s", 0),
+    ("0.5s", 500),
     ("59s", 59000),
-    ("60", 60000),
-    ("60.4s", -1),  # Only accept integer values
+    ("60", 60),
+    ("60.4s", 60400),
     ("1m1s", 61000),
+    ("1.5m", 90000),
     ("1m", 60000),
     ("1h", 3_600_000),
+    ("0.5h", 1_800_000),
     ("1h1s", 3_601_000),
-    ("1s1h", 3_601_000),  # Invariant to flipping
+    ("1h 1s", 3_601_000),
     ("1h1m", 3_660_000),
     ("1h1m1s", 3_661_000),
     ("1h1m10s", 3_670_000),
     ("10h1m10s", 36_070_000),
 ])
-def test_parse_duration(durations, out):
-    assert utils.parse_duration(durations) == out
+def test_parse_duration(duration, out):
+    assert utils.parse_duration(duration) == out
+
+
+@pytest.mark.parametrize('duration, out', [
+    ("-1s", -1),  # No sense to wait for negative seconds
+    ("-1", -1),
+    ("34ss", -1),
+])
+def test_parse_duration_invalid(duration, out):
+    with pytest.raises(ValueError, match='Invalid duration'):
+        utils.parse_duration(duration)
+
+
+@hypothesis.given(strategies.text())
+def test_parse_duration_hypothesis(duration):
+    try:
+        utils.parse_duration(duration)
+    except ValueError:
+        pass

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -818,3 +818,26 @@ def test_libgl_workaround(monkeypatch, skip):
     if skip:
         monkeypatch.setenv('QUTE_SKIP_LIBGL_WORKAROUND', '1')
     utils.libgl_workaround()  # Just make sure it doesn't crash.
+
+
+@pytest.mark.parametrize('durations, out', [
+    ("-1s", -1),  # No sense to wait for negative seconds
+    ("-1", -1),
+    ("34ss", -1),
+    ("0", 0),
+    ("0s", 0),
+    ("59s", 59000),
+    ("60", 60000),
+    ("60.4s", -1),  # Only accept integer values
+    ("1m1s", 61000),
+    ("1m", 60000),
+    ("1h", 3_600_000),
+    ("1h1s", 3_601_000),
+    ("1s1h", 3_601_000),  # Invariant to flipping
+    ("1h1m", 3_660_000),
+    ("1h1m1s", 3_661_000),
+    ("1h1m10s", 3_670_000),
+    ("10h1m10s", 36_070_000),
+])
+def test_parse_duration(durations, out):
+    assert utils.parse_duration(durations) == out

--- a/tests/unit/utils/test_utils.py
+++ b/tests/unit/utils/test_utils.py
@@ -843,12 +843,20 @@ def test_parse_duration(duration, out):
     assert utils.parse_duration(duration) == out
 
 
-@pytest.mark.parametrize('duration, out', [
-    ("-1s", -1),  # No sense to wait for negative seconds
-    ("-1", -1),
-    ("34ss", -1),
+@pytest.mark.parametrize('duration', [
+    "-1s",  # No sense to wait for negative seconds
+    "-1",
+    "34ss",
+    "",
+    "h",
+    "1.s",
+    "1.1.1s",
+    ".1s",
+    ".s",
+    "10e5s",
+    "5s10m",
 ])
-def test_parse_duration_invalid(duration, out):
+def test_parse_duration_invalid(duration):
     with pytest.raises(ValueError, match='Invalid duration'):
         utils.parse_duration(duration)
 


### PR DESCRIPTION
The :later command is modified to accept either an integer or time
duration with properly formatted units.
The expected format is XhYmZs, where X, Y and Z are integers
corresponding to hours, minutes or seconds respectively.
The user needs to specify at least one of the units for the command to
work.
In case of integer input, unit is assumed to be seconds.
Closes #5934.