### PR TITLE
More (Py)Qt 6 hacks

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1545,7 +1545,7 @@ class CommandDispatcher:
         # :search-prev            with reverse -> down
         going_up = options['reverse'] ^ prev
 
-        if found:
+        if found.numberOfMatches() > 0:
             # Check if the scroll position got smaller and show info.
             if not going_up and tab.scroller.pos_px().y() < old_scroll_pos.y():
                 message.info("Search hit BOTTOM, continuing at TOP")

--- a/qutebrowser/browser/webengine/notification.py
+++ b/qutebrowser/browser/webengine/notification.py
@@ -679,7 +679,7 @@ class _ServerCapabilities:
 def _as_uint32(x: int) -> QVariant:
     """Convert the given int to an uint32 for DBus."""
     variant = QVariant(x)
-    successful = variant.convert(QVariant.Type.UInt)
+    successful = variant.convert(QMetaType(QMetaType.Type.UInt.value))
     assert successful
     return variant
 
@@ -934,7 +934,7 @@ class DBusNotificationAdapter(AbstractNotificationAdapter):
         actions = []
         if self._capabilities.actions:
             actions = ['default', 'Activate']  # key, name
-        actions_arg = QDBusArgument(actions, QMetaType.Type.QStringList)
+        actions_arg = QDBusArgument(actions, QMetaType.Type.QStringList.value)
 
         origin_url_str = qt_notification.origin().toDisplayString()
         hints: Dict[str, Any] = {
@@ -949,7 +949,7 @@ class DBusNotificationAdapter(AbstractNotificationAdapter):
             hints["x-kde-origin-name"] = origin_url_str
 
         icon = qt_notification.icon()
-        if icon.isNull():
+        if icon.isNull() or not bool(icon.rect()):
             filename = ':/icons/qutebrowser-64x64.png'
             icon = QImage(filename)
 
@@ -1027,6 +1027,9 @@ class DBusNotificationAdapter(AbstractNotificationAdapter):
             # byteCount() is obsolete, but sizeInBytes() is only available with
             # SIP >= 5.3.0.
             size = qimage.byteCount()
+
+        if size == 0:
+            return None
 
         # Despite the spec not mandating this, many notification daemons mandate that
         # the last scanline does not have any padding bytes.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -198,8 +198,8 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._wrap_handler = _WebEngineSearchWrapHandler()
 
     def _empty_flags(self):
-        return 0
-        #return QWebEnginePage.FindFlag()  # type: ignore[call-overload]
+        #return 0
+        return QWebEnginePage.FindFlag(0)  # type: ignore[call-overload]
 
     def connect_signals(self):
         self._wrap_handler.connect_signal(self._widget.page())
@@ -230,7 +230,7 @@ class WebEngineSearch(browsertab.AbstractSearch):
             found_text = 'found' if found else "didn't find"
             if flags:
                 flag_text = 'with flags {}'.format(debug.qflags_key(
-                    QWebEnginePage, flags, klass=QWebEnginePage.FindFlag))
+                    QWebEnginePage, flags.value, klass=QWebEnginePage.FindFlag))
             else:
                 flag_text = ''
             log.webview.debug(' '.join([caller, found_text, text, flag_text])
@@ -238,7 +238,7 @@ class WebEngineSearch(browsertab.AbstractSearch):
 
             if callback is not None:
                 callback(found)
-            self.finished.emit(found)
+            self.finished.emit(found.numberOfMatches() > 0)
 
         self._widget.page().findText(text, flags, wrapped_callback)
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -845,6 +845,7 @@ class _WebEnginePermissions(QObject):
 
     _options = {
         0: 'content.notifications.enabled',
+        QWebEnginePage.Feature.Notifications: 'content.notifications.enabled',
         QWebEnginePage.Feature.Geolocation: 'content.geolocation',
         QWebEnginePage.Feature.MediaAudioCapture: 'content.media.audio_capture',
         QWebEnginePage.Feature.MediaVideoCapture: 'content.media.video_capture',
@@ -856,6 +857,7 @@ class _WebEnginePermissions(QObject):
 
     _messages = {
         0: 'show notifications',
+        QWebEnginePage.Feature.Notifications: 'show notifications',
         QWebEnginePage.Feature.Geolocation: 'access your location',
         QWebEnginePage.Feature.MediaAudioCapture: 'record audio',
         QWebEnginePage.Feature.MediaVideoCapture: 'record video',
@@ -1046,7 +1048,7 @@ class _WebEngineScripts(QObject):
     def _remove_js(self, name):
         """Remove an early QWebEngineScript."""
         scripts = self._widget.page().scripts()
-        for s in scripts.find(f'_qute_{name}'):
+        for script in scripts.find(f'_qute_{name}'):
             scripts.remove(script)
 
     def init(self):

--- a/qutebrowser/commands/runners.py
+++ b/qutebrowser/commands/runners.py
@@ -55,9 +55,12 @@ def _init_variable_replacements() -> Mapping[str, _ReplacementFunction]:
     """Return a dict from variable replacements to fns processing them."""
     replacements: Dict[str, _ReplacementFunction] = {
         'url': lambda tb: _url(tb).toString(
-            QUrl.ComponentFormattingOption.FullyEncoded | QUrl.UrlFormattingOption.RemovePassword),
+                
+                                   QUrl.UrlFormattingOption.RemovePassword |QUrl.ComponentFormattingOption.FullyEncoded),
         'url:pretty': lambda tb: _url(tb).toString(
-            QUrl.ComponentFormattingOption.DecodeReserved | QUrl.UrlFormattingOption.RemovePassword),
+            QUrl.UrlFormattingOption.RemovePassword |
+            QUrl.ComponentFormattingOption.DecodeReserved
+        ),
         'url:domain': lambda tb: "{}://{}{}".format(
             _url(tb).scheme(), _url(tb).host(),
             ":" + str(_url(tb).port()) if _url(tb).port() != -1 else ""),

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -427,7 +427,7 @@ class KeyInfo:
 
     def to_int(self) -> int:
         """Get the key as an integer (with key/modifiers)."""
-        return int(self.key) | int(self.modifiers)
+        return self.key | self.modifiers.value
 
 
 class KeySequence:
@@ -463,6 +463,8 @@ class KeySequence:
         """Convert a single key for QKeySequence."""
         #assert isinstance(key, (int, Qt.KeyboardModifier)), key
         #return int(key)
+        if isinstance(key, int):
+            return key
         return key.key()
 
     def __str__(self) -> str:

--- a/qutebrowser/keyinput/modeman.py
+++ b/qutebrowser/keyinput/modeman.py
@@ -24,7 +24,7 @@ import dataclasses
 from typing import Mapping, Callable, MutableMapping, Union, Set, cast
 
 from PyQt6.QtCore import pyqtSlot, pyqtSignal, Qt, QObject, QEvent
-from PyQt6.QtGui import QKeyEvent
+from PyQt6.QtGui import QKeySequence, QKeyEvent
 
 from qutebrowser.commands import runners
 from qutebrowser.keyinput import modeparsers, basekeyparser
@@ -296,7 +296,7 @@ class ModeManager(QObject):
 
         forward_unbound_keys = config.cache['input.forward_unbound_keys']
 
-        if match:
+        if match != QKeySequence.SequenceMatch.NoMatch:
             filter_this = True
         elif (parser.passthrough or forward_unbound_keys == 'all' or
               (forward_unbound_keys == 'auto' and is_non_alnum)):

--- a/qutebrowser/utils/debug.py
+++ b/qutebrowser/utils/debug.py
@@ -125,7 +125,7 @@ def qenum_key(base: Type[_EnumValueType],
         meta_obj = base.staticMetaObject  # type: ignore[union-attr]
         idx = meta_obj.indexOfEnumerator(klass.__name__)
         meta_enum = meta_obj.enumerator(idx)
-        ret = meta_enum.valueToKey(int(value))  # type: ignore[arg-type]
+        ret = meta_enum.valueToKey(value.value)  # type: ignore[arg-type]
     except AttributeError:
         ret = None
 
@@ -135,7 +135,7 @@ def qenum_key(base: Type[_EnumValueType],
                 ret = name
                 break
         else:
-            ret = '0x{:04x}'.format(int(value))  # type: ignore[arg-type]
+            ret = '0x{:04x}'.format(value.value)  # type: ignore[arg-type]
 
     if add_base and hasattr(base, '__name__'):
         return '.'.join([base.__name__, ret])


### PR DESCRIPTION
I managed to get a new enough cmake and icu on debian so I have a 6.2 Qt build now. I wanted to get a working browser running on it so I can look for regressions in Qt but haven't really managed to get past PyQt yet. Probably won't have too much more time to look at it until next weekend.

This PR is based on the qt6-test branch and all the fun on there. The good news is that a lot of stuff works! (To be clear to anyone unclear of the state of qutebrowser's 6.2 support: getting stuff working at this point just lets us do regression testing, there is still a bunch of refactoring to do to make the codebase work on both 5.15 and 6.2.)
The most widespread issue I've seen so far is from enums. There are a bunch of places where we do things like:

`int(some_enum_value)`
`if some_enum_value:`  (so `TheEnum(0)` is expected to be falsey)

Stuff like that. Basically most(?) enums aren't acting as much like ints as they used to. Here are ones I've spotted so far (I'm sure there are more):

QtCore.Qt.KeyboardModifier
QtCore.Qt.Key
QtGui.QKeySequence.SequenceMatch
QtGui.QKeySequence.SequenceFormat
QtWebEngineCore.QWebEnginePage.Feature
QtCore.QMetaType.Type
QtWebEngineCore.QWebEnginePage.FindFlags

I sent an email to the PyQt mailing list yesterday (I don't see it in the archives yet though, maybe I was supposed to subscribe before sending to it?) about most of them, apart from the last one. It is weird that it is fixed for some and not others, for instance `int(QWebEngineScript.ScriptWorldId.UserWorld)` works fine, probably because you reported it separately already.

The issue you reported about UrlFormattingOption and ComponentFormattingOption isn't entirely resolved, you can combine them now (with `|`) but you can't pass ComponentFormattingOption values to the methods that claim to accept a UrlFormattingOption but actually should accept both. I worked around a couple of instances in this PR but there are more.

Other, and less copypasta, issues I've seen but haven't looked into much yet:

1. The default qutebrowser icon for notifications isn't working, the QImage we create is empty
2. "Could not initialize QtNetwork SSL support.", not sure if it is my setup but downloads aren't working because of it (QNetwork.supportsSsl() reports false in python and true in c++)
3. Category headings in the completion dialog don't look fancy anymore
4. Selected completion row's background is blue
5. QWebEngineHistory serialization doesn't work anymore, for instance when closing a tab. A non fatal error from Qt is printed out `QVariant::save: unable to save type 'QObject*' (type id: 39)`. When you try to undo the tab close then the deserialization will choke on the incomplete data stream. The individual history items can be serialized fine though. Saving and loading sessions still seems to work fine. I'm not sure whether this is a Qt or PyQt issue, I thought it might be https://codereview.qt-project.org/c/qt/qtwebengine/+/327625 (parent of QWebEngineHistory is now a QObject) but I tried to reproduce in C++ and didn't get the same error (it also didn't print out as much hex as I was expecting though, so I might have messed something else up).

Relates to: https://github.com/qutebrowser/qutebrowser/issues/5395