### PR TITLE
Fix ripbang userscript

### DIFF
--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -20,7 +20,8 @@ except ImportError:
 for argument in sys.argv[1:]:
     bang = '!' + argument
     r = requests.get('https://duckduckgo.com/',
-                     params={'q': bang + ' SEARCHTEXT'})
+                     params={'q': bang + ' SEARCHTEXT'},
+                     headers={'user-agent': 'test/0.0.1'})
 
     searchengine = unquote(re.search("url=[^']+", r.text).group(0))
     searchengine = searchengine.replace('url=', '')

--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -25,11 +25,12 @@ for argument in sys.argv[1:]:
 
     searchengine = unquote(re.search("url=[^']+", r.text).group(0))
     searchengine = searchengine.replace('url=', '')
-    searchengine = searchengine.replace('/l/?kh=-1&uddg=', '')
+    searchengine = searchengine.replace('/l/?uddg=', '')
     searchengine = searchengine.replace('SEARCHTEXT', '{}')
+    searchengine = searchengine[0:searchengine.find("&rut")]
 
     if os.getenv('QUTE_FIFO'):
         with open(os.environ['QUTE_FIFO'], 'w') as fifo:
-            fifo.write('set searchengines %s %s' % (bang, searchengine))
+            fifo.write('config-dict-add url.searchengines %s %s' % (bang, searchengine))
     else:
         print('%s %s' % (bang, searchengine))

--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -9,13 +9,8 @@
 #   :spawn --userscript ripbang amazon maps
 #
 
-from __future__ import print_function
 import os, re, requests, sys
-
-try:
-    from urllib.parse import unquote
-except ImportError:
-    from urllib import unquote
+from urllib.parse import urlparse, parse_qs
 
 for argument in sys.argv[1:]:
     bang = '!' + argument

--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -18,11 +18,10 @@ for argument in sys.argv[1:]:
                      params={'q': bang + ' SEARCHTEXT'},
                      headers={'user-agent': 'qutebrowser ripbang'})
 
-    searchengine = unquote(re.search("url=[^']+", r.text).group(0))
-    searchengine = searchengine.replace('url=', '')
-    searchengine = searchengine.replace('/l/?uddg=', '')
+    searchengine = re.search("url=([^']+)", r.text).group(1)
+    searchengine = urlparse(searchengine).query
+    searchengine = parse_qs(searchengine)['uddg'][0]
     searchengine = searchengine.replace('SEARCHTEXT', '{}')
-    searchengine = searchengine[0:searchengine.find("&rut")]
 
     if os.getenv('QUTE_FIFO'):
         with open(os.environ['QUTE_FIFO'], 'w') as fifo:

--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -21,7 +21,7 @@ for argument in sys.argv[1:]:
     bang = '!' + argument
     r = requests.get('https://duckduckgo.com/',
                      params={'q': bang + ' SEARCHTEXT'},
-                     headers={'user-agent': 'ripbang'})
+                     headers={'user-agent': 'qutebrowser ripbang'})
 
     searchengine = unquote(re.search("url=[^']+", r.text).group(0))
     searchengine = searchengine.replace('url=', '')

--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -21,7 +21,7 @@ for argument in sys.argv[1:]:
     bang = '!' + argument
     r = requests.get('https://duckduckgo.com/',
                      params={'q': bang + ' SEARCHTEXT'},
-                     headers={'user-agent': 'test/0.0.1'})
+                     headers={'user-agent': 'ripbang'})
 
     searchengine = unquote(re.search("url=[^']+", r.text).group(0))
     searchengine = searchengine.replace('url=', '')


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
Duckduckgo now rejects requests without a user agent set, and has changed the redirect url format slightly.  Qutebrowser's searchengines setting moved, and needs to be set with config-dict-add instead of set.