### PR TITLE
Fix loading collapsed tabs and legacy session support

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -281,8 +281,10 @@ class TabbedBrowser(QWidget):
             raise TabDeletedError("index is -1!")
         return idx
 
-    def widgets(self):
+    def widgets(self) -> List[browsertab.AbstractTab]:
         """Get a list of open tab widgets.
+
+        Consider using `tabs()` instead of this method.
 
         We don't implement this as generator so we can delete tabs while
         iterating over the list.
@@ -295,6 +297,18 @@ class TabbedBrowser(QWidget):
             else:
                 widgets.append(widget)
         return widgets
+
+    def tabs(
+        self,
+        include_hidden: bool = False,  # pylint: disable=unused-argument
+    ) -> List[browsertab.AbstractTab]:
+        """Get a list of tabs in this browser.
+
+        Args:
+            include_hidden: Include child tabs which are not currently in the
+                            tab bar.
+        """
+        return self.widgets()
 
     def _update_window_title(self, field=None):
         """Change the window title to match the current tab.

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -377,7 +377,7 @@ class TabbedBrowser(QWidget):
             tab.history_item_triggered.connect(
                 history.web_history.add_from_tab)
 
-    def _current_tab(self) -> browsertab.AbstractTab:
+    def current_tab(self) -> browsertab.AbstractTab:
         """Get the current browser tab.
 
         Note: The assert ensures the current tab is never None.
@@ -586,7 +586,7 @@ class TabbedBrowser(QWidget):
         if newtab or self.widget.currentWidget() is None:
             self.tabopen(url, background=False)
         else:
-            self._current_tab().load_url(url)
+            self.current_tab().load_url(url)
 
     @pyqtSlot(int)
     def on_tab_close_requested(self, idx):
@@ -672,7 +672,7 @@ class TabbedBrowser(QWidget):
             # Make sure the background tab has the correct initial size.
             # With a foreground tab, it's going to be resized correctly by the
             # layout anyways.
-            current_widget = self._current_tab()
+            current_widget = self.current_tab()
             tab.resize(current_widget.size())
             self.widget.tab_index_changed.emit(self.widget.currentIndex(),
                                                self.widget.count())
@@ -1087,7 +1087,7 @@ class TabbedBrowser(QWidget):
             if key != "'":
                 message.error("Failed to set mark: url invalid")
             return
-        point = self._current_tab().scroller.pos_px()
+        point = self.current_tab().scroller.pos_px()
 
         if key.isupper():
             self._global_marks[key] = point, url
@@ -1108,7 +1108,7 @@ class TabbedBrowser(QWidget):
         except qtutils.QtValueError:
             urlkey = None
 
-        tab = self._current_tab()
+        tab = self.current_tab()
 
         if key.isupper():
             if key in self._global_marks:

--- a/qutebrowser/mainwindow/treetabbedbrowser.py
+++ b/qutebrowser/mainwindow/treetabbedbrowser.py
@@ -195,6 +195,25 @@ class TreeTabbedBrowser(TabbedBrowser):
 
         self.widget.tree_tab_update()
 
+    def tabs(
+        self,
+        include_hidden: bool = False,
+    ) -> List[browsertab.AbstractTab]:
+        """Get a list of tabs in this browser.
+
+        Args:
+            include_hidden: Include child tabs which are not currently in the
+                            tab bar.
+        """
+        return [
+            node.value
+            for node
+            in self.widget.tree_root.traverse(
+                render_collapsed=include_hidden,
+            )
+            if node.value
+        ]
+
     @pyqtSlot('QUrl')
     @pyqtSlot('QUrl', bool)
     @pyqtSlot('QUrl', bool, bool)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -330,8 +330,8 @@ class SessionManager(QObject):
                 ]
             else:
                 tabs = tabbed_browser.widgets()
-            for i, tab in enumerate(tabs):
-                active = i == tabbed_browser.widget.currentIndex()
+            for tab in tabs:
+                active = tab == tabbed_browser.current_tab()
                 tab_data = self._save_tab(tab,
                                           active,
                                           with_history=with_history)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -600,7 +600,7 @@ class SessionManager(QObject):
             tabbed_browser.is_treetabbedbrowser
         if load_tree_tabs:
             tree_data = reconstruct_tree_data(win)
-            self._load_tree(tabbed_browser, tree_data)
+            tab_to_focus = self._load_tree(tabbed_browser, tree_data)
         elif not legacy_tree_loaded:
             for i, tab in enumerate(tabs):
                 new_tab = tabbed_browser.tabopen(background=False)

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -321,7 +321,16 @@ class SessionManager(QObject):
                 win_data['private'] = True
 
             win_data['tabs'] = []
-            for i, tab in enumerate(tabbed_browser.widgets()):
+            if tabbed_browser.is_treetabbedbrowser:
+                tabs = [
+                    node.value
+                    for node
+                    in tabbed_browser.widget.tree_root.traverse()
+                    if node.value
+                ]
+            else:
+                tabs = tabbed_browser.widgets()
+            for i, tab in enumerate(tabs):
                 active = i == tabbed_browser.widget.currentIndex()
                 tab_data = self._save_tab(tab,
                                           active,

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -537,7 +537,11 @@ class SessionManager(QObject):
             if tab_data.get('active'):
                 tab_to_focus = index
 
-            new_tab = tabbed_browser.tabopen(background=False)
+            new_tab = tabbed_browser.tabopen(
+                background=False,
+                related=False,
+                idx=index,
+            )
             self._load_tab(new_tab, tab_data)
 
             new_tab.node.parent = root_node
@@ -603,7 +607,11 @@ class SessionManager(QObject):
             tab_to_focus = self._load_tree(tabbed_browser, tree_data)
         elif not legacy_tree_loaded:
             for i, tab in enumerate(tabs):
-                new_tab = tabbed_browser.tabopen(background=False)
+                new_tab = tabbed_browser.tabopen(
+                    background=False,
+                    related=False,
+                    idx=i,
+                )
                 self._load_tab(new_tab, tab)
                 if tab.get('active', False):
                     tab_to_focus = i

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -554,6 +554,13 @@ class SessionManager(QObject):
             child = recursive_load_node(child_uid)
             child.parent = root_node
 
+        # Make sure any collapsed tabs are removed from the widget.
+        # Since we only set the "collapsed" attribute after loading the tab,
+        # and the tree only gets updated in the above loop on tab loads. So if
+        # the last set of tabs we load is a collapsed group this children
+        # won't know they are support to be hidden yet.
+        tabbed_browser.widget.tree_tab_update()
+
         return tab_to_focus
 
     def _load_legacy_tree_tabs(self, win, tabbed_browser):

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -338,7 +338,6 @@ class SessionManager(QObject):
                 if tabbed_browser.is_treetabbedbrowser:
                     node = tab.node
                     node_data = {
-                        'node': node.uid,
                         'parent': node.parent.uid,
                         'children': [c.uid for c in node.children],
                         'collapsed': node.collapsed,

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -321,16 +321,7 @@ class SessionManager(QObject):
                 win_data['private'] = True
 
             win_data['tabs'] = []
-            if tabbed_browser.is_treetabbedbrowser:
-                tabs = [
-                    node.value
-                    for node
-                    in tabbed_browser.widget.tree_root.traverse()
-                    if node.value
-                ]
-            else:
-                tabs = tabbed_browser.widgets()
-            for tab in tabs:
+            for tab in tabbed_browser.tabs(include_hidden=True):
                 active = tab == tabbed_browser.current_tab()
                 tab_data = self._save_tab(tab,
                                           active,

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -440,3 +440,18 @@ Feature: Saving and loading sessions
         - data/numbers/2.txt (active) (pinned)
         - data/numbers/4.txt
         - data/numbers/3.txt
+
+  # Make sure the new_position.related setting doesn't change the tab order
+  # when loading from a session.
+  Scenario: Loading a session with tabs.new_position.related=prev
+      When I open data/numbers/1.txt
+      And I open data/numbers/2.txt in a new tab
+      And I open data/numbers/3.txt in a new tab
+      And I run :session-save foo
+      And I set tabs.new_position.related to prev
+      And I run :session-load -c foo
+      And I wait until data/numbers/3.txt is loaded
+      Then the following tabs should be open:
+        - data/numbers/1.txt
+        - data/numbers/2.txt
+        - data/numbers/3.txt (active)

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -47,6 +47,8 @@ Feature: Tree tab management
         # Now actually load the saved session
         And I run :session-save foo
         And I run :session-load -c foo
+        And I wait until data/numbers/1.txt is loaded
+        And I wait until data/numbers/2.txt is loaded
         And I wait until data/numbers/3.txt is loaded
         # And of course the same assertion as above too
         Then the following tabs should be open:
@@ -80,6 +82,9 @@ Feature: Tree tab management
         And I set tabs.new_position.tree.new_child to last
         And I set tabs.new_position.tree.new_toplevel to prev
         And I run :session-load -c foo
+        And I wait until data/numbers/1.txt is loaded
+        And I wait until data/numbers/2.txt is loaded
+        And I wait until data/numbers/3.txt is loaded
         And I wait until data/numbers/4.txt is loaded
         Then the following tabs should be open:
           - data/numbers/1.txt

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -25,3 +25,64 @@ Feature: Tree tab management
         Then the following tabs should be open:
             - data/numbers/1.txt
               - data/numbers/2.txt (active)
+
+    Scenario: Collapse a subtree
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I run :tab-focus 2
+        And I run :tree-tab-toggle-hide
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+              - data/numbers/2.txt (active) (collapsed)
+                - data/numbers/3.txt
+
+    Scenario: Load a collapsed subtree
+        # Same setup as above
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I run :tab-focus 2
+        And I run :tree-tab-toggle-hide
+        # Now actually load the saved session
+        And I run :session-save foo
+        And I run :session-load -c foo
+        And I wait until data/numbers/3.txt is loaded
+        # And of course the same assertion as above too
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+              - data/numbers/2.txt (active) (collapsed)
+                - data/numbers/3.txt
+
+    Scenario: Uncollapse a subtree
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I run :tab-focus 2
+        And I run :tree-tab-toggle-hide
+        And I run :tree-tab-toggle-hide
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+              - data/numbers/2.txt (active)
+                - data/numbers/3.txt
+
+    # Same as a test in sessions.feature but tree tabs and the related
+    # settings.
+    Scenario: TreeTabs: Loading a session with tabs.new_position.related=prev
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I open data/numbers/4.txt in a new tab
+        And I run :tab-focus 2
+        And I run :tree-tab-toggle-hide
+        And I run :session-save foo
+        And I set tabs.new_position.related to prev
+        And I set tabs.new_position.tree.new_child to last
+        And I set tabs.new_position.tree.new_toplevel to prev
+        And I run :session-load -c foo
+        And I wait until data/numbers/4.txt is loaded
+        Then the following tabs should be open:
+          - data/numbers/1.txt
+            - data/numbers/2.txt (active) (collapsed)
+              - data/numbers/3.txt
+          - data/numbers/4.txt


### PR DESCRIPTION
Relating to https://github.com/qutebrowser/qutebrowser/issues/8076 and following on from https://github.com/qutebrowser/qutebrowser/commit/a2f98aa78b529de9a730beaafe522b38a8a977c3 this PR proposes a fix and an improvement:

**fix loading of tab in collapsed tab groups**

Tabs in collapsed tab groups were being dropped because the code was iterating over the tabs loaded into the tab widget instead of all those in the tree. Easy spot, easy fix.

**support loading legacy tree tab session formats**

There are some long time community members who have been using this PR for a while and may have built up complicated session files which they are dreading having to rebuild. Currently if they pull the latest on the `tree-tab-integration` branch the browser will just crash on startup.

I had a look at how hard it would be to continue supporting the previous session format and it turned out to be pretty easy by copying some old code and adding a couple of conditionals. A few two many conditionals for my tastes but at least they are tiny.

**bonus: remove unused attribute**

Tree tabs were ending up in session files with their uid in both the `node` and `uid` attribute. It looks like only the `uid` one is being used.

**PS**: I haven't reviewed a2f98aa78b529de9a yet, but I've tested it! Everything seems to be working as it was. And from a brief look the diff sure looks smaller. I think `_save_all()` looks much cleaner iterating on tabs like normal and then taking a quick diversion to do add tab data
**PPS**: I've seen another issue where if you load a non-tree session while sessions are enabled every tab will be opened as "related" so instead of a flat set of tabs loaded you get a staircase. This might depend on what your `new_position` settings are set to. This could be fixed by setting `related=True` in the call to `tabopen()` but I think this is exposing a problem you can run into with the existing session loading too. Eg tabopen has `related=True` false and that isn't overriden by the session code and the session code passes `background=False`. Both of which seem incorrect, so it seems the session code is using knowledge of the positioning code in tabbedbrowser instead of overriding it completely (eg `background=False, related=False, idx=i`). So since I think it's a preexisting thing I would prefer to wait until we fix up the tests around sessions (lots of them are disabled on webengine) before fixing it "properly". But if someone complains I suppooose fixing it in an isolated manner is okay. ~TODO: raise a ticket to track this~ resolved in this PR
Edit: this also causes issues with:
```
- about:blank?one
  - about:blank?two
    - about:blank?three (collapsed) (active)
      - about:blank?four
- about:blank?five
```
If you load the session tab five is also collapsed. If you toggle collapse it gets restored to the correct visibility. This seems to be happening in `_position_tab()` because `related` is set to True. Not sure why it's only happening when there is a collapsed tab, or why the `child.parent = root_node` at the end of `_load_tree()` isn't fixing it. But it gets fixed with related=False anyhow...
Hmm, had a look at the e2e tests, which do work on webengine, they don't reproduce this issue because they test against a saved session and the session saves fine, it's the tabs in the browser that are borked (how!). Well, session-load does have some coverage so might just have to be a "it doesn't make things worse" change. Either that or we add a `:debug-dump-tree $winid` command.
Anyway, you can reproduce manually with `python3 -m qutebrowser -T -s tabs.tree_tabs true -s tabs.position left ":open about:blank?one" ":open -tr about:blank?two" ":open -tr about:blank?three" ":open -t about:blank?four" ":tab-focus 2" ":tree-tab-toggle-hide" ":cmd-later 300 session-save asdf" ":cmd-later 350 session-load asdf"` then look how one window looks like it has less tabs than the other one!