### PR TITLE
adding space key for :fake-key to the doc

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -539,7 +539,7 @@ Syntax: +:fake-key [*--global*] 'keystring'+
 
 Send a fake keypress or key string to the website or qutebrowser.
 
-:fake-key xy - sends the keychain 'xy' :fake-key <Ctrl-x> - sends Ctrl-x :fake-key <Escape> - sends the escape key
+:fake-key xy - sends the keychain 'xy' :fake-key <Ctrl-x> - sends Ctrl-x :fake-key <Escape> - sends the escape key :fake-key <Space> - sends the space key
 
 ==== positional arguments
 * +'keystring'+: The keystring to send.


### PR DESCRIPTION
adding it to the documentation would remove ambiguity.
