### PR TITLE
Display title or alt text on hover if available

### DIFF
--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -27,7 +27,7 @@ from PyQt5.QtGui import QMouseEvent
 
 from qutebrowser.config import config
 from qutebrowser.keyinput import modeman
-from qutebrowser.utils import log, usertypes, utils, qtutils, objreg
+from qutebrowser.utils import log, usertypes, utils, qtutils, objreg, message
 
 if TYPE_CHECKING:
     from qutebrowser.browser import browsertab
@@ -449,6 +449,9 @@ class AbstractWebElement(collections.abc.MutableMapping):  # type: ignore[type-a
         event = QMouseEvent(QEvent.MouseMove, pos, Qt.NoButton, Qt.NoButton,
                             Qt.NoModifier)
         self._tab.send_event(event)
+        title_or_alt_text = self.get("title") or self.get("alt") or ""
+        if len(title_or_alt_text):
+            message.info(title_or_alt_text)
 
     def right_click(self) -> None:
         """Simulate a right-click on the element."""


### PR DESCRIPTION
When I create a keyboard driven hover event with `;h`, I want to get the same information I would have received if I created the hover event with the mouse.

I spent a while trying to do this with various QEvent types, but none of them would display the title text. Title text also didn't display if I used the linux keyboard navigation tool `keynav` to warp the mouse pointer into the middle of the element -- the title really only wants to show up if it sees the mouse start outside the element's rectangle and then gradually move into it.

Putting it in the message bar instead works fine, though, and since I added alt text as a fall back, it is more likely to display useful information than a mouse driven hover event would:

![2022-07-31-132429_1280x1024_scrot](https://user-images.githubusercontent.com/25477622/182029352-9bc135f1-e238-4e15-8923-dcab04c84ce5.png)

