### PR TITLE
Add statusbar match counter and option to silence search wrap messages, fix wrap messages not displaying

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -364,6 +364,22 @@ class AbstractSearch(QObject):
         """
         raise NotImplementedError
 
+    def get_current_match(self) -> int:
+        """Get the 1-based index of the currently highlighted match on the page.
+
+        Returns 0 if no successful search has been performed or this feature is unavailable
+        (QtWebKit and QtWebEngine < 5.14)
+        """
+        raise NotImplementedError
+
+    def get_total_match_count(self) -> int:
+        """Get the total number of search matches on the page.
+
+        Returns 0 if no successful search has been performed or this feature is unavailable
+        (QtWebKit and QtWebEngine < 5.14)
+        """
+        raise NotImplementedError
+
 
 class AbstractZoom(QObject):
 

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -926,7 +926,7 @@ class AbstractTab(QWidget):
     icon_changed = pyqtSignal(QIcon)
     #: Signal emitted when a page's title changed (new title as str)
     title_changed = pyqtSignal(str)
-
+    #: Signal emitted when a page's currently active search match changed (match as current/total)
     search_match_changed = pyqtSignal(int, int)
     #: Signal emitted when this tab was pinned/unpinned (new pinned state as bool)
     pinned_changed = pyqtSignal(bool)

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -926,6 +926,8 @@ class AbstractTab(QWidget):
     icon_changed = pyqtSignal(QIcon)
     #: Signal emitted when a page's title changed (new title as str)
     title_changed = pyqtSignal(str)
+
+    search_match_changed = pyqtSignal(int, int)
     #: Signal emitted when this tab was pinned/unpinned (new pinned state as bool)
     pinned_changed = pyqtSignal(bool)
     #: Signal emitted when a new tab should be opened (url as QUrl)
@@ -1211,6 +1213,9 @@ class AbstractTab(QWidget):
         raise NotImplementedError
 
     def icon(self) -> None:
+        raise NotImplementedError
+
+    def current_search_match(self) -> (int, int):
         raise NotImplementedError
 
     def set_html(self, html: str, base_url: QUrl = QUrl()) -> None:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1534,7 +1534,8 @@ class CommandDispatcher:
         Args:
             found: Whether the text was found.
             tab: The AbstractTab in which the search was made.
-            old_current_match: The previously active match before the search was performed.
+            old_current_match: The previously active match before the search
+                               was performed.
             options: The options (dict) the search was made with.
             text: The text searched for.
             prev: Whether we're searching backwards (i.e. :search-prev)
@@ -1549,7 +1550,7 @@ class CommandDispatcher:
             if not config.val.search.wrap_messages:
                 return
 
-            new_current_match = tab.search.get_current_match()
+            new_current_match = tab.search.current_match
             # Check if the match count change is opposite to the search direction
             if old_current_match > 0:
                 if not going_up:
@@ -1627,7 +1628,7 @@ class CommandDispatcher:
             return
 
         cb = functools.partial(self._search_cb, tab=tab,
-                               old_current_match=tab.search.get_current_match(),
+                               old_current_match=tab.search.current_match,
                                options=window_options, text=window_text,
                                prev=False)
 
@@ -1661,7 +1662,7 @@ class CommandDispatcher:
             return
 
         cb = functools.partial(self._search_cb, tab=tab,
-                               old_current_match=tab.search.get_current_match(),
+                               old_current_match=tab.search.current_match,
                                options=window_options, text=window_text,
                                prev=True)
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1546,8 +1546,10 @@ class CommandDispatcher:
         going_up = options['reverse'] ^ prev
 
         if found:
+            if not config.val.search.wrap_messages:
+                return
+
             new_current_match = tab.search.get_current_match()
-            total_match_count = tab.search.get_total_match_count()
             # Check if the match count change is opposite to the search direction
             if old_current_match > 0:
                 if not going_up:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1548,9 +1548,6 @@ class CommandDispatcher:
         if found:
             new_current_match = tab.search.get_current_match()
             total_match_count = tab.search.get_total_match_count()
-            if total_match_count > 0:
-                message.info("Match {}/{}".format(new_current_match, total_match_count),
-                             replace="search-match-count")
             # Check if the match count change is opposite to the search direction
             if old_current_match > 0:
                 if not going_up:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -184,6 +184,10 @@ class WebEngineSearch(browsertab.AbstractSearch):
         _flags: The QWebEnginePage.FindFlags of the last search.
         _pending_searches: How many searches have been started but not called
                            back yet.
+
+    Signals:
+        search_match_changed: The currently active search match has changed.
+                              Emits (0, 0) if no search is active.
     """
 
     search_match_changed = pyqtSignal(int, int)
