### PR TITLE
qute-pass: support gopass configuration option: safecontent

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -165,7 +165,10 @@ def _run_pass(pass_arguments):
 
 
 def pass_(path):
-    return _run_pass(['show', path])
+    args = ['show', path]
+    if arguments.mode == "gopass":
+        args = ['show', '-o', path]
+    return _run_pass(args)
 
 
 def pass_otp(path):


### PR DESCRIPTION
```
qute-pass: support gopass configuration option: safecontent

This patch adds the `-o` flag to the `show` command passed to the pass
executable when the mode is set to "gopass". This ensures the script
supports users who have `safecontent: true` set in their configuration
file, which hides the first line of content (which is typically the
password for the entry).

closes #6760
```

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
