### PR TITLE
Allow navigating from file:// to remote origins via hints

### DIFF
--- a/qutebrowser/browser/webengine/webengineelem.py
+++ b/qutebrowser/browser/webengine/webengineelem.py
@@ -215,14 +215,16 @@ class WebEngineElement(webelem.AbstractWebElement):
             return False
 
         # Qt 6.3+ needs a user interaction to allow navigations from qute:// to
-        # outside qute:// (like e.g. on qute://bookmarks).
+        # outside qute:// (like e.g. on qute://bookmarks), as well as from file:// to
+        # outside of file:// (e.g. users having a local bookmarks.html).
         versions = version.qtwebengine_versions()
-        if (
-            baseurl.scheme() == "qute" and
-            url.scheme() != "qute" and
-            versions.webengine >= utils.VersionNumber(6, 3)
-        ):
-            return True
+        for scheme in ["qute", "file"]:
+            if (
+                baseurl.scheme() == scheme and
+                url.scheme() != scheme and
+                versions.webengine >= utils.VersionNumber(6, 3)
+            ):
+                return True
 
         return url.scheme() not in urlutils.WEBENGINE_SCHEMES
 

--- a/tests/end2end/data/hints/link_inject.html
+++ b/tests/end2end/data/hints/link_inject.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <title>A link to use hints on</title>
+        <script>
+            function injectPort() {
+                const queryString = document.location.search;
+                const params = new URLSearchParams(queryString);
+                const port = params.get("port")
+                let link = document.getElementById("link");
+                link.href = link.href.replace("<port>", port);
+            }
+        </script>
+    </head>
+    <body onload="injectPort()">
+        <a href="http://localhost:<port>/data/hello.txt" id="link">Follow me!</a>
+    </body>
+</html>

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -198,7 +198,7 @@ def open_path(quteproc, server, path):
     - With "... as a URL", it's opened according to new_instance_open_target.
     """
     path = path.replace('(port)', str(server.port))
-    path = path.replace('(testdata)', os.fspath(testutils.abs_datapath()))
+    path = testutils.substitute_testdata(path)
 
     new_tab = False
     new_bg_tab = False
@@ -270,7 +270,7 @@ def run_command(quteproc, server, tmpdir, command):
         invalid = False
 
     command = command.replace('(port)', str(server.port))
-    command = command.replace('(testdata)', str(testutils.abs_datapath()))
+    command = testutils.substitute_testdata(command)
     command = command.replace('(tmpdir)', str(tmpdir))
     command = command.replace('(dirsep)', os.sep)
     command = command.replace('(echo-exe)', _get_echo_exe_path())
@@ -364,7 +364,7 @@ def hint(quteproc, args):
 
 @bdd.when(bdd.parsers.parse('I hint with args "{args}" and follow {letter}'))
 def hint_and_follow(quteproc, args, letter):
-    args = args.replace('(testdata)', str(testutils.abs_datapath()))
+    args = testutils.substitute_testdata(args)
     args = args.replace('(python-executable)', sys.executable)
     quteproc.send_cmd(':hint {}'.format(args))
     quteproc.wait_for(message='hints: *')

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -199,6 +199,7 @@ def open_path(quteproc, server, path):
     - With "... as a URL", it's opened according to new_instance_open_target.
     """
     path = path.replace('(port)', str(server.port))
+    path = path.replace('(testdata)', testutils.abs_datapath())
 
     new_tab = False
     new_bg_tab = False

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -33,8 +33,7 @@ def _get_echo_exe_path():
         Path to the "echo"-utility.
     """
     if utils.is_windows:
-        return os.path.join(testutils.abs_datapath(), 'userscripts',
-                            'echo.bat')
+        return str(testutils.abs_datapath() / 'userscripts' / 'echo.bat')
     else:
         return shutil.which("echo")
 
@@ -199,7 +198,7 @@ def open_path(quteproc, server, path):
     - With "... as a URL", it's opened according to new_instance_open_target.
     """
     path = path.replace('(port)', str(server.port))
-    path = path.replace('(testdata)', testutils.abs_datapath())
+    path = path.replace('(testdata)', os.fspath(testutils.abs_datapath()))
 
     new_tab = False
     new_bg_tab = False
@@ -271,7 +270,7 @@ def run_command(quteproc, server, tmpdir, command):
         invalid = False
 
     command = command.replace('(port)', str(server.port))
