### PR TITLE
fix(userscript): remove `rofi` hard-coded invocation #6558

### DIFF
--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -98,16 +98,12 @@ def qute_command(command):
         fifo.flush()
 
 
-def ask_password():
-    process = subprocess.run([
-        'rofi',
-        '-dmenu',
-        '-p',
-        'Master Password',
-        '-password',
-        '-lines',
-        '0',
-    ], universal_newlines=True, stdout=subprocess.PIPE)
+def ask_password(dmenu_invocation):
+    command = shlex.split(dmenu_invocation)
+    process = subprocess.run(
+            command,
+            universal_newlines=True,
+            stdout=subprocess.PIPE)
     if process.returncode > 0:
         raise Exception('Could not unlock vault')
     master_pass = process.stdout.strip()
@@ -117,10 +113,10 @@ def ask_password():
     ).strip()
 
 
-def get_session_key(auto_lock):
+def get_session_key(auto_lock, dmenu_invocation):
     if auto_lock == 0:
         subprocess.call(['keyctl', 'purge', 'user', 'bw_session'])
-        return ask_password()
+        return ask_password(dmenu_invocation)
     else:
         process = subprocess.run(
             ['keyctl', 'request', 'user', 'bw_session'],
@@ -129,7 +125,7 @@ def get_session_key(auto_lock):
         )
         key_id = process.stdout.strip()
         if process.returncode > 0:
-            session = ask_password()
+            session = ask_password(dmenu_invocation)
             if not session:
                 raise Exception('Could not unlock vault')
             key_id = subprocess.check_output(
@@ -145,8 +141,8 @@ def get_session_key(auto_lock):
         ).strip()
 
 
-def pass_(domain, encoding, auto_lock):
-    session_key = get_session_key(auto_lock)
+def pass_(domain, encoding, auto_lock, dmenu_invocation):
+    session_key = get_session_key(auto_lock, dmenu_invocation)
     process = subprocess.run(
         ['bw', 'list', 'items', '--session', session_key, '--url', domain],
         stdout=subprocess.PIPE,
@@ -166,8 +162,8 @@ def pass_(domain, encoding, auto_lock):
     return out
 
 
-def get_totp_code(selection_id, domain_name, encoding, auto_lock):
-    session_key = get_session_key(auto_lock)
+def get_totp_code(selection_id, domain_name, encoding, auto_lock, dmenu_invocation):
+    session_key = get_session_key(auto_lock, dmenu_invocation)
     process = subprocess.run(
         ['bw', 'get', 'totp', '--session', session_key, selection_id],
         stdout=subprocess.PIPE,
@@ -224,6 +220,7 @@ def main(arguments):
                 target,
                 arguments.io_encoding,
                 arguments.auto_lock,
+                arguments.dmenu_invocation,
             )
         )
         if not target_candidates:
@@ -270,7 +267,8 @@ def main(arguments):
                 selection['id'],
                 selection['name'],
                 arguments.io_encoding,
-                arguments.auto_lock
+                arguments.auto_lock,
+                arguments.dmenu_invocation
             )
         )
     else:
@@ -294,7 +292,8 @@ def main(arguments):
                 selection['id'],
                 selection['name'],
                 arguments.io_encoding,
-                arguments.auto_lock
+                arguments.auto_lock,
+                arguments.dmenu_invocation
             )
         )
 


### PR DESCRIPTION
The userscript for bitwarden includes a hard-coded invocation to `rofi`.
This removes it and uses the command passed via the argument `--dmenu-invocation` instead.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
