### PR TITLE
[readability-js] Add reference to AUR package

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -8,6 +8,7 @@
 // # Prerequisites
 //
 // - Mozilla's readability library (npm install -g @mozilla/readability)
+//     - Also available in the AUR as nodejs-readability-git
 // - jsdom (npm install -g jsdom)
 // - qutejs (npm install -g qutejs)
 //


### PR DESCRIPTION
I just added the readability package to the [AUR](https://aur.archlinux.org/packages/nodejs-readability-git/).

Not much of a difference from using npm directly, but, personally, (i) I prefer to manage all my (important) packages using `yay`, and (ii) like to perform all system upgrades from one place (i.e. `yay --devel`, instead of also remembering to deal with npm).

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
