### PR TITLE
Windows Installer: Allow elevation when silent

### DIFF
--- a/misc/nsis/qutebrowser.nsi
+++ b/misc/nsis/qutebrowser.nsi
@@ -146,6 +146,8 @@ ShowUninstDetails hide
   !packhdr "$%TEMP%\exehead.tmp" '"upx" "--ultra-brute" "$%TEMP%\exehead.tmp"'
 !endif
 
+!define MULTIUSER_INSTALLMODE_ALLOW_ELEVATION_IF_SILENT 1
+
 ; Version Information
 VIFileVersion "${VERSION}.0"
 VIProductVersion "${VERSION}.0"


### PR DESCRIPTION
Because of the workaround for the uninstaller elevation bug of Windows, this is required for the silent uninstall of `AllUsers`, even when started elevated. Fixes #6496.