### PR TITLE
qt6: Delay showing windows

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -200,6 +200,7 @@ def _process_args(args):
     if not args.override_restore:
         sessions.load_default(args.session)
 
+    new_window = None
     if not sessions.session_manager.did_load:
         log.init.debug("Initializing main window...")
         private = args.target == 'private-window'
@@ -210,14 +211,16 @@ def _process_args(args):
             error.handle_fatal_exc(err, 'Cannot start in private mode',
                                    no_err_windows=args.no_err_windows)
             sys.exit(usertypes.Exit.err_init)
-        window = mainwindow.MainWindow(private=private)
-        if not args.nowindow:
-            window.show()
-        objects.qapp.setActiveWindow(window)
+
+        new_window = mainwindow.MainWindow(private=private)
 
     process_pos_args(args.command)
     _open_startpage()
     _open_special_pages(args)
+
+    if new_window is not None and not args.nowindow:
+        new_window.show()
+        objects.qapp.setActiveWindow(new_window)
 
     delta = datetime.datetime.now() - earlyinit.START_TIME
     log.init.debug("Init finished after {}s".format(delta.total_seconds()))
@@ -242,26 +245,30 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
     if command_target in {'window', 'private-window'}:
         command_target = 'tab-silent'
 
-    win_id: Optional[int] = None
+    window: Optional[mainwindow.MainWindow] = None
 
     if via_ipc and (not args or args == ['']):
-        win_id = mainwindow.get_window(via_ipc=via_ipc,
-                                       target=new_window_target)
-        _open_startpage(win_id)
+        window = mainwindow.get_window(via_ipc=via_ipc, target=new_window_target)
+        _open_startpage(window)
+        window.show()
+        window.maybe_raise()
         return
 
     for cmd in args:
         if cmd.startswith(':'):
-            if win_id is None:
-                win_id = mainwindow.get_window(via_ipc=via_ipc,
-                                               target=command_target)
+            if window is None:
+                window = mainwindow.get_window(via_ipc=via_ipc, target=command_target)
+                # FIXME preserving old behavior, but we probably shouldn't be
+                # doing this...
+                # See https://github.com/qutebrowser/qutebrowser/issues/5094
+                window.maybe_raise()
+
             log.init.debug("Startup cmd {!r}".format(cmd))
-            commandrunner = runners.CommandRunner(win_id)
+            commandrunner = runners.CommandRunner(window.win_id)
             commandrunner.run_safely(cmd[1:])
         elif not cmd:
             log.init.debug("Empty argument")
-            win_id = mainwindow.get_window(via_ipc=via_ipc,
-                                           target=new_window_target)
+            window = mainwindow.get_window(via_ipc=via_ipc, target=new_window_target)
         else:
             if via_ipc and target_arg and target_arg != 'auto':
                 open_target = target_arg
@@ -275,7 +282,7 @@ def process_pos_args(args, via_ipc=False, cwd=None, target_arg=None):
                 message.error("Error in startup argument '{}': {}".format(
                     cmd, e))
             else:
-                win_id = open_url(url, target=open_target, via_ipc=via_ipc)
+                window = open_url(url, target=open_target, via_ipc=via_ipc)
 
 
 def open_url(url, target=None, no_raise=False, via_ipc=True):
@@ -288,39 +295,37 @@ def open_url(url, target=None, no_raise=False, via_ipc=True):
         via_ipc: Whether the arguments were transmitted over IPC.
 
     Return:
-        ID of a window that was used to open URL
+        The MainWindow of a window that was used to open the URL.
     """
     target = target or config.val.new_instance_open_target
     background = target in {'tab-bg', 'tab-bg-silent'}
-    win_id = mainwindow.get_window(via_ipc=via_ipc, target=target,
-                                   no_raise=no_raise)
-    tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                window=win_id)
+    window = mainwindow.get_window(via_ipc=via_ipc, target=target, no_raise=no_raise)
     log.init.debug("About to open URL: {}".format(url.toDisplayString()))
-    tabbed_browser.tabopen(url, background=background, related=False)
-    return win_id
+    window.tabbed_browser.tabopen(url, background=background, related=False)
+    window.show()
+    window.maybe_raise()
+    return window
 
 
-def _open_startpage(win_id=None):
+def _open_startpage(window: Optional[mainwindow.MainWindow] = None) -> None:
     """Open startpage.
 
     The startpage is never opened if the given windows are not empty.
 
     Args:
