### PR TITLE
add pass command instead of password in clear text into add-nextcloud-bookmarks script

### DIFF
--- a/misc/userscripts/add-nextcloud-bookmarks
+++ b/misc/userscripts/add-nextcloud-bookmarks
@@ -101,16 +101,22 @@ else:
 settings_info = [
     ("host", "host information.", "required"),
     ("user", "username.", "required"),
-    ("password", "password.", "required"),
+    ("pass", "pass.", "choice"),
+    ("password", "password.", "choice"),
     ("description", "description or leave blank", "optional"),
     ("tags", "tags (comma separated) or leave blank", "optional"),
 ]
 
 # check for settings that need user interaction and clear optional setting if need be
 for setting in settings_info:
-    if setting[0] not in settings:
-        userInput = get_text(setting[0], setting[1])
-        settings[setting[0]] = userInput
+    if setting[1] == "pass" and setting[0] != "":
+            passwordstore=exec(setting[0])
+    if setting[0] not in settings and setting[1] =! "pass":
+        if setting[1] =! "password" and passwordstore != "":
+            settings[setting[0]] = passwordstore
+        else
+            userInput = get_text(setting[0], setting[1])
+            settings[setting[0]] = userInput
     if setting[2] == "optional":
         if settings[setting[0]] == "None":
             settings[setting[0]] = ""

--- a/misc/userscripts/add-nextcloud-bookmarks
+++ b/misc/userscripts/add-nextcloud-bookmarks
@@ -37,6 +37,8 @@ troubleshooting:
 """
 
 import configparser
+import subprocess
+
 from json import dumps
 from os import environ, path
 from sys import argv, exit
@@ -98,28 +100,17 @@ if path.isfile(config_file):
 else:
     settings = {}
 
-settings_info = [
-    ("host", "host information.", "required"),
-    ("user", "username.", "required"),
-    ("pass", "pass.", "choice"),
-    ("password", "password.", "choice"),
-    ("description", "description or leave blank", "optional"),
-    ("tags", "tags (comma separated) or leave blank", "optional"),
-]
+if settings["pass"] == "" and settings["password"] == "":
+    message("error","at least password ou pass command should be completed")
+    exit(0)
 
-# check for settings that need user interaction and clear optional setting if need be
-for setting in settings_info:
-    if setting[1] == "pass" and setting[0] != "":
-            passwordstore=exec(setting[0])
-    if setting[0] not in settings and setting[1] =! "pass":
-        if setting[1] =! "password" and passwordstore != "":
-            settings[setting[0]] = passwordstore
-        else
-            userInput = get_text(setting[0], setting[1])
-            settings[setting[0]] = userInput
-    if setting[2] == "optional":
-        if settings[setting[0]] == "None":
-            settings[setting[0]] = ""
+if settings["pass"] != "":
+    passcommand= settings["pass"]
+    process = subprocess.Popen(passcommand.split(), stdout=subprocess.PIPE)
+    output, error = process.communicate()
+    passresult = output.decode("utf-8")
+    password=passresult.partition('\n')[0]
+    settings["password"]=password
 
 tags = settings["tags"].split(",")
 

--- a/misc/userscripts/add-nextcloud-bookmarks
+++ b/misc/userscripts/add-nextcloud-bookmarks
@@ -13,16 +13,18 @@ userscript setup:
 [nextcloud]
 HOST=https://nextcloud.example.com
 USER=username
-;PASSWORD=lamepassword
+PASSWORD=lamepassword
+or
+PASS=get_password_command  #PASS=pass bookmarks/user
 DESCRIPTION=None
 ;TAGS=just-one
 TAGS=read-me-later,added-by-qutebrowser, Another-One
 
-    If settings aren't in the configuration file, the user will be prompted during
-    bookmark creation.  If DESCRIPTION and TAGS are set to None, they will be left
-    blank. If the user does not want to be prompted for a password, it is recommended
+    Settings should be into configuration file. If DESCRIPTION and TAGS are set to None, they will be left
+    blank. If the user does not want to use his password, it is recommended
     to set up an 'app password'.  See the following for instructions:
     https://docs.nextcloud.com/server/latest/user_manual/en/session_management.html#managing-devices  # noqa: E501
+    pass option has been added to avoid clear password in a conf file.
 
 qutebrowser setup:
     add bookmark via hints


### PR DESCRIPTION
I use to publish my dot files and the add-nextcloud-bookmarks.ini file was included into the repo with my password. 

I add the option to use a pass command instead of password in clear text.