### PR TITLE
Fix docstrings

### DIFF
--- a/qutebrowser/utils/message.py
+++ b/qutebrowser/utils/message.py
@@ -135,7 +135,7 @@ def ask(*args: Any, **kwargs: Any) -> Any:
     """Ask a modular question in the statusbar (blocking).
 
     Args:
-        message: The message to display to the user.
+        title: The message to display to the user.
         mode: A PromptMode.
         default: The default value to display.
         text: Additional text to show
@@ -182,7 +182,7 @@ def confirm_async(*, yes_action: _ActionType,
     """Ask a yes/no question to the user and execute the given actions.
 
     Args:
-        message: The message to display to the user.
+        title: The message to display to the user.
         yes_action: Callable to be called when the user answered yes.
         no_action: Callable to be called when the user answered no.
         cancel_action: Callable to be called when the user cancelled the


### PR DESCRIPTION
I tried to use `message` in `confirm_async` as per the docstring, resulting `TypeError: _build_question() got an unexpected keyword argument 'message'`. Nothing actually tries to use it. Follow-up to f0ed43ec203026952955882d533ecadaee4832fc. :smile: