### PR TITLE
Include namespace packages in setuptools build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ try:
     common.write_git_file()
     setuptools.setup(
         packages=setuptools.find_namespace_packages(where='qutebrowser'),
-        package_dir={'': 'qutebrowser'},
+        package_dir={'qutebrowser': 'qutebrowser'},
         include_package_data=True,
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},

--- a/setup.py
+++ b/setup.py
@@ -64,8 +64,7 @@ def _get_constant(name):
 try:
     common.write_git_file()
     setuptools.setup(
-        packages=setuptools.find_namespace_packages(where='qutebrowser'),
-        package_dir={'qutebrowser': 'qutebrowser'},
+        packages=setuptools.find_namespace_packages(include=['qutebrowser']),
         include_package_data=True,
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ def _get_constant(name):
 try:
     common.write_git_file()
     setuptools.setup(
-        packages=setuptools.find_namespace_packages(include=['qutebrowser']),
+        packages=setuptools.find_namespace_packages(include=['qutebrowser',
+                                                             'qutebrowser.*']),
         include_package_data=True,
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,8 @@ def _get_constant(name):
 try:
     common.write_git_file()
     setuptools.setup(
-        packages=setuptools.find_namespace_packages(),
+        packages=setuptools.find_namespace_packages(where='qutebrowser'),
+        package_dir={'': 'qutebrowser'},
         include_package_data=True,
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ def _get_constant(name):
 try:
     common.write_git_file()
     setuptools.setup(
-        packages=setuptools.find_packages(exclude=['scripts', 'scripts.*']),
+        packages=setuptools.find_namespace_packages(),
         include_package_data=True,
         entry_points={'gui_scripts':
                       ['qutebrowser = qutebrowser.qutebrowser:main']},


### PR DESCRIPTION
Building qutebrowser showed some warnings as the following:

```
/tmp/build-env-4jb2oh0t/lib/python3.8/site-packages/setuptools/command/build_py.py:201: _Warning: Package 'qutebrowser.html' is absent from the `packages` configuration.
!!

        ********************************************************************************
        ############################
        # Package would be ignored #
        ############################
        Python recognizes 'qutebrowser.html' as an importable package[^1],
        but it is absent from setuptools' `packages` configuration.

        This leads to an ambiguous overall configuration. If you want to distribute this
        package, please make sure that 'qutebrowser.html' is explicitly added
        to the `packages` configuration field.

        Alternatively, you can also rely on setuptools' discovery methods
        (for example by using `find_namespace_packages(...)`/`find_namespace:`
        instead of `find_packages(...)`/`find:`).

        You can read more about "package discovery" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/package_discovery.html

        If you don't want 'qutebrowser.html' to be distributed and are
        already explicitly excluding 'qutebrowser.html' via
        `find_namespace_packages(...)/find_namespace` or `find_packages(...)/find`,
        you can try to use `exclude_package_data`, or `include-package-data=False` in
        combination with a more fine grained `package-data` configuration.

        You can read more about "package data files" on setuptools documentation page:

        - https://setuptools.pypa.io/en/latest/userguide/datafiles.html

        [^1]: For Python, any directory (with suitable naming) can be imported,
              even if it does not contain any `.py` files.
              On the other hand, currently there is no concept of package data
              directory, all directories are treated like packages.
        ********************************************************************************

!!
```

Using `find_namespace_packages()` as suggested in the setuptools docs[1] solved the issue.

[1] https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#finding-namespace-packages

---

Closes #7627
