### PR TITLE
qute-pass userscript: Removed gopass -o flag in case username should be read from secret

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -152,7 +152,7 @@ def _run_pass(pass_arguments):
 
 
 def pass_(path):
-    if arguments.mode == "gopass":
+    if arguments.mode == "gopass" and arguments.username_target == "path":
         return _run_pass(['show', '-o', path])
     return _run_pass(['show', path])
 


### PR DESCRIPTION
As `gopass show -o` only shows the first line, it is currently not possible to get the username from the secrets file.