### PR TITLE
ignore -1 tabindex for hints

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1633,7 +1633,7 @@ hints.selectors:
       - '[ngClick]'
       - '[data-ng-click]'
       - '[x-ng-click]'
-      - '[tabindex]'
+      - '[tabindex]:not([tabindex="-1"])'
     links:
       - 'a[href]'
       - 'area[href]'


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

It's very common for `tabindex=-1` which just means to remove the element from sequential tabbing.  Modifying the default hinting selecto `[tabindex]` to ignore them when the value is `-1` removes a lot of false positive hints.

https://github.com/philc/vimium/blob/master/content_scripts/link_hints.js#L998

Related: https://github.com/qutebrowser/qutebrowser/issues/178

See the album text before and after change

BEFORE

<img width="1313" alt="Screen Shot 2021-10-20 at 11 14 57 PM" src="https://user-images.githubusercontent.com/1940365/138213363-17ef5054-0534-4526-8204-c98b0b625233.png">

AFTER

<img width="1388" alt="Screen Shot 2021-10-21 at 12 48 58 AM" src="https://user-images.githubusercontent.com/1940365/138213383-4d57240e-8b14-4db1-8b51-d1e52309b308.png">

