### PR TITLE
Switch `cast` userscript from youtube-dl to yt-dlp

### DIFF
--- a/misc/userscripts/cast
+++ b/misc/userscripts/cast
@@ -20,6 +20,17 @@
 #
 # Dependencies
 #   - castnow, https://github.com/xat/castnow
+#   - youtube-dl (https://youtube-dl.org/) or a drop-in replacement such as
+#     yt-dlp (https://github.com/yt-dlp/yt-dlp).
+#
+# Configuration:
+#   This script loads the bash script ~/.config/qutebrowser/cast_rc (if
+#   it exists) or whatever file is specified in QUTE_CAST_CONFIG, so you can
+#   override the program used for downloading videos.
+#
+#   For example:
+#
+#     ytdl_program=yt-dlp
 #
 # Author
 #   Simon Désaulniers <sim.desaulniers@gmail.com>
@@ -133,23 +144,40 @@ echo "jseval -q $(printjs)" >> "$QUTE_FIFO"
 
 tmpdir=$(mktemp -d)
 file_to_cast=${tmpdir}/qutecast
-program_=$(command -v castnow)
+cast_program=$(command -v castnow)
 
-if [[ "${program_}" == "" ]]; then
+# load optional config
+QUTE_CONFIG_DIR=${QUTE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/}
+QUTE_CAST_CONFIG=${QUTE_CAST_CONFIG:-${QUTE_CONFIG_DIR}/cast_rc}
+if [ -f "$QUTE_CAST_CONFIG" ] ; then
+    source "$QUTE_CAST_CONFIG"
+fi
+
+# if ytdl_program wasn't specified in config, use a fallback
+for p in "$ytdl_program" yt-dlp youtube-dl; do
+  ytdl_program=$(command -v "$p")
+  [ "$ytdl_program" == "" ] || break
+done
+
+if [[ "${cast_program}" == "" ]]; then
     msg error "castnow can't be found..."
+    exit 1
+fi
+if [[ "${ytdl_program}" == "" ]]; then
+    msg error "youtube-dl (or a drop-in replacement) can't be found..."
     exit 1
 fi
 
 # kill any running instance of castnow
-pkill -f "${program_}"
+pkill -f "${cast_program}"
 
 # start youtube download in stream mode (-o -) into temporary file
-yt-dlp -qo - "$1" > "${file_to_cast}" &
+${ytdl_program} -qo - "$1" > "${file_to_cast}" &
 ytdl_pid=$!
 
 msg info "Casting $1" >> "$QUTE_FIFO"
 # start castnow in stream mode to cast on ChromeCast
-tail -F "${file_to_cast}" | ${program_} -
+tail -F "${file_to_cast}" | ${cast_program} -
 
 # cleanup remaining background process and file on disk
 kill ${ytdl_pid}

--- a/misc/userscripts/cast
+++ b/misc/userscripts/cast
@@ -24,13 +24,10 @@
 #     yt-dlp (https://github.com/yt-dlp/yt-dlp).
 #
 # Configuration:
-#   This script loads the bash script ~/.config/qutebrowser/cast_rc (if
-#   it exists) or whatever file is specified in QUTE_CAST_CONFIG, so you can
-#   override the program used for downloading videos.
-#
-#   For example:
-#
-#     ytdl_program=yt-dlp
+#   This script looks at the optional QUTE_CAST_YTDL_PROGRAM environment
+#   variable (if it exists) to decide which program to use for downloading
+#   videos. If specified, this should be youtube-dl or a drop-in replacement
+#   for it.
 #
 # Author
 #   Simon Désaulniers <sim.desaulniers@gmail.com>
@@ -146,34 +143,27 @@ tmpdir=$(mktemp -d)
 file_to_cast=${tmpdir}/qutecast
 cast_program=$(command -v castnow)
 
