### PR TITLE
password_fill: dispatch the input event

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -362,12 +362,14 @@ cat <<EOF
                 input.focus();
                 input.value = "$(javascript_escape "${username}")";
                 input.dispatchEvent(new Event('change'));
+                input.dispatchEvent(new Event('input'));
                 input.blur();
             }
             if (input.type == "password") {
                 input.focus();
                 input.value = "$(javascript_escape "${password}")";
                 input.dispatchEvent(new Event('change'));
+                input.dispatchEvent(new Event('input'));
                 input.blur();
             }
         }

--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -361,15 +361,15 @@ cat <<EOF
             if (isVisible(input) && (input.type == "text" || input.type == "email")) {
                 input.focus();
                 input.value = "$(javascript_escape "${username}")";
-                input.dispatchEvent(new Event('change'));
-                input.dispatchEvent(new Event('input'));
+                input.dispatchEvent(new Event('change', { bubbles: true }));
+                input.dispatchEvent(new Event('input', { bubbles: true }));
                 input.blur();
             }
             if (input.type == "password") {
                 input.focus();
                 input.value = "$(javascript_escape "${password}")";
-                input.dispatchEvent(new Event('change'));
-                input.dispatchEvent(new Event('input'));
+                input.dispatchEvent(new Event('change', { bubbles: true }));
+                input.dispatchEvent(new Event('input', { bubbles: true }));
                 input.blur();
             }
         }


### PR DESCRIPTION
On certain login pages, like https://www.hosting24.com/cpanel-login, submitting the form after using password_fill causes an error, and you have to manually type a character and remove it in both fields before you can login. This is fixed by dispatching the input event.

The change event dispatch was added to fix #2111, and dispatching only the input event fixes that issue too, but there's no harm in dispatching both events.