### PR TITLE
Prevent crash on non-UTF-8 hint dictionary

### DIFF
--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -1074,6 +1074,9 @@ class WordHinter:
             except OSError as e:
                 error = "Word hints requires reading the file at {}: {}"
                 raise HintingError(error.format(dictionary, str(e)))
+            except UnicodeDecodeError as e:
+                error = "Word hints expects the file at {} to be encoded as UTF-8: {}"
+                raise HintingError(error.format(dictionary, str(e)))
 
     def extract_tag_words(
             self, elem: webelem.AbstractWebElement


### PR DESCRIPTION
This PR fixes a crash when using the `:hint` command while `hints.mode` is set to `word` and `hints.dictionary` points to a file that can't be decoded as UTF-8.