### PR TITLE
macOS: fix hide_decoration making window nonresizable

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -39,6 +39,14 @@ ignore_missing_imports = True
 # https://github.com/pygments/pygments/issues/1189
 ignore_missing_imports = True
 
+[mypy-objc]
+# https://github.com/ronaldoussoren/pyobjc/issues/417
+ignore_missing_imports = True
+
+[mypy-AppKit]
+# https://github.com/ronaldoussoren/pyobjc/issues/417
+ignore_missing_imports = True
+
 [mypy-qutebrowser.browser.browsertab]
 disallow_untyped_defs = True
 

--- a/README.asciidoc
+++ b/README.asciidoc
@@ -100,6 +100,10 @@ On older Python versions (3.7/3.8), the following backports are also required:
 
 * https://importlib-resources.readthedocs.io/[importlib_resources]
 
+On macOS, the following libraries are also required:
+
+* https://pyobjc.readthedocs.io/en/latest/[pyobjc-core and pyobjc-framework-Cocoa]
+
 The following libraries are optional:
 
 * https://pypi.org/project/adblock/[adblock] (for improved adblocking using ABP syntax)

--- a/misc/requirements/requirements-qutebrowser.txt-raw
+++ b/misc/requirements/requirements-qutebrowser.txt-raw
@@ -1,6 +1,10 @@
 Jinja2
 PyYAML
 
+## Only used on macOS to make borderless windows resizable
+pyobjc-core
+pyobjc-framework-Cocoa
+
 ## stdlib backports
 importlib-resources
 
@@ -16,3 +20,5 @@ typing_extensions  # from importlib-metadata
 #@ markers: importlib-resources python_version=="3.7.*" or python_version=="3.8.*"
 #@ markers: importlib-metadata python_version=="3.7.*"
 #@ markers: typing_extensions python_version<"3.8"
+#@ markers: pyobjc-core sys_platform=="darwin"
+#@ markers: pyobjc-framework-Cocoa sys_platform=="darwin"

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -569,6 +569,15 @@ class MainWindow(QWidget):
         if hidden:
             window_flags |= Qt.CustomizeWindowHint | Qt.NoDropShadowWindowHint
         self.setWindowFlags(window_flags)
+
+        if utils.is_mac and hidden:
+            from ctypes import c_void_p
+            # pylint: disable=import-error
+            from objc import objc_object
+            from AppKit import NSWindowStyleMaskResizable
+            win = objc_object(c_void_p=c_void_p(int(self.winId()))).window()
+            win.setStyleMask_(win.styleMask() | NSWindowStyleMaskResizable)
+
         if refresh_window:
             self.show()
 

--- a/qutebrowser/misc/earlyinit.py
+++ b/qutebrowser/misc/earlyinit.py
@@ -243,6 +243,10 @@ def check_libraries():
     if sys.version_info < (3, 9):
         # Backport required
         modules['importlib_resources'] = _missing_str("importlib_resources")
+    if sys.platform.startswith('darwin'):
+        # Used for resizable hide_decoration windows on macOS
+        modules['objc'] = _missing_str("pyobjc-core")
+        modules['AppKit'] = _missing_str("pyobjc-framework-Cocoa")
     _check_modules(modules)
 
 

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -407,6 +407,7 @@ MODULE_INFO: Mapping[str, ModuleInfo] = collections.OrderedDict([
         ('PyQt5.QtWebEngineWidgets', []),
         ('PyQt5.QtWebEngine', ['PYQT_WEBENGINE_VERSION_STR']),
         ('PyQt5.QtWebKitWidgets', []),
+        ('objc', ['__version__']),
     ]
 ])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,8 @@ importlib-resources==5.8.0 ; python_version=="3.7.*" or python_version=="3.8.*"
 Jinja2==3.1.2
 MarkupSafe==2.1.1
 Pygments==2.12.0
+pyobjc-core==8.5 ; sys_platform=="darwin"
+pyobjc-framework-Cocoa==8.5 ; sys_platform=="darwin"
 PyYAML==6.0
 typing_extensions==4.2.0 ; python_version<"3.8"
 zipp==3.8.0

--- a/scripts/dev/changelog_urls.json
+++ b/scripts/dev/changelog_urls.json
@@ -155,5 +155,7 @@
   "PyJWT": "https://github.com/jpadilla/pyjwt/blob/master/CHANGELOG.rst",
   "commonmark": "https://github.com/readthedocs/commonmark.py/blob/master/CHANGELOG.md",
   "rich": "https://github.com/Textualize/rich/blob/master/CHANGELOG.md",
-  "ply": "https://github.com/dabeaz/ply/blob/master/CHANGES"
+  "ply": "https://github.com/dabeaz/ply/blob/master/CHANGES",
+  "pyobjc-core": "https://pyobjc.readthedocs.io/en/latest/changelog.html",
+  "pyobjc-framework-Cocoa": "https://pyobjc.readthedocs.io/en/latest/changelog.html"
 }

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -751,6 +751,7 @@ class TestModuleVersions:
         ('adblock', True),
         ('dataclasses', False),
         ('importlib_resources', False),
+        ('objc', True),
     ])
     def test_existing_attributes(self, name, has_version):
         """Check if all dependencies have an expected __version__ attribute.


### PR DESCRIPTION
Use PyObjC to call `setWindowMask:` with resizable flag on the
underlying NSWindow.

Fixes #4067

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
