### PR TITLE
Add more end2end tests for tree tabs feature

### DIFF
--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -204,6 +204,7 @@ def open_path(quteproc, server, path, default_kwargs: dict = None):
     suffixes = {
         "in a new tab": "new_tab",
         "in a new related tab": ("new_tab", "related_tab"),
+        "in a new sibling tab": ("new_tab", "sibling_tab"),
         "in a new related background tab": ("new_bg_tab", "related_tab"),
         "in a new background tab": "new_bg_tab",
         "in a new window": "new_window",

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -9,6 +9,18 @@ Feature: Tree tab management
         And I clean up open tabs
         And I clear the log
 
+    Scenario: Closing a tab promotes the first child in its place
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I open data/numbers/4.txt in a new tab
+        And I run :tab-focus 1
+        And I run :tab-close
+        Then the following tabs should be open:
+            - data/numbers/2.txt
+              - data/numbers/3.txt
+            - data/numbers/4.txt
+
     Scenario: :tab-close --recursive
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -21,6 +21,16 @@ Feature: Tree tab management
               - data/numbers/3.txt
             - data/numbers/4.txt
 
+    Scenario: Focus a parent tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/3.txt in a new related tab
+        And I open data/numbers/2.txt in a new sibling tab
+        And I run :tab-focus parent
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+              - data/numbers/2.txt
+              - data/numbers/3.txt
+
     Scenario: :tab-close --recursive
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -9,6 +9,16 @@ Feature: Tree tab management
         And I clean up open tabs
         And I clear the log
 
+    Scenario: Focus previous sibling tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-prev --sibling
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+              - data/numbers/2.txt
+            - data/numbers/3.txt
+
     Scenario: Focus next sibling tab
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -69,6 +69,19 @@ Feature: Tree tab management
             - data/numbers/1.txt
               - data/numbers/2.txt (active)
 
+    Scenario: Move a tab to the given index
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new tab
+        And I open data/numbers/4.txt in a new related tab
+        And I run :tab-focus 3
+        And I run :tab-move 1
+        Then the following tabs should be open:
+            - data/numbers/3.txt
+              - data/numbers/4.txt
+            - data/numbers/1.txt
+              - data/numbers/2.txt
+
     Scenario: Collapse a subtree
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -9,6 +9,17 @@ Feature: Tree tab management
         And I clean up open tabs
         And I clear the log
 
+    Scenario: Focus next sibling tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new tab
+        And I run :tab-focus 1
+        And I run :tab-next --sibling
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+              - data/numbers/2.txt
+            - data/numbers/3.txt (active)
+
     Scenario: Closing a tab promotes the first child in its place
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -658,17 +658,19 @@ class QuteProc(testprocess.Process):
         self.set_setting(opt, old_value)
 
     def open_path(self, path, *, new_tab=False, new_bg_tab=False,
-                  related_tab=False, new_window=False, private=False,
-                  as_url=False, port=None, https=False, wait=True):
+                  related_tab=False, sibling_tab=False, new_window=False,
+                  private=False, as_url=False, port=None, https=False,
+                  wait=True):
         """Open the given path on the local webserver in qutebrowser."""
         url = self.path_to_url(path, port=port, https=https)
         self.open_url(url, new_tab=new_tab, new_bg_tab=new_bg_tab,
-                      related_tab=related_tab, new_window=new_window,
-                      private=private, as_url=as_url, wait=wait)
+                      related_tab=related_tab, sibling_tab=sibling_tab,
+                      new_window=new_window, private=private, as_url=as_url,
+                      wait=wait)
 
     def open_url(self, url, *, new_tab=False, new_bg_tab=False,
-                 related_tab=False, new_window=False, private=False,
-                 as_url=False, wait=True):
+                 related_tab=False, sibling_tab=False, new_window=False,
+                 private=False, as_url=False, wait=True):
         """Open the given url in qutebrowser."""
         if sum(1 for opt in [new_tab, new_bg_tab, new_window, private, as_url]
                if opt) > 1:
@@ -680,6 +682,8 @@ class QuteProc(testprocess.Process):
         elif new_tab:
             if related_tab:
                 line = self.send_cmd(':open -t -r ' + url)
+            elif sibling_tab:
+                line = self.send_cmd(':open -t -S ' + url)
             else:
                 line = self.send_cmd(':open -t ' + url)
         elif new_bg_tab:


### PR DESCRIPTION
I simply translated [parts of @toofar's superb documentation](https://github.com/qutebrowser/qutebrowser/blob/160e9f274f252bd54a6c03f369b0de6e0ab8c98d/doc/treetabs.md?plain=1#L60-L66) into end2end tests.

Covering
* `:tab-close` without `--recursive`
* `:tab-next --sibling`
* `:tab-prev --sibling`
* `:tab-focus parent`
* `:tab-move <index>`

---

Fixes part of #8072
