### PR TITLE
Added window id parameter in _tabs funciton used it in delete_tabs function

### DIFF
--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -103,17 +103,21 @@ def session(*, info=None):
     return model
 
 
-def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True):
+def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, current_win_id):
     """Helper to get the completion model for tabs/other_tabs.
 
     Args:
         win_id_filter: A filter function for window IDs to include.
                        Should return True for all included windows.
         add_win_id: Whether to add the window ID to the completion items.
+        current_win_id: Window ID to be passed from info.win_id
     """
     def delete_tab(data):
         """Close the selected tab."""
-        win_id, tab_index = data[0].split('/')
+        
+        win_id = current_win_id
+        tab_index = data[0].split('/')[-1]      # data[0] can be 'tabInd' or 'winID/tabInd'
+
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=int(win_id))
         tabbed_browser.on_tab_close_requested(int(tab_index) - 1)
@@ -177,13 +181,13 @@ def other_tabs(*, info):
 
     Used for the tab-take command.
     """
-    return _tabs(win_id_filter=lambda win_id: win_id != info.win_id)
+    return _tabs(win_id_filter=lambda win_id: win_id != info.win_id, current_win_id=info.win_id)
 
 
 def tab_focus(*, info):
     """A model to complete on open tabs in the current window."""
     model = _tabs(win_id_filter=lambda win_id: win_id == info.win_id,
-                  add_win_id=False)
+                  add_win_id=False, current_win_id=info.win_id)
 
     special = [
         ("last", "Focus the last-focused tab"),

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -103,7 +103,7 @@ def session(*, info=None):
     return model
 
 
-def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, current_win_id):
+def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, current_win_id=0):
     """Helper to get the completion model for tabs/other_tabs.
 
     Args:
@@ -114,7 +114,6 @@ def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, current_win_id
     """
     def delete_tab(data):
         """Close the selected tab."""
-        
         win_id = current_win_id
         tab_index = data[0].split('/')[-1]      # data[0] can be 'tabInd' or 'winID/tabInd'
 

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -103,19 +103,20 @@ def session(*, info=None):
     return model
 
 
-def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, current_win_id=0):
+def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, cur_win_id=0):
     """Helper to get the completion model for tabs/other_tabs.
 
     Args:
         win_id_filter: A filter function for window IDs to include.
                        Should return True for all included windows.
         add_win_id: Whether to add the window ID to the completion items.
-        current_win_id: Window ID to be passed from info.win_id
+        cur_win_id: Window ID to be passed from info.win_id
     """
     def delete_tab(data):
         """Close the selected tab."""
-        win_id = current_win_id
-        tab_index = data[0].split('/')[-1]      # data[0] can be 'tabInd' or 'winID/tabInd'
+        win_id = cur_win_id
+        # data[0] can be 'tabInd' or 'winID/tabInd'
+        tab_index = data[0].split('/')[-1]
 
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=int(win_id))
@@ -180,13 +181,14 @@ def other_tabs(*, info):
 
     Used for the tab-take command.
     """
-    return _tabs(win_id_filter=lambda win_id: win_id != info.win_id, current_win_id=info.win_id)
+    return _tabs(win_id_filter=lambda win_id: win_id != info.win_id,
+                  cur_win_id=info.win_id)
 
 
 def tab_focus(*, info):
     """A model to complete on open tabs in the current window."""
     model = _tabs(win_id_filter=lambda win_id: win_id == info.win_id,
-                  add_win_id=False, current_win_id=info.win_id)
+                  add_win_id=False, cur_win_id=info.win_id)
 
     special = [
         ("last", "Focus the last-focused tab"),

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -103,7 +103,7 @@ def session(*, info=None):
     return model
 
 
-def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, cur_win_id=0):
+def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, cur_win_id=None):
     """Helper to get the completion model for tabs/other_tabs.
 
     Args:
@@ -114,9 +114,11 @@ def _tabs(*, win_id_filter=lambda _win_id: True, add_win_id=True, cur_win_id=0):
     """
     def delete_tab(data):
         """Close the selected tab."""
-        win_id = cur_win_id
-        # data[0] can be 'tabInd' or 'winID/tabInd'
-        tab_index = data[0].split('/')[-1]
+        if cur_win_id is None:
+            win_id, tab_index = data[0].split('/')
+        else:
+            win_id = cur_win_id
+            tab_index = data[0]
 
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=int(win_id))

--- a/qutebrowser/completion/models/miscmodels.py
+++ b/qutebrowser/completion/models/miscmodels.py
@@ -181,8 +181,9 @@ def other_tabs(*, info):
 
     Used for the tab-take command.
     """
-    return _tabs(win_id_filter=lambda win_id: win_id != info.win_id,
-                  cur_win_id=info.win_id)
+    return _tabs(
+        win_id_filter=lambda win_id: win_id != info.win_id,
+        cur_win_id=info.win_id)
 
 
 def tab_focus(*, info):

--- a/tests/unit/completion/test_models.py
+++ b/tests/unit/completion/test_models.py
@@ -867,6 +867,34 @@ def test_tab_completion_delete(qtmodeltester, fake_web_tab, win_registry,
                       QUrl('https://duckduckgo.com')]
 
 
+def test_tab_focus_completion_delete(qtmodeltester, fake_web_tab, win_registry,
+                              tabbed_browser_stubs, info):
+    """Verify closing a tab by deleting it from the completion widget."""
+    tabbed_browser_stubs[0].widget.tabs = [
+        fake_web_tab(QUrl('https://github.com'), 'GitHub', 0),
+        fake_web_tab(QUrl('https://wikipedia.org'), 'Wikipedia', 1),
+        fake_web_tab(QUrl('https://duckduckgo.com'), 'DuckDuckGo', 2)
+    ]
+    tabbed_browser_stubs[1].widget.tabs = [
+        fake_web_tab(QUrl('https://wiki.archlinux.org'), 'ArchWiki', 0),
+    ]
+    model = miscmodels.tab_focus(info=info)
+    model.set_pattern('')
+    qtmodeltester.check(model)
+
+    parent = model.index(0, 0)
+    idx = model.index(1, 0, parent)
+
+    # # sanity checks
+    assert model.data(parent) == "Tabs"
+    assert model.data(idx) == '2'
+
+    model.delete_cur_item(idx)
+    actual = [tab.url() for tab in tabbed_browser_stubs[0].widget.tabs]
+    assert actual == [QUrl('https://github.com'),
+                      QUrl('https://duckduckgo.com')]
+
+
 def test_tab_completion_not_sorted(qtmodeltester, fake_web_tab, win_registry,
                                    tabbed_browser_stubs):
     """Ensure that the completion row order is the same as tab index order.


### PR DESCRIPTION
As delete_tab was assuming that completion column contains window ID, it was showing
exception in case of tab-focus, as it doesn't have the window ID in completion column.
So instead a new parameter named current_win_id is used in _tabs which is also passed
in all uses of the _tabs function. This PR Closes #6967.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
