### PR TITLE
feat: expose 'currently open URL' variable via hints to userscripts

### DIFF
--- a/doc/userscripts.asciidoc
+++ b/doc/userscripts.asciidoc
@@ -60,6 +60,7 @@ In `command` mode:
 In `hints` mode:
 
 - `QUTE_URL`: The URL selected via hints.
+- `QUTE_CURRENT_URL`: The current URL.
 - `QUTE_SELECTED_TEXT`: The plain text of the element selected via hints.
 - `QUTE_SELECTED_HTML`: The HTML of the element selected via hints.
 

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -325,14 +325,17 @@ class HintActions:
 
         cmd = context.args[0]
         args = context.args[1:]
+        flags = QUrl.FullyEncoded
+
         env = {
             'QUTE_MODE': 'hints',
             'QUTE_SELECTED_TEXT': str(elem),
             'QUTE_SELECTED_HTML': elem.outer_xml(),
+            'QUTE_CURRENT_URL': context.baseurl.toString(flags),
         }
+
         url = elem.resolve_url(context.baseurl)
         if url is not None:
-            flags = QUrl.FullyEncoded
             env['QUTE_URL'] = url.toString(flags)  # type: ignore[arg-type]
 
         try:


### PR DESCRIPTION
Related to #937

I used the added variable to create the following userscript that yanks the URL with an element that has an `id` attribute. (e.g. selecting "hints selectors" section puts qute://help/settings.html#hints.selectors in clipboard)

To make it work, add `"[id]"` as a `hints.selectors`.
Now in qutebrowser:
`:hint <hints.selector> userscript <script_path>`

```bash
#!/bin/bash
# dependencies: xclip

# remove the number sign and what goes after that (if given)
URL=$(echo $QUTE_CURRENT_URL | cut -f -1 -d "#")
# get id attribute
HTML_ID=$(echo "$QUTE_SELECTED_HTML" | grep -oP 'id="\K(.+?)(?=")')
LINK="$URL#$HTML_ID"

echo $LINK | xclip -selection clipboard
echo "message-info 'url copied to clipboard'" >> "$QUTE_FIFO"
```