### PR TITLE
Show chromium security patch version in :version

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -24,6 +24,10 @@ Added
 
 - When qutebrowser receives a SIGHUP it will now reload any config.py file
   in use (same as the `:config-source` command does). (#8108)
+- The Chromium security patch version is now shown in the backend string in
+  --version and :version. This reflects the latest Chromium version that
+  security fixes have been backported to the base QtWebEngine version from.
+  (#7187)
 
 Changed
 ~~~~~~~

--- a/tests/unit/utils/test_version.py
+++ b/tests/unit/utils/test_version.py
@@ -915,6 +915,17 @@ class TestWebEngineVersions:
                 source='faked'),
             "QtWebEngine 5.15.2, based on Chromium 87.0.4280.144 (from faked)",
         ),
+        (
+            version.WebEngineVersions(
+                webengine=utils.VersionNumber(5, 15, 2),
+                chromium='87.0.4280.144',
+                chromium_security='9000.1',
+                source='faked'),
+            (
+                "QtWebEngine 5.15.2, based on Chromium 87.0.4280.144, with security "
+                "patches up to 9000.1 (plus any distribution patches) (from faked)"
+            ),
+        ),
     ])
     def test_str(self, version, expected):
         assert str(version) == expected
@@ -1023,6 +1034,20 @@ class TestWebEngineVersions:
         real = webenginesettings.parsed_user_agent.upstream_browser_version
 
         assert inferred == real
+
+    def test_real_chromium_security_version(self, qapp):
+        """Check the API for reading the chromium security patch version."""
+        try:
+            from qutebrowser.qt.webenginecore import (
+                qWebEngineChromiumVersion,
+                qWebEngineChromiumSecurityPatchVersion,
+            )
+        except ImportError:
+            pytest.skip("Requires QtWebEngine 6.3+")
+
+        base = utils.VersionNumber.parse(qWebEngineChromiumVersion())
+        security = utils.VersionNumber.parse(qWebEngineChromiumSecurityPatchVersion())
+        assert security >= base
 
 
 class FakeQSslSocket:


### PR DESCRIPTION
Webengine added a getter for their chromium patch level back in Qt 6.3, since they backport security fixes from chromium in the periods between doing major chromium feature upgrades. The default simplebrowser start page (chrome://qt/) inspired me to add it to our version page:

![image](https://github.com/qutebrowser/qutebrowser/assets/7419144/6bfcfeac-0ec2-4368-8d95-5eced8b781bf)

![image](https://github.com/qutebrowser/qutebrowser/assets/7419144/a94b6f5f-c675-46bd-9d3e-953e874d6f80)

![image](https://github.com/qutebrowser/qutebrowser/assets/7419144/138600c5-9842-4780-8dec-cfcb111b1d07)

It's pulled from a hardcoded string in the webengine source `src/core/web_engine_context.cpp` that's manually updated when they backport something.

The "(plus any distribution patches)" bit in there is because it was pointed out that some distributions backport their own security patches or even use webengine from a branch when the hardcoded string only gets updated at release time, despite patches being backported in the meantime. As discussed in the linked issue.

Closes: #7187

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
