### PR TITLE
Fix qute-lastpass userscript enters text containing multiple <

### DIFF
--- a/misc/userscripts/qute-lastpass
+++ b/misc/userscripts/qute-lastpass
@@ -105,8 +105,11 @@ def fake_key_raw(text):
     sequence = ''
 
     for character in text:
-        # Escape all characters by default, space requires special handling
-        sequence += ('" "' if character == ' ' else '\\{}'.format(character))
+        # Escape all characters by default, space, '<' and '>' requires special handling
+        sequence += ('" "' if character == ' ' else
+				'<less>' if character == '<' else
+				'<greater>' if character == '>' else
+				'\\{}'.format(character))
     qute_command('fake-key {}'.format(sequence))
 
 

--- a/tests/end2end/features/keyinput.feature
+++ b/tests/end2end/features/keyinput.feature
@@ -56,11 +56,17 @@ Feature: Keyboard input
 
     Scenario: :fake-key sending keychain to the website
         When I open data/keyinput/log.html
-        And I run :fake-key xy
+        And I run :fake-key x<greater>y<less>" "
         Then the javascript message "key press: 88" should be logged
         And the javascript message "key release: 88" should be logged
+        And the javascript message "key press: 190" should be logged
+        And the javascript message "key release: 190" should be logged
         And the javascript message "key press: 89" should be logged
         And the javascript message "key release: 89" should be logged
+        And the javascript message "key press: 188" should be logged
+        And the javascript message "key release: 188" should be logged
+        And the javascript message "key press: 32" should be logged
+        And the javascript message "key release: 32" should be logged
 
     Scenario: :fake-key sending keypress to qutebrowser
         When I run :fake-key -g x

--- a/tests/unit/misc/userscripts/test_qute_lastpass.py
+++ b/tests/unit/misc/userscripts/test_qute_lastpass.py
@@ -82,10 +82,10 @@ class TestQuteLastPassComponents:
 
     def test_fake_key_raw(self, qutecommand_mock):
         """Test if fake_key_raw properly escapes characters."""
-        qute_lastpass.fake_key_raw('john.doe@example.com ')
+        qute_lastpass.fake_key_raw('john.<<doe>>@example.com ')
 
         qutecommand_mock.assert_called_once_with(
-            'fake-key \\j\\o\\h\\n\\.\\d\\o\\e\\@\\e\\x\\a\\m\\p\\l\\e\\.\\c\\o\\m" "'
+            'fake-key \\j\\o\\h\\n\\.<less><less>\\d\\o\\e<greater><greater>\\@\\e\\x\\a\\m\\p\\l\\e\\.\\c\\o\\m" "'
         )
 
     def test_dmenu(self, subprocess_mock):


### PR DESCRIPTION
Previously passwords that contains at least two `<` will be entered incorrectly. (for example `:fake-key \<\<` inserts only one `<`)

The bug starts from commit 2f9b3f5ab8ca6e5d1be188201b18ef4835d71004 which changes a somewhat-unrelated issue.

Remark:

* I think if `<less>` is always properly escaped then `<greater>` is unnecessary, but this is just to be sure.
* Actually it's possible to use `\ ` instead of `" "` to escape space too -- unless it's at the end of the string (this feels like a parsing bug somehow), in which case appending `""` works too.
* This is backward-incompatible (some user might not understand why the site reports "incorrect password" after an update), but the same thing happened with the previous change.
* Somewhat related: an error message will be raised if either the username or the password is empty -- but I'm not sure what should be done with the `<tab>` between them. The user can still invoke it with `--username-only` or `--password-only`.
