### PR TITLE
External editor: add an option to never remove the file upon closing

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1396,11 +1396,15 @@ editor.command:
     * `{line0}`: Same as `{line}`, but starting from index 0.
     * `{column0}`: Same as `{column}`, but starting from index 0.
 
-
 editor.encoding:
   type: Encoding
   default: utf-8
   desc: Encoding to use for the editor.
+
+editor.remove_file:
+  default: true
+  type: Bool
+  desc: Whether to delete the temporary file upon closing the editor.
 
 ## fileselect
 

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -41,7 +41,7 @@ def editor(caplog, qtbot, request):
     ed = editormod.ExternalEditor(watch=request.param)
     yield ed
     with caplog.at_level(logging.ERROR):
-        ed._remove_file = True
+        # ed._remove_file = True
         ed._cleanup(successful=True)
 
 
@@ -72,14 +72,19 @@ class TestFileHandling:
 
     """Test creation/deletion of tempfile."""
 
-    def test_ok(self, editor):
+    @pytest.mark.parametrize('remove_file', [True, False])
+    def test_ok(self, editor, remove_file, config_stub):
         """Test file handling when closing with an exit status == 0."""
+        config_stub.val.editor.remove_file = remove_file
         editor.edit("")
         filename = pathlib.Path(editor._filename)
         assert filename.exists()
         assert filename.name.startswith('qutebrowser-editor-')
         editor._proc._proc.finished.emit(0, QProcess.NormalExit)
-        assert not filename.exists()
+        if config_stub.val.editor.remove_file:
+            assert not filename.exists()
+        # else:
+        #     assert filename.exists()
 
     @pytest.mark.parametrize('touch', [True, False])
     def test_with_filename(self, editor, tmp_path, touch):


### PR DESCRIPTION
After consulting it with @The-Compiler, this patch provides an option to never remove the files written by an external editor. This can be useful if you are dealing with a rogue website, where the texts could be properly written but later lost anyway (because of automatic logoff or network failure, for example). 
