### PR TITLE
Add extra options for handling pinned tabs in :tab-only

### DIFF
--- a/misc/userscripts/qute-keepassxc
+++ b/misc/userscripts/qute-keepassxc
@@ -70,7 +70,7 @@ GPG might then ask for your private-key passwort whenever you query the database
 [3]: https://gnupg.org/
 [4]: https://github.com/keepassxreboot/keepassxc-browser/blob/develop/keepassxc-protocol.md
 [5]: https://github.com/qutebrowser/qutebrowser/blob/master/doc/userscripts.asciidoc
-[6]: https://keepassxc.org/docs/keepassxc-browser-migration/
+[6]: https://keepassxc.org/docs/KeePassXC_GettingStarted.html#_setup_browser_integration
 """
 
 import sys

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -798,9 +798,9 @@ class CommandDispatcher:
         if pinned_tabs_cleanup and pinned == 'prompt':
             self._tabbed_browser.tab_close_prompt_if_pinned(
                 pinned_tabs_cleanup,
-                force,
+                pinned == 'close',
                 lambda: self.tab_only(
-                    prev=prev, next_=next_, force=True),
+                    prev=prev, next_=next_, pinned='close'),
                 text="Are you sure you want to close pinned tabs?")
 
     @cmdutils.register(instance='command-dispatcher', scope='window')

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -182,7 +182,7 @@ def clean_open_tabs(quteproc):
     """Clean up open windows and tabs."""
     quteproc.set_setting('tabs.last_close', 'blank')
     quteproc.send_cmd(':window-only')
-    quteproc.send_cmd(':tab-only --force')
+    quteproc.send_cmd(':tab-only --pinned close')
     quteproc.send_cmd(':tab-close --force')
     quteproc.wait_for_load_finished_url('about:blank')
 

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -390,7 +390,7 @@ Feature: Saving and loading sessions
       And I open data/numbers/3.txt in a new tab
       And I run :tab-pin with count 2
       And I run :session-save pin_session
-      And I run :tab-only --force
+      And I run :tab-only --pinned close
       And I run :tab-close --force
       And I run :session-load -c pin_session
       And I wait until data/numbers/3.txt is loaded

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1531,6 +1531,36 @@ Feature: Tab management
         Then the following tabs should be open:
             - data/numbers/2.txt (active) (pinned)
 
+    Scenario: Pinned :tab-only --pinned close
+        When I open data/numbers/1.txt
+        And I run :tab-pin
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-pin
+        And I run :tab-next
+        And I run :tab-only --pinned close
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active) (pinned)
+
+    Scenario: Pinned :tab-only --pinned keep
+        When I open data/numbers/1.txt
+        And I run :tab-pin
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-pin
+        And I run :tab-next
+        And I run :tab-only --pinned keep
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active) (pinned)
+            - data/numbers/2.txt (pinned)
+
+    Scenario: Pinned :tab-only --pinned prompt
+        When I open data/numbers/1.txt
+        And I run :tab-pin
+        And I open data/numbers/2.txt in a new tab
+        And I run :tab-pin
+        And I run :tab-next
+        And I run :tab-only --pinned prompt
+        Then "*want to close pinned tabs*" should be logged
+
     Scenario: :tab-pin open url
         When I open data/numbers/1.txt
         And I run :tab-pin


### PR DESCRIPTION
~~Adds a `--soft` flag to `:tab-only`, which keeps pinned tabs without prompting the user. Essentially it's the opposite of `--force`.~~

Replaces the `--force` flag for `:tab-only` with a `--pinned` flag which decides how pinned tabs should be handled, allowing for the following values: `prompt` (default), `close` and `keep`.

This is my first pull request for qutebrowser, so I'd appreciate any feedback or guidance. So far this is a barebones implementation without any tests.

My use case is that I pin tabs precisely so they won't get closed by `:tab-only`, so it becomes somewhat annoying to have to decline the prompt each time.