### PR TITLE
feat: pass QUTE_TAB to userscripts

### DIFF
--- a/doc/userscripts.asciidoc
+++ b/doc/userscripts.asciidoc
@@ -56,6 +56,7 @@ In `command` mode:
 - `QUTE_TITLE`: The title of the current page.
 - `QUTE_SELECTED_TEXT`: The text currently selected on the page.
 - `QUTE_COUNT`: The `count` from the spawn command running the userscript.
+- `QUTE_TAB_INDEX`: The current tab's index.
 
 In `hints` mode:
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1152,6 +1152,9 @@ class CommandDispatcher:
 
         idx = self._current_index()
         if idx != -1:
+            env['QUTE_TAB_INDEX'] = str(idx + 1)
+
+        if idx != -1:
             env['QUTE_TITLE'] = self._tabbed_browser.widget.page_title(idx)
 
         # FIXME:qtwebengine: If tab is None, run_async will fail!


### PR DESCRIPTION
There might already be a way to do this, but I couldn't figure it out. The impetus for this change came up when I was writing a [simple "autorefresh" script](https://github.com/willruggiano/dotfiles/blob/main/modules/common/qutebrowser.nix#L47-L78).
