### PR TITLE
Get mypy working, with pyqt5, on qt6-v2 branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,8 @@ jobs:
           - testenv: pylint
           - testenv: flake8
           # FIXME:qt6 (lint)
-          # - testenv: mypy-pyqt5
           # - testenv: mypy-pyqt6
+          - testenv: mypy-pyqt5
           - testenv: docs
           - testenv: vulture
           - testenv: misc

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,8 @@ jobs:
           - testenv: pylint
           - testenv: flake8
           # FIXME:qt6 (lint)
-          # - testenv: mypy
+          # - testenv: mypy-pyqt5
+          # - testenv: mypy-pyqt6
           - testenv: docs
           - testenv: vulture
           - testenv: misc

--- a/misc/requirements/requirements-mypy.txt
+++ b/misc/requirements/requirements-mypy.txt
@@ -12,6 +12,8 @@ mypy-extensions==0.4.3
 pluggy==1.0.0
 Pygments==2.13.0
 PyQt5-stubs==5.15.6.0
+PyQt6==6.3.1
+PyQt6-WebEngine==6.3.1
 tomli==2.0.1
 types-PyYAML==6.0.11
 typing_extensions==4.3.0

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -1322,7 +1322,8 @@ class AbstractTab(QWidget):
     def __repr__(self) -> str:
         try:
             qurl = self.url()
-            url = qurl.toDisplayString(QUrl.ComponentFormattingOption.EncodeUnicode)
+            as_unicode = QUrl.ComponentFormattingOption.EncodeUnicode
+            url = qurl.toDisplayString(as_unicode)  # type: ignore[arg-type]
         except (AttributeError, RuntimeError) as exc:
             url = '<{}>'.format(exc.__class__.__name__)
         else:

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -236,12 +236,12 @@ class AbstractPrinting(QObject):
         super().__init__(parent)
         self._widget = cast(_WidgetType, None)
         self._tab = tab
-        self._dialog: QPrintDialog = None
+        self._dialog: Optional[QPrintDialog] = None
         self.printing_finished.connect(self._on_printing_finished)
         self.pdf_printing_finished.connect(self._on_pdf_printing_finished)
 
     @pyqtSlot(bool)
-    def _on_printing_finished(self, ok):
+    def _on_printing_finished(self, ok: bool) -> None:
         # Only reporting error here, as the user has feedback from the dialog
         # (and probably their printer) already.
         if not ok:
@@ -251,7 +251,7 @@ class AbstractPrinting(QObject):
             self._dialog = None
 
     @pyqtSlot(str, bool)
-    def _on_pdf_printing_finished(self, path, ok):
+    def _on_pdf_printing_finished(self, path: str, ok: bool) -> None:
         if ok:
             message.info(f"Printed to {path}")
         else:
@@ -277,7 +277,7 @@ class AbstractPrinting(QObject):
         """Print the tab to a PDF with the given filename."""
         raise NotImplementedError
 
