### PR TITLE
FilenamePrompt uses os.path.expanduser

### DIFF
--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -649,6 +649,7 @@ class FilenamePrompt(_BasePrompt):
         if os.altsep is not None:
             separators += os.altsep
 
+        path = os.path.expanduser(path)
         dirname = os.path.dirname(path)
         basename = os.path.basename(path)
         if not tabbed:


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
Resolves part of #2104 (specifically the second point).

One issue I have noticed is that if you tab it removes the `~/` path and changes it to `/home/user` which is a bit jarring. That doesn't affect functionality but isn't ideal. There isn't a reverse of `os.path.expanduser` that I could use, however.