### PR TITLE
Designed a basic startpage , reference #6066

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -601,5 +601,6 @@ def qute_start(url: QUrl) -> _HandlerRet:
                        key=lambda x: x[1])  # Sort by title
     quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),
                         key=lambda x: x[0])  # Sort by name
-    page = jinja.render('startpage.html',title='Welcome to QuteBrowser',bookmarks=bookmarks)
+    searchurl = "https://google.com/search?q="
+    page = jinja.render('startpage.html',title='Welcome to QuteBrowser',bookmarks=bookmarks,search_url=searchurl)
     return 'text/html' , page

--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -593,3 +593,13 @@ def qute_resource(url: QUrl) -> _HandlerRet:
     except FileNotFoundError as e:
         raise NotFoundError(str(e))
     return mimetype, data
+
+@add_handler('start')
+def qute_start(url: QUrl) -> _HandlerRet:
+    """Handler for qute://start."""
+    bookmarks = sorted(objreg.get('bookmark-manager').marks.items(),
+                       key=lambda x: x[1])  # Sort by title
+    quickmarks = sorted(objreg.get('quickmark-manager').marks.items(),
+                        key=lambda x: x[0])  # Sort by name
+    page = jinja.render('startpage.html',title='Welcome to QuteBrowser',bookmarks=bookmarks)
+    return 'text/html' , page

--- a/qutebrowser/html/startpage.html
+++ b/qutebrowser/html/startpage.html
@@ -1,0 +1,101 @@
+{% extends "base.html" %}
+
+{% block style %}
+@import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300&display=swap');
+body {
+    background-color: #a6dfff;
+}
+.title {
+    color: #1f84bd;
+    font-family: Roboto,Helvetica;
+}
+.title-header {
+    font-family: Roboto,Helvetica;
+}
+h3 {
+    font-size: 45px;
+}
+h6 {
+    font-size: 20px;
+}
+.bookmark-container {
+    margin: 20px;
+}
+a {
+    font-family: Roboto-Mono,Helvetica;
+}
+a:visited {
+    color:#000000;
+    text-decoration: none;
+}
+.bookmark-mega-container {
+    border-size: 3;
+    border-color: #1f84bd;
+    border-radius: 5px;
+    border-width: 1px;
+    border-style: solid;
+    margin: 10px;
+}
+h4 {
+    font-family: Roboto;
+    font-size: 30px;
+    padding: 10px;
+}
+.getting-started-container {
+    border-size: 3;
+    border-color: #1f84bd;
+    border-radius: 5px;
+    border-width: 1px;
+    border-style: solid;
+    margin: 10px;
+}
+.logo {
+    width:75px;
+    height: 75px;
+    padding: 10px;
+}
+.title-container {
+    text-align: center;
+    display: flex;
+    align-items: center;
+    max-width:500px;
+    margin:auto;
+
+}
+.link-container {
+    margin: 20px;
+}
+{% endblock %}
+
+{% block script %}
+{% endblock %}
+
+
+{% block content %}
+<div class="title-container">
+  <img src="https://qutebrowser.org/icons/qutebrowser.svg" class="logo">
+  <span>
+    <h3 class="title">qutebrowser</h3>
+  </span>
+</div>
+<div class="getting-started-container">
+  <h4>Getting Started.</h4>
+  <div class="link-container">
+    <a class="link-name" href="https://qutebrowser.org">Official Website</a>
+  </div>
+  <div class="link-container">
+    <a class="link-name" href="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png">Cheat Sheet</a>
+  </div>
+</div>
+<div class="bookmark-mega-container">
+  <h4>Bookmarks</h4>
+  {% for bookmark in bookmarks %}
+  <div class="bookmark-container">
+    <a class="bookmark-name" href="{{ bookmark[0] }}"> {{ bookmark[1] }} </a>
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}
+

--- a/qutebrowser/html/startpage.html
+++ b/qutebrowser/html/startpage.html
@@ -4,9 +4,8 @@
 @import url('https://fonts.googleapis.com/css2?family=Roboto:wght@300&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300&display=swap');
 @import url('https://fonts.googleapis.com/css2?family=Roboto+Mono:wght@300&display=swap');
-body {
-    background-color: #a6dfff;
-}
+
+@import url('https://fonts.googleapis.com/css2?family=Pacifico&display=swap');
 .title {
     color: #1f84bd;
     font-family: Roboto,Helvetica;
@@ -24,9 +23,7 @@ h6 {
     margin: 20px;
 }
 a {
-    font-family: Roboto-Mono,Helvetica;
-}
-a:visited {
+    font-family: Roboto,Helvetica;
     color:#000000;
     text-decoration: none;
 }
@@ -37,9 +34,10 @@ a:visited {
     border-width: 1px;
     border-style: solid;
     margin: 10px;
+    font-family: Roboto;
 }
 h4 {
-    font-family: Roboto;
+    font-family: Open Sans;
     font-size: 30px;
     padding: 10px;
 }
@@ -50,6 +48,7 @@ h4 {
     border-width: 1px;
     border-style: solid;
     margin: 10px;
+    font-family: Roboto;
 }
 .logo {
     width:75px;
@@ -67,9 +66,20 @@ h4 {
 .link-container {
     margin: 20px;
 }
+input {
+    font-family: Roboto;
+    font-size: 16px;
+}
 {% endblock %}
 
 {% block script %}
+const searchUrl = "{{ search_url }}"
+function search(e) {
+    if (e.keyCode == 13) {
+	var val = document.getElementById("search-field").value;
+	window.open(searchUrl + val)
+    }
+}
 {% endblock %}
 
 
@@ -80,6 +90,19 @@ h4 {
     <h3 class="title">qutebrowser</h3>
   </span>
 </div>
+<div class="search-box title-container" id="search">
+<input type="text" size="50" name="search-box" placeholder="Search..." onkeypress="return search(event)" id="search-field"/> 
+</div>
+{% if bookmarks %}
+<div class="bookmark-mega-container">
+  <h4>Bookmarks</h4>
+  {% for bookmark in bookmarks %}
+  <div class="bookmark-container">
+    <a class="bookmark-name" href="{{ bookmark[0] }}"> {{ bookmark[1] }} </a>
+  </div>
+  {% endfor %}
+</div>
+{% endif %}
 <div class="getting-started-container">
   <h4>Getting Started.</h4>
   <div class="link-container">
@@ -88,14 +111,9 @@ h4 {
   <div class="link-container">
     <a class="link-name" href="https://raw.githubusercontent.com/qutebrowser/qutebrowser/master/doc/img/cheatsheet-big.png">Cheat Sheet</a>
   </div>
-</div>
-<div class="bookmark-mega-container">
-  <h4>Bookmarks</h4>
-  {% for bookmark in bookmarks %}
-  <div class="bookmark-container">
-    <a class="bookmark-name" href="{{ bookmark[0] }}"> {{ bookmark[1] }} </a>
+  <div class="link-container">
+    <a class="link-name" href="https://qutebrowser.org/doc/changelog.html">Changelog</a>
   </div>
-  {% endfor %}
 </div>
 {% endblock %}
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
With reference to #6066 , I have desgined a simple page.(qute://start) . It contains

 - Qutebrowser name and Logo
 - Searchbox , configured to search google(for now).
 - Bookmarks (Only visible if you have any)
 - Getting Started(Links to cheatsheet,changelog,website)

I could not add changelog directly as I could not find any way to access it programmatically.
Forgot about Quickmarks , will push in next commit.

Any changes regarding content of page , or aesthetic of the page  are very welcome.