### PR TITLE
Fix crash in cmd completion for set-cmd-text.

### DIFF
--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -173,6 +173,8 @@ class KeyConfig:
         result = results[0]
         if result.cmd.name != "set-cmd-text":
             return cmdline
+        if not result.args:
+            return None  # doesn't look like this sets a command
         *flags, cmd = result.args
         if "-a" in flags or "--append" in flags or not cmd.startswith(":"):
             return None  # doesn't look like this sets a command

--- a/tests/unit/config/test_config.py
+++ b/tests/unit/config/test_config.py
@@ -211,6 +211,7 @@ class TestKeyConfig:
                 "a": "set-cmd-text no_leading_colon",
                 "b": "set-cmd-text -s -a :skip_cuz_append",
                 "c": "set-cmd-text --append :skip_cuz_append",
+                "x": "set-cmd-text",
             },
             {
                 "open": ["o"],


### PR DESCRIPTION
2c4bb064e introduced support for showing bindings in the completion menu
for commands initiated with set-cmd-text. This would crash if given a
binding for just 'set-cmd-text' with no args.

Fixes #6453.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