-        win_id: If None, open startpage in all empty windows.
+        window: If None, open startpage in all empty windows.
                 If set, open the startpage in the given window.
     """
-    if win_id is not None:
-        window_ids: Iterable[int] = [win_id]
+    if window is not None:
+        windows: Iterable[mainwindow.MainWindow] = [window]
     else:
-        window_ids = objreg.window_registry
-    for cur_win_id in list(window_ids):  # Copying as the dict could change
-        tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                    window=cur_win_id)
-        if tabbed_browser.widget.count() == 0:
+        windows = objreg.window_registry.values()
+
+    for cur_window in list(windows):  # Copying as the dict could change
+        if cur_window.tabbed_browser.widget.count() == 0:
             log.init.debug("Opening start pages")
             for url in config.val.url.start_pages:
-                tabbed_browser.tabopen(url)
+                cur_window.tabbed_browser.tabopen(url)
 
 
 def _open_special_pages(args):
@@ -425,10 +430,10 @@ def on_focus_changed(_old, new):
 def open_desktopservices_url(url):
     """Handler to open a URL via QDesktopServices."""
     target = config.val.new_instance_open_target
-    win_id = mainwindow.get_window(via_ipc=True, target=target)
-    tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                window=win_id)
-    tabbed_browser.tabopen(url)
+    window = mainwindow.get_window(via_ipc=True, target=target)
+    window.tabbed_browser.tabopen(url)
+    window.show()
+    window.maybe_raise()
 
 
 # This is effectively a @config.change_filter

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -115,7 +115,7 @@ class CommandDispatcher:
         window: bool = False,
         related: bool = False,
         private: Optional[bool] = None,
-    ):
+    ) -> None:
         """Helper function to open a page.
 
         Args:

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -70,9 +70,7 @@ class CommandDispatcher:
             raise cmdutils.CommandError("Private windows are unavailable with "
                                         "the single-process process model.")
 
-        new_window = mainwindow.MainWindow(private=private)
-        new_window.show()
-        return new_window.tabbed_browser
+        return mainwindow.MainWindow(private=private).tabbed_browser
 
     def _count(self) -> int:
         """Convenience method to get the widget count."""
@@ -138,6 +136,7 @@ class CommandDispatcher:
             assert isinstance(private, bool)
             tabbed_browser = self._new_tabbed_browser(private)
             tabbed_browser.tabopen(url)
+            tabbed_browser.window().show()
         elif tab:
             tabbed_browser.tabopen(url, background=False, related=related)
         elif background:
@@ -416,7 +415,10 @@ class CommandDispatcher:
                 private=self._tabbed_browser.is_private or private)
         else:
             new_tabbed_browser = self._tabbed_browser
+
         newtab = new_tabbed_browser.tabopen(background=bg)
+        new_tabbed_browser.window().show()
+
         # The new tab could be in a new tabbed_browser (e.g. because of
         # tabs.tabs_are_windows being set)
         new_tabbed_browser = objreg.get('tabbed-browser', scope='window',
@@ -506,6 +508,8 @@ class CommandDispatcher:
                     "The window with id {} is not private".format(win_id))
 
         tabbed_browser.tabopen(self._current_url())
+        tabbed_browser.window().show()
+
         if not keep:
             self._tabbed_browser.close_tab(self._current_widget(),
                                            add_undo=False,

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -109,8 +109,15 @@ class CommandDispatcher:
             raise cmdutils.CommandError("No WebView available yet!")
         return widget
 
-    def _open(self, url, tab=False, background=False, window=False,
-              related=False, private=None):
+    def _open(
+        self,
+        url: QUrl,
+        tab: bool = False,
+        background: bool = False,
+        window: bool = False,
+        related: bool = False,
+        private: Optional[bool] = None,
+    ):
         """Helper function to open a page.
 
         Args:
@@ -123,11 +130,12 @@ class CommandDispatcher:
         """
         urlutils.raise_cmdexc_if_invalid(url)
         tabbed_browser = self._tabbed_browser
-        cmdutils.check_exclusive((tab, background, window, private), 'tbwp')
+        cmdutils.check_exclusive((tab, background, window, private or False), 'tbwp')
         if window and private is None:
             private = self._tabbed_browser.is_private
 
         if window or private:
+            assert isinstance(private, bool)
             tabbed_browser = self._new_tabbed_browser(private)
             tabbed_browser.tabopen(url)
         elif tab:
@@ -403,14 +411,14 @@ class CommandDispatcher:
         except browsertab.WebTabError as e:
             raise cmdutils.CommandError(e)
 
-        # The new tab could be in a new tabbed_browser (e.g. because of
-        # tabs.tabs_are_windows being set)
         if window or private:
             new_tabbed_browser = self._new_tabbed_browser(
                 private=self._tabbed_browser.is_private or private)
         else:
             new_tabbed_browser = self._tabbed_browser
         newtab = new_tabbed_browser.tabopen(background=bg)
+        # The new tab could be in a new tabbed_browser (e.g. because of
+        # tabs.tabs_are_windows being set)
         new_tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=newtab.win_id)
         idx = new_tabbed_browser.widget.indexOf(newtab)

