### PR TITLE
Use lite.duckduckgo for ripbang

### DIFF
--- a/misc/userscripts/ripbang
+++ b/misc/userscripts/ripbang
@@ -9,18 +9,16 @@
 #   :spawn --userscript ripbang amazon maps
 #
 
-import os, re, requests, sys
-from urllib.parse import urlparse, parse_qs
+import os, requests, sys
 
 for argument in sys.argv[1:]:
     bang = '!' + argument
-    r = requests.get('https://duckduckgo.com/',
+    r = requests.get('https://html.duckduckgo.com/html/',
+                     allow_redirects=False,
                      params={'q': bang + ' SEARCHTEXT'},
                      headers={'user-agent': 'qutebrowser ripbang'})
 
-    searchengine = re.search("url=([^']+)", r.text).group(1)
-    searchengine = urlparse(searchengine).query
-    searchengine = parse_qs(searchengine)['uddg'][0]
+    searchengine = r.headers['location']
     searchengine = searchengine.replace('SEARCHTEXT', '{}')
 
     if os.getenv('QUTE_FIFO'):


### PR DESCRIPTION
The previous way of obtaining the Bang's URL was using the response's body, using the url atrribute of a meta tag. The way this was handled was a bit problematic: some URLs were of the format `/l/?uddg=<URL>&<some-other-query-arguments>`, while others (such as google) is simply `<URL>`. This could have been fixed by using an if-else, but I preferred another approach. Lite DuckDuckGo sends a 303 response when using Bangs, instead of a 200 response which makes the redirect. The location header of the 303 response is the search engine's URL, so it's easy to implement this function, working for both afformentioned URL templates.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
