### PR TITLE
Handle no selectionmodel on clear selection

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -53,6 +53,8 @@ Fixed
   Python upgrade) should now not crash anymore.
 - When the QtWebEngine resources dir couldn't be found, qutebrowser now doesn't
   crash anymore (but QtWebEngine still might).
+- Fixed a rare crash in the completion widget when there was no selection model
+  when we went to clear that, probably when leaving a mode. (#7901)
 
 [[v3.1.1]]
 v3.1.1 (unreleased)

--- a/qutebrowser/completion/completionwidget.py
+++ b/qutebrowser/completion/completionwidget.py
@@ -414,7 +414,7 @@ class CompletionView(QTreeView):
     def on_clear_completion_selection(self):
         """Clear the selection model when an item is activated."""
         self.hide()
-        selmod = self._selection_model()
+        selmod = self.selectionModel()
         if selmod is not None:
             selmod.clearSelection()
             selmod.clearCurrentIndex()

--- a/tests/unit/completion/test_completionwidget.py
+++ b/tests/unit/completion/test_completionwidget.py
@@ -7,7 +7,7 @@
 from unittest import mock
 
 import pytest
-from qutebrowser.qt.core import QRect
+from qutebrowser.qt.core import QRect, QItemSelectionModel
 
 from qutebrowser.completion import completionwidget
 from qutebrowser.completion.models import completionmodel, listcategory
@@ -283,6 +283,23 @@ def test_completion_show(show, rows, quick_complete, completionview, model,
     completionview.set_model(None)
     completionview.completion_item_focus('next')
     assert not completionview.isVisible()
+
+
+def test_completion_selection_clear_no_model(completionview):
+    completionview.show()
+    completionview.on_clear_completion_selection()
+    assert completionview.isVisible() is False
+
+
+def test_completion_selection_clear_with_model(completionview, mocker):
+    selmod = mock.Mock(spec=QItemSelectionModel)
+    mocker.patch.object(completionview, "selectionModel", return_value=selmod)
+    completionview.show()
+    completionview.on_clear_completion_selection()
+
+    assert completionview.isVisible() is False
+    selmod.clearSelection.assert_called_once()
+    selmod.clearCurrentIndex.assert_called_once()
 
 
 def test_completion_item_del(completionview, model):


### PR DESCRIPTION
* Change `on_clear_completion_selection()` back to call the Qt getter instead of our one that does an `assert not None` check, it already handles None being returned fine
* Add a half-hearted unit test (which was failing previously because of the assertion error)

I didn't put much effort into reproducing it beyond manually hammering the completion in a temp basedir (possibly if the completion was slower because of more items it would be easier to reproduce). That commit history was pretty clear, we've always handled this situation (whatever it is) until adapting to type hints recently.
An alternate implementation is adding an `allow_none` or similar kwarg to our getter.

Fixes: https://github.com/qutebrowser/qutebrowser/issues/7901