### PR TITLE
tox: Fix vulture-pyqtlink environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -96,7 +96,9 @@ basepython = {env:PYTHON:python3}
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/misc/requirements/requirements-vulture.txt
-setenv = PYTHONPATH={toxinidir}
+setenv =
+    {[testenv]setenv}
+    {[testenv:vulture]setenv}
 commands =
     {envpython} scripts/link_pyqt.py --tox {envdir}
     {[testenv:vulture]commands}


### PR DESCRIPTION
```
$ tox -e vulture-pyqtlink
vulture-pyqtlink installed: adblock==0.6.0,colorama==0.4.6,Jinja2==3.1.2,MarkupSafe==2.1.3,Pygments==2.15.1,PyYAML==6.0,qutebrowser==2.4.0,toml==0.10.2,vulture==2.7,zipp==3.15.0
vulture-pyqtlink run-test-pre: PYTHONHASHSEED='499409345'
vulture-pyqtlink run-test: commands[0] | .tox/vulture-pyqtlink/bin/python scripts/link_pyqt.py --tox .tox/vulture-pyqtlink
Traceback (most recent call last):
  File "scripts/link_pyqt.py", line 232, in <module>
    main()
  File "scripts/link_pyqt.py", line 226, in main
    wrapper = os.environ["QUTE_QT_WRAPPER"]
  File "/usr/lib/python3.10/os.py", line 680, in __getitem__
    raise KeyError(key) from None
KeyError: 'QUTE_QT_WRAPPER'
ERROR: InvocationError for command .tox/vulture-pyqtlink/bin/python scripts/link_pyqt.py --tox .tox/vulture-pyqtlink (exited with code 1)
_____________________________________________________________________________________________________ summary ______________________________________________________________________________________________________
ERROR:   vulture-pyqtlink: commands failed
```