### PR TITLE
Add new API for extensions (required for cosmetic filtering + scriptlet injection)

### DIFF
--- a/qutebrowser/api/hook.py
+++ b/qutebrowser/api/hook.py
@@ -78,3 +78,78 @@ class config_changed:
         info = _add_module_info(func)
         info.config_changed_hooks.append((self._filter, func))
         return func
+
+
+class before_load:
+
+    """Decorator to get notified right before page loads.
+
+    The decorated function gets called with two arguments `(tab, url)`. `tab` is the
+    :class:`qutebrowser.api.apitypes.Tab` instance which will do the loading. `url` is a
+    QUrl which represents the url that will be loaded.
+
+    Don't expect to be able to do anything on the DOM during this hook.
+
+    NOTE: The before_load hook may be called multiple times before a page loads.
+
+    Example::
+
+        @hook.before_load()
+        def do_something(tab, url):
+            message.info("Do something before the page loads.")
+    """
+
+    def __call__(
+        self,
+        func: loader.BeforeLoadHookType,
+    ) -> loader.BeforeLoadHookType:
+        info = _add_module_info(func)
+        info.before_load_hooks.append(func)
+        return func
+
+
+class load_started:
+
+    """Decorator to get notified right after page starts loading.
+
+    The decorated function gets called with two arguments `(tab)`. `tab` is the
+    :class:`qutebrowser.api.apitypes.Tab` instance which has started loading.
+
+    Example::
+
+        @hook.load_started()
+        def do_something(tab):
+            message.info("Do something while after the page has started loading.")
+    """
+
+    def __call__(
+        self,
+        func: loader.LoadStartedHookType,
+    ) -> loader.LoadStartedHookType:
+        info = _add_module_info(func)
+        info.load_started_hooks.append(func)
+        return func
+
+
+class load_finished:
+
+    """Decorator to get notified right after page finishing loading.
+
+    The decorated function gets called with two arguments `(tab, ok)`. `tab` is the
+    :class:`qutebrowser.api.apitypes.Tab` instance which just finished loading, and `ok`
+    is a bool which is True when the page loaded correctly.
+
+    Example::
+
+        @hook.load_finished()
+        def do_something(tab, ok):
+            message.info("Do something after the page loads.")
+    """
+
+    def __call__(
+        self,
+        func: loader.LoadFinishedHookType,
+    ) -> loader.LoadFinishedHookType:
+        info = _add_module_info(func)
+        info.load_finished_hooks.append(func)
+        return func

--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -1058,6 +1058,18 @@ class AbstractTab(QWidget):
 
         self.before_load_started.connect(self._on_before_load_started)
 
+        # We do a local import here to avoid a circular dependency
+        from qutebrowser.extensions import loader
+        self.before_load_started.connect(
+            functools.partial(loader.run_before_load_hooks, self)
+        )
+        self.load_started.connect(
+            functools.partial(loader.run_load_started_hooks, self)
+        )
+        self.load_finished.connect(
+            functools.partial(loader.run_load_finished_hooks, self)
+        )
+
     def _set_widget(self, widget: Union["QWebView", "QWebEngineView"]) -> None:
         # pylint: disable=protected-access
         self._widget = widget
@@ -1169,6 +1181,12 @@ class AbstractTab(QWidget):
                                   navigation.url.toDisplayString(),
                                   navigation.url.errorString()))
             navigation.accepted = False
+
+        # Sometimes a page is loaded without _load_url_prepare. This can happen when
+        # a non-clickable object is clicked to open in the background. In this case,
+        # `TabbedBrowser.tabopen` will be called with `url=None`, so `load_url` is not
+        # called. For such cases, we must emit before_load_started here as well.
+        self.before_load_started.emit(navigation.url)
 
         # WORKAROUND for QtWebEngine >= 6.2 not allowing form requests from
         # qute:// to outside domains.
@@ -1294,7 +1312,8 @@ class AbstractTab(QWidget):
             self,
             code: str,
             callback: Callable[[Any], None] = None, *,