-    def to_printer(self, printer: QPrinter):
+    def to_printer(self, printer: QPrinter) -> None:
         """Print the tab.
 
         Args:
@@ -288,7 +288,9 @@ class AbstractPrinting(QObject):
     def show_dialog(self) -> None:
         """Print with a QPrintDialog."""
         self._dialog = QPrintDialog(self._tab)
-        self._dialog.open(lambda: self.to_printer(self._dialog.printer()))
+        assert self._dialog is not None
+        not_none_dialog = self._dialog
+        self._dialog.open(lambda: self.to_printer(not_none_dialog.printer()))
         # Gets cleaned up in on_printing_finished
 
 

--- a/qutebrowser/browser/hints.py
+++ b/qutebrowser/browser/hints.py
@@ -254,7 +254,7 @@ class HintActions:
 
         flags = QUrl.ComponentFormattingOption.FullyEncoded | QUrl.UrlFormattingOption.RemovePassword
         if url.scheme() == 'mailto':
-            flags |= QUrl.UrlFormattingOption.RemoveScheme
+            flags |= QUrl.UrlFormattingOption.RemoveScheme  # type: ignore[operator]
         urlstr = url.toString(flags)
 
         new_content = urlstr

--- a/qutebrowser/browser/qtnetworkdownloads.py
+++ b/qutebrowser/browser/qtnetworkdownloads.py
@@ -177,7 +177,10 @@ class DownloadItem(downloads.AbstractDownloadItem):
 
     @pyqtSlot(QUrl)
     def _on_redirected(self, url):
-        log.downloads.debug(f"redirected: {self._reply.url()} -> {url}")
+        if self._reply is None:
+            log.downloads.warning(f"redirected: REPLY GONE -> {url}")
+        else:
+            log.downloads.debug(f"redirected: {self._reply.url()} -> {url}")
 
     def _do_cancel(self):
         self._read_timer.stop()

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -22,6 +22,7 @@
 from typing import Iterator, Optional, Set, TYPE_CHECKING, Union, Dict
 import collections.abc
 
+from qutebrowser.qt import machinery
 from qutebrowser.qt.core import QUrl, Qt, QEvent, QTimer, QRect, QPointF
 from qutebrowser.qt.gui import QMouseEvent
 
@@ -34,6 +35,11 @@ if TYPE_CHECKING:
 
 
 JsValueType = Union[int, float, str, None]
+
+if machinery.IS_QT6:
+    KeybordModifierType = Qt.KeyboardModifier
+else:
+    KeybordModifierType = Union[Qt.KeyboardModifiers, Qt.KeyboardModifier]
 
 
 class Error(Exception):
@@ -345,7 +351,7 @@ class AbstractWebElement(collections.abc.MutableMapping):  # type: ignore[type-a
         log.webelem.debug("Sending fake click to {!r} at position {} with "
                           "target {}".format(self, pos, click_target))
 
-        target_modifiers: Dict[usertypes.ClickTarget, Qt.KeyboardModifier] = {
+        target_modifiers: Dict[usertypes.ClickTarget, KeybordModifierType] = {
             usertypes.ClickTarget.normal: Qt.KeyboardModifier.NoModifier,
             usertypes.ClickTarget.window: Qt.KeyboardModifier.AltModifier | Qt.KeyboardModifier.ShiftModifier,
             usertypes.ClickTarget.tab: Qt.KeyboardModifier.ControlModifier,

--- a/qutebrowser/browser/webengine/darkmode.py
+++ b/qutebrowser/browser/webengine/darkmode.py
@@ -296,7 +296,7 @@ _DEFINITIONS[Variant.qt_63] = _DEFINITIONS[Variant.qt_515_3].copy_add_setting(
 )
 
 
-_PREFERRED_COLOR_SCHEME_DEFINITIONS = {
+_PREFERRED_COLOR_SCHEME_DEFINITIONS: Mapping[Variant, Mapping[Any, str]] = {
     Variant.qt_515_2: {
         # 0: no-preference (not exposed)
         "dark": "1",

--- a/qutebrowser/browser/webengine/notification.py
+++ b/qutebrowser/browser/webengine/notification.py
@@ -50,6 +50,7 @@ import functools
 import subprocess
 from typing import Any, List, Dict, Optional, Iterator, Type, TYPE_CHECKING
 
+from qutebrowser.qt import machinery
 from qutebrowser.qt.core import (Qt, QObject, QVariant, QMetaType, QByteArray, pyqtSlot,
                           pyqtSignal, QTimer, QProcess, QUrl)
 from qutebrowser.qt.gui import QImage, QIcon, QPixmap
@@ -686,10 +687,9 @@ def _as_uint32(x: int) -> QVariant:
     """Convert the given int to an uint32 for DBus."""
     variant = QVariant(x)
 
-    try:
-        # Qt 5
+    if machinery.IS_QT5:
         target_type = QVariant.Type.UInt
-    except AttributeError:
+    else:
         # Qt 6
         target_type = QMetaType(QMetaType.Type.UInt.value)
 

--- a/qutebrowser/browser/webengine/webenginedownloads.py
+++ b/qutebrowser/browser/webengine/webenginedownloads.py
@@ -23,6 +23,7 @@ import re
 import os.path
 import functools
 
+from qutebrowser.qt import machinery
 from qutebrowser.qt.core import pyqtSlot, Qt, QUrl, QObject
 from qutebrowser.qt.webenginecore import QWebEngineDownloadRequest
 
@@ -44,10 +45,9 @@ class DownloadItem(downloads.AbstractDownloadItem):
                  parent: QObject = None) -> None:
         super().__init__(manager=manager, parent=manager)
         self._qt_item = qt_item
-        try:
-            # Qt 5
+        if machinery.IS_QT5:
             qt_item.downloadProgress.connect(self.stats.on_download_progress)
-        except AttributeError:
+        else:
             # Qt 6
             qt_item.receivedBytesChanged.connect(
                 lambda: self.stats.on_download_progress(
@@ -106,10 +106,9 @@ class DownloadItem(downloads.AbstractDownloadItem):
                              "{}".format(state_name))
 
     def _do_die(self):
-        try:
-            # Qt 5
+        if machinery.IS_QT5:
             self._qt_item.downloadProgress.disconnect()
-        except AttributeError:
+        else:
             # Qt 6
             self._qt_item.receivedBytesChanged.disconnect()
             self._qt_item.totalBytesChanged.disconnect()

--- a/qutebrowser/browser/webengine/webengineinspector.py
+++ b/qutebrowser/browser/webengine/webengineinspector.py
@@ -19,6 +19,8 @@
 
 """Customized QWebInspector for QtWebEngine."""
 
+from typing import Optional
+
 from qutebrowser.qt import machinery
 from qutebrowser.qt.webenginewidgets import QWebEngineView
 from qutebrowser.qt.webenginecore import QWebEnginePage
@@ -70,7 +72,7 @@ class WebEngineInspector(inspector.AbstractWebInspector):
                  parent: QWidget = None) -> None:
         super().__init__(splitter, win_id, parent)
         self._check_devtools_resources()
-        self._settings = None
+        self._settings: Optional[webenginesettings.WebEngineSettings] = None
 
     def _on_window_close_requested(self) -> None:
         """Called when the 'x' was clicked in the devtools."""
@@ -115,6 +117,7 @@ class WebEngineInspector(inspector.AbstractWebInspector):
         assert inspector_page.profile() == page.profile()
 
         inspector_page.setInspectedPage(page)
+        assert self._settings is not None
         self._settings.update_for_url(inspector_page.requestedUrl())
 
     def _needs_recreate(self) -> bool:

--- a/qutebrowser/browser/webengine/webengineinspector.py
+++ b/qutebrowser/browser/webengine/webengineinspector.py
@@ -19,6 +19,7 @@
 
 """Customized QWebInspector for QtWebEngine."""
 
+from qutebrowser.qt import machinery
 from qutebrowser.qt.webenginewidgets import QWebEngineView
 from qutebrowser.qt.webenginecore import QWebEnginePage
 from qutebrowser.qt.widgets import QWidget
@@ -48,12 +49,11 @@ class WebEngineInspectorView(QWebEngineView):
         See WebEngineView.createWindow for details.
         """
         inspected_page = self.page().inspectedPage()
