### PR TITLE
Fix gopass mime format for qute-pass userscript

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -152,6 +152,8 @@ def _run_pass(pass_arguments):
 
 
 def pass_(path):
+    if arguments.mode == "gopass":
+        return _run_pass(['show', '-o', path])
     return _run_pass(['show', path])
 
 


### PR DESCRIPTION
With [this](https://github.com/gopasspw/gopass/pull/1415) gopass PR, a new password format was devised which also became the default.

This format stores passwords in a KV format instead of as raw text, so when invoking `gopass show` the entire KV entry is listed:
```
$ gopass show <my-pass>
> Password: <the-password>
```
qute-pass then pulls in the prepended `Password:`, breaking functionality.

A new `-o` switch was introduced for `show` which allows you to print just the password, which is akin to the old behavior, i.e. what we want actually want.

The switch is harmless for stores using the old format, and so shouldn't break anything for those users.


<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->