### PR TITLE
userscripts/view_in_mpv: using yt-dlp to download video

### DIFF
--- a/misc/userscripts/view_in_mpv
+++ b/misc/userscripts/view_in_mpv
@@ -140,4 +140,4 @@ printjs() {
 echo "jseval -q $(printjs)" >> "$QUTE_FIFO"
 
 msg info "Opening $QUTE_URL with mpv"
-yt-dlp -o - "$QUTE_URL" | "${video_command[@]}" "$@" -
+yt-dlp "$YT_DLP_FLAGS" -o - "$QUTE_URL" | "${video_command[@]}" "$@" -

--- a/misc/userscripts/view_in_mpv
+++ b/misc/userscripts/view_in_mpv
@@ -140,4 +140,8 @@ printjs() {
 echo "jseval -q $(printjs)" >> "$QUTE_FIFO"
 
 msg info "Opening $QUTE_URL with mpv"
-yt-dlp "$YT_DLP_FLAGS" -o - "$QUTE_URL" | "${video_command[@]}" "$@" -
+if [[ $USE_YTDLP_FOR_DOWNLOAD == "yes" ]]; then
+  yt-dlp "$YT_DLP_FLAGS" -o - "$QUTE_URL" | "${video_command[@]}" "$@" -
+else
+  "${video_command[@]}" "$@" "$QUTE_URL"
+fi

--- a/misc/userscripts/view_in_mpv
+++ b/misc/userscripts/view_in_mpv
@@ -140,4 +140,4 @@ printjs() {
 echo "jseval -q $(printjs)" >> "$QUTE_FIFO"
 
 msg info "Opening $QUTE_URL with mpv"
-"${video_command[@]}" "$@" "$QUTE_URL"
+yt-dlp -o - "$QUTE_URL" | "${video_command[@]}" "$@" -


### PR DESCRIPTION
This makes `view_in_mpv` userscript use `yt-dlp` for download.

As mentioned [here](https://github.com/mpv-player/mpv/issues/8655#issuecomment-1199594426), mpv doesn't use `yt-dlp` for downloading, but only gets an URL back from it and lets `ffmpeg` download the video. This is very slow as ffmpeg hasn't implemented same optimizations that yt-dlp has for making youtube downloads quick.

In order to go around that, it's suggested to use `yt-dlp` and `mpv` this way:

```sh
yt-dlp -o - $URL | mpv $FLAGS -
```

This may cause issues when seeking with `mpv`  stated [here](https://github.com/mpv-player/mpv/issues/8655#issuecomment-1199733728), but I can't confirm as downloads are so quick on my computer with this that I didn't see any issue yet.

For instance, trying to watch the following in MPV with the original userscript:

https://www.youtube.com/watch?v=UhM_H3lFk_Q

was sow slow that, buffering was stopped the video every 1-2 seconds. Enabling `yt-dlp` made the download instantaneous.

There is an environment variable (`USE_YTDLP_FOR_DOWNLOAD`) for enabling download through `yt-dlp` in order to keep compatibility with past version and since there's an additional dependency.
