### PR TITLE
userscripts/password_fill LastPass backend

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -210,6 +210,78 @@ choose_entry_zenity_radio() {
     choose_entry_menu || true
 }
 
+# Default backend selection.
+backend="pass"
+
+# =======================================================
+# backend: LastPass. 
+# The LastPass backend depnds only on a system installation of lastpass-cli.
+# Users must define their lastpass username in password_fill_rc and set 
+# the backend variable to "last_pass"
+# e.g.
+#
+# #!/usr/bin/env bash
+# username=lp-username@email.com
+# backend=last_pass
+#
+# Temporary files are created that store account user name along
+# with the lastpass id for a given address. Users can redefine where the
+# temporary files will be saved with LP_CACHE_PREFIX the default is as such.
+#
+# No password data is ever written to a file with this method.
+
+LP_CACHE_PREFIX=$HOME/.local/share/qutebrowser/userscripts/id_cache
+
+last_pass_backend() {
+    init() {
+      PREFIX=$LP_CACHE_PREFIX
+      set +e
+
+      # Remove any old LP temporary id files.
+      for f in $PREFIX/; do
+        [ -f $f ] && rm $f 
+      done
+
+      # Check to see if the system is logged into LP else prompt
+      # the user with the LP login.
+      lpass ls
+      if ! [ $? -eq 0 ]; then
+        lpass login --trust $username
+        lpass ls
+        if [ $? -eq 0 ]; then
+          msg "Lastpass successful login."
+        else
+          die "Lastpass failed to initialize correctly."
+        fi
+      fi
+      set -e
+    }
+
+    query_entries() {
+        local url="$1"
+
+        set +e
+        lpass show $url
+        if [ $? -eq 0 ]; then
+            # Save files as usernames w/ corresponding LP id token.
+            for id in $(lpass show --id -x $url); do
+                echo "$id" > $PREFIX/$(lpass show --username -x $id)
+                files+=("$(lpass show --username -x $id)")
+            done
+        fi
+        set -e
+    }
+
+    open_entry() {
+        # Use the id tokens to pull password form the correct LP profile.
+        username="${1#* }"
+        id=$(cat $PREFIX/$username)
+        password=$(lpass show --password -x $id)
+    }
+}
+# =======================================================
+
+
 # =======================================================
 # backend: PASS
 
@@ -299,9 +371,6 @@ secret_backend() {
 }
 # =======================================================
 
-# load some sane default backend
-reset_backend
-pass_backend
 # load configuration
 QUTE_CONFIG_DIR=${QUTE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/}
 PWFILL_CONFIG=${PWFILL_CONFIG:-${QUTE_CONFIG_DIR}/password_fill_rc}
@@ -309,6 +378,12 @@ if [ -f "$PWFILL_CONFIG" ] ; then
     # shellcheck source=/dev/null
     source "$PWFILL_CONFIG"
 fi
