### PR TITLE
Window IDs start at one; tab-give uses count as-is

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -610,7 +610,7 @@ Syntax: +:help [*--tab*] [*--bg*] [*--window*] ['topic']+
 Show help about a command or setting.
 
 ==== positional arguments
-* +'topic'+: The topic to show help for. 
+* +'topic'+: The topic to show help for.
 
  - :__command__ for commands.
  - __section__.__option__ for settings.
@@ -628,20 +628,20 @@ Syntax: +:hint [*--mode* 'mode'] [*--add-history*] [*--rapid*] [*--first*] ['gro
 Start hinting.
 
 ==== positional arguments
-* +'group'+: The element types to hint. 
+* +'group'+: The element types to hint.
 
  - `all`: All clickable elements.
  - `links`: Only links.
  - `images`: Only images.
  - `inputs`: Only input fields.
- 
+
 
  Custom groups can be added via the `hints.selectors` setting
  and also used here.
- 
 
 
-* +'target'+: What to do with the selected element. 
+
+* +'target'+: What to do with the selected element.
 
  - `normal`: Open the link.
  - `current`: Open the link in the current tab.
@@ -662,10 +662,10 @@ Start hinting.
  link.
  - `spawn`: Spawn a command.
  - `delete`: Delete the selected element.
- 
 
 
-* +'args'+: Arguments for spawn/userscript/run/fill. 
+
+* +'args'+: Arguments for spawn/userscript/run/fill.
 
  - With `spawn`: The executable and arguments to spawn.
  `{hint-url}` will get replaced by the selected
@@ -682,13 +682,13 @@ Start hinting.
 
 
 ==== optional arguments
-* +*-m*+, +*--mode*+: The hinting mode to use. 
+* +*-m*+, +*--mode*+: The hinting mode to use.
 
  - `number`: Use numeric hints.
  - `letter`: Use the chars in the hints.chars setting.
  - `word`: Use hint words based on the html elements and the
  extra words.
- 
+
 
 
 * +*-a*+, +*--add-history*+: Whether to add the spawned or yanked link to the browsing history.
@@ -758,7 +758,7 @@ Evaluate a JavaScript string.
 * +*-u*+, +*--url*+: Interpret js-code as a `javascript:...` URL.
 * +*-q*+, +*--quiet*+: Don't show resulting JS object.
 * +*-w*+, +*--world*+: Ignored on QtWebKit. On QtWebEngine, a world ID or name to run the snippet in. Predefined world names are:
- 
+
 
  - `main` (same world as the web page's JavaScript and
  Greasemonkey, unless overridden via `@qute-js-world`)
@@ -855,7 +855,7 @@ Open typical prev/next links or navigate using the URL path.
 This tries to automatically click on typical _Previous Page_ or _Next Page_ links using some heuristics. Alternatively it can navigate by changing the current URL.
 
 ==== positional arguments
-* +'where'+: What to open. 
+* +'where'+: What to open.
 
  - `prev`: Open a _previous_ link.
  - `next`: Open a _next_ link.
@@ -869,7 +869,7 @@ This tries to automatically click on typical _Previous Page_ or _Next Page_ link
  link:settings{outsuffix}#url.incdec_segments[url.incdec_segments]
  config option.
  - `strip`: Strip query and fragment from the current URL.
- 
+
 
 
 
@@ -1387,7 +1387,7 @@ If no win_id is given, the tab will get detached into a new window.
 * +*-p*+, +*--private*+: If the tab should be detached into a private instance.
 
 ==== count
-Overrides win_id (index starts at 1 for win_id=0).
+Overrides win_id.
 
 [[tab-move]]
 === tab-move
@@ -1529,7 +1529,7 @@ Syntax: +:yank [*--sel*] [*--keep*] [*--quiet*] ['what'] ['inline']+
 Yank (copy) something to the clipboard or primary selection.
 
 ==== positional arguments
-* +'what'+: What to yank. 
+* +'what'+: What to yank.
 
  - `url`: The current URL.
  - `pretty-url`: The URL in pretty decoded form.
@@ -1537,7 +1537,7 @@ Yank (copy) something to the clipboard or primary selection.
  - `domain`: The current scheme, domain, and port number.
  - `selection`: The selection under the cursor.
  - `inline`: Yank the text contained in the 'inline' argument.
- 
+
 
 
 * +'inline'+: A block of text, to be yanked if 'what' is inline and ignored otherwise.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -462,7 +462,7 @@ class CommandDispatcher:
         Args:
             win_id: The window ID of the window to give the current tab to.
             keep: If given, keep the old tab around.
-            count: Overrides win_id (index starts at 1 for win_id=0).
+            count: Overrides win_id.
             private: If the tab should be detached into a private instance.
         """
         if config.val.tabs.tabs_are_windows:
@@ -470,7 +470,7 @@ class CommandDispatcher:
                                         "windows as tabs")
 
         if count is not None:
-            win_id = count - 1
+            win_id = count
 
         if win_id == self._win_id:
             raise cmdutils.CommandError("Can't give a tab to the same window")

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -43,7 +43,7 @@ from qutebrowser.misc import crashsignal, keyhintwidget, sessions, objects
 from qutebrowser.qt import sip
 
 
-win_id_gen = itertools.count(0)
+win_id_gen = itertools.count(1)
 
 
 def get_window(*, via_ipc: bool,
@@ -285,7 +285,7 @@ class MainWindow(QWidget):
         """Initialize the window geometry or load it from disk."""
         if geometry is not None:
             self._load_geometry(geometry)
-        elif self.win_id == 0:
+        elif self.win_id == 1:
             self._load_state_geometry()
         else:
             self._set_default_geometry()

--- a/tests/helpers/fixtures.py
+++ b/tests/helpers/fixtures.py
@@ -143,20 +143,20 @@ def fake_statusbar(widget_container):
 
 @pytest.fixture
 def win_registry():
-    """Fixture providing a window registry for win_id 0 and 1."""
+    """Fixture providing a window registry for win_id 1."""
     helper = WinRegistryHelper()
-    helper.add_window(0)
+    helper.add_window(1)
     yield helper
     helper.cleanup()
 
 
 @pytest.fixture
 def tab_registry(win_registry):
-    """Fixture providing a tab registry for win_id 0."""
+    """Fixture providing a tab registry for win_id 1."""
     registry = objreg.ObjectRegistry()
-    objreg.register('tab-registry', registry, scope='window', window=0)
+    objreg.register('tab-registry', registry, scope='window', window=1)
     yield registry
-    objreg.delete('tab-registry', scope='window', window=0)
+    objreg.delete('tab-registry', scope='window', window=1)
 
 
 @pytest.fixture
@@ -217,7 +217,7 @@ def webkit_tab(web_tab_setup, qtbot, cookiejar_and_cache, mode_manager,
 
     monkeypatch.setattr(objects, 'backend', usertypes.Backend.QtWebKit)
 
-    tab = webkittab.WebKitTab(win_id=0, mode_manager=mode_manager,
+    tab = webkittab.WebKitTab(win_id=1, mode_manager=mode_manager,
                               private=False)
     tab.backend = usertypes.Backend.QtWebKit
     widget_container.set_widget(tab)
@@ -241,7 +241,7 @@ def webengine_tab(web_tab_setup, qtbot, redirect_webengine_data,
     webenginetab = pytest.importorskip(
         'qutebrowser.browser.webengine.webenginetab')
 
-    tab = webenginetab.WebEngineTab(win_id=0, mode_manager=mode_manager,
+    tab = webenginetab.WebEngineTab(win_id=1, mode_manager=mode_manager,
                                     private=False)
     tab.backend = usertypes.Backend.QtWebEngine
     widget_container.set_widget(tab)
@@ -392,14 +392,14 @@ def session_manager_stub(stubs, monkeypatch):
 
 @pytest.fixture
 def tabbed_browser_stubs(qapp, stubs, win_registry):
-    """Fixture providing a fake tabbed-browser object on win_id 0 and 1."""
-    win_registry.add_window(1)
+    """Fixture providing a fake tabbed-browser object on win_id 1 and 2."""
+    win_registry.add_window(2)
     stubs = [stubs.TabbedBrowserStub(), stubs.TabbedBrowserStub()]
-    objreg.register('tabbed-browser', stubs[0], scope='window', window=0)
-    objreg.register('tabbed-browser', stubs[1], scope='window', window=1)
+    objreg.register('tabbed-browser', stubs[0], scope='window', window=1)
+    objreg.register('tabbed-browser', stubs[1], scope='window', window=2)
     yield stubs
-    objreg.delete('tabbed-browser', scope='window', window=0)
     objreg.delete('tabbed-browser', scope='window', window=1)
+    objreg.delete('tabbed-browser', scope='window', window=2)
 
 
 @pytest.fixture
@@ -535,9 +535,9 @@ def fake_args(request, monkeypatch):
 
 @pytest.fixture
 def mode_manager(win_registry, config_stub, key_config_stub, qapp):
-    mm = modeman.init(win_id=0, parent=qapp)
+    mm = modeman.init(win_id=1, parent=qapp)
     yield mm
-    objreg.delete('mode-manager', scope='window', window=0)
+    objreg.delete('mode-manager', scope='window', window=1)
 
 
 def standarddir_tmpdir(folder, monkeypatch, tmpdir):

--- a/tests/helpers/stubs.py
+++ b/tests/helpers/stubs.py
@@ -252,7 +252,7 @@ class FakeWebTab(browsertab.AbstractTab):
                  scroll_pos_perc=(0, 0),
                  load_status=usertypes.LoadStatus.success,
                  progress=0, can_go_back=None, can_go_forward=None):
-        super().__init__(win_id=0, mode_manager=None, private=False)
+        super().__init__(win_id=1, mode_manager=None, private=False)
         self._load_status = load_status
         self._title = title
         self._url = url

--- a/tests/unit/api/test_cmdutils.py
+++ b/tests/unit/api/test_cmdutils.py
@@ -172,7 +172,7 @@ class TestRegister:
             assert not args
         cmd = objects.commands['fun']
         cmd.namespace = cmd.parser.parse_args([])
-        args, kwargs = cmd._get_call_args(win_id=0)
+        args, kwargs = cmd._get_call_args(win_id=1)
         fun(*args, **kwargs)
 
     def test_star_args_optional_annotated(self):
@@ -182,7 +182,7 @@ class TestRegister:
 
         cmd = objects.commands['fun']
         cmd.namespace = cmd.parser.parse_args([])
-        cmd._get_call_args(win_id=0)
+        cmd._get_call_args(win_id=1)
 
     @pytest.mark.parametrize('inp, expected', [
         (['--arg'], True), (['-a'], True), ([], False)])
@@ -208,7 +208,7 @@ class TestRegister:
 
         cmd.namespace = cmd.parser.parse_args(['-b'])
         assert cmd.namespace.arg
-        args, kwargs = cmd._get_call_args(win_id=0)
+        args, kwargs = cmd._get_call_args(win_id=1)
         fun(*args, **kwargs)
 
     def test_self_without_instance(self):
@@ -328,9 +328,9 @@ class TestRegister:
 
         if expected is cmdexc.ArgumentTypeError:
             with pytest.raises(cmdexc.ArgumentTypeError):
-                cmd._get_call_args(win_id=0)
+                cmd._get_call_args(win_id=1)
         else:
-            args, kwargs = cmd._get_call_args(win_id=0)
+            args, kwargs = cmd._get_call_args(win_id=1)
             assert args == [expected]
             assert kwargs == {}
             fun(*args, **kwargs)
@@ -346,7 +346,7 @@ class TestRegister:
         cmd.namespace = cmd.parser.parse_args(['fish'])
 
         with pytest.raises(cmdexc.ArgumentTypeError):
-            cmd._get_call_args(win_id=0)
+            cmd._get_call_args(win_id=1)
 
     def test_choices_no_annotation_kwonly(self):
         # https://github.com/qutebrowser/qutebrowser/issues/1871
@@ -359,7 +359,7 @@ class TestRegister:
         cmd.namespace = cmd.parser.parse_args(['--arg=fish'])
 
         with pytest.raises(cmdexc.ArgumentTypeError):
-            cmd._get_call_args(win_id=0)
+            cmd._get_call_args(win_id=1)
 
     def test_pos_arg_info(self):
         @cmdutils.register()
@@ -474,15 +474,15 @@ class TestRun:
         monkeypatch.setattr(command.objects, 'backend', used)
         cmd = _get_cmd(backend=backend)
         if ok:
-            cmd.run(win_id=0)
+            cmd.run(win_id=1)
         else:
             with pytest.raises(cmdexc.PrerequisitesError,
                                match=r'.* backend\.'):
-                cmd.run(win_id=0)
+                cmd.run(win_id=1)
 
     def test_no_args(self):
         cmd = _get_cmd()
-        cmd.run(win_id=0)
+        cmd.run(win_id=1)
 
     def test_instance_unavailable_with_backend(self, monkeypatch):
         """Test what happens when a backend doesn't have an objreg object.
@@ -500,4 +500,4 @@ class TestRun:
                             usertypes.Backend.QtWebKit)
         cmd = objects.commands['fun']
         with pytest.raises(cmdexc.PrerequisitesError, match=r'.* backend\.'):
