### PR TITLE
Make open_url_in_instance.sh check for additional parameters

### DIFF
--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -2,14 +2,18 @@
 # initial idea: Florian Bruhin (The-Compiler)
 # author: Thore Bödecker (foxxx0)
 
-_url="$1"
+_arg=$1
 _qb_version='1.0.4'
 _proto_version=1
 _ipc_socket="${XDG_RUNTIME_DIR}/qutebrowser/ipc-$(echo -n "$USER" | md5sum | cut -d' ' -f1)"
 _qute_bin="/usr/bin/qutebrowser"
 
-printf '{"args": ["%s"], "target_arg": null, "version": "%s", "protocol_version": %d, "cwd": "%s"}\n' \
-       "${_url}" \
-       "${_qb_version}" \
-       "${_proto_version}" \
-       "${PWD}" | socat -lf /dev/null - UNIX-CONNECT:"${_ipc_socket}" || "$_qute_bin" "$@" &
+if [[ $# -eq 1 ]]; then
+    printf '{"args": ["%s"], "target_arg": null, "version": "%s", "protocol_version": %d, "cwd": "%s"}\n' \
+        "${_arg}" \
+        "${_qb_version}" \
+        "${_proto_version}" \
+        "${PWD}" | socat -lf /dev/null - UNIX-CONNECT:"${_ipc_socket}"
+else
+    ${_qute_bin} $@ &
+fi


### PR DESCRIPTION
If one argument received, assume it's an url and open by socket call. If more than one argument received, let ${_qute_bin} handle it directly.

This enables us to run e.g. qutebrowser --target=window <url>.
