### PR TITLE
Disable individual quirks

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -2644,6 +2644,7 @@ Valid values:
  * +js-string-replaceall+
  * +js-globalthis+
  * +js-object-fromentries+
+ * +misc-krunker+
 
 Default: empty
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -190,7 +190,8 @@
 |<<content.proxy,content.proxy>>|Proxy to use.
 |<<content.proxy_dns_requests,content.proxy_dns_requests>>|Send DNS requests over the configured proxy.
 |<<content.register_protocol_handler,content.register_protocol_handler>>|Allow websites to register protocol handlers via `navigator.registerProtocolHandler`.
-|<<content.site_specific_quirks,content.site_specific_quirks>>|Enable quirks (such as faked user agent headers) needed to get specific sites to work properly.
+|<<content.site_specific_quirks.enabled,content.site_specific_quirks.enabled>>|Enable quirks (such as faked user agent headers) needed to get specific sites to work properly.
+|<<content.site_specific_quirks.skip,content.site_specific_quirks.skip>>|Disable a list of named quirks.
 |<<content.tls.certificate_errors,content.tls.certificate_errors>>|How to proceed on TLS certificate errors.
 |<<content.unknown_url_scheme_policy,content.unknown_url_scheme_policy>>|How navigation requests to URLs with unknown schemes are handled.
 |<<content.user_stylesheets,content.user_stylesheets>>|List of user stylesheet filenames to use.
@@ -2618,8 +2619,8 @@ Valid values:
 
 Default: +pass:[ask]+
 
-[[content.site_specific_quirks]]
-=== content.site_specific_quirks
+[[content.site_specific_quirks.enabled]]
+=== content.site_specific_quirks.enabled
 Enable quirks (such as faked user agent headers) needed to get specific sites to work properly.
 
 This setting requires a restart.
@@ -2627,6 +2628,24 @@ This setting requires a restart.
 Type: <<types,Bool>>
 
 Default: +pass:[true]+
+
+[[content.site_specific_quirks.skip]]
+=== content.site_specific_quirks.skip
+Disable a list of named quirks.
+
+Type: <<types,FlagList>>
+
+Valid values:
+
+ * +ua-whatsapp+
+ * +ua-google+
+ * +ua-slack+
+ * +js-whatsapp-web+
+ * +js-string-replaceall+
+ * +js-globalthis+
+ * +js-object-fromentries+
+
+Default: empty
 
 [[content.tls.certificate_errors]]
 === content.tls.certificate_errors

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -459,12 +459,13 @@ def _init_site_specific_quirks():
                                     pattern=urlmatch.UrlPattern(pattern),
                                     hide_userconfig=True)
 