-        try:
-            # Qt 5
+        if machinery.IS_QT5:
             view = inspected_page.view()
             assert isinstance(view, QWebEngineView), view
             return view.createWindow(wintype)
-        except AttributeError:
+        else:
             # Qt 6
             newpage = inspected_page.createWindow(wintype)
             return webview.WebEngineView.forPage(newpage)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1063,8 +1063,7 @@ class _WebEngineScripts(QObject):
     def _remove_js(self, name):
         """Remove an early QWebEngineScript."""
         scripts = self._widget.page().scripts()
-        if hasattr(scripts, 'find'):
-            # Qt 6
+        if machinery.IS_QT6:
             for script in scripts.find(f'_qute_{name}'):
                 scripts.remove(script)
         else:

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1696,6 +1696,7 @@ class WebEngineTab(browsertab.AbstractTab):
         # pylint: disable=protected-access
         self.audio._connect_signals()
         self.search.connect_signals()
+        assert isinstance(self.printing, WebEnginePrinting)
         self.printing.connect_signals()
         self._permissions.connect_signals()
         self._scripts.connect_signals()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -40,7 +40,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
 
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
                                resources, message, jinja, debug, version)
-from qutebrowser.qt import sip
+from qutebrowser.qt import sip, machinery
 from qutebrowser.misc import objects, miscwidgets
 
 
@@ -85,12 +85,8 @@ class WebEnginePrinting(browsertab.AbstractPrinting):
         """Called from WebEngineTab.connect_signals."""
         page = self._widget.page()
         page.pdfPrintingFinished.connect(self.pdf_printing_finished)
