### PR TITLE
[readability-js] Remove superfluous css

### DIFF
--- a/misc/userscripts/readability-js
+++ b/misc/userscripts/readability-js
@@ -59,9 +59,6 @@ const HEADER = `
             width: 100%;
             margin: 0 0;
         }
-        a.reader-title {
-            color: #FFFFFF !important;
-        }
         img {
             max-width:100%;
             height:auto;


### PR DESCRIPTION
It makes no sense to force text to be white, especially for users that already use a white background. I probably included this line by mistake.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
