### PR TITLE
qt6: import sip from PyQt6

### DIFF
--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -381,7 +381,6 @@ class ModuleInfo:
 
 def _create_module_info() -> Dict[str, ModuleInfo]:
     packages = [
-        ('sip', ['SIP_VERSION_STR']),
         ('colorama', ['VERSION', '__version__']),
         ('jinja2', ['__version__']),
         ('pygments', ['__version__']),
@@ -392,12 +391,16 @@ def _create_module_info() -> Dict[str, ModuleInfo]:
 
     if machinery.IS_QT5:
         packages += [
+            ('sip', ['SIP_VERSION_STR']),
             ('PyQt5.QtWebEngineWidgets', []),
             ('PyQt5.QtWebEngine', ['PYQT_WEBENGINE_VERSION_STR']),
             ('PyQt5.QtWebKitWidgets', []),
         ]
     elif machinery.IS_QT6:
-        packages.append(('PyQt6.QtWebEngineCore', ['PYQT_WEBENGINE_VERSION_STR']))
+        packages += [
+            ('PyQt6.QtWebEngineCore', ['PYQT_WEBENGINE_VERSION_STR']),
+            ('PyQt6.sip', ['SIP_VERSION_STR']),
+        ]
     else:
         raise utils.Unreachable()
 

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -644,8 +644,8 @@ class TestModuleVersions:
         assert version._module_versions() == expected
 
     @pytest.mark.parametrize('module, idx, expected', [
-        ('colorama', 1, 'colorama: no'),
-        ('adblock', 5, 'adblock: no'),
+        ('colorama', 0, 'colorama: no'),
+        ('adblock', 4, 'adblock: no'),
     ])
     def test_missing_module(self, module, idx, expected, import_fake):
         """Test with a module missing.
@@ -693,7 +693,7 @@ class TestModuleVersions:
         assert not mod_info.is_usable()
 
         expected = f"adblock: {fake_version} (< {mod_info.min_version}, outdated)"
-        assert version._module_versions()[5] == expected
+        assert version._module_versions()[4] == expected
 
     @pytest.mark.parametrize('attribute, expected_modules', [
         ('VERSION', ['colorama']),
@@ -720,7 +720,7 @@ class TestModuleVersions:
         expected = []
         for name in import_fake.modules:
             mod_info = version.MODULE_INFO[name]
-            if name in expected_modules:
+            if name in expected_modules or ("sip" in expected_modules and name == "PyQt6.sip"):
                 assert mod_info.get_version() == "1.2.3"
                 expected.append('{}: 1.2.3'.format(name))
             else:


### PR DESCRIPTION
Currently, ":version" fails to show the sip version for Qt6. This is because the sip module can't imported in the same way as Qt5. In Qt5, the sip module can be imported after "from PyQt5.QtCore import *". In Qt 6, this is no long the case,

    >>> from PyQt6.QtCore import *
    >>> import sip
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
    ModuleNotFoundError: No module named 'sip'

So import sip from PyQt6 explicitly.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
