### PR TITLE
Add `utm_name` to URL params that are stripped

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2540,6 +2540,7 @@ url.yank_ignored_parameters:
     - utm_campaign
     - utm_term
     - utm_content
+    - utm_name
   desc: URL parameters to strip with `:yank url`.
 
 ## window


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
I noticed this one was left when I yanked an URL.