### PR TITLE
Fix typos

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -595,13 +595,13 @@ Changed
 - When a shown message replaces an existing related one (e.g. for zoom levels),
   the replacing now also works even if a different message was shown in between.
 - The `.redirect(...)` method on interceptors now supports an
-  `ignore_unsupported=True` argument which supresses exceptions if a request could
+  `ignore_unsupported=True` argument which suppresses exceptions if a request could
   not be redirected. Note, however, that it is still not public API.
 - When the `--config-py` argument is used, no warning about a missing
   `config.load_autoconfig` is shown anymore, as the argument is typically used
   for temporarily testing a config.
 - The internal `_autosave` session used for crash recovery is now only saved
-  once per minute, since saving it for every page load is a noticable performance
+  once per minute, since saving it for every page load is a noticeable performance
   issue.
 - The `readability-js` userscript now displays a small header with page
   information.
@@ -1029,7 +1029,7 @@ Changed
 - `config.py` files now are required to have either
   `config.load_autoconfig(False)` (don't load `autoconfig.yml`) or
   `config.load_autoconfig()` (do load `autoconfig.yml`) in them.
-- Various host-blocking settings have been renamed to accomodate the new ABP-like
+- Various host-blocking settings have been renamed to accommodate the new ABP-like
   adblocker:
   * `content.host_blocking.enabled` -> `content.blocking.enabled` (controlling both blockers)
   * `content.host_blocking.whitelist` -> `content.blocking.whitelist` (controlling both blockers)
@@ -1205,11 +1205,11 @@ Fixed
 ~~~~~
 
 - Setting the `content.headers.referer` setting to `same-domain` (the default)
-  was supposed to truncate referers to only the host with QtWebEngine.
+  was supposed to truncate referrers to only the host with QtWebEngine.
   Unfortunately, this functionality broke in Qt 5.14. It works properly again
   with this release, including a test so this won't happen again.
 - With QtWebEngine 5.15, setting the `content.headers.referer` setting to
-  `never` did still send referers. This is now fixed as well.
+  `never` did still send referrers. This is now fixed as well.
 - In v1.14.0, a regression was introduced, causing a crash when qutebrowser was
   closed after opening a download with PDF.js. This is now fixed.
 - With Qt 5.12, the `Object.fromEntries` JavaScript API is unavailable (it was
@@ -1226,7 +1226,7 @@ Fixed
   conversion was shown. This is now fixed.
 - Ever since Qt 5.11, fetching more completion data when that data is loaded
   lazily (such as with history) and the last visible item is selected was broken.
-  The exact reason is currently unknown, but this release adds a tenative fix.
+  The exact reason is currently unknown, but this release adds a tentative fix.
 - When PgUp/PgDown were used to go beyond the last visible item, the above issue
   caused a crash, which is now also fixed.
 - As a workaround for an overzealous Microsoft Defender false-positive detecting
@@ -1342,9 +1342,9 @@ Changed
   which fixes issues with e.g. formulas on Wikipedia.
 - The `readability-js` userscript now adds some CSS to improve the reader mode
   styling in various scenarios:
-  * Images are now shrinked to the page width, similarly to what Firefox' reader
+  * Images are now shrunk to the page width, similarly to what Firefox' reader
     mode does.
-  * Some images ore now displayed as block (rather than inline) which is what
+  * Some images are now displayed as block (rather than inline) which is what
     Firefox' reader mode does as well.
   * Blockquotes are now styled more distinctively, again based on the Firefox
     reader mode.
@@ -3166,7 +3166,7 @@ Fixed
 - Fix workaround for black screens or crashes with Nvidia cards
 - Handle a filesystem going read-only gracefully
 - Fix crash when setting `fonts.monospace`
-- Fix list options not being modifyable via `.append()` in `config.py`
+- Fix list options not being modifiable via `.append()` in `config.py`
 - Mark the content.notifications setting as QtWebKit only correctly
 - Fix wrong rendering of keys like `<back>` in the completion
 
@@ -3202,7 +3202,7 @@ Major changes
   * New dependency on the QtSql module and Qt sqlite support.
   * New dependency on the https://www.attrs.org/[attrs] project (packaged as
     `python-attr` in some distributions).
-  * The depedency on PyOpenGL (when using QtWebEngine) got removed. Note
+  * The dependency on PyOpenGL (when using QtWebEngine) got removed. Note
     that PyQt5.QtOpenGL is still a dependency.
   * PyQt5.QtOpenGL is now always required, even with QtWebKit.
 - The QtWebEngine backend is now used by default. Note this means that
@@ -4423,7 +4423,7 @@ Changed
     * Add `-s`/`--space` argument to `:set-cmd-text` (as `:set-cmd-text "foo "` will now set the literal text `"foo "`)
 - Ignore `;;` for splitting with some commands like `:bind`.
 - Add unbound (new) default keybindings to config. This also adds a new `<unbound>` special command.
-    * To unbind a command keybinding without binding it to a new key, you now have to bind it to `<unbound>` or it'll be readded automatically.
+    * To unbind a command keybinding without binding it to a new key, you now have to bind it to `<unbound>` or it'll be re-added automatically.
 - If an SSL error is raised multiple times with the same error/certificate/host/scheme/port, the user is only asked once.
 - Jump to last instead of first item when pressing Shift-Tab the first time in the completion.
 - Add a fullscreen keybinding.

--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -170,7 +170,7 @@ text/html; qutebrowser %s; needsterminal; nametemplate=%s.html
 ----
 +
 Note that you might want to add additional options to qutebrowser, so that it
-runs as a seperate instance configured to disable JavaScript and avoid network
+runs as a separate instance configured to disable JavaScript and avoid network
 requests, in order to avoid privacy leaks when reading mails. The easiest way
 to do so is by specifying a non-existent proxy server, e.g.:
 +
@@ -376,7 +376,7 @@ There is a total of four possible approaches to get dark websites:
 
 How do I make copy to clipboard buttons work?::
 You can `:set content.javascript.clipboard access` to allow this globally (not
-recommended!), or `:set -u some.domain content.javascript.clipboad access` if
+recommended!), or `:set -u some.domain content.javascript.clipboard access` if
 you want to limit the setting to `some.domain`.
 
 