+BACKEND_CLASS="$backend"_backend
+
+# load some sane default backend
+reset_backend
+$BACKEND_CLASS
+
 init
 
 simplify_url "$QUTE_URL"

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -111,17 +111,18 @@ simplify_url() {
 # Another behavior is to drop another level of subdomains until search hits
 # are found:
 no_entries_found() {
-    while [ 0 -eq "${#files[@]}" ] && [ -n "$simple_url" ]; do
+    temp_simple_url=$simple_url
+    while [ 0 -eq "${#files[@]}" ] && [ -n "$temp_simple_url" ]; do
         # shellcheck disable=SC2001
-        shorter_simple_url=$(sed 's,^[^.]*\.,,' <<< "$simple_url")
-        if [ "$shorter_simple_url" = "$simple_url" ] ; then
+        shorter_simple_url=$(sed 's,^[^.]*\.,,' <<< "$temp_simple_url")
+        if [ "$shorter_simple_url" = "$temp_simple_url" ] ; then
             # if no dot, then even remove the top level domain
-            simple_url=""
-            query_entries "$simple_url"
+            temp_simple_url=""
+            query_entries "$temp_simple_url"
             break
         fi
-        simple_url="$shorter_simple_url"
-        query_entries "$simple_url"
+        temp_simple_url="$shorter_simple_url"
+        query_entries "$temp_simple_url"
         #die "No entry found for »$simple_url«"
         # enforce menu if we do "fuzzy" matching
         menu_if_one_entry=1

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -230,10 +230,13 @@ backend="pass"
 #
 # No password data is ever written to a file with this method.
 
-LP_CACHE_PREFIX=$HOME/.local/share/qutebrowser/userscripts/id_cache
+LP_CACHE_PREFIX=$HOME/.config/qutebrowser/id_cache
 
 last_pass_backend() {
     init() {
+      [ ! -d $LP_CACHE_PREFIX ] && mkdir $LP_CACHE_PREFIX
+      [ ! -d $LP_CACHE_PREFIX ] && die "Cannot make LP_CACHE_PREFIX dir : $LP_CACHE_PREFIX"
+
       PREFIX=$LP_CACHE_PREFIX
       set +e
 

--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -25,7 +25,7 @@ import shlex
 from PyQt5.QtCore import (pyqtSlot, pyqtSignal, QObject, QProcess,
                           QProcessEnvironment)
 
-from qutebrowser.utils import message, log
+from qutebrowser.utils import message, log, utils
 from qutebrowser.browser import qutescheme
 
 
@@ -78,7 +78,7 @@ class GUIProcess(QObject):
     @pyqtSlot(QProcess.ProcessError)
     def _on_error(self, error):
         """Show a message if there was an error while spawning."""
-        if error == QProcess.Crashed:
+        if error == QProcess.Crashed and not utils.is_windows:
             # Already handled via ExitStatus in _on_finished
             return
         msg = self._proc.errorString()

--- a/qutebrowser/misc/guiprocess.py
+++ b/qutebrowser/misc/guiprocess.py
@@ -75,9 +75,12 @@ class GUIProcess(QObject):
                 procenv.insert(k, v)
             self._proc.setProcessEnvironment(procenv)
 
-    @pyqtSlot()
-    def _on_error(self):
+    @pyqtSlot(QProcess.ProcessError)
+    def _on_error(self, error):
         """Show a message if there was an error while spawning."""
+        if error == QProcess.Crashed:
+            # Already handled via ExitStatus in _on_finished
+            return
         msg = self._proc.errorString()
         message.error("Error while spawning {}: {}".format(self._what, msg))
 
@@ -101,7 +104,7 @@ class GUIProcess(QObject):
                 message.error(stderr.strip())
 
         if status == QProcess.CrashExit:
-            exitinfo = "{} crashed!".format(self._what.capitalize())
+            exitinfo = "{} crashed.".format(self._what.capitalize())
             message.error(exitinfo)
         elif status == QProcess.NormalExit and code == 0:
             exitinfo = "{} exited successfully.".format(

--- a/tests/unit/misc/test_guiprocess.py
+++ b/tests/unit/misc/test_guiprocess.py
@@ -237,6 +237,18 @@ def test_exit_unsuccessful(qtbot, proc, message_mock, py_proc, caplog):
     assert msg.text == expected
 
 
+def test_exit_crash(qtbot, proc, message_mock, py_proc, caplog):
+    with caplog.at_level(logging.ERROR):
+        with qtbot.waitSignal(proc.finished, timeout=10000):
+            proc.start(*py_proc("""
+                import os, signal
+                os.kill(os.getpid(), signal.SIGSEGV)
+            """))
+
+    msg = message_mock.getmsg(usertypes.MessageLevel.error)
+    assert msg.text == "Testprocess crashed."
+
+
 @pytest.mark.parametrize('stream', ['stdout', 'stderr'])
 def test_exit_unsuccessful_output(qtbot, proc, caplog, py_proc, stream):
     """When a process fails, its output should be logged."""

--- a/tests/unit/misc/test_guiprocess.py
+++ b/tests/unit/misc/test_guiprocess.py
@@ -25,7 +25,7 @@ import pytest
 from PyQt5.QtCore import QProcess
 
 from qutebrowser.misc import guiprocess
-from qutebrowser.utils import usertypes
+from qutebrowser.utils import usertypes, utils
 from qutebrowser.browser import qutescheme
 
 
@@ -245,8 +245,12 @@ def test_exit_crash(qtbot, proc, message_mock, py_proc, caplog):
                 os.kill(os.getpid(), signal.SIGSEGV)
             """))
 
+    expected = (
+        "Testprocess exited with status 11, see :messages for details."
+        if utils.is_windows else "Testprocess crashed."
+    )
     msg = message_mock.getmsg(usertypes.MessageLevel.error)
-    assert msg.text == "Testprocess crashed."
+    assert msg.text == expected
 
 
 @pytest.mark.parametrize('stream', ['stdout', 'stderr'])


### PR DESCRIPTION
I regrettably missed the qute-lastpass userscript until I had had almost finished implementing this myself, but I thought I'd submit a PR in case this alternative could be useful.

# Summary
This is a very simple backend implementation of lastpass for the `password_fill` userscript. There are a couple of differences between this implementation and the `qute-lastpass` script.
- This implementation will automatically prompt users to log into lastpass as needed with a dialog.
- This only depends on a system installation of lastpass-cli and not `tldextract`.

## Design
The last pass `password_fill` implementation works by generating temporary files saved as all possible usernames with for a given url. These files containing their corresponding lastpass id. This id is then used to extract the password for the selected account. All temporary files are removed before the next call to the backend.

### How To:
To use, define a `username` and `backend` vars within `password_fill_rc`. A third var `LP_CACHE_PREFIX` can be defined, this is used to determine the temporary file directory for the username ids.

Example `password_fill_rc` :
```
# !/usr/bin/env bash
username=lp-username@email.com
backend=last_pass
```
