### PR TITLE
Add `[role="treeitem"]` to hintable elements

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1685,6 +1685,7 @@ hints.selectors:
       - '[role="menuitem"]'
       - '[role="menuitemcheckbox"]'
       - '[role="menuitemradio"]'
+      - '[role="treeitem"]'
       - '[ng-click]'
       - '[ngClick]'
       - '[data-ng-click]'

--- a/tests/unit/browser/webkit/test_webkitelem.py
+++ b/tests/unit/browser/webkit/test_webkitelem.py
@@ -195,6 +195,7 @@ class SelectionAndFilterTests:
         ('<p role="menuitem" foo="bar"/>', ['all']),
         ('<p role="menuitemcheckbox" foo="bar"/>', ['all']),
         ('<p role="menuitemradio" foo="bar"/>', ['all']),
+        ('<p role="treeitem" foo="bar"/>', ['all']),
         ('<p role="button" foo="bar"/>', ['all']),
         ('<p role="button" href="bar"/>', ['all', 'url']),
 


### PR DESCRIPTION
This makes e.g. channels in Slack's channel list hintable.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