-# load optional config
-QUTE_CONFIG_DIR=${QUTE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/}
-QUTE_CAST_CONFIG=${QUTE_CAST_CONFIG:-${QUTE_CONFIG_DIR}/cast_rc}
-if [ -f "$QUTE_CAST_CONFIG" ] ; then
-    # shellcheck source=/dev/null
-    source "$QUTE_CAST_CONFIG"
-fi
-
-# if ytdl_program wasn't specified in config, use a fallback
-for p in "$ytdl_program" yt-dlp youtube-dl; do
-  ytdl_program=$(command -v "$p")
+# pick a ytdl program
+for p in "$QUTE_CAST_YTDL_PROGRAM" yt-dlp youtube-dl; do
+  ytdl_program=$(command -v -- "$p")
   [ "$ytdl_program" == "" ] || break
 done
 
 if [[ "${cast_program}" == "" ]]; then
-    msg error "castnow can't be found..."
+    msg error "castnow can't be found"
     exit 1
 fi
 if [[ "${ytdl_program}" == "" ]]; then
-    msg error "youtube-dl (or a drop-in replacement) can't be found..."
+  msg error "youtube-dl or a drop-in replacement can't be found in PATH, and no installed program "\
+"specified in QUTE_CAST_YTDL_PROGRAM (currently \\\"$QUTE_CAST_YTDL_PROGRAM\\\")"
     exit 1
 fi
 
 # kill any running instance of castnow
-pkill -f "${cast_program}"
+pkill -f -- "${cast_program}"
 
 # start youtube download in stream mode (-o -) into temporary file
-${ytdl_program} -qo - "$1" > "${file_to_cast}" &
+"${ytdl_program}" -qo - "$1" > "${file_to_cast}" &
 ytdl_pid=$!
 
 msg info "Casting $1" >> "$QUTE_FIFO"

--- a/misc/userscripts/cast
+++ b/misc/userscripts/cast
@@ -145,8 +145,8 @@ cast_program=$(command -v castnow)
 
 # pick a ytdl program
 for p in "$QUTE_CAST_YTDL_PROGRAM" yt-dlp youtube-dl; do
-  ytdl_program=$(command -v -- "$p")
-  [ "$ytdl_program" == "" ] || break
+    ytdl_program=$(command -v -- "$p")
+    [ "$ytdl_program" == "" ] || break
 done
 
 if [[ "${cast_program}" == "" ]]; then
@@ -154,7 +154,7 @@ if [[ "${cast_program}" == "" ]]; then
     exit 1
 fi
 if [[ "${ytdl_program}" == "" ]]; then
-  msg error "youtube-dl or a drop-in replacement can't be found in PATH, and no installed program "\
+    msg error "youtube-dl or a drop-in replacement can't be found in PATH, and no installed program "\
 "specified in QUTE_CAST_YTDL_PROGRAM (currently \\\"$QUTE_CAST_YTDL_PROGRAM\\\")"
     exit 1
 fi

--- a/misc/userscripts/cast
+++ b/misc/userscripts/cast
@@ -144,7 +144,7 @@ fi
 pkill -f "${program_}"
 
 # start youtube download in stream mode (-o -) into temporary file
-youtube-dl -qo - "$1" > "${file_to_cast}" &
+yt-dlp -qo - "$1" > "${file_to_cast}" &
 ytdl_pid=$!
 
 msg info "Casting $1" >> "$QUTE_FIFO"

--- a/misc/userscripts/cast
+++ b/misc/userscripts/cast
@@ -150,6 +150,7 @@ cast_program=$(command -v castnow)
 QUTE_CONFIG_DIR=${QUTE_CONFIG_DIR:-${XDG_CONFIG_HOME:-$HOME/.config}/qutebrowser/}
 QUTE_CAST_CONFIG=${QUTE_CAST_CONFIG:-${QUTE_CONFIG_DIR}/cast_rc}
 if [ -f "$QUTE_CAST_CONFIG" ] ; then
+    # shellcheck source=/dev/null
     source "$QUTE_CAST_CONFIG"
 fi
 


### PR DESCRIPTION
The `cast` userscript hasn't worked for me in a while (qutebrowser says "Casting \<my url\>" but the TV just shows black), because it attempts to launch youtube-dl which has been replaced by yt-dlp for some time. Switching this one command gets `cast` working for me.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
