### PR TITLE
Fix link to cheatsheet in help page

### DIFF
--- a/doc/quickstart.asciidoc
+++ b/doc/quickstart.asciidoc
@@ -22,7 +22,7 @@ Basic keybindings to get you started
 What to do now
 --------------
 
-* View the link:https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png[key binding cheatsheet]
+* View the https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png[key binding cheatsheet]
 to make yourself familiar with the key bindings: +
 image:https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-small.png["qutebrowser key binding cheatsheet",link="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png"]
 * There's also a https://www.shortcutfoo.com/app/dojos/qutebrowser[free training

--- a/scripts/asciidoc2html.py
+++ b/scripts/asciidoc2html.py
@@ -91,7 +91,7 @@ class AsciiDoc:
         # patch image links to use local copy
         replacements = [
             ("https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png",
-             "qute://help/img/cheatsheet-big.png"),
+             "link:qute://help/img/cheatsheet-big.png"),
             ("https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-small.png",
              "qute://help/img/cheatsheet-small.png")
         ]


### PR DESCRIPTION
The link to the cheatsheet is broken when browsed using `:help` (see attached screenshot). This PR fixes this - at least locally.

![2021-01-29-121929_747x240_scrot](https://user-images.githubusercontent.com/25295717/106269123-63f4c200-622c-11eb-941c-98251d1e26c9.png)
