### PR TITLE
Allow forcing tab-mute to a specific value

### DIFF
--- a/qutebrowser/components/misccommands.py
+++ b/qutebrowser/components/misccommands.py
@@ -345,6 +345,7 @@ def tab_mute(tab: Optional[apitypes.Tab], to_set: str = None) -> None:
 
     Args:
         count: The tab index to mute or unmute, or None
+        to_set: The mute setting to force: 'true' 'false' or 'None
     """
     if tab is None:
         return


### PR DESCRIPTION
This resolves #7456.

Using tab-mute with no arguments toggles the mute like before. Passing "true" or "false" to tab-mute forces the mute to the specified setting.