### PR TITLE
browser: history: fix queries for when DQS disabled

### DIFF
--- a/qutebrowser/browser/history.py
+++ b/qutebrowser/browser/history.py
@@ -217,19 +217,19 @@ class WebHistory(sql.SqlTable):
         self.create_index('HistoryIndex', 'url')
         self.create_index('HistoryAtimeIndex', 'atime')
         self._contains_query = self.contains_query('url')
-        self._between_query = self.database.query('SELECT * FROM History '
-                                                  'where not redirect '
-                                                  'and not url like "qute://%" '
-                                                  'and atime > :earliest '
-                                                  'and atime <= :latest '
-                                                  'ORDER BY atime desc')
+        self._between_query = self.database.query("SELECT * FROM History "
+                                                  "where not redirect "
+                                                  "and not url like 'qute://%' "
+                                                  "and atime > :earliest "
+                                                  "and atime <= :latest "
+                                                  "ORDER BY atime desc")
 
-        self._before_query = self.database.query('SELECT * FROM History '
-                                                 'where not redirect '
-                                                 'and not url like "qute://%" '
-                                                 'and atime <= :latest '
-                                                 'ORDER BY atime desc '
-                                                 'limit :limit offset :offset')
+        self._before_query = self.database.query("SELECT * FROM History "
+                                                 "where not redirect "
+                                                 "and not url like 'qute://%' "
+                                                 "and atime <= :latest "
+                                                 "ORDER BY atime desc "
+                                                 "limit :limit offset :offset")
 
     def __repr__(self):
         return utils.get_repr(self, length=len(self))


### PR DESCRIPTION
Recently the FreeBSD port of sqlite has DQS feature disabled by default. Without this feature enabled, it's not allowed to use double quotes for string literals. As such quoting is used in the history.py module, qutebrowser fails to work on such configurations.

The fix is to use single quotes instead.

ref: #7596
