### PR TITLE
userscripts/readability-js: fixup of 55fdae8

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -106,7 +106,12 @@ const HEADER = `
     SAwLTIgMC44OTUtMiAyczAuODk1IDIgMiAyaDIwYzEuMTEgMCAyLTAuODk1IDItMnMtMC44OTUtMi0yLTJ6bTAgOGgtMjBjLTEuMTEgMC0yIDAuODk1LTIg
     MnMwLjg5NSAyIDIgMmgyMGMxLjExIDAgMi0wLjg5NSAyLTJzLTAuODk1LTItMi0yem0tMTIgOGgtOGMtMS4xMSAwLTIgMC44OTUtMiAyczAuODk1IDIgMiA
     yaDhjMS4xMSAwIDItMC44OTUgMi0ycy0wLjg5NS0yLTItMnoiIGZpbGw9IiNmZmYiLz4KPC9nPgo8L3N2Zz4K"/>
-</head>`;
+</head>
+<body class="qute-readability">
+    %s
+</body>
+</html>
+`;
 const scriptsDir = path.join(process.env.QUTE_DATA_DIR, 'userscripts');
 const tmpFile = path.join(scriptsDir, '/readability.html');
 
@@ -129,10 +134,7 @@ else {
 getDOM(target, domOpts).then(dom => {
     let reader = new Readability(dom.window.document);
     let article = reader.parse();
-    let content = util.format(HEADER, article.title) + article.content;
-
-    // add a class to make styling the page easier
-    content = content.replace('<body>', '<body class="qute-readability">')
+    let content = util.format(HEADER, article.title, article.content);
 
     fs.writeFile(tmpFile, content, (err) => {
         if (err) {


### PR DESCRIPTION
The mozilla/readability library doesn't output a body by default.
So, let's add one in the header and plug the result in.

I set up nodejs and tested this properly: It seems to work now.
By the way, I see these two warnings in the console:
```﻿
readability.html:5 The key "text/html" is not recognized and ignored.
readability.html:5 The key "charset" is not recognized and ignored.
```
which are about this tag:
```
<meta name="viewport" content="width=device-width, initial-scale=1, text/html, charset=UTF-8" http-equiv="Content-Type">
```
I'm not sure if it's expected...

cc: @The-Compiler @rien333