### PR TITLE
Add Promise.withResolvers polyfill for latest PDF.js version

### DIFF
--- a/.github/workflows/bleeding.yml
+++ b/.github/workflows/bleeding.yml
@@ -37,6 +37,9 @@ jobs:
           persist-credentials: false
       - name: Set up problem matchers
         run: "python scripts/dev/ci/problemmatchers.py py3 ${{ runner.temp }}"
+      - name: Upgrade 3rd party assets
+        run: "tox exec -e ${{ matrix.testenv }} -- python scripts/dev/update_3rdparty.py --gh-token ${{ secrets.GITHUB_TOKEN }}"
+        if: "endsWith(matrix.image, '-qt6')"
       - name: Run tox
         run: dbus-run-session tox -e ${{ matrix.testenv }}
   irc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -214,6 +214,9 @@ jobs:
         run: |
             python -m pip install -U pip
             python -m pip install -U -r misc/requirements/requirements-tox.txt
+      - name: Upgrade 3rd party assets
+        run: "tox exec -e ${{ matrix.testenv }} -- python scripts/dev/update_3rdparty.py --gh-token ${{ secrets.GITHUB_TOKEN }}"
+        if: "startsWith(matrix.os, 'windows-')"
       - name: "Run ${{ matrix.testenv }}"
         run: "dbus-run-session -- tox -e ${{ matrix.testenv }} -- ${{ matrix.args }}"
         if: "startsWith(matrix.os, 'ubuntu-')"

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -57,6 +57,8 @@ Fixed
   when we went to clear that, probably when leaving a mode. (#7901)
 - Worked around a minor issue around QTimers on Windows where the IPC server
   could close the socket early. (#8191)
+- The latest PDF.js release (v4.2.67) is now supported when backed by
+  QtWebEngine 6.6+ (#8170)
 
 [[v3.1.1]]
 v3.1.1 (unreleased)

--- a/qutebrowser/utils/version.py
+++ b/qutebrowser/utils/version.py
@@ -486,7 +486,7 @@ def _pdfjs_version() -> str:
     else:
         pdfjs_file = pdfjs_file.decode('utf-8')
         version_re = re.compile(
-            r"^ *(PDFJS\.version|(var|const) pdfjsVersion) = '(?P<version>[^']+)';$",
+            r"^ *(PDFJS\.version|(var|const) pdfjsVersion) = ('|\")(?P<version>[^']+)('|\");$",
             re.MULTILINE)
 
         match = version_re.search(pdfjs_file)

--- a/scripts/dev/ci/docker/Dockerfile.j2
+++ b/scripts/dev/ci/docker/Dockerfile.j2
@@ -16,6 +16,7 @@ RUN pacman -Su --noconfirm \
       qt6-declarative \
       {% if webengine %}
         qt6-webengine python-pyqt6-webengine \
+        pdfjs \
       {% else %}{{ 1/0 }}{% endif %}
       python-pyqt6 \
     {% else %}

--- a/scripts/dev/update_3rdparty.py
+++ b/scripts/dev/update_3rdparty.py
@@ -17,8 +17,6 @@ import sys
 
 sys.path.insert(
     0, os.path.join(os.path.dirname(__file__), os.pardir, os.pardir))
-from scripts import dictcli
-from qutebrowser.config import configdata
 
 
 def download_nsis_plugins():
@@ -160,6 +158,8 @@ def update_ace():
 
 def test_dicts():
     """Test available dictionaries."""
+    from scripts import dictcli
+    from qutebrowser.config import configdata
     configdata.init()
     for lang in dictcli.available_languages():
         print('Testing dictionary {}... '.format(lang.code), end='')


### PR DESCRIPTION
* Add polyfill of `Promise.withResolvers` for recent versions of PDF.js.
* Enable some existing PDF.js related tests (in qutescheme.feature) in just a couple of CI environments.
* Fix a unit test for newer PDF.js versions (oh, actually it was the real version parsing code, that the unit test was testing)
* Adapt `update_3rdparty.py` to only import stuff from qutebrowser if needed, due to some weirdness trying to run it in the bleeding edge test setup

I tested the docker container locally and the relevant tests passed.

Closes: #8170