@@ -256,6 +260,7 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._widget.page().findText(text, flags, wrapped_callback)
 
     def _on_find_finished(self, findTextResult):
+        """Unwrap the QWebEngineFindTextResult and pass it along."""
         self.search_match_changed.emit(findTextResult.activeMatch(),
                                        findTextResult.numberOfMatches())
 
@@ -1646,6 +1651,7 @@ class WebEngineTab(browsertab.AbstractTab):
 
     @pyqtSlot(int, int)
     def _on_search_match_changed(self, current: int, total: int):
+        """Pass the signal from the WebEngineSearch along."""
         self.search_match_changed.emit(current, total)
 
     @pyqtSlot(usertypes.NavigationRequest)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -259,10 +259,10 @@ class WebEngineSearch(browsertab.AbstractSearch):
 
         self._widget.page().findText(text, flags, wrapped_callback)
 
-    def _on_find_finished(self, findTextResult):
+    def _on_find_finished(self, find_text_result):
         """Unwrap the QWebEngineFindTextResult and pass it along."""
-        self.search_match_changed.emit(findTextResult.activeMatch(),
-                                       findTextResult.numberOfMatches())
+        self.search_match_changed.emit(find_text_result.activeMatch(),
+                                       find_text_result.numberOfMatches())
 
     def search(self, text, *, ignore_case=usertypes.IgnoreCase.never,
                reverse=False, wrap=True, result_cb=None):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -189,13 +189,6 @@ class WebKitSearch(browsertab.AbstractSearch):
         found = self._widget.findText(self.text, flags)
         self._call_cb(result_cb, found, self.text, flags, 'prev_result')
 
-    # These aren't supported when using the QtWebKit backend.
-    def get_current_match(self):
-        return 0
-
-    def get_total_match_count(self):
-        return 0
-
 
 class WebKitCaret(browsertab.AbstractCaret):
 
@@ -884,10 +877,6 @@ class WebKitTab(browsertab.AbstractTab):
 
     def icon(self):
         return self._widget.icon()
-
-    def current_search_match(self):
-        """QtWebKit doesn't support match counts."""
-        return (0, 0)
 
     def reload(self, *, force=False):
         if force:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -189,6 +189,13 @@ class WebKitSearch(browsertab.AbstractSearch):
         found = self._widget.findText(self.text, flags)
         self._call_cb(result_cb, found, self.text, flags, 'prev_result')
 
+    # These aren't supported when using the QtWebKit backend.
+    def get_current_match(self):
+        return 0
+
+    def get_total_match_count(self):
+        return 0
+
 
 class WebKitCaret(browsertab.AbstractCaret):
 

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -886,6 +886,7 @@ class WebKitTab(browsertab.AbstractTab):
         return self._widget.icon()
 
     def current_search_match(self):
+        """QtWebKit doesn't support match counts."""
         return (0, 0)
 
     def reload(self, *, force=False):

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -885,6 +885,9 @@ class WebKitTab(browsertab.AbstractTab):
     def icon(self):
         return self._widget.icon()
 
+    def current_search_match(self):
+        return (0, 0)
+
     def reload(self, *, force=False):
         if force:
             action = QWebPage.ReloadAndBypassCache

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -72,6 +72,13 @@ search.wrap:
     Wrap around at the top and bottom of the page when advancing through text
     matches using `:search-next` and `:search-prev`.
 
+search.wrap_messages:
+  type: Bool
+  default: true
+  desc: >-
+    Display messages when advancing through text matches at the top and bottom
+    of the page, e.g. `Search hit TOP`.
+
 new_instance_open_target:
   type:
     name: String

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1963,12 +1963,13 @@ statusbar.widgets:
         - scroll_raw: "Raw percentage of the current page position like `10`."
         - history: "Display an arrow when possible to go back/forward in
           history."
+        - search_match: "A match count when searching, e.g. `Match [2/10]`."
         - tabs: "Current active tab, e.g. `2`."
         - keypress: "Display pressed keys when composing a vi command."
         - progress: "Progress bar for the current page loading."
         - 'text:foo': "Display the static text after the colon, `foo` in the example."
     none_ok: true
