### PR TITLE
Allow to change ipc socket with QUTE_SOCKET env var

### DIFF
--- a/qutebrowser/misc/ipc.py
+++ b/qutebrowser/misc/ipc.py
@@ -71,6 +71,9 @@ def _get_socketname(basedir):
     if utils.is_windows:  # pragma: no cover
         return _get_socketname_windows(basedir)
 
+    if os.getenv("QUTE_SOCKET"):
+        return os.getenv("QUTE_SOCKET")
+
     parts_to_hash = [getpass.getuser()]
     if basedir is not None:
         parts_to_hash.append(basedir)

--- a/tests/unit/misc/test_ipc.py
+++ b/tests/unit/misc/test_ipc.py
@@ -89,6 +89,14 @@ def fake_runtime_dir(monkeypatch, short_tmpdir):
     return short_tmpdir
 
 
+@pytest.fixture
+def fake_qute_socket_path(monkeypatch, short_tmpdir):
+    qute_socket = str(short_tmpdir / "qutesocket")
+    monkeypatch.setenv('QUTE_SOCKET', qute_socket)
+    standarddir._init_runtime(args=None)
+    return qute_socket
+
+
 class FakeSocket(QObject):
 
     """A stub for a QLocalSocket.
@@ -226,6 +234,12 @@ class TestSocketName:
     def test_linux(self, basedir, fake_runtime_dir, expected):
         socketname = ipc._get_socketname(basedir)
         expected_path = str(fake_runtime_dir / 'qutebrowser' / expected)
+        assert socketname == expected_path
+
+    @pytest.mark.linux
+    def test_qute_socket_env(self, fake_qute_socket_path):
+        expected_path = str(fake_qute_socket_path)
+        socketname = ipc._get_socketname(None)
         assert socketname == expected_path
 
     def test_other_unix(self):


### PR DESCRIPTION
Hi! I'm using this patch to change the ipc socket path on load; Im new to qutebrowser and not sure if it could be a problem to allow that. Thanks cheers