### PR TITLE
userscripts/readability: add unique body class

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -57,6 +57,9 @@ with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
         title = doc.title()
         content = doc.summary().replace('<html>', HEADER % title)
 
+    # add a class to make styling the page easier
+    content = content.replace('<body>', '<body class="qute-readability">')
+
     with codecs.open(tmpfile, 'w', 'utf-8') as target:
         target.write(content.lstrip())
 

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -131,6 +131,9 @@ getDOM(target, domOpts).then(dom => {
     let article = reader.parse();
     let content = util.format(HEADER, article.title) + article.content;
 
+    // add a class to make styling the page easier
+    content = content.replace('<body>', '<body class="qute-readability">')
+
     fs.writeFile(tmpFile, content, (err) => {
         if (err) {
             qute.messageError([`"${err}"`])


### PR DESCRIPTION
Until per-domains stylesheets are implemented, there is no way to
apply style to the readability page only. With this patch, you can
just use the global setting `content.user_stylesheets` by writing
a more specific CSS selector. For example:

    body.qute-readability {
      font-family: Libertinus;
      font-size: 1.2em;
      text-align: justify;
    }

will change the font and text alignment of the readability page,
without altering the style of other websites.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
