### PR TITLE
External editor: add an option to never remove the file upon closing

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1404,7 +1404,7 @@ editor.encoding:
 editor.remove_file:
   default: true
   type: Bool
-  desc: Whether to delete the temporary file upon closing the editor.
+  desc: Delete the temporary file upon closing the editor.
 
 ## fileselect
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1396,11 +1396,15 @@ editor.command:
     * `{line0}`: Same as `{line}`, but starting from index 0.
     * `{column0}`: Same as `{column}`, but starting from index 0.
 
-
 editor.encoding:
   type: Encoding
   default: utf-8
   desc: Encoding to use for the editor.
+
+editor.remove_file:
+  default: true
+  type: Bool
+  desc: Whether to delete the temporary file upon closing the editor.
 
 ## fileselect
 

--- a/qutebrowser/misc/editor.py
+++ b/qutebrowser/misc/editor.py
@@ -135,7 +135,7 @@ class ExternalEditor(QObject):
             message.error("Failed to create initial file: {}".format(e))
             return
 
-        self._remove_file = True
+        self._remove_file = config.val.editor.remove_file
 
         line, column = self._calc_line_and_column(text, caret_position)
         self._start_editor(line=line, column=column)

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -81,8 +81,7 @@ class TestFileHandling:
         assert filename.exists()
         assert filename.name.startswith('qutebrowser-editor-')
         editor._proc._proc.finished.emit(0, QProcess.NormalExit)
-        if config_stub.val.editor.remove_file:
-            assert filename.exists() != config_stub.val.editor.remove_file
+        assert filename.exists() != config_stub.val.editor.remove_file
 
     @pytest.mark.parametrize('touch', [True, False])
     def test_with_filename(self, editor, tmp_path, touch):

--- a/tests/unit/misc/test_editor.py
+++ b/tests/unit/misc/test_editor.py
@@ -72,14 +72,17 @@ class TestFileHandling:
 
     """Test creation/deletion of tempfile."""
 
-    def test_ok(self, editor):
+    @pytest.mark.parametrize('remove_file', [True, False])
+    def test_ok(self, editor, remove_file, config_stub):
         """Test file handling when closing with an exit status == 0."""
+        config_stub.val.editor.remove_file = remove_file
         editor.edit("")
         filename = pathlib.Path(editor._filename)
         assert filename.exists()
         assert filename.name.startswith('qutebrowser-editor-')
         editor._proc._proc.finished.emit(0, QProcess.NormalExit)
-        assert not filename.exists()
+        if config_stub.val.editor.remove_file:
+            assert filename.exists() != config_stub.val.editor.remove_file
 
     @pytest.mark.parametrize('touch', [True, False])
     def test_with_filename(self, editor, tmp_path, touch):


### PR DESCRIPTION
Second attempt, thanks to the comments by @The-Compiler.

This patch provides an option to never remove the files written by an external editor. This can be useful if you are dealing with a rogue website, where the texts could be properly written but later lost anyway (because of automatic logoff or network failure, for example).