### PR TITLE
Make progress bar border visible

### DIFF
--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -33,7 +33,7 @@ class Progress(QProgressBar):
     STYLESHEET = """
         QProgressBar {
             border-radius: 0px;
-            border: 2px solid transparent;
+            border: 1px solid {{ conf.colors.statusbar.progress.bg }};
             background-color: transparent;
             font: {{ conf.fonts.statusbar }};
         }


### PR DESCRIPTION
When progress bar is the leftmost widget in statusbar.widgets, it is invisible at 0% progress without a border.