### PR TITLE
Add a --private option to :tab-clone

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -383,17 +383,18 @@ class CommandDispatcher:
                 yield parsed
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
-    def tab_clone(self, bg=False, window=False):
+    def tab_clone(self, bg=False, window=False, private=False):
         """Duplicate the current tab.
 
         Args:
             bg: Open in a background tab.
             window: Open in a new window.
+            private: If the tab should be detached into a private instance.
 
         Return:
             The new QWebView.
         """
-        cmdutils.check_exclusive((bg, window), 'bw')
+        cmdutils.check_exclusive((bg, window, private), 'bwp')
         curtab = self._current_widget()
         cur_title = self._tabbed_browser.widget.page_title(
             self._current_index())
@@ -404,9 +405,9 @@ class CommandDispatcher:
 
         # The new tab could be in a new tabbed_browser (e.g. because of
         # tabs.tabs_are_windows being set)
-        if window:
+        if window or private:
             new_tabbed_browser = self._new_tabbed_browser(
-                private=self._tabbed_browser.is_private)
+                private=self._tabbed_browser.is_private or private)
         else:
             new_tabbed_browser = self._tabbed_browser
         newtab = new_tabbed_browser.tabopen(background=bg)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -389,7 +389,7 @@ class CommandDispatcher:
         Args:
             bg: Open in a background tab.
             window: Open in a new window.
-            private: If the tab should be detached into a private instance.
+            private: Open in a new private window.
 
         Return:
             The new QWebView.

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -653,7 +653,7 @@ Feature: Tab management
 
     Scenario: :tab-clone with -b and -w
         When I run :tab-clone -b -w
-        Then the error "Only one of -b/-w can be given!" should be shown.
+        Then the error "Only one of -b/-w/-p can be given!" should be shown.
 
     Scenario: Cloning a tab with history and title
         When I open data/title.html
@@ -731,6 +731,26 @@ Feature: Tab management
                 - url: http://localhost:*/data/title.html
                   title: Test title
             - tabs:
+              - active: true
+                history:
+                - url: about:blank
+                - url: http://localhost:*/data/title.html
+                  title: Test title
+
+    Scenario: Cloning to private window
+        When I open data/title.html
+        And I run :tab-clone -p
+        And I wait until data/title.html is loaded
+        Then the session should look like:
+            windows:
+            - tabs:
+              - active: true
+                history:
+                - url: about:blank
+                - url: http://localhost:*/data/title.html
+                  title: Test title
+            - tabs:
+              - private: true
               - active: true
                 history:
                 - url: about:blank

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -749,8 +749,8 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/title.html
                   title: Test title
-            - tabs:
-              - private: true
+            - private: true
+              tabs:
               - active: true
                 history:
                 - url: about:blank


### PR DESCRIPTION
Adds a `--private` option to `:tab-clone` to clone the tab into a private window, matching the flags already available for `:open` and `:tab-give`.