### PR TITLE
Qt6 WebEnginePage creatWindow api change

### DIFF
--- a/qutebrowser/browser/webengine/webengineinspector.py
+++ b/qutebrowser/browser/webengine/webengineinspector.py
@@ -27,7 +27,7 @@ from PyQt6.QtWebEngineCore import QWebEnginePage
 from PyQt6.QtWidgets import QWidget
 
 from qutebrowser.browser import inspector
-from qutebrowser.browser.webengine import webenginesettings
+from qutebrowser.browser.webengine import webenginesettings, webview
 from qutebrowser.misc import miscwidgets
 from qutebrowser.utils import version, usertypes
 from qutebrowser.keyinput import modeman
@@ -51,7 +51,7 @@ class WebEngineInspectorView(QWebEngineView):
         See WebEngineView.createWindow for details.
         """
         newpage = self.page().inspectedPage().createWindow(wintype)
-        return self.forPage(newpage)
+        return webview.WebEngineView.forPage(newpage)
 
 
 class WebEngineInspector(inspector.AbstractWebInspector):

--- a/qutebrowser/browser/webengine/webengineinspector.py
+++ b/qutebrowser/browser/webengine/webengineinspector.py
@@ -50,7 +50,8 @@ class WebEngineInspectorView(QWebEngineView):
 
         See WebEngineView.createWindow for details.
         """
-        return self.page().inspectedPage().view().createWindow(wintype)
+        newpage = self.page().inspectedPage().createWindow(wintype)
+        return self.forPage(newpage)
 
 
 class WebEngineInspector(inspector.AbstractWebInspector):


### PR DESCRIPTION
When double-clicking a network resource in the devtools, one
get AttributeError: 'WebEnginePage' object has no attribute 'view'.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
