### PR TITLE
qute-pass: dont run pass twice when otp-only is used

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -240,9 +240,10 @@ def main(arguments):
     if not selection:
         return ExitCodes.SUCCESS
 
-    # If username-target is path and user asked for username-only, we don't need to run pass
+    # If username-target is path and user asked for username-only, we don't need to run pass.
+    # Or if using otp-only, it will run pass on its own.
     secret = None
-    if not (arguments.username_target == 'path' and arguments.username_only):
+    if not (arguments.username_target == 'path' and arguments.username_only) and not arguments.otp_only:
         secret = pass_(selection)
     username_target = selection if arguments.username_target == 'path' else secret
     try:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
`qute-pass` in its current state runs pass twice when ran with `--otp-only` arguments, which is annoying having to authorize twice when using hardware gpg key etc.
So I added `not arguments.otp_only` to the condition here to avoid that.
