### PR TITLE
Add yomichad to userscripts

### DIFF
--- a/misc/userscripts/README.md
+++ b/misc/userscripts/README.md
@@ -85,6 +85,9 @@ The following userscripts can be found on their own repositories.
   various small userscripts written in Raku.
 - [bitwarden-rofi](https://github.com/haztecaso/bitwarden-rofi), rofi wrapper for bitwarden cli
   interface using gpg instead of keyctl.
+- [yomichad](https://github.com/potamides/yomichad): Japanese pop-up dictionary
+  for looking up readings and definitions of currently selected words, kanji
+  and names
   
 [Zotero]: https://www.zotero.org/
 [Pocket]: https://getpocket.com/


### PR DESCRIPTION
In response to the request on [r/qutebrowser](https://www.reddit.com/r/qutebrowser/comments/s3xqas/comment/hsqn8db/?utm_source=share&utm_medium=web2x&context=3), I'd like to add yomichad, a Japanese pop-up dictionary to the list of userscripts.