-  default: ['keypress', 'url', 'scroll', 'history', 'tabs', 'progress']
+  default: ['keypress', 'search_match', 'url', 'scroll', 'history', 'tabs', 'progress']
   desc: "List of widgets displayed in the statusbar."
 
 ## tabs

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -537,6 +537,9 @@ class MainWindow(QWidget):
         self.tabbed_browser.cur_load_status_changed.connect(
             self.status.url.on_load_status_changed)
 
+        self.tabbed_browser.search_match_changed.connect(
+            self.status.search_match.set_match_index)
+
         self.tabbed_browser.cur_caret_selection_toggled.connect(
             self.status.on_caret_selection_toggled)
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -537,7 +537,7 @@ class MainWindow(QWidget):
         self.tabbed_browser.cur_load_status_changed.connect(
             self.status.url.on_load_status_changed)
 
-        self.tabbed_browser.search_match_changed.connect(
+        self.tabbed_browser.cur_search_match_changed.connect(
             self.status.search_match.set_match_index)
 
         self.tabbed_browser.cur_caret_selection_toggled.connect(

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -32,7 +32,7 @@ from qutebrowser.keyinput import modeman
 from qutebrowser.utils import usertypes, log, objreg, utils
 from qutebrowser.mainwindow.statusbar import (backforward, command, progress,
                                               keystring, percentage, url,
-                                              tabindex, textbase)
+                                              tabindex, textbase, searchmatch)
 
 
 @dataclasses.dataclass
@@ -144,6 +144,7 @@ class StatusBar(QWidget):
         url: The UrlText widget in the statusbar.
         prog: The Progress widget in the statusbar.
         cmd: The Command widget in the statusbar.
+        search_match: The SearchMatch widget in the statusbar.
         _hbox: The main QHBoxLayout.
         _stack: The QStackedLayout with cmd/txt widgets.
         _win_id: The window ID the statusbar is associated with.
@@ -194,6 +195,8 @@ class StatusBar(QWidget):
         self.cmd.hide_cmd.connect(self._hide_cmd_widget)
         self._hide_cmd_widget()
 
+        self.search_match = searchmatch.SearchMatch()
+
         self.url = url.UrlText()
         self.percentage = percentage.Percentage()
         self.backforward = backforward.Backforward()
@@ -226,7 +229,9 @@ class StatusBar(QWidget):
 
         # Read the list and set widgets accordingly
         for segment in config.val.statusbar.widgets:
-            if segment == 'url':
+            if segment == 'search_match':
+                self._hbox.addWidget(self.search_match)
+            elif segment == 'url':
                 self._hbox.addWidget(self.url)
                 self.url.show()
             elif segment == 'scroll':

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -221,7 +221,7 @@ class StatusBar(QWidget):
         elif option == 'statusbar.widgets':
             self._draw_widgets()
 
-    def _draw_widgets(self):
+    def _draw_widgets(self):  # noqa: C901
         """Draw statusbar widgets."""
         self._clear_widgets()
 

--- a/qutebrowser/mainwindow/statusbar/searchmatch.py
+++ b/qutebrowser/mainwindow/statusbar/searchmatch.py
@@ -1,0 +1,61 @@
+# vim: ft=python fileencoding=utf-8 sts=4 sw=4 et:
+
+# Copyright 2014-2021 Florian Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# This file is part of qutebrowser.
+#
+# qutebrowser is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# qutebrowser is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with qutebrowser.  If not, see <https://www.gnu.org/licenses/>.
+
+"""The search match indicator in the statusbar."""
+
+
+from PyQt5.QtCore import pyqtSlot
+
+from qutebrowser.utils import log
+from qutebrowser.config import config
+from qutebrowser.mainwindow.statusbar import textbase
+
+
+class SearchMatch(textbase.TextBase):
+
+    """The commandline part of the statusbar.
+
+    Attributes:
+        _win_id: The window ID this widget is associated with.
+
+    Signals:
+        got_cmd: Emitted when a command is triggered by the user.
+                 arg: The command string and also potentially the count.
+        got_search: Emitted when a search should happen.
+        clear_completion_selection: Emitted before the completion widget is
+                                    hidden.
+        hide_completion: Emitted when the completion widget should be hidden.
+        update_completion: Emitted when the completion should be shown/updated.
+        show_cmd: Emitted when command input should be shown.
+        hide_cmd: Emitted when command input can be hidden.
+    """
+
+    @pyqtSlot(int, int)
+    def set_match_index(self, current: int, total: int) -> None:
+        """Preset the statusbar to some text.
+
+        Args:
+            text: The text to set as string.
+        """
+        if current <= 0 and total <= 0:
+            self.setText('')
+            log.statusbar.debug('Clearing search match text.')
+        else:
+            self.setText('Match [{}/{}]'.format(current, total))
+            log.statusbar.debug('Setting search match text to {}/{}'.format(current, total))

--- a/qutebrowser/mainwindow/statusbar/searchmatch.py
+++ b/qutebrowser/mainwindow/statusbar/searchmatch.py
@@ -29,29 +29,16 @@ from qutebrowser.mainwindow.statusbar import textbase
 
 class SearchMatch(textbase.TextBase):
 
-    """The commandline part of the statusbar.
-
-    Attributes:
-        _win_id: The window ID this widget is associated with.
-
-    Signals:
-        got_cmd: Emitted when a command is triggered by the user.
-                 arg: The command string and also potentially the count.
-        got_search: Emitted when a search should happen.
-        clear_completion_selection: Emitted before the completion widget is
-                                    hidden.
-        hide_completion: Emitted when the completion widget should be hidden.
-        update_completion: Emitted when the completion should be shown/updated.
-        show_cmd: Emitted when command input should be shown.
-        hide_cmd: Emitted when command input can be hidden.
-    """
+    """The part of the statusbar that displays the search match counter."""
 
     @pyqtSlot(int, int)
     def set_match_index(self, current: int, total: int) -> None:
-        """Preset the statusbar to some text.
+        """Set the match counts in the statusbar.
+           Passing (0, 0) hides the match counter.
 
         Args:
-            text: The text to set as string.
+            current: The currently active search match.
+            total: The total number of search matches on the page.
         """
         if current <= 0 and total <= 0:
             self.setText('')

--- a/qutebrowser/mainwindow/statusbar/searchmatch.py
+++ b/qutebrowser/mainwindow/statusbar/searchmatch.py
@@ -34,6 +34,7 @@ class SearchMatch(textbase.TextBase):
     @pyqtSlot(int, int)
     def set_match_index(self, current: int, total: int) -> None:
         """Set the match counts in the statusbar.
+
            Passing (0, 0) hides the match counter.
 
         Args:

--- a/qutebrowser/mainwindow/statusbar/searchmatch.py
+++ b/qutebrowser/mainwindow/statusbar/searchmatch.py
@@ -23,7 +23,6 @@
 from PyQt5.QtCore import pyqtSlot
 
 from qutebrowser.utils import log
-from qutebrowser.config import config
 from qutebrowser.mainwindow.statusbar import textbase
 
 
@@ -46,4 +45,5 @@ class SearchMatch(textbase.TextBase):
             log.statusbar.debug('Clearing search match text.')
         else:
             self.setText('Match [{}/{}]'.format(current, total))
-            log.statusbar.debug('Setting search match text to {}/{}'.format(current, total))
+            log.statusbar.debug('Setting search match text to {}/{}'
+                    .format(current, total))

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -196,6 +196,7 @@ class TabbedBrowser(QWidget):
     cur_link_hovered = pyqtSignal(str)
     cur_scroll_perc_changed = pyqtSignal(int, int)
     cur_load_status_changed = pyqtSignal(usertypes.LoadStatus)
+    search_match_changed = pyqtSignal(int, int)
     cur_fullscreen_requested = pyqtSignal(bool)
     cur_caret_selection_toggled = pyqtSignal(browsertab.SelectionState)
     close_window = pyqtSignal()
@@ -346,6 +347,8 @@ class TabbedBrowser(QWidget):
             functools.partial(self._on_title_changed, tab))
         tab.icon_changed.connect(
             functools.partial(self._on_icon_changed, tab))
