### PR TITLE
Change default fileselect commands

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -2797,7 +2797,8 @@ Default:
 
 - +pass:[xterm]+
 - +pass:[-e]+
-- +pass:[ranger --choosefiles={}]+
+- +pass:[ranger]+
+- +pass:[--choosefiles={}]+
 
 [[fileselect.single_file.command]]
 === fileselect.single_file.command
@@ -2811,7 +2812,8 @@ Default:
 
 - +pass:[xterm]+
 - +pass:[-e]+
-- +pass:[ranger --choosefile={}]+
+- +pass:[ranger]+
+- +pass:[--choosefile={}]+
 
 [[fonts.completion.category]]
 === fonts.completion.category

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1222,9 +1222,9 @@ fileselect.single_file.command:
     name: ShellCommand
     placeholder: true
     completions:
-      - ['["xterm", "-e", "ranger --choosefile={}"]', "Ranger in xterm"]
+      - ['["xterm", "-e", "ranger", "--choosefile={}"]', "Ranger in xterm"]
       - ['["xterm", "-e", "vifm", "--choose-file", "{}"]', "vifm in xterm"]
-  default: ['xterm', '-e', 'ranger --choosefile={}']
+  default: ['xterm', '-e', 'ranger', '--choosefile={}']
   desc: >-
     Command (and arguments) to use for selecting a single file in forms.
     The command should write the selected file path to the specified file.
@@ -1238,9 +1238,9 @@ fileselect.multiple_files.command:
     name: ShellCommand
     placeholder: true
     completions:
-      - ['["xterm", "-e", "ranger --choosefiles={}"]', "Ranger in xterm"]
+      - ['["xterm", "-e", "ranger", "--choosefiles={}"]', "Ranger in xterm"]
       - ['["xterm", "-e", "vifm", "--choose-files", "{}"]', "vifm in xterm"]
-  default: ['xterm', '-e', 'ranger --choosefiles={}']
+  default: ['xterm', '-e', 'ranger', '--choosefiles={}']
   desc: >-
     Command (and arguments) to use for selecting multiple files in forms.
     The command should write the selected file paths to the specified file,


### PR DESCRIPTION
Default `fileselect.*.command` doesn't work with terminals other than xterm (at lease in st and alacritty). Since default is xterm, this is fine but simply replacing xterm with another terminal should work.
