### PR TITLE
Don't show warning when jumping to next/prev search result without matches

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1597,8 +1597,7 @@ class CommandDispatcher:
     def _search_navigation_cb(self, result):
         """Callback called from :search-prev/next."""
         if result == browsertab.SearchNavigationResult.not_found:
-            # FIXME check if this actually can happen...
-            message.warning("Search result vanished...")
+            self._search_cb(found=False, text=self._tabbed_browser.search_text)
             return
         elif result == browsertab.SearchNavigationResult.found:
             return

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -147,6 +147,14 @@ Feature: Searching on a page
         And I run :search-next
         Then the error "No search done yet." should be shown
 
+    # https://github.com/qutebrowser/qutebrowser/issues/7275
+    @qtwebkit_skip
+    Scenario: Jumping to next without matches
+        When I run :search doesnotmatch
+        And I wait for the warning "Text 'doesnotmatch' not found on page!"
+        And I run :search-next
+        Then the warning "Text 'doesnotmatch' not found on page!" should be shown
+
     Scenario: Repeating search in a second tab (issue #940)
         When I open data/search.html in a new tab
         And I run :search foo
@@ -221,6 +229,14 @@ Feature: Searching on a page
         When I open data/search.html in a new window
         And I run :search-prev
         Then the error "No search done yet." should be shown
+
+    # https://github.com/qutebrowser/qutebrowser/issues/7275
+    @qtwebkit_skip
+    Scenario: Jumping to previous without matches
+        When I run :search doesnotmatch
+        And I wait for the warning "Text 'doesnotmatch' not found on page!"
+        And I run :search-prev
+        Then the warning "Text 'doesnotmatch' not found on page!" should be shown
 
     ## wrapping
 


### PR DESCRIPTION
These changes fix a regression introduced in e15bda307e42c288b926f578e7bf8c610e4767af:  
> When doing `/thisdoesnotexist` and then pressing `n` or `N`, "Search result vanished..." gets displayed.

We do not want to display any message. So we simply remove the message and cover this behavior with two test cases.

---

Closes #7275
