### PR TITLE
Workaround IPC connection closing due to misfiring QTimers on Windows

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -240,6 +240,9 @@ disallow_untyped_defs = False
 [mypy-qutebrowser.misc.httpclient]
 disallow_untyped_defs = False
 
+[mypy-qutebrowser.misc.ipc]
+disallow_untyped_defs = False
+
 [mypy-qutebrowser.misc.keyhintwidget]
 disallow_untyped_defs = False
 
@@ -263,7 +266,6 @@ disallow_untyped_defs = False
 
 [mypy-qutebrowser.misc.split]
 disallow_untyped_defs = False
-
 
 [mypy-qutebrowser.qutebrowser]
 disallow_untyped_defs = False

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -240,9 +240,6 @@ disallow_untyped_defs = False
 [mypy-qutebrowser.misc.httpclient]
 disallow_untyped_defs = False
 
-[mypy-qutebrowser.misc.ipc]
-disallow_untyped_defs = False
-
 [mypy-qutebrowser.misc.keyhintwidget]
 disallow_untyped_defs = False
 
@@ -266,6 +263,7 @@ disallow_untyped_defs = False
 
 [mypy-qutebrowser.misc.split]
 disallow_untyped_defs = False
+
 
 [mypy-qutebrowser.qutebrowser]
 disallow_untyped_defs = False

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -102,6 +102,8 @@ Fixed
   evident on Qt 6.6.0. (#7489)
 - The `colors.webpage.darkmode.threshold.foreground` setting (`.text` in older
   versions) now works correctly with Qt 6.4+.
+- Worked around a minor issue around QTimers on Windows where the IPC server
+  could close the socket early. (#8191)
 
 
 [[v3.0.2]]

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -12,7 +12,7 @@ import re
 import html as html_utils
 from typing import cast, Union, Optional
 
-from qutebrowser.qt.core import (pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QTimer, QUrl,
+from qutebrowser.qt.core import (pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QUrl,
                           QObject, QByteArray)
 from qutebrowser.qt.network import QAuthenticator
 from qutebrowser.qt.webenginecore import QWebEnginePage, QWebEngineScript, QWebEngineHistory

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -816,7 +816,7 @@ class WebEngineAudio(browsertab.AbstractAudio):
         # Implements the intended two-second delay specified at
         # https://doc.qt.io/archives/qt-5.14/qwebenginepage.html#recentlyAudibleChanged
         delay_ms = 2000
-        self._silence_timer = QTimer(self)
+        self._silence_timer = usertypes.Timer(self)
         self._silence_timer.setSingleShot(True)
         self._silence_timer.setInterval(delay_ms)
 

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -7,7 +7,7 @@
 import dataclasses
 from typing import TYPE_CHECKING
 
-from qutebrowser.qt.core import pyqtSlot, QObject, QTimer
+from qutebrowser.qt.core import pyqtSlot, QObject
 
 from qutebrowser.config import config
 from qutebrowser.commands import parser, cmdexc

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -12,7 +12,7 @@ from qutebrowser.qt.core import pyqtSlot, QObject, QTimer
 from qutebrowser.config import config
 from qutebrowser.commands import parser, cmdexc
 from qutebrowser.misc import objects, split
-from qutebrowser.utils import log, utils, debug, objreg
+from qutebrowser.utils import log, utils, debug, objreg, usertypes
 from qutebrowser.completion.models import miscmodels
 from qutebrowser.completion import completionwidget
 if TYPE_CHECKING:
@@ -49,7 +49,7 @@ class Completer(QObject):
         super().__init__(parent)
         self._cmd = cmd
         self._win_id = win_id
-        self._timer = QTimer()
+        self._timer = usertypes.Timer()
         self._timer.setSingleShot(True)
         self._timer.setInterval(0)
         self._timer.timeout.connect(self._update_completion)

--- a/qutebrowser/mainwindow/messageview.py
+++ b/qutebrowser/mainwindow/messageview.py
@@ -101,7 +101,7 @@ class MessageView(QWidget):
         self._vbox.setSpacing(0)
         self.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
 
-        self._clear_timer = QTimer()
+        self._clear_timer = usertypes.Timer()
         self._clear_timer.timeout.connect(self.clear_messages)
         config.instance.changed.connect(self._set_clear_timer_interval)
 

--- a/qutebrowser/mainwindow/messageview.py
+++ b/qutebrowser/mainwindow/messageview.py
@@ -6,7 +6,7 @@
 
 from typing import MutableSequence, Optional
 
-from qutebrowser.qt.core import pyqtSlot, pyqtSignal, QTimer, Qt
+from qutebrowser.qt.core import pyqtSlot, pyqtSignal, Qt
 from qutebrowser.qt.widgets import QWidget, QVBoxLayout, QLabel, QSizePolicy
 
 from qutebrowser.config import config, stylesheet

--- a/qutebrowser/mainwindow/statusbar/clock.py
+++ b/qutebrowser/mainwindow/statusbar/clock.py
@@ -5,7 +5,7 @@
 """Clock displayed in the statusbar."""
 from datetime import datetime
 
-from qutebrowser.qt.core import Qt, QTimer
+from qutebrowser.qt.core import Qt
 
 from qutebrowser.mainwindow.statusbar import textbase
 from qutebrowser.utils import usertypes

--- a/qutebrowser/mainwindow/statusbar/clock.py
+++ b/qutebrowser/mainwindow/statusbar/clock.py
@@ -8,6 +8,7 @@ from datetime import datetime
 from qutebrowser.qt.core import Qt, QTimer
 
 from qutebrowser.mainwindow.statusbar import textbase
+from qutebrowser.utils import usertypes
 
 
 class Clock(textbase.TextBase):
@@ -20,7 +21,7 @@ class Clock(textbase.TextBase):
         super().__init__(parent, elidemode=Qt.TextElideMode.ElideNone)
         self.format = ""
 
-        self.timer = QTimer(self)
+        self.timer = usertypes.Timer(self)
         self.timer.timeout.connect(self._show_time)
 
     def _show_time(self):

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -398,7 +398,7 @@ class TabBar(QTabBar):
         self.setStyle(self._our_style)
         self.setFocusPolicy(Qt.FocusPolicy.NoFocus)
         self.vertical = False
-        self._auto_hide_timer = QTimer()
+        self._auto_hide_timer = usertypes.Timer()
         self._auto_hide_timer.setSingleShot(True)
         self._auto_hide_timer.timeout.connect(self.maybe_hide)
         self._on_show_switching_delay_changed()

--- a/qutebrowser/misc/httpclient.py
+++ b/qutebrowser/misc/httpclient.py
@@ -12,7 +12,7 @@ from qutebrowser.qt.core import pyqtSignal, QObject, QTimer
 from qutebrowser.qt.network import (QNetworkAccessManager, QNetworkRequest,
                              QNetworkReply)
 
-from qutebrowser.utils import qtlog
+from qutebrowser.utils import qtlog, usertypes
 
 
 class HTTPRequest(QNetworkRequest):
@@ -85,7 +85,7 @@ class HTTPClient(QObject):
         if reply.isFinished():
             self.on_reply_finished(reply)
         else:
-            timer = QTimer(self)
+            timer = usertypes.Timer(self)
             timer.setInterval(10000)
             timer.timeout.connect(reply.abort)
             timer.start()

--- a/qutebrowser/misc/ipc.py
+++ b/qutebrowser/misc/ipc.py
@@ -168,7 +168,6 @@ class IPCServer(QObject):
         self._timer = usertypes.Timer(self, 'ipc-timeout')
         self._timer.setInterval(READ_TIMEOUT)
         self._timer.timeout.connect(self.on_timeout)
-        self._timer_start_time = None
 
         if utils.is_windows:  # pragma: no cover
             self._atime_timer = None
@@ -262,7 +261,6 @@ class IPCServer(QObject):
         log.ipc.debug("Client connected (socket {}).".format(self._socket_id))
         self._socket = socket
         self._timer.start()
-        self._timer_start_time = time.monotonic()
         socket.readyRead.connect(self.on_ready_read)
         if socket.canReadLine():
             log.ipc.debug("We can read a line immediately.")
@@ -395,20 +393,13 @@ class IPCServer(QObject):
 
         if self._socket is not None:
             self._timer.start()
-            self._timer_start_time = time.monotonic()
 
     @pyqtSlot()
     def on_timeout(self):
         """Cancel the current connection if it was idle for too long."""
         assert self._socket is not None
-        assert self._timer_start_time is not None
-        if (
-            time.monotonic() - self._timer_start_time < READ_TIMEOUT / 1000 / 10
-            and qtutils.version_check("6.7.0", exact=True, compiled=False)
-            and utils.is_windows
-        ):
-            # WORKAROUND for unknown Qt bug (?) where the timer triggers immediately
-            # https://github.com/qutebrowser/qutebrowser/issues/8191
+        if not self._timer.check_timeout_validity():
+            # WORKAROUND for https://bugreports.qt.io/browse/QTBUG-124496
             log.ipc.debug("Ignoring early on_timeout call")
             return
 

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -9,6 +9,7 @@ import operator
 import enum
 import time
 import dataclasses
+import logging
 from typing import Optional, Sequence, TypeVar, Union
 
 from qutebrowser.qt.core import pyqtSignal, pyqtSlot, QObject, QTimer
@@ -459,9 +460,15 @@ class Timer(QTimer):
     def _validity_check_handler(self) -> None:
         if not self.check_timeout_validity() and self._start_time is not None:
             elapsed = time.monotonic() - self._start_time
-            log.misc.warning(
-                f"Timer {self._name} (id {self.timerId()}) triggered too early: "
-                f"interval {self.interval()} but only {elapsed:.3f}s passed"
+            level = logging.WARNING
+            if utils.is_windows and self._name == "ipc-timeout":
+                level = logging.DEBUG
+            log.misc.log(
+                level,
+                (
+                    f"Timer {self._name} (id {self.timerId()}) triggered too early: "
+                    f"interval {self.interval()} but only {elapsed:.3f}s passed"
+                )
             )
 
     def check_timeout_validity(self) -> bool:

--- a/qutebrowser/utils/usertypes.py
+++ b/qutebrowser/utils/usertypes.py
@@ -461,9 +461,9 @@ class Timer(QTimer):
             # manual emission?
             return
         elapsed = time.monotonic() - self._start_time
-        if elapsed < self.interval() / 1000 / 2:
+        if elapsed < self.interval() / 1000 / 2 and self._name != "ipc-timeout":
             log.misc.warning(
-                f"Timer {self._name} (id {self.timerId()} triggered too early: "
+                f"Timer {self._name} (id {self.timerId()}) triggered too early: "
                 f"interval {self.interval()} but only {elapsed:.3f}s passed")
 
     def setInterval(self, msec: int) -> None:

--- a/scripts/dev/misc_checks.py
+++ b/scripts/dev/misc_checks.py
@@ -274,6 +274,10 @@ def check_spelling(args: argparse.Namespace) -> Optional[bool]:
             re.compile(r'qutebrowser is free software: you can redistribute'),
             "use 'SPDX-License-Identifier: GPL-3.0-or-later' instead",
         ),
+        (
+            re.compile(r'QTimer\(.*\)$'),
+            "use usertypes.Timer() instead of a plain QTimer",
+        ),
     ]
 
     # Files which should be ignored, e.g. because they come from another

--- a/tests/end2end/fixtures/webserver.py
+++ b/tests/end2end/fixtures/webserver.py
@@ -115,7 +115,7 @@ class ExpectedRequest:
 def is_ignored_webserver_message(line: str) -> bool:
     return testutils.pattern_match(
         pattern=(
-            "Client ('127.0.0.1', *) lost — peer dropped the TLS connection suddenly, "
+            "Client ('127.0.0.1', *) lost * peer dropped the TLS connection suddenly, "
             "during handshake: (1, '[SSL: SSLV3_ALERT_CERTIFICATE_UNKNOWN] * "
             "alert certificate unknown (_ssl.c:*)')"
         ),

--- a/tests/unit/completion/test_completer.py
+++ b/tests/unit/completion/test_completer.py
@@ -55,7 +55,7 @@ def completion_widget_stub():
 def completer_obj(qtbot, status_command_stub, config_stub, monkeypatch, stubs,
                   completion_widget_stub):
     """Create the completer used for testing."""
-    monkeypatch.setattr(completer, 'QTimer', stubs.InstaTimer)
+    monkeypatch.setattr(completer.usertypes, 'Timer', stubs.InstaTimer)
     config_stub.val.completion.show = 'auto'
     return completer.Completer(cmd=status_command_stub, win_id=0,
                                parent=completion_widget_stub)

--- a/tests/unit/misc/test_guiprocess.py
+++ b/tests/unit/misc/test_guiprocess.py
@@ -9,7 +9,7 @@ import logging
 import signal
 
 import pytest
-from qutebrowser.qt.core import QProcess, QUrl
+from qutebrowser.qt.core import QProcess, QUrl, Qt
 
 from qutebrowser.misc import guiprocess
 from qutebrowser.utils import usertypes, utils, version
@@ -534,6 +534,7 @@ def test_str(proc, py_proc):
 
 
 def test_cleanup(proc, py_proc, qtbot):
+    proc._cleanup_timer.setTimerType(Qt.TimerType.CoarseTimer)
     proc._cleanup_timer.setInterval(100)
 
     with qtbot.wait_signal(proc._cleanup_timer.timeout):

--- a/tests/unit/misc/test_ipc.py
+++ b/tests/unit/misc/test_ipc.py
@@ -404,7 +404,7 @@ class TestOnError:
         socket.setErrorString("Connection refused.")
 
         with pytest.raises(ipc.Error, match=r"Error while handling IPC "
-                           r"connection: Connection refused \(ConnectionRefusedError\)"):
+                           r"connection [0-9]: Connection refused \(ConnectionRefusedError\)"):
             ipc_server.on_error(QLocalSocket.LocalSocketError.ConnectionRefusedError)
 
 
@@ -439,7 +439,7 @@ class TestHandleConnection:
         ipc_server._server = FakeServer(socket)
 
         with pytest.raises(ipc.Error, match=r"Error while handling IPC "
-                           r"connection: Error string \(ConnectionError\)"):
+                           r"connection [0-9]: Error string \(ConnectionError\)"):
             ipc_server.handle_connection()
 
         assert "We got an error immediately." in caplog.messages

--- a/tests/unit/utils/test_qtutils.py
+++ b/tests/unit/utils/test_qtutils.py
@@ -1116,13 +1116,13 @@ class TestQObjRepr:
         assert qtutils.qobj_repr(obj) == expected
 
     def test_class_name(self):
-        obj = QTimer()
+        obj = QTimer()  # misc: ignore
         hidden = sip.cast(obj, QObject)
         expected = f"<{self._py_repr(hidden)}, className='QTimer'>"
         assert qtutils.qobj_repr(hidden) == expected
 
     def test_both(self):
-        obj = QTimer()
+        obj = QTimer()  # misc: ignore
         obj.setObjectName("Pomodoro")
         hidden = sip.cast(obj, QObject)
         expected = f"<{self._py_repr(hidden)}, objectName='Pomodoro', className='QTimer'>"

--- a/tests/unit/utils/usertypes/test_timer.py
+++ b/tests/unit/utils/usertypes/test_timer.py
@@ -4,6 +4,9 @@
 
 """Tests for Timer."""
 
+import logging
+import fnmatch
+
 import pytest
 from qutebrowser.qt.core import QObject
 
@@ -65,3 +68,63 @@ def test_timeout_set_interval(qtbot):
     with qtbot.wait_signal(t.timeout, timeout=3000):
         t.setInterval(200)
         t.start()
+
+
+@pytest.mark.parametrize(
+    "elapsed_ms,expected",
+    [
+        (0, False,),
+        (1, False,),
+        (600, True,),
+        (999, True,),
+        (1000, True,),
+    ],
+)
+def test_early_timeout_check(qtbot, mocker, elapsed_ms, expected):
+    time_mock = mocker.patch("time.monotonic", autospec=True)
+
+    t = usertypes.Timer()
+    t.setInterval(1000)  # anything long enough to not actually fire
+    time_mock.return_value = 0  # assigned to _start_time in start()
+    t.start()
+    time_mock.return_value = elapsed_ms / 1000  # used for `elapsed`
+
+    assert t.check_timeout_validity() is expected
+
+    t.stop()
+
+
+def test_early_timeout_handler(qtbot, mocker, caplog):
+    time_mock = mocker.patch("time.monotonic", autospec=True)
+
+    t = usertypes.Timer(name="t")
+    t.setInterval(3)
+    t.setSingleShot(True)
+    time_mock.return_value = 0
+    with caplog.at_level(logging.WARNING):
+        with qtbot.wait_signal(t.timeout, timeout=10):
+            t.start()
+            time_mock.return_value = 1 / 1000
+
+        assert len(caplog.messages) == 1
+        assert fnmatch.fnmatch(
+            caplog.messages[-1],
+            "Timer t (id *) triggered too early: interval 3 but only 0.001s passed",
+        )
+
+
+def test_early_manual_fire(qtbot, mocker, caplog):
+    """Same as above but start() never gets called."""
+    time_mock = mocker.patch("time.monotonic", autospec=True)
+
+    t = usertypes.Timer(name="t")
+    t.setInterval(3)
+    t.setSingleShot(True)
+    time_mock.return_value = 0
+    with caplog.at_level(logging.WARNING):
+        with qtbot.wait_signal(t.timeout, timeout=10):
+            t.timeout.emit()
+            time_mock.return_value = 1 / 1000
+
+        assert len(caplog.messages) == 0
+        assert t.check_timeout_validity()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->

I figured I would create a PR for visibility before merging. These are the changes discussed in #8191. I've dropped the changes to CI.yml but left the made-then-reverted changes to ipc.py, in case someone wants to find them again in the future.

This PR adds a sanity check for QTimers firing early do to a Qt but, and logs a warning if it sees that happening. It also adds code into the IPC server to avoid closing a connection early if that did happen, which we were seeing a lot in tests - not sure why, possibly because we are stopping and starting a timer a fair bit in there.

It also switches more places to use our usertypes.Timer subclass of QTimer, instead of QTimer directly, so that we can do the sanity check in more places and logs an incrementing ID from the IPC server so we can better tell sockets apart even if IDs get re-used.

Closes: #8191
