### PR TITLE
Replaced os.stat by the pathlib equivalent

### DIFF
--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -223,12 +223,13 @@ def _update_file(filename, contents):
     This might write the file multiple times, but different systems have
     different mtime's, so we can't be sure how long to wait otherwise.
     """
-    old_mtime = new_mtime = os.stat(filename).st_mtime
+    file_path = pathlib.Path(filename)
+    old_mtime = new_mtime = file_path.stat().st_mtime
     while old_mtime == new_mtime:
         time.sleep(0.1)
         with open(filename, 'w', encoding='utf-8') as f:
             f.write(contents)
-        new_mtime = os.stat(filename).st_mtime
+        new_mtime = file_path.stat().st_mtime
 
 
 def test_modify_watch(qtbot):

--- a/tests/unit/misc/test_ipc.py
+++ b/tests/unit/misc/test_ipc.py
@@ -322,7 +322,7 @@ class TestListen:
         print('sockdir: {} / owner {} / mode {:o}'.format(
             sockdir, dir_stat.st_uid, dir_stat.st_mode))
         print('sockfile: {} / owner {} / mode {:o}'.format(
-            sockfile, file_stat.st_uid, file_stat.st_mode))
+            sockfile_path, file_stat.st_uid, file_stat.st_mode))
 
         assert file_owner_ok or dir_owner_ok
         assert file_mode_ok or dir_mode_ok

--- a/tests/unit/misc/test_ipc.py
+++ b/tests/unit/misc/test_ipc.py
@@ -309,7 +309,8 @@ class TestListen:
         sockfile = ipc_server._server.fullServerName()
         sockdir = pathlib.Path(sockfile).parent
 
-        file_stat = os.stat(sockfile)
+        sockfile_path = pathlib.Path(sockfile)
+        file_stat = sockfile_path.stat()
         dir_stat = sockdir.stat()
 
         # pylint: disable=no-member,useless-suppression
@@ -331,7 +332,9 @@ class TestListen:
     def test_atime_update(self, qtbot, ipc_server):
         ipc_server._atime_timer.setInterval(500)  # We don't want to wait
         ipc_server.listen()
-        old_atime = os.stat(ipc_server._server.fullServerName()).st_atime_ns
+
+        sockfile_path = pathlib.Path(ipc_server._server.fullServerName())
+        old_atime = sockfile_path.stat().st_atime_ns
 
         with qtbot.waitSignal(ipc_server._atime_timer.timeout, timeout=2000):
             pass
@@ -340,7 +343,7 @@ class TestListen:
         with qtbot.waitSignal(ipc_server._atime_timer.timeout, timeout=2000):
             pass
 
-        new_atime = os.stat(ipc_server._server.fullServerName()).st_atime_ns
+        new_atime = sockfile_path.stat().st_atime_ns
 
         assert old_atime != new_atime
 

--- a/tests/unit/misc/test_ipc.py
+++ b/tests/unit/misc/test_ipc.py
@@ -306,10 +306,9 @@ class TestListen:
     @pytest.mark.posix
     def test_permissions_posix(self, ipc_server):
         ipc_server.listen()
-        sockfile = ipc_server._server.fullServerName()
-        sockdir = pathlib.Path(sockfile).parent
+        sockfile_path = pathlib.Path(ipc_server._server.fullServerName())
+        sockdir = sockfile_path.parent
 
-        sockfile_path = pathlib.Path(sockfile)
         file_stat = sockfile_path.stat()
         dir_stat = sockdir.stat()
 


### PR DESCRIPTION
Replaced the os methods by their pathlib equivalent when available according to the doc and #176
in the tests/units/misc directory

I'll look into the rest when my exams are finished