### PR TITLE
fix: use app-name as notification application name

### DIFF
--- a/qutebrowser/browser/webengine/notification.py
+++ b/qutebrowser/browser/webengine/notification.py
@@ -1059,7 +1059,7 @@ class DBusNotificationAdapter(AbstractNotificationAdapter):
             replaces_id = 0  # 0 is never a valid ID according to the spec
 
         reply = self._call_notify_wrapper(
-            appname="qutebrowser",
+            appname=objects.qapp.desktopFileName(),
             replaces_id=_as_uint32(replaces_id),
             icon="",  # we use image-data and friends instead
             title=self._get_title_arg(qt_notification.title()),


### PR DESCRIPTION
Hello !
Closes #7338, now the notification app name follows the real app-name.

The current behavior is that qutebrowser real app-name is `org.qutebrowser.qutebrowser`, but the application name in notification has been set to simply `qutebrowser`. I was wondering if I should add an exception to keep this behavior if the flag `--desktop-file-name` is not in use.