### PR TITLE
Use link instead of button+JS in error page

### DIFF
--- a/qutebrowser/html/error.html
+++ b/qutebrowser/html/error.html
@@ -57,14 +57,6 @@ li {
 }
 {% endblock %}
 
-{% block script %}
-{{ super() }}
-function tryagain()
-{
-    location.href = "{{ url|js_string_escape|safe }}";
-}
-{% endblock %}
-
 {% block content %}
 <div id="error-container">
 	<table>
@@ -77,9 +69,7 @@ function tryagain()
 				Error while opening {{ url | default('page', true) }}<br>
 				<p id="error-message-text" style="color: #a31a1a;">{{ error }}</p><br><br>
 
-				<form name="bl">
-					<input type="button" value="Try again" onclick="javascript:tryagain()" />
-				</form>
+				<a href="{{ url }}">Try again</a>
 			</td>
 		</tr>
 	</table>

--- a/qutebrowser/utils/jinja.py
+++ b/qutebrowser/utils/jinja.py
@@ -31,7 +31,7 @@ import jinja2
 import jinja2.nodes
 from PyQt5.QtCore import QUrl
 
-from qutebrowser.utils import utils, urlutils, log, qtutils, javascript
+from qutebrowser.utils import utils, urlutils, log, qtutils
 from qutebrowser.misc import debugcachestats
 
 
@@ -95,7 +95,6 @@ class Environment(jinja2.Environment):
         self.globals['file_url'] = urlutils.file_url
         self.globals['data_url'] = self._data_url
         self.globals['qcolor_to_qsscolor'] = qtutils.qcolor_to_qsscolor
-        self.filters['js_string_escape'] = javascript.string_escape
         self._autoescape = True
 
     @contextlib.contextmanager


### PR DESCRIPTION
Instead of using JavaScript for the "Try again" link on the error page, use a regular link which works even when `content.javascript.enabled` is set to false.

Closes #6204