-            world: Union[usertypes.JsWorld, int] = None
+            world: Union[usertypes.JsWorld, int] = None,
+            name: str = ''
     ) -> None:
         """Run javascript async.
 
@@ -1306,6 +1325,7 @@ class AbstractTab(QWidget):
             callback: The callback to call with the result, or None.
             world: A world ID (int or usertypes.JsWorld member) to run the JS
                    in the main world or in another isolated world.
+            name: An optional name to give the js code. Useful for debugging.
         """
         raise NotImplementedError
 
@@ -1350,6 +1370,57 @@ class AbstractTab(QWidget):
             pic = cast(QPixmap, pic)
 
         return pic
+
+    def add_dynamic_css(self, name: str, css: str) -> None:
+        """Adds css which is expected to be updated often.
+
+        For example, the css may be updated right before a page load.
+
+        Note that this has lower precedence than the user-specified stylsheets.
+
+        The css will be scheduled to update right away.
+        """
+        raise NotImplementedError
+
+    def remove_dynamic_css(self, name: str) -> None:
+        """Remove the specified tab-specific css.
+
+        If the given name for the css wasn't added before, nothing happens.
+
+        The css will be scheduled to update right away.
+        """
+        raise NotImplementedError
+
+    def add_web_script(
+        self,
+        name: str,
+        js_code: str,
+        world: Optional[Union[usertypes.JsWorld, int]] = None,
+        injection_point: usertypes.InjectionPoint = (
+            usertypes.InjectionPoint.creation
+        ),
+        subframes: bool = False,
+    ) -> None:
+        """Adds a web scripts to be run at given injection point.
+
+        Web scripts, similar to greasemonkey scripts, are javascript snippets which are
+        set to be run whenever a page loads. The exact point time in which the script
+        run can be specified with `injection_point`. Web scripts are different to
+        greasemonkey scripts in that the user is given more precise control over their
+        exact parameters (e.g., which world to run in).
+
+        If a script with the name was added before, it will be removed and replaced with
+        the given data.
+        """
+        raise NotImplementedError
+
+    def remove_web_script(self, name: str) -> None:
+        """Remove a web script with the given name.
+
+        If a script with the corresponding name was not previously added, nothing
+        happens.
+        """
+        raise NotImplementedError
 
     def __repr__(self) -> str:
         try:

--- a/qutebrowser/browser/webkit/webkittab.py
+++ b/qutebrowser/browser/webkit/webkittab.py
@@ -7,7 +7,7 @@
 import re
 import functools
 import xml.etree.ElementTree
-from typing import cast, Iterable, Optional
+from typing import cast, Iterable, Optional, Union
 
 from qutebrowser.qt.core import pyqtSlot, Qt, QUrl, QPoint, QTimer, QSizeF, QSize
 from qutebrowser.qt.gui import QIcon
@@ -906,7 +906,7 @@ class WebKitTab(browsertab.AbstractTab):
         else:
             callback(frame.toHtml())
 
-    def run_js_async(self, code, callback=None, *, world=None):
+    def run_js_async(self, code, callback=None, *, world=None, name=''):
         if world is not None and world != usertypes.JsWorld.jseval:
             log.webview.warning("Ignoring world ID {}".format(world))
         result = self.private_api.run_js_sync(code)
@@ -928,6 +928,61 @@ class WebKitTab(browsertab.AbstractTab):
 
     def title(self):
         return self._widget.title()
