### PR TITLE
added "--open" optional argument to ":tab-select"

### DIFF
--- a/doc/help/commands.asciidoc
+++ b/doc/help/commands.asciidoc
@@ -1504,7 +1504,7 @@ How many tabs to switch back.
 
 [[tab-select]]
 === tab-select
-Syntax: +:tab-select ['index']+
+Syntax: +:tab-select [*--open*] ['index']+
 
 Select tab by index or url/title best match.
 
@@ -1513,6 +1513,8 @@ Focuses window if necessary when index is given. If both index and count are giv
 ==== positional arguments
 * +'index'+: The [win_id/]index of the tab to focus. Or a substring in which case the closest match will be focused.
 
+==== optional arguments
+* +*-o*+, +*--open*+: If index is a substring and it didn't match any tab, open it in a new tab.
 
 ==== count
 The tab index to focus, starting with 1.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -932,7 +932,7 @@ class CommandDispatcher:
                        maxsplit=0)
     @cmdutils.argument('index', completion=miscmodels.tabs)
     @cmdutils.argument('count', value=cmdutils.Value.count)
-    def tab_select(self, index=None, count=None):
+    def tab_select(self, index=None, open=False, count=None):
         """Select tab by index or url/title best match.
 
         Focuses window if necessary when index is given. If both index and
@@ -944,6 +944,7 @@ class CommandDispatcher:
             index: The [win_id/]index of the tab to focus. Or a substring
                    in which case the closest match will be focused.
             count: The tab index to focus, starting with 1.
+            open: If index is a substring and it didn't match any tab, open it in a new tab.
         """
         if count is None and index is None:
             self.openurl('qute://tabs/', tab=True)
@@ -952,7 +953,14 @@ class CommandDispatcher:
         if count is not None:
             index = str(count)
 
-        tabbed_browser, tab = self._resolve_tab_index(index)
+        tabbed_browser, tab = None, None
+        try:
+            tabbed_browser, tab = self._resolve_tab_index(index)
+        except cmdutils.CommandError:
+            if open:
+                self.openurl(index, tab=True)
+                return
+            raise
 
         window = tabbed_browser.widget.window()
         mainwindow.raise_window(window)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

The option might be usefull, e.g., when using `:tab-select` from external scripts or OS-shortcuts that try to focus a tab by match with a given URL. This option will allow to open the URL in a new tab, if no existing tab matched.
