### PR TITLE
[readability-js] Add article metadata on top of the page

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -118,7 +118,7 @@ const HEADER = `
 </head>
 <body class="qute-readability">
     <h1 class="reader-title">%s</h1>
-    <div>From <a class="reader-title" href=%s>%s</a></div>
+    <div>From <a class="reader-title" href="%s">%s</a></div>
     <hr>
     %s
 </body>

--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -52,6 +52,15 @@ const HEADER = `
         h1, h2, h3 {
             line-height: 1.2;
         }
+        h1.reader-title {
+            font-size: 1.85em;
+            line-height: 1.25em;
+            width: 100%;
+            margin: 0 0;
+        }
+        a.reader-title {
+            color: #FFFFFF !important;
+        }
         img {
             max-width:100%;
             height:auto;
@@ -108,6 +117,9 @@ const HEADER = `
     yaDhjMS4xMSAwIDItMC44OTUgMi0ycy0wLjg5NS0yLTItMnoiIGZpbGw9IiNmZmYiLz4KPC9nPgo8L3N2Zz4K"/>
 </head>
 <body class="qute-readability">
+    <h1 class="reader-title">%s</h1>
+    <div>From <a class="reader-title" href=%s>%s</a></div>
+    <hr>
     %s
 </body>
 </html>
@@ -134,7 +146,8 @@ else {
 getDOM(target, domOpts).then(dom => {
     let reader = new Readability(dom.window.document);
     let article = reader.parse();
-    let content = util.format(HEADER, article.title, article.content);
+    let subtitle = (article.siteName == null) ? new URL(process.env.QUTE_URL).hostname : article.siteName;
+    let content = util.format(HEADER, article.title, article.title, process.env.QUTE_URL, subtitle, article.content);
 
     fs.writeFile(tmpFile, content, (err) => {
         if (err) {


### PR DESCRIPTION
This PR solves two problems.

### Problem 1 ###

Unlike chromium's and firefox's reader mode, qute's reader output doesn't display the article's title on top of the page. This was done intentionally, because I felt that one could simply glance the title from the tab bar.

I changed my mind, however. First, one's tab bar can be  hidden. Second, it can also be too cramped to contain discernible textual information. Often, I found myself longing for a quick, easy to parse way to tell what a reader tab I once opened was all about. 


Given the screenshot below, it's difficult to tell what the focused article is about.
![qute-wo-border](https://user-images.githubusercontent.com/10417027/110837411-789f8d80-82a1-11eb-9466-d00c0c7c719a.png)

I think this PR improves this a lot:

![qute1](https://user-images.githubusercontent.com/10417027/110838322-9faa8f00-82a2-11eb-97e6-7fe1d58db7cc.png)

It's also more aesthetically pleasing (imo), and more in line with what people expect from a "reader mode".  (note that the text justification is custom css enabled by the work done in https://github.com/qutebrowser/qutebrowser/commit/55fdae8eed0f93152b5676cca77b6243fd95d9b0)

---

### Problem 2

There's no way to easily get back to the original article if you happened to have closed it (which is not true for firefox/chromium, since they implement reader mode with a toggle button). Hence, I decided to credit the website source in the subtitle as a clickable link. 

mozilla's readability library often returns a website's source as a natural name (e.g. "Encyclopedia Britannica", see above). If this source is unavailable (i.e. `null`) , this PR shows the "base url" of the original site instead. 

For example:

![qute2](https://user-images.githubusercontent.com/10417027/110840152-af2ad780-82a4-11eb-82f6-315d1161426a.png)

