### PR TITLE
pdfjs is in the official repositories, no more in the AUR

### DIFF
--- a/qutebrowser/browser/pdfjs.py
+++ b/qutebrowser/browser/pdfjs.py
@@ -30,11 +30,11 @@ from qutebrowser.config import config
 
 _SYSTEM_PATHS = [
     # Debian pdf.js-common
-    # Arch Linux pdfjs (AUR)
+    # Arch Linux pdfjs
     '/usr/share/pdf.js/',
     # Flatpak (Flathub)
     '/app/share/pdf.js/',
-    # Arch Linux pdf.js (AUR)
+    # Arch Linux pdf.js (defunct)
     '/usr/share/javascript/pdf.js/',
     # Debian libjs-pdf
     '/usr/share/javascript/pdf/',

--- a/qutebrowser/html/no_pdfjs.html
+++ b/qutebrowser/html/no_pdfjs.html
@@ -91,8 +91,9 @@ li {
             If you have installed a packaged version of qutebrowser, make sure
             the required packages for pdf.js are also installed.
             <br/>
-            The package is named <b>pdfjs</b> on Archlinux (AUR) and
-            <b>libjs-pdf</b> on Debian.
+            The package is named
+            <a href="https://archlinux.org/packages/community/any/pdfjs/"><b>pdfjs</b></a> on Archlinux
+            and <a href="https://packages.debian.org/bullseye/libjs-pdf"><b>libjs-pdf</b></a> on Debian.
           </li>
 
           <li>


### PR DESCRIPTION
Closes #6076 (which is actually a "discussion", not an "issue").