### PR TITLE
Retain sort order for undo completion model

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -293,6 +293,6 @@ def undo(*, info):
         enumerate(reversed(tabbed_browser.undo_stack), start=1)
     ]
 
-    cat = listcategory.ListCategory("Closed tabs", entries)
+    cat = listcategory.ListCategory("Closed tabs", entries, sort=False)
     model.add_category(cat)
     return model

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -1329,6 +1329,30 @@ def test_undo_completion(tabbed_browser_stubs, info):
     })
 
 
+def undo_completion_retains_sort_order(tabbed_browser_stubs, info):
+    """Test :undo completion sort order with > 10 entries."""
+    created_dt = datetime(2020, 1, 1)
+    created_str = "2020-01-02 00:00"
+
+    tabbed_browser_stubs[0].undo_stack = [
+        tabbedbrowser._UndoEntry(
+            url=QUrl(f'https://example.org/{idx}'),
+            history=None, index=None, pinned=None,
+            created_at=created_dt,
+        )
+        for idx in range(1, 11)
+    ]
+
+    model = miscmodels.undo(info=info)
+    model.set_pattern('')
+
+    expected = [
+        (str(idx), f'https://example.org/{idx}', created_str)
+        for idx in range(1, 11)
+    ]
+    _check_completions(model, {"Closed tabs": expected})
+
+
 @hypothesis.given(text=hypothesis.strategies.text())
 def test_listcategory_hypothesis(text):
     """Make sure we can't produce invalid patterns."""


### PR DESCRIPTION
Because 10 shouldn't be higher than 2.

![image](https://user-images.githubusercontent.com/7419144/102324990-79e55500-3fe7-11eb-8dab-11bf6b191fff.png)


<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