+        tab.search_match_changed.connect(
+            functools.partial(self._on_search_match_changed, tab))
         tab.pinned_changed.connect(
             functools.partial(self._on_pinned_changed, tab))
         tab.load_progress.connect(
@@ -793,6 +796,10 @@ class TabbedBrowser(QWidget):
             return
         self.widget.update_tab_favicon(tab)
 
+    @pyqtSlot(browsertab.AbstractTab, int, int)
+    def _on_search_match_changed(self, tab, current: int, total: int):
+        self.search_match_changed.emit(current, total)
+
     @pyqtSlot(usertypes.KeyMode)
     def on_mode_entered(self, mode):
         """Save input mode when tabs.mode_on_change = restore."""
@@ -851,6 +858,7 @@ class TabbedBrowser(QWidget):
                         .format(current_mode.name, mode_on_change))
         self._now_focused = tab
         self.current_tab_changed.emit(tab)
+        self.search_match_changed.emit(*tab.current_search_match())
         QTimer.singleShot(0, self._update_window_title)
         self._tab_insert_idx_left = self.widget.currentIndex()
         self._tab_insert_idx_right = self.widget.currentIndex() + 1

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -180,6 +180,7 @@ class TabbedBrowser(QWidget):
                                  arg 1: x-position in %.
                                  arg 2: y-position in %.
         cur_load_status_changed: Loading status of current tab changed.
