### PR TITLE
Override IconProvider for QFileSystemModel

### DIFF
--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -16,7 +16,7 @@ from qutebrowser.qt.core import (pyqtSlot, pyqtSignal, Qt, QTimer, QDir, QModelI
 from qutebrowser.qt.widgets import (QWidget, QGridLayout, QVBoxLayout, QLineEdit,
                              QLabel, QTreeView, QSizePolicy,
                              QSpacerItem)
-from qutebrowser.qt.gui import QFileSystemModel
+from qutebrowser.qt.gui import (QFileSystemModel, QAbstractFileIconProvider, QIcon)
 
 from qutebrowser.browser import downloads
 from qutebrowser.config import config, configtypes, configexc, stylesheet
@@ -624,6 +624,19 @@ class LineEditPrompt(_BasePrompt):
         return [('prompt-accept', 'Accept'), ('mode-leave', 'Abort')]
 
 
+class NullIconProvider(QAbstractFileIconProvider):
+
+    def __init__(self):
+        super().__init__()
+        self.null_icon = QIcon()
+
+    def icon(self, type):
+        return self.null_icon
+
+    def type(self, info):
+        return ""
+
+
 class FilenamePrompt(_BasePrompt):
 
     """A prompt for a filename."""
@@ -725,6 +738,8 @@ class FilenamePrompt(_BasePrompt):
     def _init_fileview(self):
         self._file_view = QTreeView(self)
         self._file_model = QFileSystemModel(self)
+
+        self._file_model.setIconProvider(NullIconProvider())
         self._file_view.setModel(self._file_model)
         self._file_view.clicked.connect(self._insert_path)
 

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -626,16 +626,17 @@ class LineEditPrompt(_BasePrompt):
 
 class NullIconProvider(QAbstractFileIconProvider):
 
+    """Returns empty icon for everything."""
+
     def __init__(self):
         super().__init__()
         self.null_icon = QIcon()
 
-    def icon(self, type):
+    def icon(self, t):
         return self.null_icon
 
-    def type(self, info):
-        return ""
-
+    def type(self, _info):
+        return 'unknown'
 
 class FilenamePrompt(_BasePrompt):
 

--- a/qutebrowser/mainwindow/prompt.py
+++ b/qutebrowser/mainwindow/prompt.py
@@ -15,8 +15,8 @@ from qutebrowser.qt.core import (pyqtSlot, pyqtSignal, Qt, QTimer, QDir, QModelI
                           QItemSelectionModel, QObject, QEventLoop)
 from qutebrowser.qt.widgets import (QWidget, QGridLayout, QVBoxLayout, QLineEdit,
                              QLabel, QTreeView, QSizePolicy,
-                             QSpacerItem)
-from qutebrowser.qt.gui import (QFileSystemModel, QAbstractFileIconProvider, QIcon)
+                             QSpacerItem, QFileIconProvider)
+from qutebrowser.qt.gui import (QFileSystemModel, QIcon)
 
 from qutebrowser.browser import downloads
 from qutebrowser.config import config, configtypes, configexc, stylesheet
@@ -624,7 +624,7 @@ class LineEditPrompt(_BasePrompt):
         return [('prompt-accept', 'Accept'), ('mode-leave', 'Abort')]
 
 
-class NullIconProvider(QAbstractFileIconProvider):
+class NullIconProvider(QFileIconProvider):
 
     """Returns empty icon for everything."""
 
@@ -632,11 +632,12 @@ class NullIconProvider(QAbstractFileIconProvider):
         super().__init__()
         self.null_icon = QIcon()
 
-    def icon(self, t):
+    def icon(self, _t):
         return self.null_icon
 
     def type(self, _info):
         return 'unknown'
+
 
 class FilenamePrompt(_BasePrompt):
 
@@ -740,7 +741,9 @@ class FilenamePrompt(_BasePrompt):
         self._file_view = QTreeView(self)
         self._file_model = QFileSystemModel(self)
 
+        # avoid icon and mime type lookups, they are slow in Qt6
         self._file_model.setIconProvider(NullIconProvider())
+
         self._file_view.setModel(self._file_model)
         self._file_view.clicked.connect(self._insert_path)
 


### PR DESCRIPTION
A possible solution for #7222 

Prevents `QFileSystemModel` from trying to load an icon for every entry in the download directory (which is not needed since the download prompt doesn't display icons), by overriding the `icon` method of `QAbstractFileIconProvider` with one that always returns a "null icon". The `type` method returning some (nonempty) fixed string replaces a further lookup for the textual description of a mime type.