### PR TITLE
Make audio, mute and private browsing indicators configurable

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2221,6 +2221,21 @@ tabs.indicator.padding:
   type: Padding
   desc: Padding (in pixels) for tab indicators.
 
+tabs.indicator.audio:
+  default: '[A] '
+  type: String
+  desc: Text shown in a tab tab when audio is being played
+
+tabs.indicator.mute:
+  default: '[M] '
+  type: String
+  desc: Text shown in a muted tab
+
+tabs.indicator.private:
+  default: '[Private Mode] '
+  type: String
+  desc: Text shown to indicate a tab is in private mode
+
 tabs.width.pinned:
   deleted: true
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -51,10 +51,6 @@ class TabWidget(QTabWidget):
     tab_index_changed = pyqtSignal(int, int)
     new_tab_requested = pyqtSignal('QUrl', bool, bool)
 
-    # Strings for controlling the mute/audible text
-    MUTE_STRING = '[M] '
-    AUDIBLE_STRING = '[A] '
-
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
         bar = TabBar(win_id, self)
@@ -164,12 +160,12 @@ class TabWidget(QTabWidget):
         fields['title_sep'] = ' - ' if page_title else ''
         fields['perc_raw'] = tab.progress()
         fields['backend'] = objects.backend.name
-        fields['private'] = ' [Private Mode] ' if tab.is_private else ''
+        fields['private'] = config.val.tabs.indicator.private if tab.is_private else ''
         try:
             if tab.audio.is_muted():
-                fields['audio'] = TabWidget.MUTE_STRING
+                fields['audio'] = config.val.tabs.indicator.mute
             elif tab.audio.is_recently_audible():
-                fields['audio'] = TabWidget.AUDIBLE_STRING
+                fields['audio'] = config.val.tabs.indicator.audio
             else:
                 fields['audio'] = ''
         except browsertab.WebTabError:


### PR DESCRIPTION
I set the options in the tabs object, but I didn't think of the fact that they can also be used in the window title so it might not make sens to have them there, if you'd rather have them somewhere else, let me know.