### PR TITLE
Pick backend automatically for tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -229,10 +229,10 @@ def pytest_configure(config):
         import PyQt5.QtWebEngineWidgets
         config.backend = 'webengine'
 
-    webengine_arg = config.getoption('--qute-bdd-backend')
-    webengine_env = os.environ.get('QUTE_BDD_BACKEND')
-    config.webengine = (webengine_arg == 'webengine' or
-                        webengine_env == 'webengine' or
+    backend_arg = config.getoption('--qute-bdd-backend')
+    backend_env = os.environ.get('QUTE_BDD_BACKEND')
+    config.webengine = (backend_arg == 'webengine' or
+                        backend_env == 'webengine' or
                         config.backend == 'webengine')
 
     earlyinit.configure_pyqt()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -219,6 +219,16 @@ def pytest_addoption(parser):
 
 
 def pytest_configure(config):
+    try:
+        # Try to use QtWebkit as the default backend
+        import PyQt5.QtWebKitWidgets
+        config.backend = 'webkit'
+    except ImportError:
+        # Try to use QtWebEngine as a fallback and fail early
+        # if that's also not available
+        import PyQt5.QtWebEngineWidgets
+        config.backend = 'webengine'
+
     webengine_arg = config.getoption('--qute-bdd-webengine')
     webengine_env = os.environ.get('QUTE_BDD_WEBENGINE', 'false')
     config.webengine = webengine_arg or webengine_env == 'true'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,7 +239,14 @@ def pytest_configure(config):
 
 
 def pytest_report_header(config):
-    return f'backend: {config.backend}'
+    if config.backend == 'webkit':
+        backend_version = version.qWebKitVersion()
+    elif config.backend == 'webengine':
+        backend_version = version.qtwebengine_versions(avoid_init=True)
+    else:
+        raise utils.Unreachable(config.backend)
+
+    return f'backend: {config.backend} ({backend_version})'
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -220,7 +220,7 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     try:
-        # Try to use QtWebkit as the default backend
+        # Try to use QtWebKit as the default backend
         import PyQt5.QtWebKitWidgets
         config.backend = 'webkit'
     except ImportError:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -226,6 +226,25 @@ def pytest_configure(config):
 
 
 def _select_backend(config):
+    """Select the backend for running tests.
+
+    The backend is auto-selected in the following manner:
+    1. Use QtWebKit if available
+    2. Otherwise use QtWebEngine as a fallback
+
+    Auto-selection is overridden by either passing a backend via
+    `--qute-bdd-backend=<backend>` or setting the environment variable
+    `QUTE_BDD_BACKEND=<backend>`.
+
+    Args:
+        config: pytest config
+
+    Raises:
+        ImportError if the selected backend is not available.
+
+    Returns:
+        The selected backend as a string (e.g. 'webkit').
+    """
     backend_arg = config.getoption('--qute-bdd-backend')
     backend_env = os.environ.get('QUTE_BDD_BACKEND')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -231,10 +231,9 @@ def pytest_configure(config):
 
     webengine_arg = config.getoption('--qute-bdd-webengine')
     webengine_env = os.environ.get('QUTE_BDD_WEBENGINE', 'false')
-    config.webengine = webengine_arg or webengine_env == 'true'
-    # Fail early if QtWebEngine is not available
-    if config.webengine:
-        import PyQt5.QtWebEngineWidgets
+    config.webengine = (webengine_arg or webengine_env == 'true' or
+                        config.backend == 'webengine')
+
     earlyinit.configure_pyqt()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -237,6 +237,10 @@ def pytest_configure(config):
     earlyinit.configure_pyqt()
 
 
+def pytest_report_header(config):
+    return f'backend: {config.backend}'
+
+
 @pytest.fixture(scope='session', autouse=True)
 def check_display(request):
     if utils.is_linux and not os.environ.get('DISPLAY', ''):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,8 +214,8 @@ def pytest_addoption(parser):
                      help="Delay between qutebrowser commands.")
     parser.addoption('--qute-profile-subprocs', action='store_true',
                      default=False, help="Run cProfile for subprocesses.")
