### PR TITLE
Send source URL to Breadability

### DIFF
--- a/misc/userscripts/readability
+++ b/misc/userscripts/readability
@@ -47,7 +47,7 @@ with codecs.open(os.environ['QUTE_HTML'], 'r', 'utf-8') as source:
 
     try:
         from breadability.readable import Article as reader
-        doc = reader(data)
+        doc = reader(data, os.environ['QUTE_URL'])
         title = doc._original_document.title
         content = HEADER % title + doc.readable + "</html>"
     except ImportError:


### PR DESCRIPTION
Used to construct fully-qualified URLs from relative links. Without it you get broken images and links.