-    command = command.replace('(testdata)', testutils.abs_datapath())
+    command = command.replace('(testdata)', str(testutils.abs_datapath()))
     command = command.replace('(tmpdir)', str(tmpdir))
     command = command.replace('(dirsep)', os.sep)
     command = command.replace('(echo-exe)', _get_echo_exe_path())
@@ -365,7 +364,7 @@ def hint(quteproc, args):
 
 @bdd.when(bdd.parsers.parse('I hint with args "{args}" and follow {letter}'))
 def hint_and_follow(quteproc, args, letter):
-    args = args.replace('(testdata)', testutils.abs_datapath())
+    args = args.replace('(testdata)', str(testutils.abs_datapath()))
     args = args.replace('(python-executable)', sys.executable)
     quteproc.send_cmd(':hint {}'.format(args))
     quteproc.wait_for(message='hints: *')

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -44,6 +44,13 @@ Feature: Using hints
             - data/hints/link_blank.html
             - data/hello.txt
 
+    # https://github.com/qutebrowser/qutebrowser/issues/7842
+    @qtwebkit_skip
+    Scenario: Following a hint from a local file to a remote origin
+        When I open file://(testdata)/hints/link_inject.html?port=(port)
+        And I hint with args "links" and follow a
+        Then data/hello.txt should be loaded
+
     Scenario: Following a hint to link with sub-element and force to open in current tab.
         When I open data/hints/link_span.html
         And I hint with args "links current" and follow a

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -393,7 +393,7 @@ class QuteProc(testprocess.Process):
         verbatim.
         """
         special_schemes = ['about:', 'qute:', 'chrome:', 'view-source:',
-                           'data:', 'http:', 'https:']
+                           'data:', 'http:', 'https:', 'file:']
         server = self.request.getfixturevalue('server')
         server_port = server.port if port is None else port
 

--- a/tests/helpers/testutils.py
+++ b/tests/helpers/testutils.py
@@ -196,6 +196,24 @@ def abs_datapath():
     return path.resolve()
 
 
+def substitute_testdata(path):
+    r"""Replace the (testdata) placeholder in path with `abs_datapath()`.
+
+    If path is starting with file://, return path as an URI with file:// removed. This
+    is useful if path is going to be inserted into an URI:
+
+    >>> path = substitute_testdata("C:\Users\qute")
+    >>> f"file://{path}/slug  # results in valid URI
+    'file:///C:/Users/qute/slug'
+    """
+    if path.startswith('file://'):
+        testdata_path = abs_datapath().as_uri().replace('file://', '')
+    else:
+        testdata_path = str(abs_datapath())
+
+    return path.replace('(testdata)', testdata_path)
+
+
 @contextlib.contextmanager
 def nop_contextmanager():
     yield

--- a/tests/helpers/testutils.py
+++ b/tests/helpers/testutils.py
@@ -192,8 +192,8 @@ def pattern_match(*, pattern, value):
 
 def abs_datapath():
     """Get the absolute path to the end2end data directory."""
-    file_abs = os.path.abspath(os.path.dirname(__file__))
-    return os.path.join(file_abs, '..', 'end2end', 'data')
+    path = pathlib.Path(__file__).parent / '..' / 'end2end' / 'data'
+    return path.resolve()
 
 
 @contextlib.contextmanager


### PR DESCRIPTION
As of Qt 6 navigating from local to remote origins requires user interaction. This broke following links to remote origins via hints from a local file (e.g. `bookmarks.html`), because hints use JavaScript to open links by default.

Example:

1. Have a local `bookmarks.html`:
   ```html
   <!DOCTYPE html>
   <html>
       <head>
           <meta charset="utf-8">
           <title>My bookmarks</title>
       </head>
       <body>
           <a href="https://example.com/" id="link">some bookmark</a>
       </body>
   </html>
   ```
2. Open that local `bookmarks.html` in qutebrowser (e.g. `:open path/to/bookmarks.html`)
3. Start hinting
4. Follow a link to a bookmark (e.g. https://example.com/)
5. Instead of the link opening, be presented with `Your internet access is blocked` error

To fix this, we simply force a user interaction for all hints on file:// URLs (like we did for `qute://` URLs in 8defe1ae44c1c524e937ae08ed16052ee0724e0f).

---

Closes #7842 