--- a/qutebrowser/browser/navigate.py
+++ b/qutebrowser/browser/navigate.py
@@ -219,10 +219,10 @@ def prevnext(*, browsertab, win_id, baseurl, prev=False,
         if window:
             new_window = mainwindow.MainWindow(
                 private=cur_tabbed_browser.is_private)
-            new_window.show()
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=new_window.win_id)
             tabbed_browser.tabopen(url, background=False)
+            new_window.show()
         elif tab:
             cur_tabbed_browser.tabopen(url, background=background)
         else:

--- a/qutebrowser/browser/shared.py
+++ b/qutebrowser/browser/shared.py
@@ -360,23 +360,19 @@ def get_tab(win_id, target):
         win_id: The window ID to open new tabs in
         target: A usertypes.ClickTarget
     """
-    if target == usertypes.ClickTarget.tab:
-        bg_tab = False
-    elif target == usertypes.ClickTarget.tab_bg:
-        bg_tab = True
-    elif target == usertypes.ClickTarget.window:
-        tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                    window=win_id)
+    tabbed_browser = objreg.get('tabbed-browser', scope='window', window=win_id)
+    if target == usertypes.ClickTarget.window:
         window = mainwindow.MainWindow(private=tabbed_browser.is_private)
+        tab = window.tabbed_browser.tabopen(url=None, background=False)
         window.show()
-        win_id = window.win_id
-        bg_tab = False
-    else:
-        raise ValueError("Invalid ClickTarget {}".format(target))
+        return tab
+    elif target in [usertypes.ClickTarget.tab, usertypes.ClickTarget.tab_bg]:
+        return tabbed_browser.tabopen(
+            url=None,
+            background=target == usertypes.ClickTarget.tab_bg,
+        )
 
-    tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                window=win_id)
-    return tabbed_browser.tabopen(url=None, background=bg_tab)
+    raise ValueError(f"Invalid ClickTarget {target}")
 
 
 def get_user_stylesheet(searching=False):

--- a/qutebrowser/browser/webelem.py
+++ b/qutebrowser/browser/webelem.py
@@ -405,8 +405,8 @@ class AbstractWebElement(collections.abc.MutableMapping):  # type: ignore[type-a
         elif click_target == usertypes.ClickTarget.window:
             from qutebrowser.mainwindow import mainwindow
             window = mainwindow.MainWindow(private=tabbed_browser.is_private)
-            window.show()
             window.tabbed_browser.tabopen(url)
+            window.show()
         else:
             raise ValueError("Unknown ClickTarget {}".format(click_target))
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -95,10 +95,11 @@ def raise_window(window, alert=True):
     QCoreApplication.processEvents(
         QEventLoop.ProcessEventsFlag.ExcludeUserInputEvents | QEventLoop.ProcessEventsFlag.ExcludeSocketNotifiers)
 
-    if not sip.isdeleted(window):
+    if sip.isdeleted(window):
         # Could be deleted by the events run above
-        window.activateWindow()
+        return
 
+    window.activateWindow()
     if alert:
         objects.qapp.alert(window)
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -65,7 +65,6 @@ def get_window(*, via_ipc: bool,
         return objreg.get("main-window", scope="window", window=0)
 
     window = None
-    should_raise = False
 
     # Try to find the existing tab target if opening in a tab
     if target not in {'window', 'private-window'}:
@@ -278,7 +277,7 @@ class MainWindow(QWidget):
         self._set_decoration(config.val.window.hide_decoration)
 
         self.state_before_fullscreen = self.windowState()
-        self.should_raise = False
+        self.should_raise: bool = False
 
         stylesheet.set_register(self)
 

--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -48,7 +48,7 @@ win_id_gen = itertools.count(0)
 
 def get_window(*, via_ipc: bool,
                target: str,
-               no_raise: bool = False) -> int:
+               no_raise: bool = False) -> "MainWindow":
     """Helper function for app.py to get a window id.
 
     Args:
@@ -58,11 +58,11 @@ def get_window(*, via_ipc: bool,
         no_raise: suppress target window raising
 
     Return:
-        ID of a window that was used to open URL
+        The MainWindow that was used to open URL
     """
     if not via_ipc:
         # Initial main window
-        return 0
+        return objreg.get("main-window", scope="window", window=0)
 
     window = None
     should_raise = False
@@ -70,20 +70,16 @@ def get_window(*, via_ipc: bool,
     # Try to find the existing tab target if opening in a tab
     if target not in {'window', 'private-window'}:
         window = get_target_window()
-        should_raise = target not in {'tab-silent', 'tab-bg-silent'}
+        window.should_raise = target not in {'tab-silent', 'tab-bg-silent'} and not no_raise
 
     is_private = target == 'private-window'
 
     # Otherwise, or if no window was found, create a new one
     if window is None:
         window = MainWindow(private=is_private)
-        window.show()
-        should_raise = True
+        window.should_raise = not no_raise
 
-    if should_raise and not no_raise:
-        raise_window(window)
-
-    return window.win_id
+    return window
 
 
 def raise_window(window, alert=True):
@@ -133,6 +129,8 @@ class MainWindow(QWidget):
         status: The StatusBar widget.
         tabbed_browser: The TabbedBrowser widget.
         state_before_fullscreen: window state before activation of fullscreen.
+        should_raise: Whether the window should be raised/activated when maybe_raise()
+                      gets called.
         _downloadview: The DownloadView widget.
         _download_model: The DownloadModel instance.
         _vbox: The main QVBoxLayout.
@@ -280,6 +278,8 @@ class MainWindow(QWidget):
         self._set_decoration(config.val.window.hide_decoration)
 
         self.state_before_fullscreen = self.windowState()
+        self.should_raise = False
+
         stylesheet.set_register(self)
 
     def _init_geometry(self, geometry):
@@ -665,6 +665,12 @@ class MainWindow(QWidget):
                 return False
 
         return True
+
+    def maybe_raise(self) -> None:
+        """Raise the window if self.should_raise is set."""
+        if self.should_raise:
+            raise_window(self)
+            self.should_raise = False
 
     def closeEvent(self, e):
         """Override closeEvent to display a confirmation if needed."""

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -131,20 +131,12 @@ class PromptQueue(QObject):
         """Cancel all blocking questions.
 
         Quits and removes all running event loops.
-
-        Return:
-            True if loops needed to be aborted,
-            False otherwise.
         """
-        log.prompt.debug("Shutting down with loops {}".format(self._loops))
+        log.prompt.debug(f"Shutting down with loops {self._loops}")
         self._shutting_down = True
-        if self._loops:
-            for loop in self._loops:
-                loop.quit()
-                loop.deleteLater()
-            return True
-        else:
-            return False
+        for loop in self._loops:
+            loop.quit()
+            loop.deleteLater()
 
     @pyqtSlot(usertypes.Question, bool)
     def ask_question(self, question, blocking):

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -639,11 +639,10 @@ class TabbedBrowser(QWidget):
 
         if config.val.tabs.tabs_are_windows and self.widget.count() > 0:
             window = mainwindow.MainWindow(private=self.is_private)
+            tab = window.tabbed_browser.tabopen(
+                url=url, background=background, related=related)
             window.show()
-            tabbed_browser = objreg.get('tabbed-browser', scope='window',
-                                        window=window.win_id)
-            return tabbed_browser.tabopen(url=url, background=background,
-                                          related=related)
+            return tab
 
         tab = browsertab.create(win_id=self._win_id,
                                 private=self.is_private,

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -34,7 +34,7 @@ from qutebrowser.config import config
 from qutebrowser.keyinput import modeman
 from qutebrowser.mainwindow import tabwidget, mainwindow
 from qutebrowser.browser import signalfilter, browsertab, history
-from qutebrowser.utils import (log, usertypes, utils, qtutils, objreg,
+from qutebrowser.utils import (log, usertypes, utils, qtutils,
                                urlutils, message, jinja, version)
 from qutebrowser.misc import quitter, objects
 

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -28,7 +28,7 @@ from qutebrowser.qt.core import (pyqtSignal, pyqtSlot, Qt, QSize, QRect, QPoint,
                           QTimer, QUrl)
 from qutebrowser.qt.widgets import (QTabWidget, QTabBar, QSizePolicy, QProxyStyle,
                              QStyle, QStylePainter, QStyleOptionTab,
-                             QStyleFactory, QCommonStyle)
+                             QCommonStyle)
 from qutebrowser.qt.gui import QIcon, QPalette, QColor
 
 from qutebrowser.utils import qtutils, objreg, utils, usertypes, log
@@ -854,13 +854,15 @@ class TabBarStyle(QProxyStyle):
                 self._draw_icon(layouts, opt, p)
             alignment = (config.cache['tabs.title.alignment'] |
                          Qt.AlignmentFlag.AlignVCenter | Qt.TextFlag.TextHideMnemonic)
-            self.baseStyle().drawItemText(p,
-                                     layouts.text,
-                                     int(alignment),
-                                     opt.palette,
-                                     bool(opt.state & QStyle.StateFlag.State_Enabled),
-                                     opt.text,
-                                     QPalette.ColorRole.WindowText)
+            self.baseStyle().drawItemText(
+                p,
+                layouts.text,
+                int(alignment),
+                opt.palette,
+                bool(opt.state & QStyle.StateFlag.State_Enabled),
+                opt.text,
+                QPalette.ColorRole.WindowText
+            )
         else:
             raise ValueError("Invalid element {!r}".format(element))
 

--- a/qutebrowser/mainwindow/windowundo.py
+++ b/qutebrowser/mainwindow/windowundo.py
@@ -83,9 +83,9 @@ class WindowUndoManager(QObject):
             private=False,
             geometry=entry.geometry,
         )
-        window.show()
         window.tabbed_browser.undo_stack = entry.tab_stack
         window.tabbed_browser.undo()
+        window.show()
 
 
 def init():

--- a/qutebrowser/misc/quitter.py
+++ b/qutebrowser/misc/quitter.py
@@ -221,21 +221,18 @@ class Quitter(QObject):
             status, session))
 
         sessions.shutdown(session, last_window=last_window)
+        prompt.prompt_queue.shutdown()
 
-        if prompt.prompt_queue.shutdown():
-            # If shutdown was called while we were asking a question, we're in
-            # a still sub-eventloop (which gets quit now) and not in the main
-            # one.
-            # This means we need to defer the real shutdown to when we're back
-            # in the real main event loop, or we'll get a segfault.
-            log.destroy.debug("Deferring real shutdown because question was "
-                              "active.")
-            QTimer.singleShot(0, functools.partial(self._shutdown_2, status,
-                                                   is_restart=is_restart))
-        else:
-            # If we have no questions to shut down, we are already in the real
-            # event loop, so we can shut down immediately.
-            self._shutdown_2(status, is_restart=is_restart)
+        # If shutdown was called while we were asking a question, we're in
+        # a still sub-eventloop (which gets quit now) and not in the main
+        # one.
+        # But there's also other situations where it's problematic to shut down
+        # immediately (e.g. when we're just starting up).
+        # This means we need to defer the real shutdown to when we're back
+        # in the real main event loop, or we'll get a segfault.
+        log.destroy.debug("Deferring shutdown stage 2")
+        QTimer.singleShot(
+            0, functools.partial(self._shutdown_2, status, is_restart=is_restart))
 
     def _shutdown_2(self, status: int, is_restart: bool) -> None:
         """Second stage of shutdown."""

--- a/qutebrowser/misc/quitter.py
+++ b/qutebrowser/misc/quitter.py
@@ -282,12 +282,10 @@ def quit_(save: bool = False,
     """
     if session is not None and not save:
         raise cmdutils.CommandError("Session name given without --save!")
-    if save:
-        if session is None:
-            session = sessions.default
-        instance.shutdown(session=session)
-    else:
-        instance.shutdown()
+    if save and session is None:
+        session = sessions.default
+
+    instance.shutdown(session=session)
 
 
 @cmdutils.register()

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -467,7 +467,6 @@ class SessionManager(QObject):
         """Turn yaml data into windows."""
         window = mainwindow.MainWindow(geometry=win['geometry'],
                                        private=win.get('private', None))
-        window.show()
         tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                     window=window.win_id)
         tab_to_focus = None
@@ -480,6 +479,8 @@ class SessionManager(QObject):
                 new_tab.set_pinned(True)
         if tab_to_focus is not None:
             tabbed_browser.widget.setCurrentIndex(tab_to_focus)
+
+        window.show()
         if win.get('active', False):
             QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
 


### PR DESCRIPTION
To fix #7504, delay calling `.show()` on windows until after a tab has been added to them.

This needed various bigger changes - I've tried to keep things in separate commits and add explanations to the commit messages. 

Other than the actual changes needed for the issue, this also contains a workaround/fix (hopefully!) for QStyle-related crashes in #5385 and #5124 - and finally, while I was at it, switches to QProxyStyle: #812.