### PR TITLE
qute-pass: Support folder prefixes in gopass-mode

### DIFF
--- a/misc/userscripts/qute-pass
+++ b/misc/userscripts/qute-pass
@@ -77,6 +77,8 @@ argument_parser.add_argument('--password-store', '-p',
                              help='Path to your pass password-store (only used in pass-mode)', type=expanded_path)
 argument_parser.add_argument('--mode', '-M', choices=['pass', 'gopass'], default="pass",
                              help='Select mode [gopass] to use gopass instead of the standard pass.')
+argument_parser.add_argument('--prefix', type=str,
+                             help='Search only the given subfolder of the store (only used in gopass-mode)')
 argument_parser.add_argument('--username-pattern', '-u', default=r'.*/(.+)',
                              help='Regular expression that matches the username')
 argument_parser.add_argument('--username-target', '-U', choices=['path', 'secret'], default='path',
@@ -132,7 +134,10 @@ def find_pass_candidates(domain, unfiltered=False):
     candidates = []
 
     if arguments.mode == "gopass":
-        all_passwords = subprocess.run(["gopass", "list", "--flat" ], stdout=subprocess.PIPE).stdout.decode("UTF-8").splitlines()
+        gopass_args = ["gopass", "list", "--flat"]
+        if arguments.prefix:
+            gopass_args.append(arguments.prefix)
+        all_passwords = subprocess.run(gopass_args, stdout=subprocess.PIPE).stdout.decode("UTF-8").splitlines()
 
         for password in all_passwords:
             if unfiltered or domain in password:


### PR DESCRIPTION
Since at least two years back (gopass 1.9, but probably further back) gopass has supported specifying a subfolder prefix when listing secrets (`gopass list mysubdir`). This can easily be supported by qute-pass in gopass-mode, without affecting any other use cases: Even if the user specifies an invalid subfolder, gopass will handle that problem and fail gracefully.