### PR TITLE
[readability-js] horizontally align codeblock contents

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -76,6 +76,10 @@ const HEADER = `
             margin: 0;
             background-color: #dddddd;
         }
+        pre > code {
+            padding-right: 0;
+            padding-left: 0;
+        }
         blockquote {
             border-inline-start: 2px solid grey !important;
             padding: 0;

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -1,23 +1,23 @@
 #!/usr/bin/env node
-// 
+//
 // # Description
-// 
+//
 // Summarize the current page in a new tab, by processing it with the standalone readability
 // library used for Firefox Reader View.
-// 
+//
 // # Prerequisites
-// 
-//   - setting NODE_PATH might be required to point Qutebrowser to your global node libraries:
+//
+//   - Setting NODE_PATH might be required to point qutebrowser to your global node libraries:
 //     export NODE_PATH=$NODE_PATH:$(npm root -g)
 //   - Mozilla's readability library (npm install -g @mozilla/readability)
 //   - jsdom (npm install -g jsdom)
 //   - qutejs (npm install -g qutejs)
-// 
+//
 // # Usage
-// 
+//
 // :spawn --userscript readability-js
-// 
-// One may wish to define an easy to type command alias in Qutebrowser's configuration file:
+//
+// One may wish to define an easy to type command alias in qutebrowser's configuration file:
 // c.aliases = {"readability" : "spawn --userscript readability-js", ...}
 
 const { Readability } = require('@mozilla/readability');
@@ -75,6 +75,10 @@ const HEADER = `
             padding: .2em .4em;
             margin: 0;
             background-color: #dddddd;
+        }
+        pre > code {
+            padding-right: 0;
+            padding-left: 0;
         }
         blockquote {
             border-inline-start: 2px solid grey !important;

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -76,10 +76,6 @@ const HEADER = `
             margin: 0;
             background-color: #dddddd;
         }
-        pre > code {
-            padding-right: 0;
-            padding-left: 0;
-        }
         blockquote {
             border-inline-start: 2px solid grey !important;
             padding: 0;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

Before, the first line of a `code` element within a `pre` element had indentation/padding applied to it, creating the illusion that the first line started with a space. Now, all the lines in `code` elements horizontally align.

Sorry for the messy git stuff, not really sure what I did wrong. The whitespace and capitalization changes in this commit actually match the current contents of readability-js.