+        cur_search_match_changed: The active search match changed.
         close_window: The last tab was closed, close this window.
         resized: Emitted when the browser window has resized, so the completion
                  widget can adjust its size to it.
@@ -196,7 +197,7 @@ class TabbedBrowser(QWidget):
     cur_link_hovered = pyqtSignal(str)
     cur_scroll_perc_changed = pyqtSignal(int, int)
     cur_load_status_changed = pyqtSignal(usertypes.LoadStatus)
-    search_match_changed = pyqtSignal(int, int)
+    cur_search_match_changed = pyqtSignal(int, int)
     cur_fullscreen_requested = pyqtSignal(bool)
     cur_caret_selection_toggled = pyqtSignal(browsertab.SelectionState)
     close_window = pyqtSignal()
@@ -338,6 +339,8 @@ class TabbedBrowser(QWidget):
             self._filter.create(self.cur_fullscreen_requested, tab))
         tab.caret.selection_toggled.connect(
             self._filter.create(self.cur_caret_selection_toggled, tab))
+        tab.search.search_match_changed.connect(
+            self._filter.create(self.cur_search_match_changed, tab))
         # misc
         tab.scroller.perc_changed.connect(self._on_scroll_pos_changed)
         tab.scroller.before_jump_requested.connect(lambda: self.set_mark("'"))
@@ -347,8 +350,6 @@ class TabbedBrowser(QWidget):
             functools.partial(self._on_title_changed, tab))
         tab.icon_changed.connect(
             functools.partial(self._on_icon_changed, tab))
-        tab.search_match_changed.connect(
-            functools.partial(self._on_search_match_changed, tab))
         tab.pinned_changed.connect(
             functools.partial(self._on_pinned_changed, tab))
         tab.load_progress.connect(
@@ -796,16 +797,6 @@ class TabbedBrowser(QWidget):
             return
         self.widget.update_tab_favicon(tab)
 
-    @pyqtSlot(browsertab.AbstractTab, int, int)
-    def _on_search_match_changed(self, tab, current: int, total: int):
-        """Pass along the signal of a changed active match.
-
-        Args:
-            current: The number of the currently active match.
-            total: The total number of matches on the page.
-        """
-        self.search_match_changed.emit(current, total)
-
     @pyqtSlot(usertypes.KeyMode)
     def on_mode_entered(self, mode):
         """Save input mode when tabs.mode_on_change = restore."""
@@ -864,7 +855,8 @@ class TabbedBrowser(QWidget):
                         .format(current_mode.name, mode_on_change))
         self._now_focused = tab
         self.current_tab_changed.emit(tab)
-        self.search_match_changed.emit(*tab.current_search_match())
+        self.cur_search_match_changed.emit(tab.search.current_match,
+                                           tab.search.total_match_count)
         QTimer.singleShot(0, self._update_window_title)
         self._tab_insert_idx_left = self.widget.currentIndex()
         self._tab_insert_idx_right = self.widget.currentIndex() + 1

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -798,6 +798,12 @@ class TabbedBrowser(QWidget):
 
     @pyqtSlot(browsertab.AbstractTab, int, int)
     def _on_search_match_changed(self, tab, current: int, total: int):
+        """Pass along the signal of a changed active match.
+
+        Args:
+            current: The number of the currently active match.
+            total: The total number of matches on the page.
+        """
         self.search_match_changed.emit(current, total)
 
     @pyqtSlot(usertypes.KeyMode)