-            cmd.run(win_id=0)
+            cmd.run(win_id=1)

--- a/tests/unit/browser/test_hints.py
+++ b/tests/unit/browser/test_hints.py
@@ -51,7 +51,7 @@ def test_show_benchmark(benchmark, tabbed_browser, qtbot, mode_manager):
     with qtbot.wait_signal(tab.load_finished):
         tab.load_url(QUrl('qute://testdata/data/hints/benchmark.html'))
 
-    manager = qutebrowser.browser.hints.HintManager(win_id=0)
+    manager = qutebrowser.browser.hints.HintManager(win_id=1)
 
     def bench():
         with qtbot.wait_signal(mode_manager.entered):
@@ -72,7 +72,7 @@ def test_match_benchmark(benchmark, tabbed_browser, qtbot, mode_manager, qapp,
         tab.load_url(QUrl('qute://testdata/data/hints/benchmark.html'))
 
     config_stub.val.hints.scatter = False
-    manager = qutebrowser.browser.hints.HintManager(win_id=0)
+    manager = qutebrowser.browser.hints.HintManager(win_id=1)
 
     with qtbot.wait_signal(mode_manager.entered):
         manager.start()
@@ -101,7 +101,7 @@ def test_scattered_hints_count(min_len, num_chars, num_elements):
     2. There can only be two hint lengths, only 1 apart
     3. There are no unique prefixes for long hints, such as 'la' with no 'l<x>'
     """
-    manager = qutebrowser.browser.hints.HintManager(win_id=0)
+    manager = qutebrowser.browser.hints.HintManager(win_id=1)
     chars = string.ascii_lowercase[:num_chars]
 
     hints = manager._hint_scattered(min_len, chars,

--- a/tests/unit/browser/test_inspector.py
+++ b/tests/unit/browser/test_inspector.py
@@ -57,7 +57,7 @@ def inspector_widget(red_widget):
 @pytest.fixture
 def splitter(qtbot, webview_widget):
     splitter = miscwidgets.InspectorSplitter(
-        win_id=0, main_webview=webview_widget)
+        win_id=1, main_webview=webview_widget)
     qtbot.add_widget(splitter)
     return splitter
 
@@ -67,7 +67,7 @@ def fake_inspector(qtbot, splitter, inspector_widget,
                    state_config, mode_manager):
     insp = FakeInspector(inspector_widget=inspector_widget,
                          splitter=splitter,
-                         win_id=0)
+                         win_id=1)
     qtbot.add_widget(insp)
     return insp
 

--- a/tests/unit/browser/webkit/network/test_networkmanager.py
+++ b/tests/unit/browser/webkit/network/test_networkmanager.py
@@ -27,6 +27,6 @@ pytestmark = pytest.mark.usefixtures('cookiejar_and_cache')
 
 
 def test_init_with_private_mode(fake_args):
-    nam = networkmanager.NetworkManager(win_id=0, tab_id=0, private=True)
+    nam = networkmanager.NetworkManager(win_id=1, tab_id=0, private=True)
     assert isinstance(nam.cookieJar(), cookies.RAMCookieJar)
     assert nam.cache() is None

--- a/tests/unit/browser/webkit/test_webview.py
+++ b/tests/unit/browser/webkit/test_webview.py
@@ -23,7 +23,7 @@ webview = pytest.importorskip('qutebrowser.browser.webkit.webview')
 
 @pytest.fixture
 def real_webview(webkit_tab, qtbot):
-    wv = webview.WebView(win_id=0, tab_id=0, tab=webkit_tab, private=False)
+    wv = webview.WebView(win_id=1, tab_id=0, tab=webkit_tab, private=False)
     qtbot.add_widget(wv)
     return wv
 

--- a/tests/unit/commands/test_userscripts.py
+++ b/tests/unit/commands/test_userscripts.py
@@ -251,4 +251,4 @@ def test_unicode_error(caplog, qtbot, py_proc, runner):
 def test_unsupported(tabbed_browser_stubs):
     with pytest.raises(userscripts.UnsupportedError, match="Userscripts are "
                        "not supported on this platform!"):
-        userscripts.run_async(tab=None, cmd=None, win_id=0, env=None)
+        userscripts.run_async(tab=None, cmd=None, win_id=1, env=None)

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -73,7 +73,7 @@ def completer_obj(qtbot, status_command_stub, config_stub, monkeypatch, stubs,
     """Create the completer used for testing."""
     monkeypatch.setattr(completer, 'QTimer', stubs.InstaTimer)
     config_stub.val.completion.show = 'auto'
-    return completer.Completer(cmd=status_command_stub, win_id=0,
+    return completer.Completer(cmd=status_command_stub, win_id=1,
                                parent=completion_widget_stub)
 
 

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -38,7 +38,7 @@ def completionview(qtbot, status_command_stub, config_stub, win_registry,
     mocker.patch(
         'qutebrowser.completion.completiondelegate.CompletionItemDelegate',
         new=lambda *_: None)
-    view = completionwidget.CompletionView(cmd=status_command_stub, win_id=0)
+    view = completionwidget.CompletionView(cmd=status_command_stub, win_id=1)
     qtbot.addWidget(view)
     return view
 

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -221,7 +221,7 @@ def web_history_populated(web_history):
 def info(config_stub, key_config_stub):
     return completer.CompletionInfo(config=config_stub,
                                     keyconf=key_config_stub,
-                                    win_id=0,
+                                    win_id=1,
                                     cur_tab=None)
 
 
@@ -833,7 +833,7 @@ def test_other_buffer_completion(qtmodeltester, fake_web_tab, win_registry,
     tabbed_browser_stubs[1].widget.tabs = [
         fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
     ]
-    info.win_id = 1
+    info.win_id = 2
     model = miscmodels.other_buffer(info=info)
     model.set_pattern('')
     qtmodeltester.check(model)
@@ -857,7 +857,7 @@ def test_other_buffer_completion_id0(qtmodeltester, fake_web_tab,
     tabbed_browser_stubs[1].widget.tabs = [
         fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
     ]
-    info.win_id = 0
+    info.win_id = 1
     model = miscmodels.other_buffer(info=info)
     model.set_pattern('')
     qtmodeltester.check(model)
@@ -879,7 +879,7 @@ def test_tab_focus_completion(qtmodeltester, fake_web_tab, win_registry,
     tabbed_browser_stubs[1].widget.tabs = [
         fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
     ]
-    info.win_id = 1
+    info.win_id = 2
     model = miscmodels.tab_focus(info=info)
     model.set_pattern('')
     qtmodeltester.check(model)
@@ -915,7 +915,7 @@ def test_window_completion(qtmodeltester, fake_web_tab, tabbed_browser_stubs,
         fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0)
     ]
 
-    info.win_id = 1
+    info.win_id = 2
     model = miscmodels.window(info=info)
     model.set_pattern('')
     qtmodeltester.check(model)

--- a/tests/unit/config/test_configcommands.py
+++ b/tests/unit/config/test_configcommands.py
@@ -58,7 +58,7 @@ class TestSet:
         """Run ':set'.
 
         Should open qute://settings."""
-        commands.set(win_id=0)
+        commands.set(win_id=1)
         assert tabbed_browser_stubs[0].loaded_url == QUrl('qute://settings')
 
     @pytest.mark.parametrize('option', ['url.auto_search?', 'url.auto_search'])
@@ -68,7 +68,7 @@ class TestSet:
         Should show the value.
         """
         config_stub.val.url.auto_search = 'never'
-        commands.set(win_id=0, option=option)
+        commands.set(win_id=1, option=option)
         msg = message_mock.getmsg(usertypes.MessageLevel.info)
         assert msg.text == 'url.auto_search = never'
 
@@ -191,7 +191,7 @@ class TestSet:
         See https://github.com/qutebrowser/qutebrowser/issues/1109
         """
         with pytest.raises(cmdutils.CommandError, match="No option '?'"):
-            commands.set(win_id=0, option='?')
+            commands.set(win_id=1, option='?')
 
     def test_toggle(self, commands):
         """Try toggling a value.
@@ -201,7 +201,7 @@ class TestSet:
         with pytest.raises(cmdutils.CommandError,
                            match="Toggling values was moved to the "
                                  ":config-cycle command"):
-            commands.set(win_id=0, option='javascript.enabled!')
+            commands.set(win_id=1, option='javascript.enabled!')
 
     def test_invalid(self, commands):
         """Run ':set foo?'.
@@ -209,14 +209,14 @@ class TestSet:
         Should show an error.
         """
         with pytest.raises(cmdutils.CommandError, match="No option 'foo'"):
-            commands.set(win_id=0, option='foo?')
+            commands.set(win_id=1, option='foo?')
 
 
 def test_diff(commands, tabbed_browser_stubs):
     """Run ':config-diff'.
 
     Should open qute://configdiff."""
-    commands.config_diff(win_id=0)
+    commands.config_diff(win_id=1)
     assert tabbed_browser_stubs[0].loaded_url == QUrl('qute://configdiff')
 
 
@@ -698,7 +698,7 @@ class TestBind:
         Should open qute://bindings."""
         config_stub.val.bindings.default = no_bindings
         config_stub.val.bindings.commands = no_bindings
-        commands.bind(win_id=0)
+        commands.bind(win_id=1)
         assert tabbed_browser_stubs[0].loaded_url == QUrl('qute://bindings')
 
     @pytest.mark.parametrize('command', ['nop', 'nope'])

--- a/tests/unit/keyinput/test_basekeyparser.py
+++ b/tests/unit/keyinput/test_basekeyparser.py
@@ -34,7 +34,7 @@ def keyseq(s):
 
 
 def _create_keyparser(mode):
-    kp = basekeyparser.BaseKeyParser(mode=mode, win_id=0)
+    kp = basekeyparser.BaseKeyParser(mode=mode, win_id=1)
     kp.execute = mock.Mock()
     return kp
 
@@ -84,7 +84,7 @@ class TestDebugLog:
 ])
 def test_split_count(config_stub, key_config_stub,
                      input_key, supports_count, count, command):
