### PR TITLE
Make qute-bitwarden to use return code rather than stderr for error check

### DIFF
--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -153,8 +153,8 @@ def pass_(domain, encoding, auto_lock):
         stderr=subprocess.PIPE,
     )
 
-    err = process.stderr.decode(encoding).strip()
-    if err:
+    if process.returncode:
+        err = process.stderr.decode(encoding).strip()
         msg = 'Bitwarden CLI returned for {:s} - {:s}'.format(domain, err)
         stderr(msg)
         return '[]'

--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -153,10 +153,12 @@ def pass_(domain, encoding, auto_lock):
         stderr=subprocess.PIPE,
     )
 
-    if process.returncode:
-        err = process.stderr.decode(encoding).strip()
+    err = process.stderr.decode(encoding).strip()
+    if err:
         msg = 'Bitwarden CLI returned for {:s} - {:s}'.format(domain, err)
         stderr(msg)
+
+    if process.returncode:
         return '[]'
 
     out = process.stdout.decode(encoding).strip()
@@ -177,6 +179,8 @@ def get_totp_code(selection_id, domain_name, encoding, auto_lock):
         # domain_name instead of selection_id to make it more user-friendly
         msg = 'Bitwarden CLI returned for {:s} - {:s}'.format(domain_name, err)
         stderr(msg)
+
+    if process.returncode:
         return '[]'
 
     out = process.stdout.decode(encoding).strip()


### PR DESCRIPTION
Closes #6376 

When requesting credentials from bitwarden CLI (`bw`), this makes the script to check for return code of the process, rather than the current `stderr`.