-    parser.addoption('--qute-bdd-webengine', action='store_true',
-                     help='Use QtWebEngine for BDD tests')
+    parser.addoption('--qute-bdd-backend', action='store',
+                     choices=['webkit', 'webengine'], help='Set backend for BDD tests')
 
 
 def pytest_configure(config):
@@ -229,9 +229,10 @@ def pytest_configure(config):
         import PyQt5.QtWebEngineWidgets
         config.backend = 'webengine'
 
-    webengine_arg = config.getoption('--qute-bdd-webengine')
-    webengine_env = os.environ.get('QUTE_BDD_WEBENGINE', 'false')
-    config.webengine = (webengine_arg or webengine_env == 'true' or
+    webengine_arg = config.getoption('--qute-bdd-backend')
+    webengine_env = os.environ.get('QUTE_BDD_BACKEND')
+    config.webengine = (webengine_arg == 'webengine' or
+                        webengine_env == 'webengine' or
                         config.backend == 'webengine')
 
     earlyinit.configure_pyqt()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -239,14 +239,12 @@ def pytest_configure(config):
 
 
 def pytest_report_header(config):
-    if config.backend == 'webkit':
-        backend_version = version.qWebKitVersion()
-    elif config.backend == 'webengine':
+    if config.webengine:
         backend_version = version.qtwebengine_versions(avoid_init=True)
     else:
-        raise utils.Unreachable(config.backend)
+        backend_version = version.qWebKitVersion()
 
-    return f'backend: {config.backend} ({backend_version})'
+    return f'backend: {backend_version}'
 
 
 @pytest.fixture(scope='session', autouse=True)

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -165,7 +165,7 @@ if not getattr(sys, 'frozen', False):
 
 
 def pytest_collection_modifyitems(config, items):
-    """Apply @qtwebengine_* markers; skip unittests with QUTE_BDD_WEBENGINE."""
+    """Apply @qtwebengine_* markers; skip unittests with QUTE_BDD_BACKEND=webengine."""
     # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-75884
     # (note this isn't actually fixed properly before Qt 5.15)
     header_bug_fixed = qtutils.version_check('5.15', compiled=False)

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ minversion = 3.15
 setenv =
     PYTEST_QT_API=pyqt5
     pyqt{,512,513,514,515,5150}: LINK_PYQT_SKIP=true
-    pyqt{,512,513,514,515,5150}: QUTE_BDD_WEBENGINE=true
     cov: PYTEST_ADDOPTS=--cov --cov-report xml --cov-report=html --cov-report=
 passenv = PYTHON DISPLAY XAUTHORITY HOME USERNAME USER CI XDG_* QUTE_* DOCKER QT_QUICK_BACKEND PY_COLORS DBUS_SESSION_BUS_ADDRESS
 basepython =
@@ -42,7 +41,6 @@ commands =
 basepython = {env:PYTHON:python3}
 setenv =
     PYTEST_QT_API=pyqt5
-    QUTE_BDD_WEBENGINE=true
 pip_pre = true
 deps = -r{toxinidir}/misc/requirements/requirements-tests-bleeding.txt
 commands_pre = pip install --index-url https://www.riverbankcomputing.com/pypi/simple/ --pre --upgrade PyQt5 PyQtWebEngine


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
With these changes the backend is picked automatically when running tests.

QtWebKit will be picked over QtWebEngine if both are available. Otherwise we pick the backend, which is available.

The backend auto-detection mechanism can be overriden by passing the backend to pytest via `--qute-bdd-backend=<backend>` or by settings the environment variable `QUTE_BDD_BACKEND=<backend>`. Accepted values for `<backend>` are `webkit` or `webengine`.

Closes #3051 
