### PR TITLE
Fix tab-focus bind in default config

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3298,7 +3298,7 @@ bindings.default:
       <Ctrl-Shift-W>: close
       D: tab-close -o
       co: tab-only
-      T: tab-focus
+      T: set-cmd-text -s :tab-focus
       gm: tab-move
       gK: tab-move -
       gJ: tab-move +


### PR DESCRIPTION
Old version is just useless, so I think this is bug.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
