### PR TITLE
Hide long description of settings 

### DIFF
--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -143,7 +143,7 @@ input[type="radio"]:checked + label {
 .show-more {
     all: inherit;
     display: inline;
-    color: #681982;
+    color: #1a98de;
     font-size: 105%;
 }
 

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -124,13 +124,25 @@ input[type="radio"]:checked + label {
     white-space: pre-line;
 }
 
+details summary > * {
+    display: inline;
+}
+
+details[open] .details {
+    display: none;
+}
+
 summary {
     margin: .5ex 0;
     width: fit-content;
-    outline: none;
     color: #1887c5;
+    outline: none;
     font-size: 105%;
     cursor: pointer;
+}
+
+summary .short-description {
+    color: #635d5dcf;
 }
 
 summary::selection {
@@ -153,12 +165,16 @@ summary::selection {
         {% if option.description %}
           {% set description = option.description.split('\n', 1) %}
           <div class="option-description">
-            <p>{{ description[0]|e }}</p>
             {% if description|length > 1 %}
               <details>
-                <summary>Details</summary>
-                <p class="long-description">{{ description[1] }}</p>
+                <summary>
+                  <p class="short-description">{{ description[0]|e }}</p>
+                  <span class="details">Details</span>
+                </summary>
+                <p class="long-description">{{ description[1]|e }}</p>
               </details>
+            {% else %}
+              <p>{{ description[0]|e }}</p>
             {% endif %}
           </div>
         {% endif %}

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -123,7 +123,6 @@ input[type="radio"]:checked + label {
     color: #635d5dcf;
     font-size: 80%;
     font-style: italic;
-    white-space: pre-line;
 }
 
 .radio-button {
@@ -132,8 +131,24 @@ input[type="radio"]:checked + label {
     margin: 3px 1px;
 }
 
+.short-desc {
+   margin: 0;
+   display: inline;
+}
 .long-desc {
     display: none;
+    white-space: pre-line;
+}
+
+.show-more {
+    all: inherit;
+    display: inline;
+    color: #681982;
+    font-size: 105%;
+}
+
+.show-more:focus {
+    outline: none;
 }
 {% endblock %}
 
@@ -150,12 +165,14 @@ input[type="radio"]:checked + label {
       <!-- FIXME: convert to string properly -->
       <td class="setting">{{ option.name }}
         {% if option.description %}
-	  <p class="option-description" id="description-{{ loopIndex }}">{{ option.description.split('\n', 1)[0]|e }}
-	    {% if option.description.split('\n', 1)|length > 1 %}
-	      <span class="long-desc" id="long-desc-{{ loopIndex }}">{{ option.description.split('\n',1)[1]|e }}</span>
-	      <button id="show-more-{{ loopIndex }}" onclick="displayDesc('{{ loopIndex }}')">Show more</button>
+	  {% set description = option.description.split('\n', 1) %}
+	  <div class="option-description">
+            <p class="short-desc">{{ description[0]|e }}</p>
+	    {% if description|length > 1 %}
+	      <span class="long-desc" id="long-desc-{{ loopIndex }}">{{ description[1]|e }}</span>
+	      <button class="show-more" id="show-more-{{ loopIndex }}" onclick="displayDesc('{{ loopIndex }}')">Show more</button>
             {% endif %}
-          </p>
+          </div>
         {% endif %}
       </td>
       {% if option.typ.valid_values is not none %}

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -10,22 +10,6 @@ var cset = function(option, value) {
   xhr.open("GET", url);
   xhr.send();
 }
-
-let displayDesc = (index) => {
-  let idDesc = `long-desc-${index}`
-  let longDesc = document.getElementById(idDesc)
-  let idButton = `show-more-${index}`
-  let button = document.getElementById(idButton)
-  let display = longDesc.style.display
-
-  if (display === "block") {
-    longDesc.style.display = "none";
-    button.innerHTML = "Show more";
-  } else {
-    longDesc.style.display = "block";
-    button.innerHTML = "Show less";
-  }
-}
 {% endblock %}
 
 {% block style %}
@@ -98,6 +82,12 @@ input[type="radio"]:checked + label {
     color: #084c88;
 }
 
+.radio-button {
+    position: relative; /* The absolutely positioned element inside this tag (the radio button) gets positioned relative to it. */
+    display: inline-flex;
+    margin: 3px 1px;
+}
+
 .setting {
     width: 60%;
 }
@@ -126,32 +116,25 @@ input[type="radio"]:checked + label {
     font-style: italic;
 }
 
-.radio-button {
-    position: relative; /* The absolutely positioned element inside this tag (the radio button) gets positioned relative to it. */
-    display: inline-flex;
-    margin: 3px 1px;
+.option-description p {
+    margin: 0;
 }
 
-.short-desc {
-   margin: 0;
-   display: inline;
-}
-
-.long-desc {
-    display: none;
+.long-description {
     white-space: pre-line;
 }
 
-.show-more {
-    all: inherit;
-    display: inline;
-    color: #1a98de;
+summary {
+    margin: .5ex 0;
+    width: fit-content;
+    outline: none;
+    color: #1887c5;
     font-size: 105%;
     cursor: pointer;
 }
 
-.show-more:focus {
-    outline: none;
+summary::selection {
+    background-color: inherit;
 }
 {% endblock %}
 
@@ -170,10 +153,12 @@ input[type="radio"]:checked + label {
         {% if option.description %}
           {% set description = option.description.split('\n', 1) %}
           <div class="option-description">
-            <p class="short-desc">{{ description[0]|e }}</p>
+            <p>{{ description[0]|e }}</p>
             {% if description|length > 1 %}
-              <span class="long-desc" id="long-desc-{{ loopIndex }}">{{ description[1]|e }}</span>
-              <button class="show-more" id="show-more-{{ loopIndex }}" onclick="displayDesc('{{ loopIndex }}')">Show more</button>
+              <details>
+                <summary>Details</summary>
+                <p class="long-description">{{ description[1] }}</p>
+              </details>
             {% endif %}
           </div>
         {% endif %}

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -81,6 +81,7 @@ input[type="radio"] {
     width: min-content;
     margin: 0;
     border: none;
+    cursor: pointer;
 }
 
 label {
@@ -135,6 +136,7 @@ input[type="radio"]:checked + label {
    margin: 0;
    display: inline;
 }
+
 .long-desc {
     display: none;
     white-space: pre-line;
@@ -180,13 +182,13 @@ input[type="radio"]:checked + label {
         <td class="valid-value">
           {% for value in option.typ.valid_values.values %}
             <div class="radio-button">
-              <input type="radio" id="input-{{ option.name }}-{{ loopIndex }}"
+              <input type="radio" id="input-{{ option.name }}-{{ loop.index0 }}"
                 name="{{ option.name }}" value="{{ value }}"
                 onclick="cset('{{ option.name }}', this.value)"
                 {% if confget(option.name) == value %}
                   checked
                 {% endif %}>
-              <label for="input-{{ option.name }}-{{ loopIndex }}">
+              <label for="input-{{ option.name }}-{{ loop.index0 }}">
                 {{ value }}
               </label>
               </div>

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -145,6 +145,7 @@ input[type="radio"]:checked + label {
     display: inline;
     color: #1a98de;
     font-size: 105%;
+    cursor: pointer;
 }
 
 .show-more:focus {
@@ -165,12 +166,12 @@ input[type="radio"]:checked + label {
       <!-- FIXME: convert to string properly -->
       <td class="setting">{{ option.name }}
         {% if option.description %}
-	  {% set description = option.description.split('\n', 1) %}
-	  <div class="option-description">
+          {% set description = option.description.split('\n', 1) %}
+          <div class="option-description">
             <p class="short-desc">{{ description[0]|e }}</p>
-	    {% if description|length > 1 %}
-	      <span class="long-desc" id="long-desc-{{ loopIndex }}">{{ description[1]|e }}</span>
-	      <button class="show-more" id="show-more-{{ loopIndex }}" onclick="displayDesc('{{ loopIndex }}')">Show more</button>
+            {% if description|length > 1 %}
+              <span class="long-desc" id="long-desc-{{ loopIndex }}">{{ description[1]|e }}</span>
+              <button class="show-more" id="show-more-{{ loopIndex }}" onclick="displayDesc('{{ loopIndex }}')">Show more</button>
             {% endif %}
           </div>
         {% endif %}
@@ -178,26 +179,26 @@ input[type="radio"]:checked + label {
       {% if option.typ.valid_values is not none %}
         <td class="valid-value">
           {% for value in option.typ.valid_values.values %}
-	    <div class="radio-button">
-	      <input type="radio" id="input-{{ option.name }}-{{ loopIndex }}"
-	        name="{{ option.name }}" value="{{ value }}"
-	        onclick="cset('{{ option.name }}', this.value)"
-	        {% if confget(option.name) == value %}
-		  checked
-		{% endif %}>
-	      <label for="input-{{ option.name }}-{{ loopIndex }}">
-	        {{ value }}
-	      </label>
-	      </div>
-	  {% endfor %}
-	</td>
+            <div class="radio-button">
+              <input type="radio" id="input-{{ option.name }}-{{ loopIndex }}"
+                name="{{ option.name }}" value="{{ value }}"
+                onclick="cset('{{ option.name }}', this.value)"
+                {% if confget(option.name) == value %}
+                  checked
+                {% endif %}>
+              <label for="input-{{ option.name }}-{{ loopIndex }}">
+                {{ value }}
+              </label>
+              </div>
+          {% endfor %}
+        </td>
       {% else %}
         <td class="value">
-	  <input type="text"
-	    id="input-{{ option.name }}"
-	    onblur="cset('{{ option.name }}', this.value)"
-	    value="{{ confget(option.name) }}">
-	  </input>
+          <input type="text"
+            id="input-{{ option.name }}"
+            onblur="cset('{{ option.name }}', this.value)"
+            value="{{ confget(option.name) }}">
+          </input>
         </td>
       {% endif %}
     </tr>

--- a/qutebrowser/html/settings.html
+++ b/qutebrowser/html/settings.html
@@ -10,6 +10,22 @@ var cset = function(option, value) {
   xhr.open("GET", url);
   xhr.send();
 }
+
+let displayDesc = (index) => {
+  let idDesc = `long-desc-${index}`
+  let longDesc = document.getElementById(idDesc)
+  let idButton = `show-more-${index}`
+  let button = document.getElementById(idButton)
+  let display = longDesc.style.display
+
+  if (display === "block") {
+    longDesc.style.display = "none";
+    button.innerHTML = "Show more";
+  } else {
+    longDesc.style.display = "block";
+    button.innerHTML = "Show less";
+  }
+}
 {% endblock %}
 
 {% block style %}
@@ -115,6 +131,10 @@ input[type="radio"]:checked + label {
     display: inline-flex;
     margin: 3px 1px;
 }
+
+.long-desc {
+    display: none;
+}
 {% endblock %}
 
 {% block content %}
@@ -126,23 +146,29 @@ input[type="radio"]:checked + label {
     </tr>
   {% for option in configdata.DATA.values()|sort(attribute='name') if not option.no_autoconfig %}
     <tr>
+      {% set loopIndex = loop.index0 %}
       <!-- FIXME: convert to string properly -->
       <td class="setting">{{ option.name }}
         {% if option.description %}
-          <p class="option-description">{{ option.description|e }}</p>
+	  <p class="option-description" id="description-{{ loopIndex }}">{{ option.description.split('\n', 1)[0]|e }}
+	    {% if option.description.split('\n', 1)|length > 1 %}
+	      <span class="long-desc" id="long-desc-{{ loopIndex }}">{{ option.description.split('\n',1)[1]|e }}</span>
+	      <button id="show-more-{{ loopIndex }}" onclick="displayDesc('{{ loopIndex }}')">Show more</button>
+            {% endif %}
+          </p>
         {% endif %}
       </td>
       {% if option.typ.valid_values is not none %}
         <td class="valid-value">
           {% for value in option.typ.valid_values.values %}
 	    <div class="radio-button">
-	      <input type="radio" id="input-{{ option.name }}-{{ loop.index0 }}"
+	      <input type="radio" id="input-{{ option.name }}-{{ loopIndex }}"
 	        name="{{ option.name }}" value="{{ value }}"
 	        onclick="cset('{{ option.name }}', this.value)"
 	        {% if confget(option.name) == value %}
 		  checked
 		{% endif %}>
-	      <label for="input-{{ option.name }}-{{ loop.index0 }}">
+	      <label for="input-{{ option.name }}-{{ loopIndex }}">
 	        {{ value }}
 	      </label>
 	      </div>


### PR DESCRIPTION
Show only the first line of the description of a setting. 
This makes all the settings the same size, giving a better overview. 
Display or hide the description according to the button click.

Show more:
![qute-show-more](https://user-images.githubusercontent.com/36052282/152547964-d39ee1fd-fc1d-4180-9e97-fb26082ee3ff.png)

Show less:
![show-less](https://user-images.githubusercontent.com/36052282/152547998-269f09d0-4500-4876-817c-9533c0e32350.png)