### PR TITLE
Fix qute-bitwarden userscript URL matching for multi level subdomains

### DIFF
--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -212,7 +212,7 @@ def main(arguments):
     for target in filter(None, [
                 extract_result.fqdn,
                 extract_result.registered_domain,
-                extract_result.subdomain + extract_result.domain,
+                extract_result.subdomain + '.' + extract_result.domain,
                 extract_result.domain,
                 extract_result.ipv4]):
         target_candidates = json.loads(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
The qute-bitwarden userscript is not able to autofill for a multi-level subdomain URLs (e.g. `http://my.sub.domain.local/`).
qute-bitwarden exits with status code 2 and returns the following on stderr:
```
No pass candidates for URL 'http://my.sub.domain.local/' found!
```
Joining the extracted subdomain and domain with a `.` solves the issue.