### PR TITLE
Add qt.environ setting in config

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -160,14 +160,14 @@ qt.environ:
   type:
     name: Dict
     keytype: String
-    valtype: 
+    valtype:
       name: String
       none_ok: true
     none_ok: true
   default: {}
   restart: true
   desc: >-
-    Additional environment variables to set. 
+    Additional environment variables to set.
 
     Setting an environment variable to null/None will unset it.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -160,13 +160,16 @@ qt.environ:
   type:
     name: Dict
     keytype: String
-    valtype: String
+    valtype: 
+      name: String
+      none_ok: true
     none_ok: true
   default: {}
   restart: true
   desc: >-
-    Additional environment variables to set. Set to `None` to unset an environment
-    variable.
+    Additional environment variables to set. 
+
+    Setting an environment variable to null/None will unset it.
 
 force_software_rendering:
   renamed: qt.force_software_rendering

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -156,6 +156,18 @@ qt.args:
     https://peter.sh/experiments/chromium-command-line-switches/ for a list)
     will work.
 
+qt.environ:
+  type:
+    name: Dict
+    keytype: String
+    valtype: String
+    none_ok: true
+  default: {}
+  restart: true
+  desc: >-
+    Additional environment variables to set. Set to `None` to unset an environment
+    variable.
+
 force_software_rendering:
   renamed: qt.force_software_rendering
 

--- a/qutebrowser/config/qtargs.py
+++ b/qutebrowser/config/qtargs.py
@@ -259,3 +259,10 @@ def init_envvars() -> None:
                    if qtutils.version_check('5.14', compiled=False)
                    else 'QT_AUTO_SCREEN_SCALE_FACTOR')
         os.environ[env_var] = '1'
+
+    for var in config.val.qt.environ:
+        val = config.val.qt.environ[var]
+        if val == 'None':
+            os.environ[var] = ''
+        else:
+            os.environ[var] = val

--- a/qutebrowser/config/qtargs.py
+++ b/qutebrowser/config/qtargs.py
@@ -260,9 +260,8 @@ def init_envvars() -> None:
                    else 'QT_AUTO_SCREEN_SCALE_FACTOR')
         os.environ[env_var] = '1'
 
-    for var in config.val.qt.environ:
-        val = config.val.qt.environ[var]
-        if val == 'None':
-            os.environ[var] = ''
-        else:
+    for var, val in config.val.qt.environ.items():
+        if val is None and var in os.environ:
+            del os.environ[var]
+        elif val is not None:
             os.environ[var] = val

--- a/tests/unit/config/test_qtargs.py
+++ b/tests/unit/config/test_qtargs.py
@@ -428,38 +428,46 @@ class TestEnvVars:
 
         assert os.environ[envvar] == expected
 
-    @pytest.mark.parametrize('config_opt, config_val, init_val, envvar, expected', [
-        ('qt.environ', {'QT_SCALE_FACTOR': '2'},
-         [None], ['QT_SCALE_FACTOR'], ['2']),
-        #Test changing an environment variable
-        ('qt.environ', {'QT_SCALE_FACTOR': '4'},
-         ['2'], ['QT_SCALE_FACTOR'], ['4']),
-        ('qt.environ', {'QT_SCALE_FACTOR': '4'},
-         ['unset'], ['QT_SCALE_FACTOR'], ['4']),
-        #Test unsetting an environment variable
-        ('qt.environ', {'QT_SCALE_FACTOR': 'None'},
-         ['3'], ['QT_SCALE_FACTOR'], ['']),
-        #Test setting multiple environment variables
-        ('qt.environ', {'QT_SCALE_FACTOR': '3', 'QT_PLUGIN_PATH': '/tmp/',
-                        'QT_NEWVAR': 'newval'},
-         [None, None, None], ['QT_SCALE_FACTOR', 'QT_PLUGIN_PATH', 'QT_NEWVAR'],
-         ['3', '/tmp/', 'newval']),
+    @pytest.mark.parametrize('init_val, config_val', [
+        (   # Test setting a variable
+            {'QT_SCALE_FACTOR': None},
+            {'QT_SCALE_FACTOR': '2'},
+        ),
+        (   # Test changing a set variable
+            {'QT_SCALE_FACTOR': '2'},
+            {'QT_SCALE_FACTOR': '4'},
+        ),
+        (   # Test setting an unset variable
+            {'QT_SCALE_FACTOR': 'unset'},
+            {'QT_SCALE_FACTOR': '3'},
+        ),
+        (   # Test unsetting a variable
+            {'QT_SCALE_FACTOR': '3'},
+            {'QT_SCALE_FACTOR': None},
+        ),
+        (   # Test setting multiple variables
+            {'QT_SCALE_FACTOR': None, 'QT_PLUGIN_PATH': None, 'QT_NEWVAR': None},
+            {'QT_SCALE_FACTOR': '3', 'QT_PLUGIN_PATH': '/tmp/', 'QT_NEWVAR': 'newval'},
+        )
     ])
     def test_environ_settings(self, monkeypatch, config_stub,
-                              config_opt, config_val, init_val, envvar, expected):
-        """Test extra environment settings."""
-        for (var, val) in zip(envvar, init_val):
+                              init_val, config_val):
+        """Test setting environment variables using qt.environ."""
+        for var, val in init_val.items():
             if val is not None:
                 if val == 'unset':
                     monkeypatch.delenv(var)
                 else:
                     monkeypatch.setenv(var, val)
 
-        config_stub.set_obj(config_opt, config_val)
+        config_stub.val.qt.environ = config_val
         qtargs.init_envvars()
 
-        for (var, result) in zip(envvar, expected):
-            assert os.environ[var] == result
+        for var, result in config_val.items():
+            if result is None:
+                assert var not in os.environ
+            else:
+                assert os.environ[var] == result
 
     @pytest.mark.parametrize('new_qt', [True, False])
     def test_highdpi(self, monkeypatch, config_stub, new_qt):

--- a/tests/unit/config/test_qtargs.py
+++ b/tests/unit/config/test_qtargs.py
@@ -441,8 +441,12 @@ class TestEnvVars:
             {'QT_SCALE_FACTOR': 'unset'},
             {'QT_SCALE_FACTOR': '3'},
         ),
