### PR TITLE
browsertab: set self._default_zoom_changed==True if user's default zoom level is not 100%

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -355,10 +355,10 @@ class AbstractZoom(QObject):
         self._tab = tab
         self._widget = cast(QWidget, None)
         # Whether zoom was changed from the default.
-        self._default_zoom_changed = False
         self._init_neighborlist()
         config.instance.changed.connect(self._on_config_changed)
         self._zoom_factor = float(config.val.zoom.default) / 100
+        self._default_zoom_changed = self._zoom_factor != 1.0
 
     @pyqtSlot(str)
     def _on_config_changed(self, option: str) -> None:


### PR DESCRIPTION
Closes #5979

Tested only on v1.14.1 because master branch crashes with "ImportError: cannot import name 'sip' from 'PyQt5' (/usr/lib/python3/dist-packages/PyQt5/__init__.py)" for me.

This fixes a bug where the page doesn't apply the zoom until page
loading is complete, which results in an annoying reflow that can
cause erroneous mouse clicks due to elements jumping around under the
cursor (on WebEngine, at least).
