### PR TITLE
Handle error if fileselector deletes temporary file

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -372,8 +372,12 @@ def choose_file(multiple: bool) -> List[str]:
         proc.finished.connect(lambda _code, _status: loop.exit())
         loop.exec()
 
-        with open(tmpfilename, mode='r', encoding=sys.getfilesystemencoding()) as f:
-            selected_files = f.read().splitlines()
+        try:
+            with open(tmpfilename, mode='r', encoding=sys.getfilesystemencoding()) as f:
+                selected_files = f.read().splitlines()
+        except OSError as e:
+            message.warning(f"Failed to open tempfile {tmpfilename} ({e})!")
+            selected_files = []
 
     if not multiple:
         if len(selected_files) > 1:

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -376,7 +376,7 @@ def choose_file(multiple: bool) -> List[str]:
             with open(tmpfilename, mode='r', encoding=sys.getfilesystemencoding()) as f:
                 selected_files = f.read().splitlines()
         except OSError as e:
-            message.warning(f"Failed to open tempfile {tmpfilename} ({e})!")
+            message.error(f"Failed to open tempfile {tmpfilename} ({e})!")
             selected_files = []
 
     if not multiple:

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -227,5 +227,6 @@ Feature: Opening external editors
         And I set fileselect.single_file.command to ['rm', '{}']
         And I open data/fileselect.html
         And I run :click-element id single_file
-        Then the warning "Failed to open tempfile .*" should be shown
-        And the javascript message "Files: 1.txt" should not be logged
+        Then the javascript message "Files: 1.txt" should not be logged
+        And the error "Failed to open tempfile *" should be shown
+        And "Failed to delete tempfile *" should be logged with level error

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -219,3 +219,13 @@ Feature: Opening external editors
         And I open data/fileselect.html
         And I run :click-element id multiple_files
         Then the javascript message "Files: 1.txt, 2.txt" should be logged
+
+    ## No temporary file created
+
+    Scenario: File selector deleting temporary file
+        When I set fileselect.handler to external
+        And I set fileselect.single_file.command to ['rm', '{}']
+        And I open data/fileselect.html
+        And I run :click-element id single_file
+        Then the warning "Failed to open tempfile .*" should be shown
+        And the javascript message "Files: 1.txt" should not be logged


### PR DESCRIPTION
Closes #6175 

@The-Compiler I think actually it was indeed the `nnn` which accidentally deleted the file, since we do create it [here](https://github.com/AckslD/qutebrowser/blob/6175-no-tmp-file/qutebrowser/browser/shared.py#L358).

Anyway, I added a try-except block and a test where the fileselector is just `['rm', '{}']`.

Is there any way to assert a warning but using e.g. a regex in the `Then the warning ... should be shown`? For example the error is now something like 
```
Failed to open tempfile /tmp/qutebrowser-fileselect-moc83tj9 ([Errno 2] No such file or directory: '/tmp/qutebrowser-fileselect-moc83tj9')!
```
but I would like to just assert the
```
Failed to open tempfile .*!
```
part.

Btw, what's your view on #6116 ?