### PR TITLE
Fix brew installation instructions

### DIFF
--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -330,7 +330,7 @@ This binary is also available through the
 https://caskroom.github.io/[Homebrew Cask] package manager:
 
 ----
-$ brew cask install qutebrowser
+$ brew install qutebrowser --cask
 ----
 
 Manual Install


### PR DESCRIPTION
The provided MacOS installation command provided in the docs:

    $ brew cask install qutebrowser

When running this, I received the following:

    Error: Calling brew cask install is disabled! Use brew install [--cask] instead.

I was able to install using:

    $ brew install qutebrowser --cask

My homebrew is up to date (2.7.2).