### PR TITLE
mkvenv: Fix '--pyqt-type link' without --pyqt-version

### DIFF
--- a/scripts/mkvenv.py
+++ b/scripts/mkvenv.py
@@ -277,7 +277,7 @@ def install_pyqt_link(venv_dir: pathlib.Path, version: str) -> None:
     utils.print_title("Linking system-wide PyQt")
     lib_path = link_pyqt.get_venv_lib_path(str(venv_dir))
     major_version: str = "6" if _is_qt6_version(version) else "5"
-    link_pyqt.link_pyqt(sys.executable, lib_path, major_version)
+    link_pyqt.link_pyqt(sys.executable, lib_path, version=major_version)
 
 
 def install_pyqt_wheels(venv_dir: pathlib.Path,

--- a/scripts/mkvenv.py
+++ b/scripts/mkvenv.py
@@ -276,7 +276,10 @@ def install_pyqt_link(venv_dir: pathlib.Path, version: str) -> None:
     """Install PyQt by linking a system-wide install."""
     utils.print_title("Linking system-wide PyQt")
     lib_path = link_pyqt.get_venv_lib_path(str(venv_dir))
-    link_pyqt.link_pyqt(sys.executable, lib_path, version=version)
+    if _is_qt6_version(version):
+        link_pyqt.link_pyqt(sys.executable, lib_path, version="6")
+    else:
+        link_pyqt.link_pyqt(sys.executable, lib_path, version)
 
 
 def install_pyqt_wheels(venv_dir: pathlib.Path,

--- a/scripts/mkvenv.py
+++ b/scripts/mkvenv.py
@@ -276,10 +276,8 @@ def install_pyqt_link(venv_dir: pathlib.Path, version: str) -> None:
     """Install PyQt by linking a system-wide install."""
     utils.print_title("Linking system-wide PyQt")
     lib_path = link_pyqt.get_venv_lib_path(str(venv_dir))
-    if _is_qt6_version(version):
-        link_pyqt.link_pyqt(sys.executable, lib_path, version="6")
-    else:
-        link_pyqt.link_pyqt(sys.executable, lib_path, version)
+    major_version: str = "6" if _is_qt6_version(version) else "5"
+    link_pyqt.link_pyqt(sys.executable, lib_path, major_version)
 
 
 def install_pyqt_wheels(venv_dir: pathlib.Path,


### PR DESCRIPTION
This is a follow-up of #7770 which was an attempt to fix the script broken in 9212ba9.
Before flipping the QT6 switch.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