-    config.instance.set_obj(
-        'content.headers.accept_language',
-        '',
-        pattern=urlmatch.UrlPattern('https://matchmaker.krunker.io/*'),
-        hide_userconfig=True,
-    )
+    if 'misc-krunker' not in config.val.content.site_specific_quirks.skip:
+        config.instance.set_obj(
+            'content.headers.accept_language',
+            '',
+            pattern=urlmatch.UrlPattern('https://matchmaker.krunker.io/*'),
+            hide_userconfig=True,
+        )
 
 
 def _init_devtools_settings():

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -411,7 +411,7 @@ def _init_site_specific_quirks():
 
     See https://github.com/qutebrowser/qutebrowser/issues/4810
     """
-    if not config.val.content.site_specific_quirks:
+    if not config.val.content.site_specific_quirks.enabled:
         return
 
     # Please leave this here as a template for new UAs.
@@ -434,29 +434,30 @@ def _init_site_specific_quirks():
                "Safari/{webkit_version} "
                "Edg/{upstream_browser_version}")
 
-    user_agents = {
+    user_agents = [
         # Needed to avoid a ""WhatsApp works with Google Chrome 36+" error
         # page which doesn't allow to use WhatsApp Web at all. Also see the
         # additional JS quirk: qutebrowser/javascript/quirks/whatsapp_web.user.js
         # https://github.com/qutebrowser/qutebrowser/issues/4445
-        'https://web.whatsapp.com/': no_qtwe_ua,
+        ("ua-whatsapp", 'https://web.whatsapp.com/', no_qtwe_ua),
 
         # Needed to avoid a "you're using a browser [...] that doesn't allow us
         # to keep your account secure" error.
         # https://github.com/qutebrowser/qutebrowser/issues/5182
-        'https://accounts.google.com/*': edge_ua,
+        ("ua-google", 'https://accounts.google.com/*', edge_ua),
 
         # Needed because Slack adds an error which prevents using it relatively
         # aggressively, despite things actually working fine.
         # September 2020: Qt 5.12 works, but Qt <= 5.11 shows the error.
         # https://github.com/qutebrowser/qutebrowser/issues/4669
-        'https://*.slack.com/*': new_chrome_ua,
-    }
+        ("ua-slack", 'https://*.slack.com/*', new_chrome_ua),
+    ]
 
-    for pattern, ua in user_agents.items():
-        config.instance.set_obj('content.headers.user_agent', ua,
-                                pattern=urlmatch.UrlPattern(pattern),
-                                hide_userconfig=True)
+    for name, pattern, ua in user_agents:
+        if name not in config.val.content.site_specific_quirks.skip:
+            config.instance.set_obj('content.headers.user_agent', ua,
+                                    pattern=urlmatch.UrlPattern(pattern),
+                                    hide_userconfig=True)
 
     config.instance.set_obj(
         'content.headers.accept_language',

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1142,7 +1142,7 @@ class _WebEngineScripts(QObject):
 
     def _inject_site_specific_quirks(self):
         """Add site-specific quirk scripts."""
-        if not config.val.content.site_specific_quirks:
+        if not config.val.content.site_specific_quirks.enabled:
             return
 
         versions = version.qtwebengine_versions()
@@ -1170,12 +1170,14 @@ class _WebEngineScripts(QObject):
             if not quirk.predicate:
                 continue
             src = resources.read_file(f'javascript/quirks/{quirk.filename}.user.js')
-            self._inject_js(
-                f'quirk_{quirk.filename}',
-                src,
-                world=quirk.world,
-                injection_point=quirk.injection_point,
-            )
+            name = f"js-{quirk.filename.replace('_', '-')}"
+            if name not in config.val.content.site_specific_quirks.skip:
+                self._inject_js(
+                    f'quirk_{quirk.filename}',
+                    src,
+                    world=quirk.world,
+                    injection_point=quirk.injection_point,
+                )
 
 
 class WebEngineTabPrivate(browsertab.AbstractTabPrivate):

--- a/qutebrowser/browser/webkit/webkitsettings.py
+++ b/qutebrowser/browser/webkit/webkitsettings.py
@@ -82,7 +82,7 @@ class WebKitSettings(websettings.AbstractSettings):
             Attr(QWebSettings.PrintElementBackgrounds),
         'content.xss_auditing':
             Attr(QWebSettings.XSSAuditingEnabled),
-        'content.site_specific_quirks':
+        'content.site_specific_quirks.enabled':
             Attr(QWebSettings.SiteSpecificQuirksEnabled),
 
         'input.spatial_navigation':

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -533,7 +533,8 @@ content.site_specific_quirks.skip:
     name: FlagList
     valid_values: [ua-whatsapp, ua-google, ua-slack,
                    js-whatsapp-web, js-string-replaceall,
-                   js-globalthis, js-object-fromentries]
+                   js-globalthis, js-object-fromentries,
+                   misc-krunker]
     none_ok: true
   default: []
   desc: 'Disable a list of named quirks.'

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -519,7 +519,7 @@ content.frame_flattening:
     This will flatten all the frames to become one scrollable page.
 
 content.site_specific_quirks:
-  renamed : content.site_specific_quirks.enabled
+  renamed: content.site_specific_quirks.enabled
 
 content.site_specific_quirks.enabled:
   default: true
@@ -530,9 +530,10 @@ content.site_specific_quirks.enabled:
 
 content.site_specific_quirks.skip:
   type:
-    name : FlagList
+    name: FlagList
     valid_values: [ua-whatsapp, ua-google, ua-slack,
-    js-whatsapp-web, js-string-replaceall , js-globalthis, js-object-fromentries]
+                   js-whatsapp-web, js-string-replaceall,
+                   js-globalthis, js-object-fromentries]
     none_ok: true
   default: []
   desc: 'Disable a list of named quirks.'

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -519,11 +519,23 @@ content.frame_flattening:
     This will flatten all the frames to become one scrollable page.
 
 content.site_specific_quirks:
+  renamed : content.site_specific_quirks.enabled
+
+content.site_specific_quirks.enabled:
   default: true
   restart: true
   type: Bool
   desc: 'Enable quirks (such as faked user agent headers) needed to get
       specific sites to work properly.'
+
+content.site_specific_quirks.skip:
+  type:
+    name : FlagList
+    valid_values: [ua-whatsapp, ua-google, ua-slack,
+    js-whatsapp-web, js-string-replaceall , js-globalthis, js-object-fromentries]
+    none_ok: true
+  default: []
+  desc: 'Disable a list of named quirks.'
 
 # emacs: '
 


### PR DESCRIPTION
#6209 

Whatsapp: Things seems to be working as expected tested with ```--temp-basedir -s content.site_specific_quirks.skip "['ua-whatsapp','js-whatsapp-web']"  web.whatsapp.com```

Google : Things seems to be working too I got the error once with ``` --temp-basedir -s content.site_specific_quirks.skip "['ua-google']" accounts.google.com``` before getting detected by their js I guess

