### PR TITLE
Fix parse_webenginecore on OpenBSD

### DIFF
--- a/qutebrowser/misc/elf.py
+++ b/qutebrowser/misc/elf.py
@@ -316,20 +316,9 @@ def parse_webenginecore() -> Optional[Versions]:
     else:
         library_path = pathlib.Path(QLibraryInfo.location(QLibraryInfo.LibrariesPath))
 
-    filenames = [
-        # PyQt bundles those files with a .5 suffix, and Linux distributions
-        # most likely symlinks that.
-        'libQt5WebEngineCore.so.5',
-        # OpenBSD
-        'libQt5WebEngineCore.so.1.0',
-    ]
-    for filename in filenames:
-        lib_file = library_path / filename
-        if lib_file.exists():
-            log.misc.debug(f"QtWebEngine .so found at {lib_file}")
-            break
-    else:
-        log.misc.debug(f"No QtWebEngine .so found in {library_path}")
+    library_name = sorted(list(pathlib.Path(library_path).glob('libQt5WebEngineCore.so*')))
+    lib_file = library_path / library_name[-1].as_posix()
+    if not lib_file.exists():
         return None
 
     try:

--- a/qutebrowser/misc/elf.py
+++ b/qutebrowser/misc/elf.py
@@ -316,12 +316,12 @@ def parse_webenginecore() -> Optional[Versions]:
     else:
         library_path = pathlib.Path(QLibraryInfo.location(QLibraryInfo.LibrariesPath))
 
-    library_name = sorted(pathlib.Path(library_path).glob('libQt5WebEngineCore.so*'))
+    library_name = sorted(library_path.glob('libQt5WebEngineCore.so*'))
     if not library_name:
         log.misc.debug(f"No QtWebEngine .so found in {library_path}")
         return None
     else:
-        lib_file = library_path / library_name[-1]
+        lib_file = library_name[-1]
         log.misc.debug(f"QtWebEngine .so found at {lib_file}")
 
     try:

--- a/qutebrowser/misc/elf.py
+++ b/qutebrowser/misc/elf.py
@@ -318,7 +318,10 @@ def parse_webenginecore() -> Optional[Versions]:
 
     library_name = sorted(list(pathlib.Path(library_path).glob('libQt5WebEngineCore.so*')))
     lib_file = library_path / library_name[-1].as_posix()
-    if not lib_file.exists():
+    if lib_file.exists():
+        log.misc.debug(f"QtWebEngine .so found at {lib_file}")
+    else:
+        log.misc.debug(f"No QtWebEngine .so found in {library_path}")
         return None
 
     try:

--- a/qutebrowser/misc/elf.py
+++ b/qutebrowser/misc/elf.py
@@ -316,13 +316,13 @@ def parse_webenginecore() -> Optional[Versions]:
     else:
         library_path = pathlib.Path(QLibraryInfo.location(QLibraryInfo.LibrariesPath))
 
-    library_name = sorted(list(pathlib.Path(library_path).glob('libQt5WebEngineCore.so*')))
-    lib_file = library_path / library_name[-1].as_posix()
-    if lib_file.exists():
-        log.misc.debug(f"QtWebEngine .so found at {lib_file}")
-    else:
+    library_name = sorted(pathlib.Path(library_path).glob('libQt5WebEngineCore.so*'))
+    if not library_name:
         log.misc.debug(f"No QtWebEngine .so found in {library_path}")
         return None
+    else:
+        lib_file = library_path / library_name[-1]
+        log.misc.debug(f"QtWebEngine .so found at {lib_file}")
 
     try:
         with lib_file.open('rb') as f:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
The `colors.webpage.preferred_colorscheme` doesn't render any changes after being
set to `dark`. Running `qutebrowser -d` exposes that parse_webenginecore fails. The 
current [fix](https://github.com/qutebrowser/qutebrowser/commit/eb6f1cf9898cb431af9d2812ec40f811e37f57f0) is not correct since the library versions are `OpenBSD` specific and can change with minor updates. This change allows selecting the highest version of the `libQtWebEngineCore.so` available on the system at any time. Tested on `OpenBSD-current`.