--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -292,7 +292,7 @@ Nightly builds
 
 If you want to test out new features before an official qutebrowser release, automated
 https://github.com/qutebrowser/qutebrowser/actions/workflows/nightly.yml[nightly
-builds] are available. To download them, open the lastest run (usually the first one),
+builds] are available. To download them, open the latest run (usually the first one),
 then download the archive at the bottom of the page.
 
 Those builds also include variants with debug logging enabled, which can be useful to
@@ -369,7 +369,7 @@ Nightly builds
 
 If you want to test out new features before an official qutebrowser release, automated
 https://github.com/qutebrowser/qutebrowser/actions/workflows/nightly.yml[nightly
-builds] are available. To download them, open the lastest run (usually the first one),
+builds] are available. To download them, open the latest run (usually the first one),
 then download the archive at the bottom of the page.
 
 Those builds also include variants with debug logging enabled, which can be useful to

--- a/misc/requirements/requirements-tests-bleeding.txt
+++ b/misc/requirements/requirements-tests-bleeding.txt
@@ -9,7 +9,7 @@ git+https://github.com/HypothesisWorks/hypothesis.git#subdirectory=hypothesis-py
 git+https://github.com/pytest-dev/pytest.git
 git+https://github.com/pytest-dev/pytest-bdd.git
 git+https://github.com/ionelmc/pytest-benchmark.git
-# WORKAROUND for pytest-instafail using deprectated pytest functionality
+# WORKAROUND for pytest-instafail using deprecated pytest functionality
 # See https://github.com/pytest-dev/pytest-instafail/pull/26
 git+https://github.com/The-Compiler/pytest-instafail.git@new-hookimpl
 git+https://github.com/pytest-dev/pytest-mock.git

