### PR TITLE
[readability-js] Use HTML5 meta tag

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -39,8 +39,8 @@ const HEADER = `
 <!DOCTYPE html>
 <html>
 <head>
-    <meta name="viewport" content="width=device-width, initial-scale=1, text/html, charset=UTF-8" http-equiv="Content-Type">
-    </meta>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="UTF-8">
     <title>%s</title>
     <style type="text/css">
         body {


### PR DESCRIPTION
Apparently, a document's charset is [defined differently in HTML5](https://stackoverflow.com/questions/4696499/meta-charset-utf-8-vs-meta-http-equiv-content-type). Most pages on the web specify their `<meta>` tags in a way that matches the contents of this PR (see e.g. this [mozilla page](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta)). 

This fixes a harmless developer console warning oiginally discovered by @rnhmjoj in https://github.com/qutebrowser/qutebrowser/pull/6241#issue-587107512.
