### PR TITLE
Match binds aggressively and avoid binds in hint generation

### DIFF
--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -228,7 +228,12 @@ class BaseKeyParser(QObject):
                          - The found binding with Match.definitive.
         """
         assert sequence
-        return self.bindings.matches(sequence)
+        while len(sequence) > 0:
+            result = self.bindings.matches(sequence)
+            if result.match_type != QKeySequence.NoMatch:
+                break
+            sequence = keyutils.KeySequence(*list(sequence.iter_keys())[1:])
+        return result
 
     def _match_without_modifiers(
             self, sequence: keyutils.KeySequence) -> MatchResult:

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -471,7 +471,7 @@ class KeySequence:
 
     def __iter__(self) -> Iterator[KeyInfo]:
         """Iterate over KeyInfo objects."""
-        for key_and_modifiers in self._iter_keys():
+        for key_and_modifiers in self.iter_keys():
             key = Qt.Key(int(key_and_modifiers) & ~Qt.KeyboardModifierMask)
             modifiers = Qt.KeyboardModifiers(  # type: ignore[call-overload]
                 int(key_and_modifiers) & Qt.KeyboardModifierMask)
@@ -521,13 +521,13 @@ class KeySequence:
 
     def __getitem__(self, item: Union[int, slice]) -> Union[KeyInfo, 'KeySequence']:
         if isinstance(item, slice):
-            keys = list(self._iter_keys())
+            keys = list(self.iter_keys())
             return self.__class__(*keys[item])
         else:
             infos = list(self)
             return infos[item]
 
-    def _iter_keys(self) -> Iterator[int]:
+    def iter_keys(self) -> Iterator[int]:
         sequences = cast(Iterable[Iterable[int]], self._sequences)
         return itertools.chain.from_iterable(sequences)
 
@@ -628,7 +628,7 @@ class KeySequence:
                 modifiers &= ~Qt.MetaModifier
                 modifiers |= Qt.ControlModifier
 
-        keys = list(self._iter_keys())
+        keys = list(self.iter_keys())
         keys.append(key | int(modifiers))
 
         return self.__class__(*keys)
@@ -636,7 +636,7 @@ class KeySequence:
     def strip_modifiers(self) -> 'KeySequence':
         """Strip optional modifiers from keys."""
         modifiers = Qt.KeypadModifier
-        keys = [key & ~modifiers for key in self._iter_keys()]
+        keys = [key & ~modifiers for key in self.iter_keys()]
         return self.__class__(*keys)
 
     def with_mappings(
@@ -645,7 +645,7 @@ class KeySequence:
     ) -> 'KeySequence':
         """Get a new KeySequence with the given mappings applied."""
         keys = []
-        for key in self._iter_keys():
+        for key in self.iter_keys():
             key_seq = KeySequence(key)
             if key_seq in mappings:
                 keys += [info.to_int() for info in mappings[key_seq]]

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -216,8 +216,8 @@ class HintKeyParser(basekeyparser.BaseKeyParser):
 
         assert not dry_run
 
-        if (self._command_parser.handle(e, dry_run=True) !=
-                QKeySequence.NoMatch):
+        if (self._command_parser.handle(e, dry_run=True) ==
+                QKeySequence.ExactMatch):
             log.keyboard.debug("Handling key via command parser")
             self.clear_keystring()
             return self._command_parser.handle(e)

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -216,18 +216,19 @@ class HintKeyParser(basekeyparser.BaseKeyParser):
 
         assert not dry_run
 
-        if (self._command_parser.handle(e, dry_run=True) ==
-                QKeySequence.ExactMatch):
+        command_match = self._command_parser.handle(e)
+        match = super().handle(e)
+
+        if command_match == QKeySequence.ExactMatch:
             log.keyboard.debug("Handling key via command parser")
             self.clear_keystring()
-            return self._command_parser.handle(e)
-
-        match = super().handle(e)
+            return command_match
 
         if match == QKeySequence.PartialMatch:
             self._last_press = LastPress.keystring
         elif match == QKeySequence.ExactMatch:
             self._last_press = LastPress.none
+            self._command_parser.clear_keystring()
         elif match == QKeySequence.NoMatch:
             # We couldn't find a keychain so we check if it's a special key.
             return self._handle_filter_key(e)


### PR DESCRIPTION
With the first of these commits, binds are matched more aggressively. `:bind --mode normal ab nop` and then pressing `a:` will enter command mode, unlike before and like vim. This closes #6001.

That behavior exacerbates #6002, however, which is fixed in the second commit. It has little to no effect on performance with few hint binds, and still brings up hints in about a tenth to a quarter of a second with my eight (five of which are single letters that are also in hintchars at the moment, the worst case) on a crowded github page on my laptop.

Two issues with this PR are that it will infinitely loop if there is no 'solution,' e.g. each hint char has a hint bind, and that I made `KeySequence`'s `iter_keys` public and am not sure if I should have avoided doing so.

I was unable to get all tests to even run, though `pylint` at least is passing (I would argue it shouldn't be, I struggled to split up lines in many places). `test_hints.py` also needs to pass a `BaseKeyParser` on line 107 (see `hints.py` line 470) but I can't find where it is called to see if I can pass it one to forward instead of creating a new one.