### PR TITLE
Don't crash on long search patterns.

### DIFF
--- a/qutebrowser/completion/models/listcategory.py
+++ b/qutebrowser/completion/models/listcategory.py
@@ -59,13 +59,13 @@ class ListCategory(QSortFilterProxyModel):
         Args:
             val: The value to set.
         """
+        if len(val) > 5000:  # avoid crash on huge search terms (#5973)
+            log.completion.warning(f"Trimming {len(val)}-char pattern to 5000")
+            val = val[:5000]
         self._pattern = val
         val = re.sub(r' +', r' ', val)  # See #1919
         val = re.escape(val)
         val = val.replace(r'\ ', '.*')
-        if len(val) > 5000:  # avoid crash on huge search terms (#5973)
-            log.completion.warning(f"Pattern too long ({len(val)})")
-            val = "^$"
         rx = QRegularExpression(val, QRegularExpression.CaseInsensitiveOption)
         qtutils.ensure_valid(rx)
         self.setFilterRegularExpression(rx)

--- a/qutebrowser/completion/models/listcategory.py
+++ b/qutebrowser/completion/models/listcategory.py
@@ -64,7 +64,7 @@ class ListCategory(QSortFilterProxyModel):
         val = re.escape(val)
         val = val.replace(r'\ ', '.*')
         if len(val) > 5000:  # avoid crash on huge search terms (#5973)
-            log.completion.warning("Pattern too long ({})".format(len(val)))
+            log.completion.warning(f"Pattern too long ({len(val)})")
             val = "^$"
         rx = QRegularExpression(val, QRegularExpression.CaseInsensitiveOption)
         qtutils.ensure_valid(rx)

--- a/qutebrowser/completion/models/listcategory.py
+++ b/qutebrowser/completion/models/listcategory.py
@@ -63,6 +63,9 @@ class ListCategory(QSortFilterProxyModel):
         val = re.sub(r' +', r' ', val)  # See #1919
         val = re.escape(val)
         val = val.replace(r'\ ', '.*')
+        if len(val) > 5000:  # avoid crash on huge search terms (#5973)
+            log.completion.warning("Pattern too long ({})".format(len(val)))
+            val = "^$"
         rx = QRegularExpression(val, QRegularExpression.CaseInsensitiveOption)
         qtutils.ensure_valid(rx)
         self.setFilterRegularExpression(rx)

--- a/tests/unit/completion/test_listcategory.py
+++ b/tests/unit/completion/test_listcategory.py
@@ -20,6 +20,7 @@
 """Tests for CompletionFilterModel."""
 
 import pytest
+import logging
 
 from qutebrowser.completion.models import listcategory
 
@@ -57,3 +58,9 @@ def test_set_pattern(pattern, before, after, after_nosort, model_validator):
     model_validator.set_model(cat)
     cat.set_pattern(pattern)
     model_validator.validate(after_nosort)
+
+
+def test_long_pattern(caplog):
+    """Validate that a huge pattern doesn't crash (#5973)."""
+    with caplog.at_level(logging.WARNING):
+        listcategory.ListCategory('Foo', []).set_pattern('a' * 50000)

--- a/tests/unit/completion/test_listcategory.py
+++ b/tests/unit/completion/test_listcategory.py
@@ -60,7 +60,10 @@ def test_set_pattern(pattern, before, after, after_nosort, model_validator):
     model_validator.validate(after_nosort)
 
 
-def test_long_pattern(caplog):
+def test_long_pattern(caplog, model_validator):
     """Validate that a huge pattern doesn't crash (#5973)."""
     with caplog.at_level(logging.WARNING):
-        listcategory.ListCategory('Foo', []).set_pattern('a' * 50000)
+        cat = listcategory.ListCategory('Foo', [('a' * 5000, '')])
+        model_validator.set_model(cat)
+        cat.set_pattern('a' * 50000)
+        model_validator.validate([('a' * 5000, '')])

--- a/tests/unit/completion/test_listcategory.py
+++ b/tests/unit/completion/test_listcategory.py
@@ -19,8 +19,9 @@
 
 """Tests for CompletionFilterModel."""
 
-import pytest
 import logging
+
+import pytest
 
 from qutebrowser.completion.models import listcategory
 


### PR DESCRIPTION
Entering an overly long search term into the completion causes a crash:

```
PyQt5.QtCore.QRegularExpression.PatternOptions(1)) is not valid: regular expression is too large
```

This can happen, for example, when pressing `go` at the qutebrowser
error page. I'm unclear on exactly what the limit is, but 50k
characters seems to trip it on my machine. Still, it seems like any
pattern larger than a certain amount is likely an error, so I settled on
limiting it to 5k.

Fixes #5973


<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->