### PR TITLE
Fixing timers accumulating duplicate slots

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -817,7 +817,7 @@ class WebEngineAudio(browsertab.AbstractAudio):
         self._tab.url_changed.connect(self._on_url_changed)
         config.instance.changed.connect(self._on_config_changed)
         self._silence_timer.timeout.connect(functools.partial(
-                self.recently_audible_changed.emit, False))
+            self.recently_audible_changed.emit, False))
 
     # WORKAROUND for recentlyAudibleChanged being emitted without delay from the moment
     # that audio is dropped.

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -816,6 +816,8 @@ class WebEngineAudio(browsertab.AbstractAudio):
         page.recentlyAudibleChanged.connect(self._delayed_recently_audible_changed)
         self._tab.url_changed.connect(self._on_url_changed)
         config.instance.changed.connect(self._on_config_changed)
+        self._silence_timer.timeout.connect(functools.partial(
+                self.recently_audible_changed.emit, False))
 
     # WORKAROUND for recentlyAudibleChanged being emitted without delay from the moment
     # that audio is dropped.
@@ -831,8 +833,6 @@ class WebEngineAudio(browsertab.AbstractAudio):
             # Ignore all subsequent calls while the tab is muted with an active timer
             if timer.isActive():
                 return
-            timer.timeout.connect(
-                functools.partial(self.recently_audible_changed.emit, recently_audible))
             timer.start()
 
     def set_muted(self, muted: bool, override: bool = False) -> None:

--- a/qutebrowser/keyinput/modeparsers.py
+++ b/qutebrowser/keyinput/modeparsers.py
@@ -84,6 +84,7 @@ class NormalKeyParser(CommandKeyParser):
         self._inhibited = False
         self._inhibited_timer = usertypes.Timer(self, 'normal-inhibited')
         self._inhibited_timer.setSingleShot(True)
+        self._inhibited_timer.timeout.connect(self._clear_inhibited)
 
     def __repr__(self) -> str:
         return utils.get_repr(self)
@@ -113,7 +114,6 @@ class NormalKeyParser(CommandKeyParser):
                 timeout))
             self._inhibited = True
             self._inhibited_timer.setInterval(timeout)
-            self._inhibited_timer.timeout.connect(self._clear_inhibited)
             self._inhibited_timer.start()
 
     @pyqtSlot()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
Closes #7887.

Moves the `timer.timeout.connect` statements to regions where they will only be run once, which fixes the referenced issue and duplicate slots no longer accumulate ad infinitum.