### PR TITLE
create a javascript plugin api

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1050,24 +1050,16 @@ class _WebEngineScripts(QObject):
             utils.read_file('javascript/scroll.js'),
             utils.read_file('javascript/webelem.js'),
             utils.read_file('javascript/caret.js'),
+            utils.read_qfile(':/qtwebchannel/qwebchannel.js'),
+            utils.read_file('javascript/plugin.js'),
         )
         # FIXME:qtwebengine what about subframes=True?
         self._inject_js('js', js_code, subframes=True)
-
-        # Can only use web channel in the mainscript
-        # https://bugreports.qt.io/browse/QTBUG-88875
-        plugin_code = '\n'.join([
-            utils.read_qfile(':/qtwebchannel/qwebchannel.js'),
-            utils.read_file('javascript/plugin.js'),
-        ])
-        self._inject_js('plugin', plugin_code,
-            world=QWebEngineScript.MainWorld,
-            injection_point=QWebEngineScript.DocumentReady,
-            subframes=True)
+        self._widget.page().setWebChannel(self._channel,
+                                          QWebEngineScript.ApplicationWorld)
 
         self._init_stylesheet()
 
-        self._widget.page().setWebChannel(self._channel)
 
         self._greasemonkey.scripts_reloaded.connect(
             self._inject_all_greasemonkey_scripts)

--- a/qutebrowser/javascript/plugin.js
+++ b/qutebrowser/javascript/plugin.js
@@ -1,0 +1,24 @@
+"use strict";
+
+
+window.Qute = {
+    channel: new QWebChannel(qt.webChannelTransport, function(channel) {
+        window.addEventListener('qute', function (e) {
+            const { detail } = e
+            if (detail.type == 'command') {
+                channel.objects.handler.run_command(
+                    e.detail.command,
+                    e.detail.count || 1
+                )
+            }
+        })
+    }),
+    // run command with options
+    run(command, options) {
+        options = Object.assign({node: window, count: 1}, options)
+        options.node.dispatchEvent(new CustomEvent('qute', {
+            bubbles: true,
+            detail: { type: 'command', command, count: options.count}
+        }))
+    }
+}

--- a/qutebrowser/javascript/plugin.js
+++ b/qutebrowser/javascript/plugin.js
@@ -1,24 +1,13 @@
 "use strict";
 
 
-window.Qute = {
-    channel: new QWebChannel(qt.webChannelTransport, function(channel) {
-        window.addEventListener('qute', function (e) {
-            const { detail } = e
-            if (detail.type == 'command') {
-                channel.objects.handler.run_command(
-                    e.detail.command,
-                    e.detail.count || 1
-                )
-            }
-        })
-    }),
+window._qutebrowser.plugin = (function(){
+    const plugin = {}
+    var channel = new QWebChannel(qt.webChannelTransport, function(channel) {
+        plugin.run = function(command, count) {
+            return channel.objects.handler.run_command(command, count)
+        }
+    })
     // run command with options
-    run(command, options) {
-        options = Object.assign({node: window, count: 1}, options)
-        options.node.dispatchEvent(new CustomEvent('qute', {
-            bubbles: true,
-            detail: { type: 'command', command, count: options.count}
-        }))
-    }
-}
+    return plugin
+})()

--- a/qutebrowser/utils/utils.py
+++ b/qutebrowser/utils/utils.py
@@ -262,6 +262,12 @@ def preload_resources() -> None:
         for name in _glob_resources(resource_path, subdir, ext):
             _resource_cache[name] = read_file(name)
 
+def read_qfile(filename: str) -> str:
+    from PyQt5.QtCore import QFile, QIODevice
+    file = QFile(filename)
+    if not file.open(QIODevice.ReadOnly):
+        raise SystemError(f"Failed to load qfile {filename}")
+    return bytes(file.readAll()).decode('utf-8')
 
 def read_file(filename: str) -> str:
     """Get the contents of a file contained with qutebrowser.


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

# Proposal

This is to follow the issue #30.

I have noticed that you said in the issue that you do not want to start javascript
api for the fear that tight integration with in the internal might hamper the
progress of development. 

I am proposing a simple interface that the javascript could invoke the command-line

Basically create a new function called "window.Qute.run" which can invoke the command.

There are a few reason to do this.

1. Some features are much easier to implement in javascript than in python
2. The interface is powerful and consise enough that not much effort needs
  to spend on the qutebrowser's side. And frankly it is easy to change.
3. There is already an greasemonkey script support so this api make the system
  much more powerful.
4. I believe it is better to have some exposure (even quite premature) of
  api early and fast is beneficial. As it helps others to have an idea why
  kind of api is needed for creating a plugin.

---

# Example

Let me give you an example which is also my primary motivation to create such 
pull request in the first place. This is not related but to demostrate this
api is desirable.

I find a more intellegent switching between insert-mode and normal-mode.
1. Automatically switch to insert mode when an editable component is active
2. When pressing `<ESC>` to leave the insert mode, it will behave as if
  `<ESC>` is pressed. For example, when closing google, the suggestion will
  also collapse.
3. Some website will focus by javascript or `tabindex=0`. I want to react to 
  this by automatically switch to insert mode as I see the caret.

If the `window.Qute.run` is exposed. I would be able to achieve this will the
following greasemonkey style script:

```javascript
// == UserScript ==
// @name Auto Focus
// @description Qute autofucs based on javascript
if (!'Qute' in window) {
  console.log('Unsable to find Qute.run, this script will do nothing')
  return
}

function editable() {
  const element = document.activeElement
  return (element.isContentEditable ||
    ['INPUT', 'TEXTAREA'].includes(element.tagName))
}

function changeMode() {
  if (editable()) {
    window.Qute.run('mode-enter insert')
  } else {
    window.Qute.run('mode-enter normal')
  }
}
// after loading we will check if the page is focused automatically
window.addEventListener('load', () => {
  // will use native <esc> which might have additional bindings.
  window.Qute.run('bind -m insert <esc> mode-enter normal;; fake-key <Escape>')
  setTimeout(changeMode, 0)
})
// will remove the focus when esc is pressed, so unbind esc key
window.addEventListener('focusin', changeMode)
window.addEventListener('focusout', changeMode)
window.addEventListener('keyup', (event) => {
  if (event.key == 'Escape' && editable()) {
    document.activeElement.blur()
  }
})
```

It seems that this approach is far easier than the code that implements
the `input.insert_mode.auto_*` settings. (Which I disabled for now)

---

# Result

I understand there might be some more discussion. For example, is it
possible for the command to return values (for example set command without
new value can return the current setting). Then we have a rough but usable and
quite stable plugin system for javascript API.

Regards.
