### PR TITLE
qute-pass userscript: Add -o flag to gopass otp invocation

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -158,6 +158,8 @@ def pass_(path):
 
 
 def pass_otp(path):
+    if arguments.mode == "gopass":
+        return _run_pass(['otp', '-o', path])
     return _run_pass(['otp', path])
 
 


### PR DESCRIPTION
When the qute-pass userscript is used for OTP generation with gopass, the `-o` flag is necessary (analogous to `gopass show`), otherwise gopass returns some metadata as well, which is also pasted into qutebrowser.

Without `-o`:

    297511 lasts 29s 	|-=============================|

With `-o` (the desired behavior):

    297511

This PR adds the `-o` flag to the `gopass otp` invocation analogous to `gopass show`.