### PR TITLE
Revert "ci: Remove Python 3.12 for now"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -161,9 +161,9 @@ jobs:
             os: ubuntu-22.04
             python: "3.11"
           ### PyQt 6.5 (Python 3.12)
-          # - testenv: py312-pyqt65
-          #   os: ubuntu-22.04
-          #   python: "3.12-dev"
+          - testenv: py312-pyqt65
+            os: ubuntu-22.04
+            python: "3.12-dev"
           ### macOS Big Sur: PyQt 5.15 (Python 3.9 to match PyInstaller env)
           - testenv: py39-pyqt515
             os: macos-11


### PR DESCRIPTION
Bring back Python 3.12 testing in the CI

This reverts commit a5d6e4100542d47a3839caf5f274b369e5953e52.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
