### PR TITLE
feat(download) support external location picker

### DIFF
--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -404,7 +404,7 @@ class FileSelectionMode(enum.Enum):
 
 
 def choose_file(qb_mode: FileSelectionMode) -> List[str]:
-    """Select file(s)/folder for uploading, using external command defined in config.
+    """Select file(s)/folder for uploading/downloading, using external command defined in config.
 
     Args:
         qb_mode: File selection mode
@@ -450,7 +450,7 @@ def _execute_fileselect_command(
     """Execute external command to choose file.
 
     Args:
-        multiple: Should selecting multiple files be allowed.
+        qb_mode: Should selecting multiple files be allowed.
         tmpfilename: Path to the temporary file if used, otherwise None.
 
     Return:

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -404,7 +404,7 @@ class FileSelectionMode(enum.Enum):
 
 
 def choose_file(qb_mode: FileSelectionMode) -> List[str]:
-    """Select file(s)/folder for uploading/downloading, using external command defined in config.
+    """Select file(s)/folder for up-/downloading, using an external command.
 
     Args:
         qb_mode: File selection mode

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3780,7 +3780,7 @@ bindings.default:
       <Down>: prompt-item-focus next
       <Alt-Y>: prompt-yank
       <Alt-Shift-Y>: prompt-yank --sel
-      <Alt-E>: prompt-external-picker
+      <Alt-E>: prompt-fileselect-external
       <Ctrl-B>: rl-backward-char
       <Ctrl-F>: rl-forward-char
       <Alt-B>: rl-backward-word

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -3780,6 +3780,7 @@ bindings.default:
       <Down>: prompt-item-focus next
       <Alt-Y>: prompt-yank
       <Alt-Shift-Y>: prompt-yank --sel
+      <Alt-E>: prompt-external-picker
       <Ctrl-B>: rl-backward-char
       <Ctrl-F>: rl-forward-char
       <Alt-B>: rl-backward-word

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -490,7 +490,7 @@ class PromptContainer(QWidget):
             return
         # choose_file already checks that this is max one folder
         assert len(folders) == 1
-        self._prompt.accept(folders[0])
+        self.prompt_accept(folders[0])
 
 
 class LineEdit(QLineEdit):

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -472,9 +472,10 @@ class PromptContainer(QWidget):
         modes=[usertypes.KeyMode.prompt])
     def prompt_fileselect_external(self):
         """Choose a location using a configured external picker."""
-        if not (self._prompt and isinstance(self._prompt, FilenamePrompt)):
+        assert self._prompt is not None
+        if not isinstance(self._prompt, FilenamePrompt):
             raise cmdutils.CommandError(
-                f"Can only launch external fileselect for FilenamePrompt, not {self._prompt}"
+                f"Can only launch external fileselect for FilenamePrompt, not {self._prompt.__class__.__name__}"
             )
         picker = config.val.fileselect.folder.command
         if not picker:
@@ -489,8 +490,7 @@ class PromptContainer(QWidget):
             return
         # choose_file already checks that this is max one folder
         assert len(folders) == 1
-        folder = folders[0]
-        self._prompt.accept(folder)
+        self._prompt.accept(folders[0])
 
 
 class LineEdit(QLineEdit):
@@ -859,7 +859,7 @@ class DownloadFilenamePrompt(FilenamePrompt):
             ('prompt-open-download', "Open download"),
             ('prompt-open-download --pdfjs', "Open download via PDF.js"),
             ('prompt-yank', "Yank URL"),
-            ('prompt-fileselect-external', "Launch external fileselect"),
+            ('prompt-fileselect-external', "Launch external file selector"),
         ]
         return cmds
 

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -475,7 +475,8 @@ class PromptContainer(QWidget):
         assert self._prompt is not None
         if not isinstance(self._prompt, FilenamePrompt):
             raise cmdutils.CommandError(
-                f"Can only launch external fileselect for FilenamePrompt, not {self._prompt.__class__.__name__}"
+                "Can only launch external fileselect for FilenamePrompt, "
+                f"not {self._prompt.__class__.__name__}"
             )
         picker = config.val.fileselect.folder.command
         if not picker:

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -478,11 +478,6 @@ class PromptContainer(QWidget):
                 "Can only launch external fileselect for FilenamePrompt, "
                 f"not {self._prompt.__class__.__name__}"
             )
-        picker = config.val.fileselect.folder.command
-        if not picker:
-            raise cmdutils.CommandError(
-                "No external location picker (fileselect.folder.command) configured."
-            )
         # XXX to avoid current cyclic import
         from qutebrowser.browser import shared
         folders = shared.choose_file(shared.FileSelectionMode.folder)

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -482,7 +482,7 @@ class PromptContainer(QWidget):
             raise cmdutils.CommandError(
                 "No external location picker (fileselect.folder.command) configured."
             )
-        # TODO fix cyclic import
+        # XXX to avoid current cyclic import
         from qutebrowser.browser import shared
         folders = shared.choose_file(shared.FileSelectionMode.folder)
         if not folders:

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -712,3 +712,35 @@ def check_option_per_domain(quteproc, option, value, pattern, server):
     pattern = pattern.replace('(port)', str(server.port))
     actual_value = quteproc.get_setting(option, pattern=pattern)
     assert actual_value == value
+
+
+@bdd.when(bdd.parsers.parse('I setup a fake {kind} fileselector '
+                            'selecting "{files}" and writes to {output_type}'))
+def set_up_fileselector(quteproc, py_proc, tmpdir, kind, files, output_type):
+    """Set up fileselect.xxx.command to select the file(s)."""
+    cmd, args = py_proc(r"""
+        import os
+        import sys
+        tmp_file = None
+        for i, arg in enumerate(sys.argv):
+            if arg.startswith('--file='):
+                tmp_file = arg[len('--file='):]
+                sys.argv.pop(i)
+                break
+        selected_files = sys.argv[1:]
+        if tmp_file is None:
+            for selected_file in selected_files:
+                print(os.path.abspath(selected_file))
+        else:
+            with open(tmp_file, 'w') as f:
+                for selected_file in selected_files:
+                    f.write(os.path.abspath(selected_file) + '\n')
+    """)
+    files = files.replace('(tmpdir)', str(tmpdir))
+    files = files.replace('(dirsep)', os.sep)
+    args += files.split(' ')
+    if output_type == "a temporary file":
+        args += ['--file={}']
+    fileselect_cmd = json.dumps([cmd, *args])
+    quteproc.set_setting('fileselect.handler', 'external')
+    quteproc.set_setting(f'fileselect.{kind}.command', fileselect_cmd)

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -690,10 +690,11 @@ Feature: Downloading things from a website.
     Scenario: Select download path
         When I set downloads.location.prompt to true
         And I set fileselect.handler to external
-        And I setup a fake folder fileselector selecting "tests/end2end/data/backforward/" and writes to a temporary file
+        And I setup a fake folder fileselector selecting "(tmpdir)(dirsep)downloads(dirsep)subdir" and writes to a temporary file
         And I open data/downloads/downloads.html
         And I run :click-element id download
-        And I wait for the download prompt for "*/download.bin"
-        And I run :prompt-external-picker
+        And I wait for the download prompt for "*"
+        And I run :prompt-fileselect-external
         # TODO what should the check be?
-        Then the javascript message "Files: 1.txt" should be logged
+        And I wait until the download is finished
+        Then the downloaded file subdir/download.bin should exist

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -689,7 +689,6 @@ Feature: Downloading things from a website.
 
     Scenario: Select download path
         When I set downloads.location.prompt to true
-        And I set fileselect.handler to external
         And I setup a fake folder fileselector selecting "(tmpdir)(dirsep)downloads(dirsep)subdir" and writes to a temporary file
         And I open data/downloads/downloads.html
         And I run :click-element id download
@@ -697,3 +696,13 @@ Feature: Downloading things from a website.
         And I run :prompt-fileselect-external
         And I wait until the download is finished
         Then the downloaded file subdir/download.bin should exist
+
+    Scenario: No download folder chosen
+        When I set downloads.location.prompt to true
+        And I set fileselect.folder.command to ['echo', '{}']
+        And I open data/downloads/downloads.html
+        And I run :click-element id download
+        And I wait for the download prompt for "*"
+        And I run :prompt-fileselect-external
+        Then the message "No folder chosen." should be shown
+        And the download prompt should be shown with "(tmpdir)(dirsep)downloads"

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -695,6 +695,5 @@ Feature: Downloading things from a website.
         And I run :click-element id download
         And I wait for the download prompt for "*"
         And I run :prompt-fileselect-external
-        # TODO what should the check be?
         And I wait until the download is finished
         Then the downloaded file subdir/download.bin should exist

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -684,3 +684,16 @@ Feature: Downloading things from a website.
         When I set downloads.location.prompt to false
         And I open 500-inline
         Then the error "Download error: *INTERNAL SERVER ERROR" should be shown
+
+    ## External download path fileselector
+
+    Scenario: Select download path
+        When I set downloads.location.prompt to true
+        And I set fileselect.handler to external
+        And I setup a fake folder fileselector selecting "tests/end2end/data/backforward/" and writes to a temporary file
+        And I open data/downloads/downloads.html
+        And I run :click-element id download
+        And I wait for the download prompt for "*/download.bin"
+        And I run :prompt-external-picker
+        # TODO what should the check be?
+        Then the javascript message "Files: 1.txt" should be logged

--- a/tests/end2end/features/test_downloads_bdd.py
+++ b/tests/end2end/features/test_downloads_bdd.py
@@ -168,34 +168,3 @@ def fifo_should_be_fifo(tmpdir):
     download_dir = tmpdir / 'downloads'
     assert download_dir.exists()
     assert not os.path.isfile(str(download_dir / 'fifo'))
-
-
-# TODO how to share this with test_editor_bdd.py?
-@bdd.when(bdd.parsers.parse('I setup a fake {kind} fileselector '
-                            'selecting "{files}" and writes to {output_type}'))
-def set_up_fileselector(quteproc, py_proc, kind, files, output_type):
-    """Set up fileselect.xxx.command to select the file(s)."""
-    cmd, args = py_proc(r"""
-        import os
-        import sys
-        tmp_file = None
-        for i, arg in enumerate(sys.argv):
-            if arg.startswith('--file='):
-                tmp_file = arg[len('--file='):]
-                sys.argv.pop(i)
-                break
-        selected_files = sys.argv[1:]
-        if tmp_file is None:
-            for selected_file in selected_files:
-                print(os.path.abspath(selected_file))
-        else:
-            with open(tmp_file, 'w') as f:
-                for selected_file in selected_files:
-                    f.write(os.path.abspath(selected_file) + '\n')
-    """)
-    args += files.split(' ')
-    if output_type == "a temporary file":
-        args += ['--file={}']
-    fileselect_cmd = json.dumps([cmd, *args])
-    quteproc.set_setting('fileselect.handler', 'external')
-    quteproc.set_setting(f'fileselect.{kind}.command', fileselect_cmd)

--- a/tests/end2end/features/test_downloads_bdd.py
+++ b/tests/end2end/features/test_downloads_bdd.py
@@ -19,6 +19,7 @@
 
 import os
 import sys
+import json
 import shlex
 
 import pytest
@@ -167,3 +168,34 @@ def fifo_should_be_fifo(tmpdir):
     download_dir = tmpdir / 'downloads'
     assert download_dir.exists()
     assert not os.path.isfile(str(download_dir / 'fifo'))
+
+
+# TODO how to share this with test_editor_bdd.py?
+@bdd.when(bdd.parsers.parse('I setup a fake {kind} fileselector '
+                            'selecting "{files}" and writes to {output_type}'))
+def set_up_fileselector(quteproc, py_proc, kind, files, output_type):
+    """Set up fileselect.xxx.command to select the file(s)."""
+    cmd, args = py_proc(r"""
+        import os
+        import sys
+        tmp_file = None
+        for i, arg in enumerate(sys.argv):
+            if arg.startswith('--file='):
+                tmp_file = arg[len('--file='):]
+                sys.argv.pop(i)
+                break
+        selected_files = sys.argv[1:]
+        if tmp_file is None:
+            for selected_file in selected_files:
+                print(os.path.abspath(selected_file))
+        else:
+            with open(tmp_file, 'w') as f:
+                for selected_file in selected_files:
+                    f.write(os.path.abspath(selected_file) + '\n')
+    """)
+    args += files.split(' ')
+    if output_type == "a temporary file":
+        args += ['--file={}']
+    fileselect_cmd = json.dumps([cmd, *args])
+    quteproc.set_setting('fileselect.handler', 'external')
+    quteproc.set_setting(f'fileselect.{kind}.command', fileselect_cmd)

--- a/tests/end2end/features/test_downloads_bdd.py
+++ b/tests/end2end/features/test_downloads_bdd.py
@@ -19,7 +19,6 @@
 
 import os
 import sys
-import json
 import shlex
 
 import pytest

--- a/tests/end2end/features/test_editor_bdd.py
+++ b/tests/end2end/features/test_editor_bdd.py
@@ -178,33 +178,3 @@ def save_editor_wait(tmpdir):
     # for posix, there IS a member so we need to ignore useless-suppression
     # pylint: disable=no-member,useless-suppression
     os.kill(pid, signal.SIGUSR2)
-
-
-@bdd.when(bdd.parsers.parse('I setup a fake {kind} fileselector '
-                            'selecting "{files}" and writes to {output_type}'))
-def set_up_fileselector(quteproc, py_proc, kind, files, output_type):
-    """Set up fileselect.xxx.command to select the file(s)."""
-    cmd, args = py_proc(r"""
-        import os
-        import sys
-        tmp_file = None
-        for i, arg in enumerate(sys.argv):
-            if arg.startswith('--file='):
-                tmp_file = arg[len('--file='):]
-                sys.argv.pop(i)
-                break
-        selected_files = sys.argv[1:]
-        if tmp_file is None:
-            for selected_file in selected_files:
-                print(os.path.abspath(selected_file))
-        else:
-            with open(tmp_file, 'w') as f:
-                for selected_file in selected_files:
-                    f.write(os.path.abspath(selected_file) + '\n')
-    """)
-    args += files.split(' ')
-    if output_type == "a temporary file":
-        args += ['--file={}']
-    fileselect_cmd = json.dumps([cmd, *args])
-    quteproc.set_setting('fileselect.handler', 'external')
-    quteproc.set_setting(f'fileselect.{kind}.command', fileselect_cmd)


### PR DESCRIPTION
Closes #1365 

I haven't added tests yes cause it would be great to have some feedback if others think this is a good way to handle things.

What this MR enables is a new command and keybind in the download prompt to trigger an external folder picker. When the picker finishes the prompt gets updated with a new default value.

One could do some things differently here. For example:
* When a folder is chosen, directly accept the prompt. However I thought it would be better to first see what was chosen and then accept.
* Allow a setting such that the external picker is triggered directly. But is seems nice to still have the option to for example choose to open the download etc.