### PR TITLE
Delay changing audible status

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -26,7 +26,8 @@ import re
 import html as html_utils
 from typing import cast, Union, Optional
 
-from PyQt5.QtCore import pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QUrl, QObject
+from PyQt5.QtCore import (pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QTimer, QUrl,
+                          QObject)
 from PyQt5.QtNetwork import QAuthenticator
 from PyQt5.QtWidgets import QWidget
 from PyQt5.QtWebEngineWidgets import QWebEnginePage, QWebEngineScript, QWebEngineHistory
@@ -797,12 +798,37 @@ class WebEngineAudio(browsertab.AbstractAudio):
         super().__init__(tab, parent)
         self._overridden = False
 
+        # Implements the intended two-second delay specified at
+        # https://doc.qt.io/qt-5/qwebenginepage.html#recentlyAudibleChanged
+        delay_ms = 2000
+        self._audio_muted_timer = QTimer(self)
+        self._audio_muted_timer.setSingleShot(True)
+        self._audio_muted_timer.setInterval(delay_ms)
+
     def _connect_signals(self):
         page = self._widget.page()
         page.audioMutedChanged.connect(self.muted_changed)
-        page.recentlyAudibleChanged.connect(self.recently_audible_changed)
+        page.recentlyAudibleChanged.connect(self._delayed_recently_audible_changed)
         self._tab.url_changed.connect(self._on_url_changed)
         config.instance.changed.connect(self._on_config_changed)
+
+    # WORKAROUND for recentlyAudibleChanged being emitted without delay from the moment
+    # that audio is dropped.
+    def _delayed_recently_audible_changed(self, recently_audible):
+        timer = self._audio_muted_timer
+        # Stop any active timer and immediately display [A] if tab is audible,
+        # otherwise start a timer to update audio field
+        if recently_audible:
+            if timer.isActive():
+                timer.stop()
+            self.recently_audible_changed.emit(recently_audible)
+        else:
+            # Ignore all subsequent calls while the tab is muted with an active timer
+            if timer.isActive():
+                return
+            timer.timeout.connect(
+                functools.partial(self.recently_audible_changed.emit, recently_audible))
+            timer.start()
 
     def set_muted(self, muted: bool, override: bool = False) -> None:
         was_muted = self.is_muted()

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -221,8 +221,10 @@ class TabbedBrowser(QWidget):
         self.cur_fullscreen_requested.connect(self.widget.tabBar().maybe_hide)
         self.widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
-        # WORKAROUND for recentlyAudibleChanged being emitted without delay
-        # from the moment that the audio is paused
+        # Throttle calls to _on_audio_changed as WORKAROUND for recentlyAudibleChanged
+        # being emitted without delay from the moment that audio is dropped.
+        # delay_ms=2000 implements the intended two-second delay, specified at
+        # https://doc.qt.io/qt-5/qwebenginepage.html#recentlyAudibleChanged
         self._on_audio_changed_throttle = throttle.Throttle(
             self._on_audio_changed, delay_ms=2000, parent=self)
 

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -224,7 +224,7 @@ class TabbedBrowser(QWidget):
         # WORKAROUND for recentlyAudibleChanged being emitted without delay
         # from the moment that the audio is paused
         self._on_audio_changed_throttle = throttle.Throttle(
-            self._on_audio_changed, 2000, parent=self)
+            self._on_audio_changed, delay_ms=2000, parent=self)
 
         # load_finished instead of load_started as WORKAROUND for
         # https://bugreports.qt.io/browse/QTBUG-65223

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -25,7 +25,7 @@ import weakref
 import datetime
 import dataclasses
 from typing import (
-    Any, Deque, List, Mapping, MutableMapping, MutableSequence, Optional, Tuple)
+    Any, Deque, Dict, List, Mapping, MutableMapping, MutableSequence, Optional, Tuple)
 
 from PyQt5.QtWidgets import QSizePolicy, QWidget, QApplication
 from PyQt5.QtCore import pyqtSignal, pyqtSlot, QTimer, QUrl
@@ -219,7 +219,7 @@ class TabbedBrowser(QWidget):
         self.cur_fullscreen_requested.connect(self.widget.tabBar().maybe_hide)
         self.widget.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
 
-        self._audio_muted_timers: Mapping[QWidget, QTimer] = {}
+        self._audio_muted_timers: Dict[QWidget, QTimer] = {}
 
         # load_finished instead of load_started as WORKAROUND for
         # https://bugreports.qt.io/browse/QTBUG-65223


### PR DESCRIPTION
Closes #6168. On tabs with audio that becomes silent for short intervals, e.g. lectures or podcasts, the audible status indicator [A] no longer flickers in and out of the tab title.

I picked a 2 second delay because this change is meant to work around the QT signal [recentlyAudibleChanged](https://doc.qt.io/qt-5/qwebenginepage.html#recentlyAudibleChanged)'s failure to be "emitted with an approximate two-second delay, from the moment the audio is paused".

On my machine, starting any audio in a tab emits `recentlyAudibleChanged` twice. `tab.audio.is_recently_audible()` is `False` the first time around and `True` the second time, so the line `self._on_audio_changed_throttle._last_call_ms = None` is necessary to immediately display the indicator [A]. This asymmetry in behaviour upon dropping or picking up audio is, as far as I can tell, intended by QT.

I'm a new contributor so any feedback will be appreciated.