### PR TITLE
Don't save commands starting with space

### DIFF
--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -187,10 +187,11 @@ class Command(misc.MinimalLineEditMixin, misc.CommandLineEdit):
         Args:
             rapid: Run the command without closing or clearing the command bar.
         """
-        text = self.text()
-        self.history.append(text)
-
         was_search = self._handle_search()
+
+        text = self.text()
+        if not (self.prefix() == ':' and text[1:].startswith(' ')):
+            self.history.append(text)
 
         if not rapid:
             modeman.leave(self._win_id, usertypes.KeyMode.command,

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -468,6 +468,18 @@ Feature: Various utility commands.
         And I run :command-accept
         Then the message "blah" should be shown
 
+    Scenario: Command starting with space and calling previous command
+        When I run :set-cmd-text :message-info first
+        And I run :command-accept
+        And I wait for "first" in the log
+        When I run :set-cmd-text : message-info second
+        And I run :command-accept
+        And I wait for "second" in the log
+        And I run :set-cmd-text :
+        And I run :command-history-prev
+        And I run :command-accept
+        Then the message "first" should be shown
+
     Scenario: Calling previous command with :completion-item-focus
         When I run :set-cmd-text :message-info blah
         And I wait for "Entering mode KeyMode.command (reason: *)" in the log


### PR DESCRIPTION
Related to #2865

Ex commands (from `:` prompt) that start with a space are not saved to command history.