### PR TITLE
Windows installer fixes

### DIFF
--- a/misc/nsis/install.nsh
+++ b/misc/nsis/install.nsh
@@ -542,8 +542,16 @@ Function PageInstallModeChangeMode
 FunctionEnd
 
 Function PageComponentsPre
-  GetDlgItem $0 $HWNDPARENT 1
-  SendMessage $0 ${BCM_SETSHIELD} 0 0 ; hide SHIELD (Windows Vista and above)
+  SendMessage $mui.Button.Next ${BCM_SETSHIELD} 0 0
+  StrCmpS $HasCurrentModeInstallation 0 +9
+  IfFileExists "$DESKTOP\${PRODUCT_NAME}.lnk" +4
+  SectionGetFlags ${SectionDesktopIcon} $1
+  IntOp $1 $1 & 0xFFFFFFFE
+  SectionSetFlags ${SectionDesktopIcon} $1
+  IfFileExists "$STARTMENU\${PRODUCT_NAME}.lnk" +4
+  SectionGetFlags ${SectionStartMenuIcon} $1
+  IntOp $1 $1 & 0xFFFFFFFE
+  SectionSetFlags ${SectionStartMenuIcon} $1
 FunctionEnd
 
 Function PageDirectoryPre

--- a/misc/nsis/qutebrowser.nsi
+++ b/misc/nsis/qutebrowser.nsi
@@ -43,6 +43,9 @@ ShowUninstDetails hide
 !addplugindir /x86-unicode ".\plugins\x86-unicode"
 !addincludedir ".\include"
 
+!define MUI_BGCOLOR "SYSCLR:Window"
+!define MUI_TEXTCOLOR "SYSCLR:WindowText"
+
 !include MUI2.nsh
 !include NsisMultiUser.nsh
 !include StdUtils.nsh


### PR DESCRIPTION
I'm submitting these two small fixes, in case the new version won't be ready for the next release.

Fixes #7109: On upgrades, the Desktop/StartMenu icon creation is deselected, if not already present.

Fixes #7112: Change the default color values of the interface, so that they are retrieved from the system, instead of being hardcoded.
