### PR TITLE
Fix condition for using overlay scrollbar

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -283,7 +283,7 @@ def get_user_stylesheet(searching=False):
             css += f.read()
 
     setting = config.val.scrolling.bar
-    if setting == 'overlay' and not utils.is_mac:
+    if setting == 'overlay' and utils.is_mac:
         setting = 'when-searching'
 
     if setting == 'never' or setting == 'when-searching' and not searching:


### PR DESCRIPTION
`scrolling.bar = 'overlay'` does not apply since a14d0d433eec6edb5c9ecb872d458b5793c7f2bd.
It was caused by a simple mistake so I fixed it.