### PR TITLE
fix(doc): mutt mailcap missing argument

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -155,7 +155,7 @@ How do I use qutebrowser with mutt?::
     extension:
 +
 ----
-    text/html; qutebrowser %s; needsterminal; nametemplate=%s.html
+text/html; qutebrowser %s; needsterminal; copiousoutput; nametemplate=%s.html;
 ----
 
 What is the difference between bookmarks and quickmarks?::


### PR DESCRIPTION
The instruction to use `mutt` with `qutebrowser` is currently missing an argument (Point 11 of https://github.com/qutebrowser/qutebrowser/blob/master/doc/faq.asciidoc). This PR fixes it.

ref: https://narkive.com/mN8KVWGY.7