-    kp = basekeyparser.BaseKeyParser(mode=usertypes.KeyMode.normal, win_id=0,
+    kp = basekeyparser.BaseKeyParser(mode=usertypes.KeyMode.normal, win_id=1,
                                      supports_count=supports_count)
 
     for info in keyseq(input_key):

--- a/tests/unit/keyinput/test_modeparsers.py
+++ b/tests/unit/keyinput/test_modeparsers.py
@@ -43,7 +43,7 @@ class TestsNormalKeyParser:
 
     @pytest.fixture
     def keyparser(self, commandrunner):
-        kp = modeparsers.NormalKeyParser(win_id=0, commandrunner=commandrunner)
+        kp = modeparsers.NormalKeyParser(win_id=1, commandrunner=commandrunner)
         return kp
 
     def test_keychain(self, keyparser, commandrunner):
@@ -91,7 +91,7 @@ class TestHintKeyParser:
     @pytest.fixture
     def keyparser(self, config_stub, key_config_stub, commandrunner,
                   hintmanager):
-        return modeparsers.HintKeyParser(win_id=0,
+        return modeparsers.HintKeyParser(win_id=1,
                                          hintmanager=hintmanager,
                                          commandrunner=commandrunner)
 

--- a/tests/unit/misc/test_miscwidgets.py
+++ b/tests/unit/misc/test_miscwidgets.py
@@ -145,7 +145,7 @@ class TestInspectorSplitter:
     @pytest.fixture
     def splitter(self, qtbot, fake_webview):
         inspector_splitter = miscwidgets.InspectorSplitter(
-            win_id=0, main_webview=fake_webview)
+            win_id=1, main_webview=fake_webview)
         qtbot.add_widget(inspector_splitter)
         return inspector_splitter
 

--- a/tests/unit/misc/test_sessions.py
+++ b/tests/unit/misc/test_sessions.py
@@ -144,10 +144,10 @@ class FakeMainWindow(QObject):
 @pytest.fixture
 def fake_window(tabbed_browser_stubs):
     """Fixture which provides a fake main windows with a tabbedbrowser."""
-    win0 = FakeMainWindow(b'fake-geometry-0', win_id=0)
-    objreg.register('main-window', win0, scope='window', window=0)
+    win1 = FakeMainWindow(b'fake-geometry-0', win_id=1)
+    objreg.register('main-window', win1, scope='window', window=1)
     yield
-    objreg.delete('main-window', scope='window', window=0)
+    objreg.delete('main-window', scope='window', window=1)
 
 
 class TestSaveAll:
@@ -184,8 +184,8 @@ class TestSave:
     @pytest.fixture
     def fake_history(self, stubs, tabbed_browser_stubs, monkeypatch, webview):
         """Fixture which provides a window with a fake history."""
-        win = FakeMainWindow(b'fake-geometry-0', win_id=0)
-        objreg.register('main-window', win, scope='window', window=0)
+        win = FakeMainWindow(b'fake-geometry-0', win_id=1)
+        objreg.register('main-window', win, scope='window', window=1)
 
         browser = tabbed_browser_stubs[0]
         qapp = stubs.FakeQApplication(active_window=win)
@@ -200,8 +200,8 @@ class TestSave:
 
         yield set_data
 
-        objreg.delete('main-window', scope='window', window=0)
-        objreg.delete('tabbed-browser', scope='window', window=0)
+        objreg.delete('main-window', scope='window', window=1)
+        objreg.delete('tabbed-browser', scope='window', window=1)
 
     def test_no_state_config(self, sess_man, tmp_path, state_config):
         session_path = tmp_path / 'foo.yml'

--- a/tests/unit/misc/test_utilcmds.py
+++ b/tests/unit/misc/test_utilcmds.py
@@ -37,7 +37,7 @@ def test_repeat_command_initial(mocker, mode_manager):
     objreg_mock.get.return_value = mode_manager
     with pytest.raises(cmdutils.CommandError,
                        match="You didn't do anything yet."):
-        utilcmds.repeat_command(win_id=0)
+        utilcmds.repeat_command(win_id=1)
 
 
 class FakeWindow:
@@ -60,7 +60,7 @@ def test_window_only(mocker, monkeypatch):
     winreg_mock.window_registry = test_windows
     sip_mock = mocker.patch('qutebrowser.misc.utilcmds.sip')
     sip_mock.isdeleted.side_effect = lambda window: window.deleted
-    utilcmds.window_only(current_win_id=0)
+    utilcmds.window_only(current_win_id=1)
     assert not test_windows[0].closed
     assert not test_windows[1].closed
     assert test_windows[2].closed
@@ -75,5 +75,5 @@ def tabbed_browser(stubs, win_registry):
 
 
 def test_version(tabbed_browser, qapp):
-    utilcmds.version(win_id=0)
+    utilcmds.version(win_id=1)
     assert tabbed_browser.loaded_url == QUrl('qute://version/')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
Seems to work for me and tests ran ok afaict. (Little unhappy with only having python 3.9, not 3.8).
`1gD` now correctly gives to the window with `win_id == 1`.

This solves part of #4529. Doing the same change for tabs is also suggested, but `1gm` works fine. So not sure if the change makes sense there. The difference is also, that tabs are organized as a list and the user-facing tab_index afaics is already starting from `1`.