--- a/scripts/dev/check_coverage.py
+++ b/scripts/dev/check_coverage.py
@@ -139,6 +139,8 @@ PERFECT_FILES = [
 
     (None,
      'qutebrowser/mainwindow/statusbar/keystring.py'),
+    (None,
+     'qutebrowser/mainwindow/statusbar/searchmatch.py'),
     ('tests/unit/mainwindow/statusbar/test_percentage.py',
      'qutebrowser/mainwindow/statusbar/percentage.py'),
     ('tests/unit/mainwindow/statusbar/test_progress.py',

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -219,13 +219,13 @@ Feature: Searching on a page
     Scenario: Preventing wrapping at the top of the page with QtWebEngine
         When I set search.ignore_case to always
         And I set search.wrap to false
+        And I set search.wrap_messages to true
         And I run :search --reverse foo
         And I wait for "search found foo with flags FindBackward" in the log
         And I run :search-next
         And I wait for "next_result found foo with flags FindBackward" in the log
         And I run :search-next
-        And I wait for "Search hit TOP" in the log
-        Then "foo" should be found
+        Then the message "Search hit TOP" should be shown
 
     @qtwebkit_skip @qt>=5.14
     Scenario: Preventing wrapping at the bottom of the page with QtWebEngine
@@ -236,8 +236,7 @@ Feature: Searching on a page
         And I run :search-next
         And I wait for "next_result found foo" in the log
         And I run :search-next
-        And I wait for "Search hit BOTTOM" in the log
-        Then "Foo" should be found
+        Then the message "Search hit BOTTOM" should be shown
 
     @qtwebengine_skip
     Scenario: Preventing wrapping at the top of the page with QtWebKit
@@ -262,6 +261,48 @@ Feature: Searching on a page
         And I run :search-next
         And I wait for "next_result didn't find foo" in the log
         Then the warning "Text 'foo' not found on page!" should be shown
+
+    ## search match counter
+
+    @qtwebkit_skip @qt>=5.14
+    Scenario: Setting search match counter on search
+        When I set search.ignore_case to always
+        And I set search.wrap to true
+        And I run :search ba
+        And I wait for "search found ba" in the log
+        Then "Setting search match text to 1/5" should be logged
+
+    @qtwebkit_skip @qt>=5.14
+    Scenario: Updating search match counter on search-next
+        When I set search.ignore_case to always
+        And I set search.wrap to true
+        And I run :search ba
+        And I wait for "search found ba" in the log
+        And I run :search-next
+        And I wait for "next_result found ba" in the log
+        And I run :search-next
+        And I wait for "next_result found ba" in the log
+        Then "Setting search match text to 3/5" should be logged
+
+    @qtwebkit_skip @qt>=5.14
+    Scenario: Updating search match counter on search-prev with wrapping
+        When I set search.ignore_case to always
+        And I set search.wrap to true
+        And I run :search ba
+        And I wait for "search found ba" in the log
+        And I run :search-prev
+        And I wait for the message "Search hit TOP, continuing at BOTTOM"
+        Then "Setting search match text to 5/5" should be logged
+
+    @qtwebkit_skip @qt>=5.14
+    Scenario: Updating search match counter on search-prev without wrapping
+        When I set search.ignore_case to always
+        And I set search.wrap to false
+        And I run :search ba
+        And I wait for "search found ba" in the log
+        And I run :search-prev
+        And I wait for the message "Search hit TOP"
+        Then "Setting search match text to 1/5" should be logged
 
     ## follow searched links
     @skip  # Too flaky


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

Fixes #3910, #6345, #5351.

This PR adds a match counter to the statusbar when starting a search and using `:search-prev` and `:search-next`, which is between the keystring and URL display by default (but can be moved and disabled like the other statusbar widgets).

It also adds an option to disable the search wrapping messages (`Search hit TOP` and so on) and restructures some of the QtWebEngine searching code in general.

I removed the janky "check scroll position to determine whether we wrapped around" code and replaced it with a match counter comparison, which does mean that the wrapping messages will no longer display on `qt < 5.14`, but will now work even when wrapping doesn't cause scrolling (because all the results are grouped together or the page is very short). If the messages disappearing on older versions is a problem, I can reinsert the scroll position-checking code.

Some things that aren't quite done yet:
- [x] Some lints need fixing
- [x] There aren't any tests for the new functionality yet
