### PR TITLE
do not display URIs longer than 100 chars on download prompt

### DIFF
--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -183,11 +183,11 @@ def get_filename_question(*, suggested_filename, url, parent=None):
         parent: The parent of the question (a QObject).
     """
     suggested_filename = utils.sanitize_filename(suggested_filename)
+    trimmed_url = html.escape(utils.elide(url.toDisplayString(), 100))
 
     q = usertypes.Question(parent)
     q.title = "Save file to:"
-    q.text = "Please enter a location for <b>{}</b>".format(
-        html.escape(url.toDisplayString()))
+    q.text = "Please enter a location for <b>{}</b>".format(trimmed_url)
     q.url = url.toString(QUrl.RemovePassword | QUrl.FullyEncoded)
     q.mode = usertypes.PromptMode.download
     q.completed.connect(q.deleteLater)


### PR DESCRIPTION
Fixing issue #7529, when download uri is generated by for example `data:text/csv` or other formats, or the uri is just too long, it causes hanging of qutebrowser, because it tries to render the whole uri for download. The uri with lenght over 100 chars will be trimmed by `utils.elide` otherwise the whole uri is displayed to user.

I am unable to run qutebrowser in dev/test environment, because rendering is crashing (I am on sway), however the qutebrowser prod package is running fine with exported `QT_QPA_PLATFORM=wayland`. So I am unable to provide tests for now. Is someone able to help me with running qutebrowser dev on sway? thx


