### PR TITLE
add link to 'leosolid/qutebrowser-themes' in docs under 'Pre-built colorschemes'

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -392,6 +392,7 @@ Pre-built colorschemes
 ^^^^^^^^^^^^^^^^^^^^^^
 
 - A collection of https://github.com/chriskempson/base16[base16] color-schemes can be found in https://github.com/theova/base16-qutebrowser[base16-qutebrowser] and used with https://github.com/AuditeMarlow/base16-manager[base16-manager].
+- Another collection: https://github.com/leosolid/qutebrowser-themes[qutebrowser-themes]
 - https://gitlab.com/jjzmajic/qutewal[Pywal integration]
 - https://github.com/arcticicestudio/nord[Nord]: https://github.com/Linuus/nord-qutebrowser[Linuus], https://github.com/KnownAsDon/QuteBrowser-Nord-Theme[KnownAsDon]
 - https://github.com/dracula/qutebrowser-dracula-theme[Dracula]


### PR DESCRIPTION
Adding link to a new collection of qutebrowser themes I just started, as requested in [discussions](https://github.com/qutebrowser/qutebrowser/discussions/6612#discussioncomment-1033462).

There's only onedark so far, but I'll be adding more.