### PR TITLE
Make confirm_quit=downloads only ask when closing the last window

### DIFF
--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -620,13 +620,15 @@ class MainWindow(QWidget):
             True if closing is okay, False if a closeEvent should be ignored.
         """
         tab_count = self.tabbed_browser.widget.count()
+        window_count = len(objreg.window_registry)
         download_count = self._download_model.running_downloads()
         quit_texts = []
         # Ask if multiple-tabs are open
         if 'multiple-tabs' in config.val.confirm_quit and tab_count > 1:
             quit_texts.append("{} tabs are open.".format(tab_count))
-        # Ask if multiple downloads running
-        if 'downloads' in config.val.confirm_quit and download_count > 0:
+        # Ask if downloads running
+        if ('downloads' in config.val.confirm_quit and download_count > 0 and
+                window_count <= 1):
             quit_texts.append("{} {} running.".format(
                 download_count,
                 "download is" if download_count == 1 else "downloads are"))


### PR DESCRIPTION
Fixes #3615. This is maybe only a temporary fix, given the larger issues in #632, but I'm submitting a PR anyway because the current behaviour is a *major* annoyance for `tabs_are_windows` users.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
