### PR TITLE
README.asciidoc: avoid HTML redirect for luakit website

### DIFF
--- a/README.asciidoc
+++ b/README.asciidoc
@@ -201,7 +201,7 @@ Active
 ~~~~~~
 
 * https://fanglingsu.github.io/vimb/[vimb] (C, GTK+ with WebKit2)
-* https://luakit.github.io/luakit/[luakit] (C/Lua, GTK+ with WebKit2)
+* https://luakit.github.io/[luakit] (C/Lua, GTK+ with WebKit2)
 * https://nyxt.atlas.engineer/[Nyxt browser] (formerly "Next browser", Lisp, Emacs-like but also offers Vim bindings, QtWebEngine or GTK+/WebKit2 - note there was a https://jgkamat.gitlab.io/blog/next-rce.html[critical remote code execution in 2019] which was handled quite badly)
 * https://vieb.dev/[Vieb] (JavaScript, Electron)
 * https://surf.suckless.org/[surf] (C, GTK+ with WebKit1/WebKit2)


### PR DESCRIPTION
It seems that, now, the luakit homepage is at <https://luakit.github.io/> and <https://luakit.github.io/luakit/> is just an HTML redirect to it.
Let's avoid the annoying redirect.