-        (   # Test unsetting a variable
+        (   # Test unsetting a variable which is set
             {'QT_SCALE_FACTOR': '3'},
+            {'QT_SCALE_FACTOR': None},
+        ),
+        (   # Test unsetting a variable which is unset
+            {'QT_SCALE_FACTOR': 'unset'},
             {'QT_SCALE_FACTOR': None},
         ),
         (   # Test setting multiple variables

--- a/tests/unit/config/test_qtargs.py
+++ b/tests/unit/config/test_qtargs.py
@@ -429,16 +429,12 @@ class TestEnvVars:
         assert os.environ[envvar] == expected
 
     @pytest.mark.parametrize('init_val, config_val', [
-        (   # Test setting a variable
-            {'QT_SCALE_FACTOR': None},
-            {'QT_SCALE_FACTOR': '2'},
-        ),
         (   # Test changing a set variable
             {'QT_SCALE_FACTOR': '2'},
             {'QT_SCALE_FACTOR': '4'},
         ),
         (   # Test setting an unset variable
-            {'QT_SCALE_FACTOR': 'unset'},
+            {'QT_SCALE_FACTOR': None},
             {'QT_SCALE_FACTOR': '3'},
         ),
         (   # Test unsetting a variable which is set
@@ -446,11 +442,11 @@ class TestEnvVars:
             {'QT_SCALE_FACTOR': None},
         ),
         (   # Test unsetting a variable which is unset
-            {'QT_SCALE_FACTOR': 'unset'},
+            {'QT_SCALE_FACTOR': None},
             {'QT_SCALE_FACTOR': None},
         ),
         (   # Test setting multiple variables
-            {'QT_SCALE_FACTOR': None, 'QT_PLUGIN_PATH': None, 'QT_NEWVAR': None},
+            {'QT_SCALE_FACTOR': '0', 'QT_PLUGIN_PATH': '/usr/bin', 'QT_NEWVAR': None},
             {'QT_SCALE_FACTOR': '3', 'QT_PLUGIN_PATH': '/tmp/', 'QT_NEWVAR': 'newval'},
         )
     ])
@@ -458,11 +454,11 @@ class TestEnvVars:
                               init_val, config_val):
         """Test setting environment variables using qt.environ."""
         for var, val in init_val.items():
-            if val is not None:
-                if val == 'unset':
-                    monkeypatch.delenv(var)
-                else:
-                    monkeypatch.setenv(var, val)
+            if val is None:
+                monkeypatch.setenv(var, '0')
+                monkeypatch.delenv(var, raising=False)
+            else:
+                monkeypatch.setenv(var, val)
 
         config_stub.val.qt.environ = config_val
         qtargs.init_envvars()


### PR DESCRIPTION
Any environment variables can be set using the qt.environ setting in the config.

Closes #5899 

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
