### PR TITLE
PR makes :open command in pinned-tab open in new tab.

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -329,7 +329,9 @@ class CommandDispatcher:
                         # Explicit count with a tab that doesn't exist.
                         return
                 elif curtab.navigation_blocked():
-                    message.info("Tab is pinned!")
+                    message.info("Tab is pinned! Opening in new tab")
+                    self._tabbed_browser.tabopen(cur_url)
+
                 else:
                     curtab.load_url(cur_url)
 

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -395,9 +395,10 @@ Feature: Saving and loading sessions
       And I run :session-load -c pin_session
       And I wait until data/numbers/3.txt is loaded
       And I run :tab-focus 2
-      And I run :open hello world
-      Then the message "Tab is pinned!" should be shown
+      And I run :open data/numbers/4.txt
+      Then the message "Tab is pinned! Opening in new tab" should be shown
       And the following tabs should be open:
         - data/numbers/1.txt
         - data/numbers/2.txt (active) (pinned)
+        - data/numbers/4.txt
         - data/numbers/3.txt

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1534,7 +1534,7 @@ Feature: Tab management
     Scenario: :tab-pin open url
         When I open data/numbers/1.txt
         And I run :tab-pin
-        And I open data/numbers/2.txt without waiting
+        And I open data/numbers/2.txt
         Then the message "Tab is pinned! Opening in new tab" should be shown
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1535,9 +1535,10 @@ Feature: Tab management
         When I open data/numbers/1.txt
         And I run :tab-pin
         And I open data/numbers/2.txt without waiting
-        Then the message "Tab is pinned!" should be shown
+        Then the message "Tab is pinned!Opening in new tab" should be shown
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
+            - data/numbers/2.txt
 
     Scenario: :tab-pin open url with tabs.pinned.frozen = false
         When I set tabs.pinned.frozen to false

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1535,7 +1535,7 @@ Feature: Tab management
         When I open data/numbers/1.txt
         And I run :tab-pin
         And I open data/numbers/2.txt without waiting
-        Then the message "Tab is pinned!Opening in new tab" should be shown
+        Then the message "Tab is pinned! Opening in new tab" should be shown
         And the following tabs should be open:
             - data/numbers/1.txt (active) (pinned)
             - data/numbers/2.txt


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
This PR modifies the existing :open command so that in a pinned tab it shows a warning '_**Tab is pinned!Opening in new tab**_'.And then opens in a new tab like expected.
Closes #6184 .