### PR TITLE
add relative line numbers for tabs

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -4360,6 +4360,7 @@ The following placeholders are defined:
 * `{index}`: Index of this tab.
 * `{aligned_index}`: Index of this tab padded with spaces to have the same
   width.
+* `{relative_index}`: Index of this tab relative to the current tab.
 * `{id}`: Internal tab ID of this tab.
 * `{scroll_pos}`: Page scroll position.
 * `{host}`: Host of the current web page.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2140,6 +2140,7 @@ tabs.title.format:
       - title_sep
       - index
       - aligned_index
+      - relative_index
       - id
       - scroll_pos
       - host
@@ -2159,6 +2160,7 @@ tabs.title.format:
     * `{index}`: Index of this tab.
     * `{aligned_index}`: Index of this tab padded with spaces to have the same
       width.
+    * `{relative_index}`: Index of this tab relative to the current tab.
     * `{id}`: Internal tab ID of this tab.
     * `{scroll_pos}`: Page scroll position.
     * `{host}`: Host of the current web page.
@@ -2179,6 +2181,7 @@ tabs.title.format_pinned:
       - title_sep
       - index
       - aligned_index
+      - relative_index
       - id
       - scroll_pos
       - host

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -136,18 +136,31 @@ class TabWidget(QTabWidget):
                 (fmt is None or ('{' + field + '}') not in fmt)):
             return
 
+        def right_align(text):
+            return str(text).rjust(len(str(self.count())))
+
+        def left_align(text):
+            return str(text).ljust(len(str(self.count())))
+
+        bar = self.tabBar()
+        cur_idx = bar.currentIndex()
+        if idx == cur_idx:
+            rel_idx = left_align(idx + 1) + " "
+        else:
+            rel_idx = " " + right_align(abs(idx - cur_idx))
+
         fields = self.get_tab_fields(idx)
         fields['current_title'] = fields['current_title'].replace('&', '&&')
         fields['index'] = idx + 1
-        fields['aligned_index'] = str(idx + 1).rjust(len(str(self.count())))
+        fields['aligned_index'] = right_align(idx + 1)
+        fields['relative_index'] = rel_idx
 
         title = '' if fmt is None else fmt.format(**fields)
-        tabbar = self.tabBar()
 
         # Only change the tab title if it changes, setting the tab title causes
         # a size recalculation which is slow.
-        if tabbar.tabText(idx) != title:
-            tabbar.setTabText(idx, title)
+        if bar.tabText(idx) != title:
+            bar.setTabText(idx, title)
 
     def get_tab_fields(self, idx):
         """Get the tab field data."""
@@ -305,6 +318,7 @@ class TabWidget(QTabWidget):
     def _on_current_changed(self, index):
         """Emit the tab_index_changed signal if the current tab changed."""
         self.tabBar().on_current_changed()
+        self.update_tab_titles()
         self.tab_index_changed.emit(index, self.count())
 
     @pyqtSlot()


### PR DESCRIPTION
Adds `relative_index` to FormatString, which provides tab numbers like to `relativenumber` in vim.  You can try it out by running:
 ```
set tabs.position left;; 
set tabs.title.format '{relative_index} |{aligned_index}: {current_title}';;
repeat 20 tab-clone
```

This closes #6616. 

EDIT: This is what it looks like

![image](https://user-images.githubusercontent.com/13348080/127763934-83de5803-6fd7-419b-a8b4-8fc3b7991001.png)
