### PR TITLE
asciidoc2html.py: also install qute://install.html and qute://stacktrace.html

### DIFF
--- a/scripts/asciidoc2html.py
+++ b/scripts/asciidoc2html.py
@@ -43,7 +43,10 @@ class AsciiDoc:
 
     """Abstraction of an asciidoc subprocess."""
 
-    FILES = ['faq', 'changelog', 'contributing', 'quickstart', 'userscripts']
+    FILES = [
+        'faq', 'changelog', 'contributing', 'quickstart', 'userscripts',
+        'install', 'stacktrace'
+    ]
 
     def __init__(self,
                  asciidoc: Optional[str],


### PR DESCRIPTION
I recently tested the patched I proposed a few months ago in<https://github.com/qutebrowser/qutebrowser/issues/7106#issuecomment-1087654549> in a virtual environment installation of `qutebrowser` and it worked.

As mentioned in #7106, this issue will probably be resolved either way once qutebrowser v3 is released and the documentation will be rewritten in `sphinx` instead of `asciidoc`, but, since qutebrowser v2.5.1 has been released after I published the patch, and there is a plan for a qutebrowser v2.5.2 release, I think it makes sense to use the patch and fix this issue. :)

Closes #6900 