-        try:
-            # Qt 6
+        if machinery.IS_QT6:
             self._widget.printFinished.connect(self.printing_finished)
-        except AttributeError:
-            # Qt 5: Uses callbacks instead
-            pass
 
     def check_pdf_support(self):
         pass
@@ -103,10 +99,9 @@ class WebEnginePrinting(browsertab.AbstractPrinting):
         self._widget.page().printToPdf(filename)
 
     def to_printer(self, printer):
-        try:
-            # Qt 5
+        if machinery.IS_QT5:
             self._widget.page().print(printer, self.printing_finished.emit)
-        except AttributeError:
+        else:
             # Qt 6
             self._widget.print(printer)
 

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -196,7 +196,9 @@ class WebEnginePage(QWebEnginePage):
         self._set_bg_color()
         config.instance.changed.connect(self._set_bg_color)
         if machinery.IS_QT6:
-            self.certificateError.connect(self._handle_certificate_error)
+            self.certificateError.connect(  # pylint: disable=no-member
+                self._handle_certificate_error
+            )
 
     @config.change_filter('colors.webpage.bg')
     def _set_bg_color(self):

--- a/qutebrowser/browser/webengine/webview.py
+++ b/qutebrowser/browser/webengine/webview.py
@@ -195,11 +195,8 @@ class WebEnginePage(QWebEnginePage):
         self._theme_color = theme_color
         self._set_bg_color()
         config.instance.changed.connect(self._set_bg_color)
-        try:
+        if machinery.IS_QT6:
             self.certificateError.connect(self._handle_certificate_error)
-        except AttributeError:
-            # Qt 5: Overridden method instead of signal
-            pass
 
     @config.change_filter('colors.webpage.bg')
     def _set_bg_color(self):

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -547,7 +547,10 @@ class KeySequence:
 
     def __iter__(self) -> Iterator[KeyInfo]:
         """Iterate over KeyInfo objects."""
-        for combination in itertools.chain.from_iterable(self._sequences):
+        combination: QKeySequence
+        for combination in itertools.chain.from_iterable(
+            self._sequences  # type: ignore[arg-type]
+        ):
             yield KeyInfo.from_qt(combination)
 
     def __repr__(self) -> str:
@@ -719,7 +722,7 @@ class KeySequence:
             mappings: Mapping['KeySequence', 'KeySequence']
     ) -> 'KeySequence':
         """Get a new KeySequence with the given mappings applied."""
-        infos = []
+        infos: List[KeyInfo] = []
         for info in self:
             key_seq = KeySequence(info)
             if key_seq in mappings:

--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -39,7 +39,9 @@ from qutebrowser.qt import machinery
 from qutebrowser.qt.core import Qt, QEvent
 from qutebrowser.qt.gui import QKeySequence, QKeyEvent
 if machinery.IS_QT6:
-    from qutebrowser.qt.core import QKeyCombination
+    # FIXME:qt6 (lint) how come pylint isn't picking this up with both backends
+    # installed?
+    from qutebrowser.qt.core import QKeyCombination  # pylint: disable=no-name-in-module
 else:
     QKeyCombination = None
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -567,7 +567,8 @@ class MainWindow(QWidget):
         window_flags = Qt.WindowType.Window
         refresh_window = self.isVisible()
         if hidden:
-            window_flags |= Qt.WindowType.CustomizeWindowHint | Qt.WindowType.NoDropShadowWindowHint
+            modifiers = Qt.WindowType.CustomizeWindowHint | Qt.WindowType.NoDropShadowWindowHint
+            window_flags |= modifiers  # type: ignore[assignment]
         self.setWindowFlags(window_flags)
 
         if utils.is_mac and hidden and not qtutils.version_check('6.3', compiled=False):

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -197,7 +197,7 @@ class PromptQueue(QObject):
             question.completed.connect(loop.deleteLater)
             log.prompt.debug("Starting loop.exec() for {}".format(question))
             flags = QEventLoop.ProcessEventsFlag.ExcludeSocketNotifiers
