### PR TITLE
docs: fix asciidoc syntax in install.asciidoc

### DIFF
--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -488,7 +488,7 @@ PyQt/Qt install instead of installing PyQt in the virtualenv. However, unless
 you have a new QtWebKit or QtWebEngine available, qutebrowser will not work. It
 also typically means you'll be using an older release of QtWebEngine.
 
-On Windows, run `set PYTHON=C:\path\to\python.exe` (CMD) or ``$Env:PYTHON =
+On Windows, run `set PYTHON=C:\path\to\python.exe` (CMD) or `$Env:PYTHON =
 "..."` (Powershell) first.
 
 There is a third mode, `mkvenv.py --pyqt-type source` which uses a system-wide


### PR DESCRIPTION
Before the patch:
![before](https://user-images.githubusercontent.com/20175435/176033959-5a14d651-0645-4867-a7d2-34124ce18f4d.png)

After the patch:
![after](https://user-images.githubusercontent.com/20175435/176033961-0e0cc507-1c4c-4c01-8939-444d93c570f5.png)
