### PR TITLE
mkvenv: Fix '--pyqt-type link' without --pyqt-version

### DIFF
--- a/scripts/mkvenv.py
+++ b/scripts/mkvenv.py
@@ -277,7 +277,10 @@ def install_pyqt_link(venv_dir: pathlib.Path, version: str) -> None:
     """Install PyQt by linking a system-wide install."""
     utils.print_title("Linking system-wide PyQt")
     lib_path = link_pyqt.get_venv_lib_path(str(venv_dir))
-    link_pyqt.link_pyqt(sys.executable, lib_path, version=version)
+    if version == 'auto':
+        link_pyqt.link_pyqt(sys.executable, lib_path)
+    else:
+        link_pyqt.link_pyqt(sys.executable, lib_path, version=version)
 
 
 def install_pyqt_wheels(venv_dir: pathlib.Path,


### PR DESCRIPTION
```
$ python scripts/mkvenv.py --venv-dir .venv-2023-07-06 --pyqt-type link
...
==================== Linking system-wide PyQt ====================
Traceback (most recent call last):
  File "scripts/mkvenv.py", line 577, in <module>
    main()
  File "scripts/mkvenv.py", line 570, in main
    run(args)
  File "scripts/mkvenv.py", line 552, in run
    install_pyqt(venv_dir, args)
  File "scripts/mkvenv.py", line 511, in install_pyqt
    install_pyqt_link(venv_dir, args.pyqt_version)
  File "scripts/mkvenv.py", line 280, in install_pyqt_link
    link_pyqt.link_pyqt(sys.executable, lib_path, version=version)
  File "scripts/../scripts/link_pyqt.py", line 137, in link_pyqt
    raise ValueError(f"Invalid version {version}")
ValueError: Invalid version auto
```
Broken in 9212ba94d651e4bed5724dea28e90ca2e190b007.
