### PR TITLE
userscripts/open_download: Flatpak compatibility

### DIFF
--- a/misc/userscripts/open_download
+++ b/misc/userscripts/open_download
@@ -121,4 +121,4 @@ else
     msg info "Opening »$file« (of type $filetype) with ${application%.desktop}"
 fi
 
-xdg-open "$path" &
+xdg-open "$path"

--- a/misc/userscripts/open_download
+++ b/misc/userscripts/open_download
@@ -103,13 +103,22 @@ fi
 file="${entries[$line]}"
 file="${file%%$'\t'*}"
 path="$DOWNLOAD_DIR/$file"
-filetype=$(xdg-mime query filetype "$path")
-application=$(xdg-mime query default "$filetype")
 
-if [ -z "$application" ] ; then
-    die "Do not know how to open »$file« of type $filetype"
+if [ -f /.flatpak-info ]; then
+    # with the help of the appchooser portal, flatpak let the user select the
+    # app associated with a mime type after executing xdg-open.
+    # we can't know ahead of time which app will be launched, and the sandbox
+    # doesn't have access to mime types known to the host.
+    msg info "Opening »$file« with XDG Desktop Portal"
+else
+    filetype=$(xdg-mime query filetype "$path")
+    application=$(xdg-mime query default "$filetype")
+
+    if [ -z "$application" ] ; then
+        die "Do not know how to open »$file« of type $filetype"
+    fi
+
+    msg info "Opening »$file« (of type $filetype) with ${application%.desktop}"
 fi
-
-msg info "Opening »$file« (of type $filetype) with ${application%.desktop}"
 
 xdg-open "$path" &


### PR DESCRIPTION
Make `open_download` compatible with Flatpak.

flatpak-xdg-utils's `xdg-open` send the request to open a file with associated application through XDG Desktop Portal, letting the user select application with the AppChooser Portal.  
In the Flatpak sandbox, we don't know which app would be launched, and we know very little about mime types.  

I also think that `open_download` should wait for `xdg-open` return code. We want to know when `xdg-open` failed, and we want to read the output with `:process`.