### PR TITLE
Make sure we clean up old QItemSelectionModels

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -72,6 +72,10 @@ qt_log_ignore =
     ^[^ ]*qtwebengine_dictionaries'$
     # Qt 5 on Archlinux
     ^QSslSocket: cannot resolve .*
+    # Seems to happen after we try to complete immediately after clearing a
+    # model, for example, when no completion function is available for the
+    # current text pattern.
+    QItemSelectionModel: Selecting when no model has been set will result in a no-op.
 xfail_strict = true
 filterwarnings =
     error

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -364,15 +364,13 @@ class CompletionView(QTreeView):
         old_model = self.model()
         if old_model is not None and model is not old_model:
             old_model.deleteLater()
-            self._selection_model().deleteLater()
-
-        self.setModel(model)
 
         if model is None:
             self._active = False
             self.hide()
             return
 
+        self.setModel(model)
         model.setParent(self)
         self._active = True
         self.pattern = None

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -146,6 +146,18 @@ def test_completion_item_focus_no_model(which, completionview, model, qtbot):
         completionview.completion_item_focus(which)
 
 
+def test_models_deleted_on_clear(completionview, model, qtbot):
+    """Ensure set_model(None) deleted the model and selmodel."""
+    completionview.set_model(model)
+    selmod = completionview._selection_model()
+    completionview.set_model(None)
+
+    with qtbot.wait_signal(model.destroyed):
+        pass
+    with qtbot.wait_signal(selmod.destroyed):
+        pass
+
+
 @pytest.mark.skip("Seems to disagree with reality, see #5897")
 def test_completion_item_focus_fetch(completionview, model, qtbot):
     """Test that on_next_prev_item moves the selection properly."""


### PR DESCRIPTION
Don't call `QTreeView.setModel(None)` as it cases a leak of `QItemSelectionModel`s. Normally the selection models get cleaned up when the model they are linked to is destroyed. But when you set a null model the selection models get linked to a static empty model that lives forever.

Just deleting the model and letting the connections to its `destroyed` signal seems to be an alternate way of resetting the state of the `QTreeView` and deleting the selection models and it does have the problem of creating new `QItemSelectionModel`s with a long lifetime.

I spotted this leak with KDAB's Gammary. Maybe we'll spot more that way later (it gets really slow with many objects though).

![image](https://github.com/qutebrowser/qutebrowser/assets/7419144/58869b91-1548-47bd-abd2-ec0e9fe86540)


I'm not sure how to add a test to ensure these are getting cleaned up since it's being done async. I think the fact that all the existing tests are still passing is a pretty strong signal!

Previously I had a comment in about "do we even get called twice with the same model"? I don't think we do in the normal flow of things because we always close and re-open the completion. But who knows what kind of shenanigins you can get up to with IPC.

Fixes: #7947

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