+
+    def add_dynamic_css(self, name: str, css: str) -> None:
+        """Adds css which is expected to be updated often.
+
+        For example, the css may be updated right before a page load.
+
+        Note that this has lower precedence than the user-specified stylsheets.
+
+        The css will be scheduled to update right away.
+
+        Does nothing on webkit.
+        """
+
+    def remove_dynamic_css(self, name: str) -> None:
+        """Remove the specified tab-specific css.
+
+        If the given name for the css wasn't added before, nothing happens.
+
+        The css will be scheduled to update right away.
+
+        Does nothing on webkit.
+        """
+
+    def add_web_script(
+        self,
+        name: str,
+        js_code: str,
+        world: Optional[Union[usertypes.JsWorld, int]] = None,
+        injection_point: usertypes.InjectionPoint = (
+            usertypes.InjectionPoint.creation
+        ),
+        subframes: bool = False,
+    ) -> None:
+        """Adds a web scripts to be run at given injection point.
+
+        Web scripts, similar to greasemonkey scripts, are javascript snippets which are
+        set to be run whenever a page loads. The exact point time in which the script
+        run can be specified with `injection_point`. Web scripts are different to
+        greasemonkey scripts in that the user is given more precise control over their
+        exact parameters (e.g., which world to run in).
+
+        If a script with the name was added before, it will be removed and replaced with
+        the given data.
+
+        Does nothing on webkit.
+        """
+
+    def remove_web_script(self, name: str) -> None:
+        """Remove a web script with the given name.
+
+        If a script with the corresponding name was not previously added, nothing
+        happens.
+
+        Does nothing on webkit.
+        """
 
     def renderer_process_pid(self) -> Optional[int]:
         return None

--- a/qutebrowser/extensions/loader.py
+++ b/qutebrowser/extensions/loader.py
@@ -13,9 +13,10 @@ import argparse
 import dataclasses
 from typing import Callable, Iterator, List, Optional, Set, Tuple
 
-from qutebrowser.qt.core import pyqtSlot
+from qutebrowser.qt.core import pyqtSlot, QUrl
 
 from qutebrowser import components
+from qutebrowser.api import apitypes  # pylint: disable=unused-import
 from qutebrowser.config import config
 from qutebrowser.utils import log, standarddir
 from qutebrowser.misc import objects
@@ -26,6 +27,9 @@ _module_infos = []
 
 InitHookType = Callable[['InitContext'], None]
 ConfigChangedHookType = Callable[[], None]
+BeforeLoadHookType = Callable[['apitypes.Tab', QUrl], None]
+LoadStartedHookType = Callable[['apitypes.Tab'], None]
+LoadFinishedHookType = Callable[['apitypes.Tab', bool], None]
 
 
 @dataclasses.dataclass
@@ -54,6 +58,12 @@ class ModuleInfo:
             ConfigChangedHookType,
         ]
     ] = dataclasses.field(default_factory=list)
+    before_load_hooks: List[BeforeLoadHookType] = dataclasses.field(
+        default_factory=list)
+    load_started_hooks: List[LoadStartedHookType] = dataclasses.field(
+        default_factory=list)
+    load_finished_hooks: List[LoadFinishedHookType] = dataclasses.field(
+        default_factory=list)
 
 
 @dataclasses.dataclass
@@ -165,6 +175,36 @@ def _on_config_changed(changed_name: str) -> None:
                 cfilter.validate()
                 if cfilter.check_match(changed_name):
                     hook()
+
+
+@pyqtSlot(QUrl)
+def run_before_load_hooks(tab: 'apitypes.Tab', url: QUrl) -> None:
+    """Run all before_load_hooks."""
+    for mod_info in _module_infos:
+        if mod_info.skip_hooks:
+            continue
+        for hook in mod_info.before_load_hooks:
+            hook(tab, url)
+
+
+@pyqtSlot()
+def run_load_started_hooks(tab: 'apitypes.Tab') -> None:
+    """Run all load_finished_hooks."""
+    for mod_info in _module_infos:
+        if mod_info.skip_hooks:
+            continue
+        for hook in mod_info.load_started_hooks:
+            hook(tab)
+
+
+@pyqtSlot(bool)
+def run_load_finished_hooks(tab: 'apitypes.Tab', ok: bool) -> None:
+    """Run all load_finished_hooks."""
+    for mod_info in _module_infos:
+        if mod_info.skip_hooks:
+            continue
+        for hook in mod_info.load_finished_hooks:
+            hook(tab, ok)
 
 
 def init() -> None:

