### PR TITLE
Search ListCategory in any order of search terms

### DIFF
--- a/qutebrowser/completion/models/listcategory.py
+++ b/qutebrowser/completion/models/listcategory.py
@@ -61,6 +61,10 @@ class ListCategory(QSortFilterProxyModel):
             log.completion.warning(f"Trimming {len(val)}-char pattern to 5000")
             val = val[:5000]
         self._pattern = val
+
+        # Positive lookahead per search term. This means that all search terms must
+        # be matched but they can be matched anywhere in the string, so they can be
+        # in any order. For example "foo bar" -> "(?=.*foo)(?=.*bar)"
         val = '(?=.*' + ')(?=.*'.join(map(re.escape, val.split())) + ')'
         rx = QRegularExpression(val, QRegularExpression.PatternOption.CaseInsensitiveOption)
         qtutils.ensure_valid(rx)

--- a/qutebrowser/completion/models/listcategory.py
+++ b/qutebrowser/completion/models/listcategory.py
@@ -61,9 +61,7 @@ class ListCategory(QSortFilterProxyModel):
             log.completion.warning(f"Trimming {len(val)}-char pattern to 5000")
             val = val[:5000]
         self._pattern = val
-        val = re.sub(r' +', r' ', val)  # See #1919
-        val = re.escape(val)
-        val = val.replace(r'\ ', '.*')
+        val = '(?=.*' + ')(?=.*'.join(map(re.escape, val.split())) + ')'
         rx = QRegularExpression(val, QRegularExpression.PatternOption.CaseInsensitiveOption)
         qtutils.ensure_valid(rx)
         self.setFilterRegularExpression(rx)

--- a/tests/unit/completion/test_listcategory.py
+++ b/tests/unit/completion/test_listcategory.py
@@ -45,6 +45,11 @@ from qutebrowser.completion.models import listcategory
      [('foo', 'bar'), ('bar', 'foo'), ('bar', 'bar')],
      [('foo', 'bar'), ('bar', 'foo')],
      [('foo', 'bar'), ('bar', 'foo')]),
+
+    ('foo bar',
+     [('foobar', ''), ('barfoo', ''), ('foobaz', '')],
+     [('barfoo', ''), ('foobar', '')],
+     [('foobar', ''), ('barfoo', '')]),
 ])
 def test_set_pattern(pattern, before, after, after_nosort, model_validator):
     """Validate the filtering and sorting results of set_pattern."""


### PR DESCRIPTION
Part of #6114. Bookmarks and `:tab-select` are searched in any order of search terms. Commands and setting names etc. don't yet support multi-word searches.

`url_completion_benchmark` becomes 11% slower (453->505ms) and a [heavier benchmark](https://github.com/arza-zara/qutebrowser/commit/4f447faeb748027785b5e49f2542e218debcc74b) becomes 20% slower.

This seems to be compatible with #3855 (I haven't tested).