### PR TITLE
Switch to a matching tab when clicking on notification

### DIFF
--- a/qutebrowser/browser/webengine/notification.py
+++ b/qutebrowser/browser/webengine/notification.py
@@ -361,7 +361,6 @@ class NotificationBridgePresenter(QObject):
             log.misc.debug("Did not find matching notification, ignoring")
             return
 
-        self._focus_first_matching_tab(notification)
         try:
             notification.click()
         except RuntimeError:
@@ -369,6 +368,8 @@ class NotificationBridgePresenter(QObject):
             # https://www.riverbankcomputing.com/pipermail/pyqt/2020-May/042918.html
             log.misc.debug(f"Ignoring click request for notification {notification_id} "
                            "due to PyQt bug")
+            return
+        self._focus_first_matching_tab(notification)
 
     def _focus_first_matching_tab(self, notification: "QWebEngineNotification") -> None:
         for win_id in objreg.window_registry:

--- a/qutebrowser/browser/webengine/notification.py
+++ b/qutebrowser/browser/webengine/notification.py
@@ -361,8 +361,8 @@ class NotificationBridgePresenter(QObject):
             log.misc.debug("Did not find matching notification, ignoring")
             return
 
+        self._focus_first_matching_tab(notification)
         try:
-            self._focus_first_matching_tab(notification)
             notification.click()
         except RuntimeError:
             # WORKAROUND for

--- a/qutebrowser/browser/webengine/notification.py
+++ b/qutebrowser/browser/webengine/notification.py
@@ -377,6 +377,7 @@ class NotificationBridgePresenter(QObject):
                 if tab.url().matches(notification.origin(), QUrl.RemovePath):
                     tabbedbrowser.widget.setCurrentIndex(idx)
                     return
+        log.misc.debug(f"No matching tab found for {notification.origin()}")
 
     def _drop_adapter(self) -> None:
         """Drop the currently active adapter (if any).

--- a/tests/end2end/features/notifications.feature
+++ b/tests/end2end/features/notifications.feature
@@ -4,7 +4,8 @@ Feature: Notifications
     HTML5 notification API interaction
 
     Background:
-        Given I open data/javascript/notifications.html
+        Given I clean up open tabs
+        And I open data/javascript/notifications.html
         And I set content.notifications.enabled to true
         And I run :click-element id button
         And I clean up the notification server
@@ -120,8 +121,13 @@ Feature: Notifications
     Scenario: User clicks presented notification
         When I run :click-element id show-button
         And I wait for the javascript message "notification shown"
+        And I open about:blank in a new tab
         And I click the notification
         Then the javascript message "notification clicked" should be logged
+        And the following tabs should be open:
+         - about:blank
+         - data/javascript/notifications.html (active)
+         - about:blank
 
     @pyqtwebengine<5.15.0
     Scenario: User clicks presented notification (old Qt)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

This is my first time in the qutebrowser codebase, so apologies if I did things in a weird/roundabout way.

Fixes #5796.