### PR TITLE
Run package building on CI with warnings turned into errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
             args: "-f gcc"  # For problem matchers
           - testenv: yamllint
           - testenv: actionlint
+          - testenv: package
     steps:
       - uses: actions/checkout@v3
         with:

--- a/tox.ini
+++ b/tox.ini
@@ -280,3 +280,13 @@ deps =
 commands =
     !qt5: {envpython} {toxinidir}/scripts/dev/build_release.py {posargs}
     qt5: {envpython} {toxinidir}/scripts/dev/build_release.py --qt5 {posargs}
+
+[testenv:package]
+basepython = {env:PYTHON:python3}
+setenv =
+    PYTHONWARNINGS=error
+    VIRTUALENV_PIP=23.2
+deps =
+    -r{toxinidir}/requirements.txt
+    -r{toxinidir}/misc/requirements/requirements-dev.txt
+commands = {envpython} -m build

--- a/tox.ini
+++ b/tox.ini
@@ -284,8 +284,7 @@ commands =
 [testenv:package]
 basepython = {env:PYTHON:python3}
 setenv =
-    PYTHONWARNINGS=error
-    VIRTUALENV_PIP=23.2
+    PYTHONWARNINGS=error,default:pkg_resources is deprecated as an API.:DeprecationWarning
 deps =
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/misc/requirements/requirements-dev.txt


### PR DESCRIPTION
Add a CI job for running a package build with warnings turned into exceptions.

Now CI will fail on any warnings popping up during the package build (e.g. `DeprecationWarning`). This will help catch potential issues early on.

Related docs:
* https://docs.python.org/3/using/cmdline.html?highlight=pythonwarnings#envvar-PYTHONWARNINGS
* https://docs.python.org/3/library/warnings.html#warning-filter
* https://docs.python.org/3/library/warnings.html#describing-warning-filters

---

Closes #7773 
