### PR TITLE
Added `text:` to statusbar.widgets valid_values

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -3973,7 +3973,6 @@ Default: +pass:[always]+
 [[statusbar.widgets]]
 === statusbar.widgets
 List of widgets displayed in the statusbar.
-In addition to the listed values there is also the possibility to add `text:foo` widgets that will display `foo`.
 
 Type: <<types,List of StatusbarWidget>>
 
@@ -3986,6 +3985,7 @@ Valid values:
  * +tabs+: Current active tab, e.g. `2`.
  * +keypress+: Display pressed keys when composing a vi command.
  * +progress+: Progress bar for the current page loading.
+ * +text:+: `text:foo` displays the static text foo.
 
 Default: 
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -3985,7 +3985,7 @@ Valid values:
  * +tabs+: Current active tab, e.g. `2`.
  * +keypress+: Display pressed keys when composing a vi command.
  * +progress+: Progress bar for the current page loading.
- * +text:+: `text:foo` displays the static text foo.
+ * +text:foo+: Display the static text after the colon, `foo` in the example.
 
 Default: 
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1933,13 +1933,10 @@ statusbar.widgets:
         - tabs: "Current active tab, e.g. `2`."
         - keypress: "Display pressed keys when composing a vi command."
         - progress: "Progress bar for the current page loading."
+        - 'text:': "`text:foo` displays the static text foo."
     none_ok: true
   default: ['keypress', 'url', 'scroll', 'history', 'tabs', 'progress']
-  desc: >-
-    List of widgets displayed in the statusbar.
-
-    In addition to the listed values there is also the possibility
-    to add `text:foo` widgets that will display `foo`.
+  desc: "List of widgets displayed in the statusbar."
 
 ## tabs
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1933,7 +1933,7 @@ statusbar.widgets:
         - tabs: "Current active tab, e.g. `2`."
         - keypress: "Display pressed keys when composing a vi command."
         - progress: "Progress bar for the current page loading."
-        - 'text:': "`text:foo` displays the static text foo."
+        - 'text:foo': "Display the static text after the colon, `foo` in the example."
     none_ok: true
   default: ['keypress', 'url', 'scroll', 'history', 'tabs', 'progress']
   desc: "List of widgets displayed in the statusbar."


### PR DESCRIPTION
Having `text` at a different part of the documentation confused people, so I added it to valid_values. This should not change anything in behavior, since this option will be intercepted before the valid_values are handled.

Closes #6414 