### PR TITLE
Add python3 as shebang to avoid lintian warning when building debian …

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Executes python-readability on current page and opens the summary as new tab.
 #

--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 #
 # Adds DuckDuckGo bang as searchengine.
 #


### PR DESCRIPTION
…packages

As discussed in IRC this is used to fix lintian warning when building the debian packages and would spare us one patch.