-            loop.exec(flags)
+            loop.exec(flags)  # type: ignore[arg-type]
             log.prompt.debug("Ending loop.exec() for {}".format(question))
 
             log.prompt.debug("Restoring old question {}".format(old_question))

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -223,7 +223,7 @@ class TabbedBrowser(QWidget):
         self.widget.tabCloseRequested.connect(self.on_tab_close_requested)
         self.widget.new_tab_requested.connect(self.tabopen)
         self.widget.currentChanged.connect(self._on_current_changed)
-        self.cur_fullscreen_requested.connect(self.widget.tabBar().maybe_hide)
+        self.cur_fullscreen_requested.connect(self.widget.tab_bar().maybe_hide)
 
         self.widget.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Expanding)
 

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -29,7 +29,7 @@ from typing import Any, Dict, Iterator, List, Mapping, MutableSequence, Optional
 from qutebrowser.qt.core import QObject, pyqtSignal
 from qutebrowser.qt.sql import QSqlDatabase, QSqlError, QSqlQuery
 
-from qutebrowser.qt import sip
+from qutebrowser.qt import sip, machinery
 from qutebrowser.utils import debug, log
 
 
@@ -352,10 +352,10 @@ class Query:
     def _validate_bound_values(self):
         """Make sure all placeholders are bound."""
         qt_bound_values = self.query.boundValues()
-        try:
+        if machinery.IS_QT5:
             # Qt 5: Returns a dict
-            values = qt_bound_values.values()
-        except AttributeError:
+            values = list(qt_bound_values.values())
+        else:
             # Qt 6: Returns a list
             values = qt_bound_values
 

--- a/qutebrowser/misc/sql.py
+++ b/qutebrowser/misc/sql.py
@@ -24,7 +24,7 @@ import collections
 import contextlib
 import dataclasses
 import types
-from typing import Any, Dict, Iterator, List, Mapping, MutableSequence, Optional, Type
+from typing import Any, Dict, Iterator, List, Mapping, MutableSequence, Optional, Type, Union
 
 from qutebrowser.qt.core import QObject, pyqtSignal
 from qutebrowser.qt.sql import QSqlDatabase, QSqlError, QSqlQuery
@@ -149,6 +149,7 @@ class BugError(Error):
 def raise_sqlite_error(msg: str, error: QSqlError) -> None:
     """Raise either a BugError or KnownError."""
     error_code = error.nativeErrorCode()
+    primary_error_code: Union[SqliteErrorCode, str]
     try:
         # https://sqlite.org/rescode.html#pve
         primary_error_code = SqliteErrorCode(int(error_code) & 0xff)

--- a/qutebrowser/qt/sip.py
+++ b/qutebrowser/qt/sip.py
@@ -28,4 +28,4 @@ else:
     raise machinery.UnknownWrapper()
 
 if not VENDORED_SIP:
-    from sip import *  # type: ignore[import]
+    from sip import *  # type: ignore[import]  # pylint: disable=import-error

--- a/qutebrowser/qt/sip.py
+++ b/qutebrowser/qt/sip.py
@@ -7,18 +7,25 @@ from qutebrowser.qt import machinery
 
 # While upstream recommends using PyQt6.sip ever since PyQt6 5.11, some distributions
 # still package later versions of PyQt6 with a top-level "sip" rather than "PyQt6.sip".
+VENDORED_SIP=False
 
 if machinery.USE_PYSIDE6:
     raise machinery.Unavailable()
 elif machinery.USE_PYQT5:
     try:
         from PyQt5.sip import *
+        VENDORED_SIP=True
     except ImportError:
-        from sip import *
+        pass
 elif machinery.USE_PYQT6:
     try:
         from PyQt6.sip import *
+        VENDORED_SIP=True
     except ImportError:
-        from sip import *
+        pass
+
 else:
     raise machinery.UnknownWrapper()
+
+if not VENDORED_SIP:
+    from sip import *  # type: ignore[import]

--- a/qutebrowser/utils/debug.py
+++ b/qutebrowser/utils/debug.py
@@ -104,7 +104,7 @@ _EnumValueType = Union[sip.simplewrapper, int]
 
 def _qenum_key_python(
     value: _EnumValueType,
-    klass: Type[_EnumValueType] = None,
+    klass: Type[_EnumValueType],
 ) -> Optional[str]:
     """New-style PyQt6: Try getting value from Python enum."""
     if isinstance(value, enum.Enum) and value.name:
@@ -113,6 +113,7 @@ def _qenum_key_python(
     # We got an int with klass passed: Try asking Python enum for member
     if issubclass(klass, enum.Enum):
         try:
+            assert isinstance(value, int)
             name = klass(value).name
             if name is not None and name != str(value):
                 return name
@@ -125,7 +126,7 @@ def _qenum_key_python(
 def _qenum_key_qt(
     base: Type[_EnumValueType],
     value: _EnumValueType,
-    klass: Type[_EnumValueType] = None,
+    klass: Type[_EnumValueType],
 ) -> Optional[str]:
     # On PyQt5, or PyQt6 with int passed: Try to ask Qt's introspection.
     # However, not every Qt enum value has a staticMetaObject
@@ -168,6 +169,7 @@ def qenum_key(
         klass = value.__class__
         if klass == int:
             raise TypeError("Can't guess enum class of an int!")
+    assert klass is not None
 
     name = _qenum_key_python(value=value, klass=klass)
     if name is not None:

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -455,6 +455,12 @@ class QtValueError(ValueError):
         super().__init__(err)
 
 
+if machinery.IS_QT6:
+    _ProcessEventFlagType = QEventLoop.ProcessEventsFlag
+else:
+    _ProcessEventFlagType = QEventLoop.ProcessEventsFlags
+
+
 class EventLoop(QEventLoop):
 
     """A thin wrapper around QEventLoop.
@@ -468,8 +474,9 @@ class EventLoop(QEventLoop):
 
     def exec(
             self,
-            flags: QEventLoop.ProcessEventsFlag =
-            QEventLoop.ProcessEventsFlag.AllEvents
+            flags: _ProcessEventFlagType = (
+                QEventLoop.ProcessEventsFlag.AllEvents  # type: ignore[assignment]
+            ),
     ) -> int:
         """Override exec_ to raise an exception when re-running."""
         if self._executing:

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -36,6 +36,7 @@ import contextlib
 from typing import (Any, AnyStr, TYPE_CHECKING, BinaryIO, IO, Iterator,
                     Optional, Union, Tuple, cast)
 
+from qutebrowser.qt import machinery
 from qutebrowser.qt.core import (qVersion, QEventLoop, QDataStream, QByteArray,
                           QIODevice, QFileDevice, QSaveFile, QT_VERSION_STR,
                           PYQT_VERSION_STR, QObject, QUrl, QLibraryInfo)
@@ -588,8 +589,7 @@ class LibraryPath(enum.Enum):
 
 def library_path(which: LibraryPath) -> pathlib.Path:
     """Wrapper around QLibraryInfo.path / .location."""
-    if hasattr(QLibraryInfo, "path"):
-        # Qt 6
+    if machinery.IS_QT6:
         val = getattr(QLibraryInfo.LibraryPath, which.value)
         ret = QLibraryInfo.path(val)
     else:

--- a/qutebrowser/utils/qtutils.py
+++ b/qutebrowser/utils/qtutils.py
@@ -36,7 +36,7 @@ import contextlib
 from typing import (Any, AnyStr, TYPE_CHECKING, BinaryIO, IO, Iterator,
                     Optional, Union, Tuple, cast)
 
-from qutebrowser.qt import machinery
+from qutebrowser.qt import machinery, sip
 from qutebrowser.qt.core import (qVersion, QEventLoop, QDataStream, QByteArray,
                           QIODevice, QFileDevice, QSaveFile, QT_VERSION_STR,
                           PYQT_VERSION_STR, QObject, QUrl, QLibraryInfo)
@@ -600,7 +600,7 @@ def library_path(which: LibraryPath) -> pathlib.Path:
     return pathlib.Path(ret)
 
 
-def extract_enum_val(val: Union[int, enum.Enum]) -> int:
+def extract_enum_val(val: Union[sip.simplewrapper, int, enum.Enum]) -> int:
     """Extract an int value from a Qt enum value.
 
     For Qt 5, enum values are basically Python integers.
@@ -609,4 +609,6 @@ def extract_enum_val(val: Union[int, enum.Enum]) -> int:
     """
     if isinstance(val, enum.Enum):
         return val.value
+    elif isinstance(val, sip.simplewrapper):
+        return int(val)  # type: ignore[call-overload]
     return int(val)

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -491,7 +491,7 @@ class AbstractCertificateErrorWrapper:
     """A wrapper over an SSL/certificate error."""
 
     def __init__(self) -> None:
-        self._certificate_accepted = None
+        self._certificate_accepted: Optional[bool] = None
 
     def __str__(self) -> str:
         raise NotImplementedError
@@ -514,7 +514,7 @@ class AbstractCertificateErrorWrapper:
     def defer(self) -> None:
         raise NotImplementedError
 
-    def certificate_was_accepted(self) -> None:
+    def certificate_was_accepted(self) -> bool:
         """Check whether the certificate was accepted by the user."""
         if not self.is_overridable():
             return False

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -1029,7 +1029,6 @@ def opengl_info() -> Optional[OpenGLInfo]:  # pragma: no cover
             else:
                 # Qt 6
                 # FIXME:qt6 (lint)
-                # pylint: disable-next=no-name-in-module
                 from qutebrowser.qt.opengl import QOpenGLVersionFunctionsFactory
                 vf = QOpenGLVersionFunctionsFactory.get(vp, ctx)
         except ImportError as e:

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -785,18 +785,19 @@ def qtwebengine_versions(*, avoid_init: bool = False) -> WebEngineVersions:
     if override is not None:
         return WebEngineVersions.from_pyqt(override, source='override')
 
-    try:
-        from qutebrowser.qt.webenginecore import (
-            qWebEngineVersion,
-            qWebEngineChromiumVersion,
-        )
-    except ImportError:
-        pass  # Needs QtWebEngine 6.2+ with PyQtWebEngine 6.3.1+
-    else:
-        return WebEngineVersions.from_api(
-            qtwe_version=qWebEngineVersion(),
-            chromium_version=qWebEngineChromiumVersion(),
-        )
+    if machinery.IS_QT6:
+        try:
+            from qutebrowser.qt.webenginecore import (
+                qWebEngineVersion,
+                qWebEngineChromiumVersion,
+            )
+        except ImportError:
+            pass  # Needs QtWebEngine 6.2+ with PyQtWebEngine 6.3.1+
+        else:
+            return WebEngineVersions.from_api(
+                qtwe_version=qWebEngineVersion(),
+                chromium_version=qWebEngineChromiumVersion(),
+            )
 
     from qutebrowser.browser.webengine import webenginesettings
 

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -1024,10 +1024,9 @@ def opengl_info() -> Optional[OpenGLInfo]:  # pragma: no cover
         vp.setVersion(2, 0)
 
         try:
-            try:
-                # Qt 5
+            if machinery.IS_QT5:
                 vf = ctx.versionFunctions(vp)
-            except AttributeError:
+            else:
                 # Qt 6
                 # FIXME:qt6 (lint)
                 # pylint: disable-next=no-name-in-module

--- a/tox.ini
+++ b/tox.ini
@@ -180,12 +180,12 @@ deps =
 whitelist_externals = bash
 commands = bash scripts/dev/run_shellcheck.sh {posargs}
 
-[testenv:mypy-{qt5,qt6}]
+[testenv:mypy-{pyqt5,pyqt6}]
 basepython = {env:PYTHON:python3}
 passenv = TERM MYPY_FORCE_TERMINAL_WIDTH
 setenv =
-    qt6: CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6
-    qt5: CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6
+    pyqt6: CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6
+    pyqt5: CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/misc/requirements/requirements-dev.txt
@@ -207,13 +207,13 @@ whitelist_externals = actionlint
 commands =
     actionlint
 
-[testenv:mypy-{qt5,qt6}-diff]
+[testenv:mypy-{pyqt5,pyqt6}-diff]
 basepython = {env:PYTHON:python3}
-passenv = {[testenv:mypy-qt6]passenv}
-deps = {[testenv:mypy-qt6]deps}
+passenv = {[testenv:mypy-pyqt6]passenv}
+deps = {[testenv:mypy-pyqt6]deps}
 setenv =
-    qt6: CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6
-    qt5: CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6
+    pyqt6: CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6
+    pyqt5: CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6
 commands =
     {envpython} -m mypy --cobertura-xml-report {envtmpdir} {env:CONSTANTS_ARGS} qutebrowser tests {posargs}
     {envdir}/bin/diff-cover --fail-under=100 --compare-branch={env:DIFF_BRANCH:origin/{env:GITHUB_BASE_REF:master}} {envtmpdir}/cobertura.xml

--- a/tox.ini
+++ b/tox.ini
@@ -180,16 +180,19 @@ deps =
 whitelist_externals = bash
 commands = bash scripts/dev/run_shellcheck.sh {posargs}
 
-[testenv:mypy]
+[testenv:mypy-{qt5,qt6}]
 basepython = {env:PYTHON:python3}
 passenv = TERM MYPY_FORCE_TERMINAL_WIDTH
+setenv =
+    qt6: CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6
+    qt5: CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/misc/requirements/requirements-dev.txt
     -r{toxinidir}/misc/requirements/requirements-tests.txt
     -r{toxinidir}/misc/requirements/requirements-mypy.txt
 commands =
-    {envpython} -m mypy qutebrowser {posargs}
+    {envpython} -m mypy {env:CONSTANTS_ARGS} qutebrowser {posargs}
 
 [testenv:yamllint]
 basepython = {env:PYTHON:python3}
@@ -204,12 +207,15 @@ whitelist_externals = actionlint
 commands =
     actionlint
 
-[testenv:mypy-diff]
+[testenv:mypy-{qt5,qt6}-diff]
 basepython = {env:PYTHON:python3}
-passenv = {[testenv:mypy]passenv}
-deps = {[testenv:mypy]deps}
+passenv = {[testenv:mypy-qt6]passenv}
+deps = {[testenv:mypy-qt6]deps}
+setenv =
+    qt6: CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6
+    qt5: CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE2 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6
 commands =
-    {envpython} -m mypy --cobertura-xml-report {envtmpdir} qutebrowser tests {posargs}
+    {envpython} -m mypy --cobertura-xml-report {envtmpdir} {env:CONSTANTS_ARGS} qutebrowser tests {posargs}
     {envdir}/bin/diff-cover --fail-under=100 --compare-branch={env:DIFF_BRANCH:origin/{env:GITHUB_BASE_REF:master}} {envtmpdir}/cobertura.xml
 
 [testenv:sphinx]


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

I'll probably merge this next week some time since I don't think it is too contentious. But if anyone wants to have a look at the mypy fixes/hacks and suggest any improvements then please feel free!

As per the discussion https://github.com/qutebrowser/qutebrowser/discussions/7372 we're gonna get mypy running in CI with PyQt5 first, as that's the closes by far to actually working, and then figure out PyQt6 later. This PR re-enables the mypy github action, based on PyQt5, and fixes (well, ignores) errors mypy raises in that.

There are three general classes of issues here:
1. stuff that was added in the last few months when we didn't have mypy setup in CI and just didn't have (the right) type hints
2. stuff that was dependant on the backend that mypy couldn't reason about
3. the PyQt5-stubs being a bit broken, and incompatible with PyQt6 types, around Enums

For 2 I've been trying to consistently gate conditional behaviour behind `machinery.IS_QT{5,6}` so that we only have one place to tell mypy "just follow this path" with compile time constants as described in https://github.com/qutebrowser/qutebrowser/issues/7370
TODO: add that to contributing guide

3 is really unfortunate. Qt has Enums which hold possible values, and it has QtFlags which is some kind of typedef of the enum that is supped to be like a bit flag version of multiple enum members. In the C++ API those two things are interchangeable. With PyQt they are at runtime to but the PyQt5 stubs treat the QtFlags type specifically. There isn't a way to convert between them while preserving type information and the QtFlag types aren't even exposed in PyQt6. It seems like the issue described in https://github.com/python-qt-tools/PyQt5-stubs/issues/142 but I think we are on the latest version so it seems unresolved. I'm not sure why it's just showing up now either. Did we remove some ignore statements when adding PyQt support? Was it from that big PyQt5 update the other day?
It might be possible to make our own general framweork for converting back and forth between them but there is only a few so I don't think it's work it.

I mostly raised this PR so I can better find this list of #ignore's later when we drop Qt5 since finding PRs is easier than finding a bunch of commits.

The enums I've added ignores (for operators, assignments and args) are:

    ComponentFormattingOption
    UrlFormattingOption
    KeyboardModifier
    WindowType
    ProcessEventsFlag