--- a/qutebrowser/javascript/stylesheet.js
+++ b/qutebrowser/javascript/stylesheet.js
@@ -103,7 +103,11 @@ window._qutebrowser.stylesheet = (function() {
         style_observer.observe(document, {"childList": true, "subtree": true});
     }
 
-    funcs.set_css = function(css) {
+    funcs.set_css = function(css, debug = false) {
+        if (debug) {
+            console.log(`Setting css to: ${css.substring(0, 30)}`);
+        }
+
         if (!initialized) {
             init();
         }

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -301,6 +301,20 @@ class JsWorld(enum.Enum):
     jseval = enum.auto()  #: World used for the jseval-command.
 
 
+class InjectionPoint(enum.Enum):
+
+    """The point at which the injected web script will fire."""
+
+    # As soon as the page finished loading, or 500ms after the document is ready,
+    # whichever comes first.
+    deferred = enum.auto()
+    # As soon as document is ready. This is the same as DOMContentLoaded event firing in
+    # javascript.
+    ready = enum.auto()
+    # As soon as document is created. This is not suitable for DOM manipulation.
+    creation = enum.auto()
+
+
 class JsLogLevel(enum.Enum):
 
     """Log level of a JS message.


### PR DESCRIPTION
As per https://github.com/qutebrowser/qutebrowser/pull/7629#issuecomment-1475122756, I've separated out the API changes required by #7629 into another PR. The proposed API changes are, however, general enough that they can be used for other components/extensions. For example, per-domain user stylesheets (#3854) would be very simple to implement as a separate component/extension using the newly suggested `api.hook.before_loaded` and  `api.Tab.add_dynamic_css`. I believe the proposed changes should also be enough to support something like Dark Reader in qutebrowser (#3780). 


# API Changes
## `api.hook.before_loaded`
A hook that is guaranteed to be notified before a page loads. Components which need to do something before a page loads should use this hook. Note the hook may be called multiple times before a page loads. The `api.Tab` object which is about to load and the url which we are about to load are passed in as arguments.

## `api.hook.load_started`
A hook that is called after the page loads. Components which need to do something after a page starts loading should use this hook. The `api.Tab` object which is starting to load is passed in as an argument.

## `api.hook.load_finished`
A hook that is called after the page finishes loading. Components which need to do something after a page load finishes should use this hook. The `api.Tab` object which just finished loading and the success flag of whether the load was done successfully is passed in as arguments.

## `api.Tab.add_dynamic_css`
Adds css which will get applied to every page the `api.Tab` object loads. This has lower precedence than the user-specified stylesheet in the user config. This css is expected to change often, hence the "dynamic".

## `api.Tab.remove_dynamic_css`
Removes the aforementioned css which will get applied to every page the `api.Tab` object loads.

## `api.Tab.add_web_script`
Adds a snippet of javascript to be executed during the `api.Tab` object's page load. The specific moment in which the web script executes can be controlled with `api.usertypes.InjectionPoint`. These "web scripts" are intentionally separated from the greasemonkey scripts. Greasemonkey scripts are added and managed by the end user, but these scripts are meant to be used by the components/extensions of qutebrowser. 

## `api.Tab.remove_web_script`
Removes the aforementioned snippet of javascript to be executed during the `api.Tab` object's page load. 

## `api.usertypes.InjectionPoint`
A type representing the point at which to execute an injected web script.

# Non-API changes to core implementation
## Emitting `api.Tab.before_loaded` signal multiple times
In addition to being emitted during `_load_url_prepare`, the `api.Tab.before_load_started` signal is now also emitted during `_on_navigation_request`. The reason for this is that `_load_url_prepare` is not always called before a new page loads. For example, this can happen when a non-clickable object is clicked to open in the background. In this case, `TabbedBrowser.tabopen` will be called with `url=None`, so `load_url` and `_load_url_prepare` are not called. However, `_on_navigation_request` is always called, and the url is always known by this point. For a reliable `api.hook.before_loaded` hook, it is essential we emit `before_load_started` during `_on_navigation_request` as well. We don't want to remove the emit from `_load_url_prepare` either, since that gets called before `_on_navigation_request`, and we need the hook to fire as soon as possible.

## Other changes
* `_update_stylesheet` now also includes `stylesheet.js` in its injected script (wrapped in the global wrapper) because sometimes asynchronous code runs before injected scripts, and `stylesheet.set_css` will obviously fail if `window._qutebrowser.stylesheet` has not been specified.
* Added additional javascript logging to scripts to denote when certain scripts are run (only if the current logging level is DEBUG).