--- a/qutebrowser/completion/models/filepathcategory.py
+++ b/qutebrowser/completion/models/filepathcategory.py
@@ -19,7 +19,7 @@
 
 """Completion category for filesystem paths.
 
-NOTE: This module deliberatly uses os.path rather than pathlib, because of how
+NOTE: This module deliberately uses os.path rather than pathlib, because of how
 it interacts with the completion, which operates on strings. For example, we
 need to be able to tell the difference between "~/input" and "~/input/". Also,
 if we get "~/input", we want to glob "~/input*" rather than "~/input/*" which

--- a/qutebrowser/config/config.py
+++ b/qutebrowser/config/config.py
@@ -109,7 +109,7 @@ class change_filter:  # noqa: N801,N806 pylint: disable=invalid-name
         and calls the wrapped function if we are.
 
         We assume the function passed doesn't take any parameters. However, it
-        could take a "self" argument, so we can't cleary express this in the
+        could take a "self" argument, so we can't clearly express this in the
         type above.
 
         Args:
@@ -188,7 +188,7 @@ class KeyConfig:
     def get_reverse_bindings_for(self, mode: str) -> '_ReverseBindings':
         """Get a dict of commands to a list of bindings for the mode.
 
-        This is intented for user-facing display of keybindings.
+        This is intended for user-facing display of keybindings.
         As such, bindings for 'set-cmd-text [flags] :<cmd> ...' are translated
         to '<cmd> ...', as from the user's perspective these keys behave like
         bindings for '<cmd>' (that allow for further input before running).

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -412,7 +412,7 @@ class MainWindow(QWidget):
             self._set_decoration(config.val.window.hide_decoration)
 
     def _add_widgets(self):
-        """Add or readd all widgets to the VBox."""
+        """Add or re-add all widgets to the VBox."""
         self._vbox.removeWidget(self.tabbed_browser.widget)
         self._vbox.removeWidget(self._downloadview)
         self._vbox.removeWidget(self.status)

--- a/scripts/dev/misc_checks.py
+++ b/scripts/dev/misc_checks.py
@@ -165,7 +165,7 @@ def check_spelling(args: argparse.Namespace) -> Optional[bool]:
              'artefact', 'an unix', 'an utf', 'an unicode', 'unparseable',
              'dependancies', 'convertable', 'chosing', 'authentification'}
 
-    # Words which look better when splitted, but might need some fine tuning.
+    # Words which look better when split, but might need some fine tuning.
     words |= {'webelements', 'mouseevent', 'keysequence', 'normalmode',
               'eventloops', 'sizehint', 'statemachine', 'metaobject',
               'logrecord'}

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -11,7 +11,7 @@ Feature: Miscellaneous utility commands exposed to the user.
     Scenario: :later before
         When I run :later 500 scroll down
         Then the page should not be scrolled
-        # wait for scroll to execture so we don't ruin our future
+        # wait for scroll to execute so we don't ruin our future
         And the page should be scrolled vertically
 
     Scenario: :later after

--- a/tests/end2end/test_invocations.py
+++ b/tests/end2end/test_invocations.py
@@ -822,7 +822,7 @@ def test_unavailable_backend(request, quteproc_new):
 def test_json_logging_without_debug(request, quteproc_new, runtime_tmpdir):
     args = _base_args(request.config) + ['--temp-basedir', ':quit']
     args.remove('--debug')
-    args.remove('about:blank')  # interfers with :quit at the end
+    args.remove('about:blank')  # interferes with :quit at the end
 
     quteproc_new.exit_expected = True
     quteproc_new.start(args, env={'XDG_RUNTIME_DIR': str(runtime_tmpdir)})

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -196,7 +196,7 @@ def _set_cmd_prompt(cmd, txt):
                  marks=pytest.mark.xfail(reason='issue #74')),
     (':set -t -p |', 'section', '', []),
     (':open -- |', None, '', []),
-    (':gibberish nonesense |', None, '', []),
+    (':gibberish nonsense |', None, '', []),
     ('/:help|', None, '', []),
     ('::bind|', 'command', ':bind', []),
     (':-w open |', None, '', []),


### PR DESCRIPTION
Found via `codespell -S *.js -L  
technik,gir,nam,ans,wih,wil,ro,nowe,te,datas,qutie,ned,fo,clude,alph,crashers,nd,wasn,cros,  ue,possition`

