### PR TITLE
userscripts: keepassxc: Fix broken link

### DIFF
--- a/misc/userscripts/qute-keepassxc
+++ b/misc/userscripts/qute-keepassxc
@@ -70,7 +70,7 @@ GPG might then ask for your private-key passwort whenever you query the database
 [3]: https://gnupg.org/
 [4]: https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-protocol.md
 [5]: https://github.com/qutebrowser/qutebrowser/blob/master/doc/userscripts.asciidoc
-[6]: https://keepassxc.org/docs/keepassxc-browser-migration/
+[6]: https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_setup_browser_integration
 """
 
 import sys


### PR DESCRIPTION
The link [6] in the `qute-keepassxc` userscript points to a documentation site that is not reachable (as of 2021-03-14). This commit repleaces it with the corresponding section in the official doc’s Getting Started guide that explains the steps necessary to set up browser integration with KeepasXC.