### PR TITLE
Extract widget enable/dislable logic from StatusBar

### DIFF
--- a/qutebrowser/mainwindow/statusbar/backforward.py
+++ b/qutebrowser/mainwindow/statusbar/backforward.py
@@ -5,14 +5,21 @@
 """Navigation (back/forward) indicator displayed in the statusbar."""
 
 from qutebrowser.mainwindow.statusbar import textbase
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 
 
-class Backforward(textbase.TextBase):
+class Backforward(StatusBarWidget, textbase.TextBase):
 
     """Shows navigation indicator (if you can go backward and/or forward)."""
 
     def __init__(self, parent=None):
         super().__init__(parent)
+        self.enabled = False
+
+    def enable(self):
+        self.enabled = True
+
+    def disable(self):
         self.enabled = False
 
     def on_tab_cur_url_changed(self, tabs):

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -7,6 +7,7 @@
 import enum
 import dataclasses
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSignal, pyqtProperty, pyqtSlot, Qt, QSize, QTimer
 from qutebrowser.qt.widgets import QWidget, QHBoxLayout, QStackedLayout, QSizePolicy
 
@@ -14,9 +15,7 @@ from qutebrowser.browser import browsertab
 from qutebrowser.config import config, stylesheet
 from qutebrowser.keyinput import modeman
 from qutebrowser.utils import usertypes, log, objreg, utils
-from qutebrowser.mainwindow.statusbar import (backforward, command, progress,
-                                              keystring, percentage, url,
-                                              tabindex, textbase, clock, searchmatch)
+from qutebrowser.mainwindow.statusbar import command, textbase, searchmatch
 
 
 @dataclasses.dataclass
@@ -181,14 +180,9 @@ class StatusBar(QWidget):
 
         self.search_match = searchmatch.SearchMatch()
 
-        self.url = url.UrlText()
-        self.percentage = percentage.Percentage()
-        self.backforward = backforward.Backforward()
-        self.tabindex = tabindex.TabIndex()
-        self.keystring = keystring.KeyString()
-        self.prog = progress.Progress(self)
-        self.clock = clock.Clock()
-        self._text_widgets = []
+        tab = self._current_tab()
+        self._widgets = [StatusBarWidget.from_config(segment, tab)
+                         for segment in config.val.statusbar.widgets]
         self._draw_widgets()
 
         config.instance.changed.connect(self._on_config_changed)
@@ -196,33 +190,6 @@ class StatusBar(QWidget):
 
     def __repr__(self):
         return utils.get_repr(self)
-
-    def _get_widget_from_config(self, key):
-        """Return the widget that fits with config string key."""
-        if key == 'url':
-            return self.url
-        elif key == 'scroll':
-            return self.percentage
-        elif key == 'scroll_raw':
-            return self.percentage
-        elif key == 'history':
-            return self.backforward
-        elif key == 'tabs':
-            return self.tabindex
-        elif key == 'keypress':
-            return self.keystring
-        elif key == 'progress':
-            return self.prog
-        elif key == 'search_match':
-            return self.search_match
-        elif key.startswith('text:'):
-            new_text_widget = textbase.TextBase()
-            self._text_widgets.append(new_text_widget)
-            return new_text_widget
-        elif key.startswith('clock:') or key == 'clock':
-            return self.clock
-        else:
-            raise utils.Unreachable(key)
 
     @pyqtSlot(str)
     def _on_config_changed(self, option):
@@ -237,46 +204,16 @@ class StatusBar(QWidget):
         """Draw statusbar widgets."""
         self._clear_widgets()
 
-        tab = self._current_tab()
-
-        # Read the list and set widgets accordingly
-        for segment in config.val.statusbar.widgets:
-            widget = self._get_widget_from_config(segment)
+        for widget in self._widgets:
             self._hbox.addWidget(widget)
-
-            if segment == 'scroll_raw':
-                widget.set_raw()
-            elif segment in ('history', 'progress'):
-                widget.enabled = True
-                if tab:
-                    widget.on_tab_changed(tab)
-
-                # Do not call .show() for these widgets. They are not always shown, and
-                # dynamically show/hide themselves in their on_tab_changed() methods.
-                continue
-            elif segment.startswith('text:'):
-                widget.setText(segment.split(':', maxsplit=1)[1])
-            elif segment.startswith('clock:') or segment == 'clock':
-                split_segment = segment.split(':', maxsplit=1)
-                if len(split_segment) == 2 and split_segment[1]:
-                    widget.format = split_segment[1]
-                else:
-                    widget.format = '%X'
-
-            widget.show()
+            widget.enable()
 
     def _clear_widgets(self):
         """Clear widgets before redrawing them."""
         # Start with widgets hidden and show them when needed
-        for widget in [self.url, self.percentage,
-                       self.backforward, self.tabindex,
-                       self.keystring, self.prog, self.clock, *self._text_widgets]:
-            assert isinstance(widget, QWidget)
-            if widget in [self.prog, self.backforward]:
-                widget.enabled = False  # type: ignore[attr-defined]
-            widget.hide()
+        for widget in self._widgets:
+            widget.disable()
             self._hbox.removeWidget(widget)
-        self._text_widgets.clear()
 
     @pyqtSlot()
     def maybe_hide(self):
@@ -416,10 +353,13 @@ class StatusBar(QWidget):
     @pyqtSlot(browsertab.AbstractTab)
     def on_tab_changed(self, tab):
         """Notify sub-widgets when the tab has been changed."""
-        self.url.on_tab_changed(tab)
-        self.prog.on_tab_changed(tab)
-        self.percentage.on_tab_changed(tab)
-        self.backforward.on_tab_changed(tab)
+        for widget in self._widgets:
+            try:
+                widget.on_tab_changed(tab)
+            except AttributeError:
+                # not all widgets have on_tab_changed
+                pass
+
         self.maybe_hide()
         assert tab.is_private == self._color_flags.private
 

--- a/qutebrowser/mainwindow/statusbar/clock.py
+++ b/qutebrowser/mainwindow/statusbar/clock.py
@@ -5,12 +5,13 @@
 """Clock displayed in the statusbar."""
 from datetime import datetime
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import Qt, QTimer
 
 from qutebrowser.mainwindow.statusbar import textbase
 
 
-class Clock(textbase.TextBase):
+class Clock(StatusBarWidget, textbase.TextBase):
 
     """Shows current time and date in the statusbar."""
 
@@ -22,6 +23,12 @@ class Clock(textbase.TextBase):
 
         self.timer = QTimer(self)
         self.timer.timeout.connect(self._show_time)
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
 
     def _show_time(self):
         """Set text to current time, using self.format as format-string."""

--- a/qutebrowser/mainwindow/statusbar/keystring.py
+++ b/qutebrowser/mainwindow/statusbar/keystring.py
@@ -4,15 +4,22 @@
 
 """Keychain string displayed in the statusbar."""
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSlot
 
 from qutebrowser.mainwindow.statusbar import textbase
 from qutebrowser.utils import usertypes
 
 
-class KeyString(textbase.TextBase):
+class KeyString(StatusBarWidget, textbase.TextBase):
 
     """Keychain string displayed in the statusbar."""
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
 
     @pyqtSlot(usertypes.KeyMode, str)
     def on_keystring_updated(self, _mode, keystr):

--- a/qutebrowser/mainwindow/statusbar/percentage.py
+++ b/qutebrowser/mainwindow/statusbar/percentage.py
@@ -4,6 +4,7 @@
 
 """Scroll percentage displayed in the statusbar."""
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSlot, Qt
 
 from qutebrowser.mainwindow.statusbar import textbase
@@ -11,7 +12,7 @@ from qutebrowser.misc import throttle
 from qutebrowser.utils import utils
 
 
-class Percentage(textbase.TextBase):
+class Percentage(StatusBarWidget, textbase.TextBase):
 
     """Reading percentage displayed in the statusbar."""
 
@@ -21,6 +22,12 @@ class Percentage(textbase.TextBase):
         self._strings = self._calc_strings()
         self._set_text = throttle.Throttle(self.setText, 100, parent=self)
         self.set_perc(0, 0)
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
 
     def set_raw(self):
         self._strings = self._calc_strings(raw=True)

--- a/qutebrowser/mainwindow/statusbar/progress.py
+++ b/qutebrowser/mainwindow/statusbar/progress.py
@@ -4,6 +4,7 @@
 
 """The progress bar in the statusbar."""
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSlot, QSize
 from qutebrowser.qt.widgets import QProgressBar, QSizePolicy
 
@@ -11,7 +12,7 @@ from qutebrowser.config import stylesheet
 from qutebrowser.utils import utils, usertypes
 
 
-class Progress(QProgressBar):
+class Progress(StatusBarWidget, QProgressBar):
 
     """The progress bar part of the status bar."""
 
@@ -35,6 +36,12 @@ class Progress(QProgressBar):
         self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
         self.setTextVisible(False)
         self.hide()
+
+    def enable(self):
+        self.enabled = True
+
+    def disable(self):
+        self.enabled = False
 
     def __repr__(self):
         return utils.get_repr(self, value=self.value())

--- a/qutebrowser/mainwindow/statusbar/searchmatch.py
+++ b/qutebrowser/mainwindow/statusbar/searchmatch.py
@@ -5,6 +5,7 @@
 """The search match indicator in the statusbar."""
 
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSlot
 
 from qutebrowser.browser import browsertab
@@ -12,9 +13,15 @@ from qutebrowser.mainwindow.statusbar import textbase
 from qutebrowser.utils import log
 
 
-class SearchMatch(textbase.TextBase):
+class SearchMatch(StatusBarWidget, textbase.TextBase):
 
     """The part of the statusbar that displays the search match counter."""
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
 
     @pyqtSlot(browsertab.SearchMatch)
     def set_match(self, search_match: browsertab.SearchMatch) -> None:

--- a/qutebrowser/mainwindow/statusbar/tabindex.py
+++ b/qutebrowser/mainwindow/statusbar/tabindex.py
@@ -4,14 +4,21 @@
 
 """TabIndex displayed in the statusbar."""
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSlot
 
 from qutebrowser.mainwindow.statusbar import textbase
 
 
-class TabIndex(textbase.TextBase):
+class TabIndex(StatusBarWidget, textbase.TextBase):
 
     """Shows current tab index and number of tabs in the statusbar."""
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
 
     @pyqtSlot(int, int)
     def on_tab_index_changed(self, current, count):

--- a/qutebrowser/mainwindow/statusbar/textbase.py
+++ b/qutebrowser/mainwindow/statusbar/textbase.py
@@ -11,7 +11,7 @@ from qutebrowser.qt.gui import QPainter
 from qutebrowser.utils import qtutils, utils
 
 
-class TextBase(QLabel):
+class TextBase(StatusBarWidget, QLabel):
 
     """A text in the statusbar.
 
@@ -30,6 +30,13 @@ class TextBase(QLabel):
         self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Minimum)
         self._elidemode = elidemode
         self._elided_text = ''
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
+        self.clear()
 
     def __repr__(self):
         return utils.get_repr(self, text=self.text())

--- a/qutebrowser/mainwindow/statusbar/url.py
+++ b/qutebrowser/mainwindow/statusbar/url.py
@@ -6,6 +6,7 @@
 
 import enum
 
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
 from qutebrowser.qt.core import pyqtSlot, pyqtProperty, QUrl
 
 from qutebrowser.mainwindow.statusbar import textbase
@@ -28,7 +29,7 @@ class UrlType(enum.Enum):
     normal = enum.auto()
 
 
-class UrlText(textbase.TextBase):
+class UrlText(StatusBarWidget, textbase.TextBase):
 
     """URL displayed in the statusbar.
 
@@ -75,6 +76,12 @@ class UrlText(textbase.TextBase):
         self._hover_url = None
         self._normal_url = None
         self._normal_url_type = UrlType.normal
+
+    def enable(self):
+        self.show()
+
+    def disable(self):
+        self.hide()
 
     @pyqtProperty(str)  # type: ignore[type-var]
     def urltype(self):

--- a/qutebrowser/mainwindow/statusbar/widget.py
+++ b/qutebrowser/mainwindow/statusbar/widget.py
@@ -1,4 +1,14 @@
 from abc import ABCMeta, ABC, abstractmethod
+from typing import Self
+from qutebrowser.browser.browsertab import AbstractTab
+from qutebrowser.mainwindow.statusbar.backforward import Backforward
+from qutebrowser.mainwindow.statusbar.clock import Clock
+from qutebrowser.mainwindow.statusbar.keystring import KeyString
+from qutebrowser.mainwindow.statusbar.percentage import Percentage
+from qutebrowser.mainwindow.statusbar.progress import Progress
+from qutebrowser.mainwindow.statusbar.searchmatch import SearchMatch
+from qutebrowser.mainwindow.statusbar.tabindex import TabIndex
+from qutebrowser.mainwindow.statusbar.textbase import TextBase
 from qutebrowser.qt.widgets import QWidget
 
 
@@ -9,6 +19,51 @@ class QABCMeta(ABCMeta, type(QWidget)):
 
 class StatusBarWidget(ABC, metaclass=QABCMeta):
     """Abstract base class for all status bar widgets"""
+
+    @classmethod
+    def from_config(cls, segment: str, tab: AbstractTab | None = None) -> Self:
+        if segment == 'scroll_raw':
+            widget = Percentage()
+            widget.set_raw()
+
+        elif segment.startswith('text:'):
+            widget = TextBase()
+            widget.setText(segment.split(':', maxsplit=1)[1])
+
+        elif segment.startswith('clock:') or segment == 'clock':
+            widget = Clock()
+            split_segment = segment.split(':', maxsplit=1)
+            if len(split_segment) == 2 and split_segment[1]:
+                widget.format = split_segment[1]
+            else:
+                widget.format = '%X'
+
+        elif segment == 'history':
+            widget = Backforward()
+            if tab:
+                widget.on_tab_changed(tab)
+
+        elif segment == 'progress':
+            widget = Progress()
+            if tab:
+                widget.on_tab_changed(tab)
+
+        elif segment == 'scroll':
+            widget = Percentage()
+
+        elif segment == 'tabs':
+            widget = TabIndex()
+
+        elif segment == 'keypress':
+            widget = KeyString()
+
+        elif segment == 'search_match':
+            widget = SearchMatch()
+
+        else:
+            raise ValueError(f"unknown config widget: {segment}")
+
+        return widget
 
     @abstractmethod
     def enable(self):

--- a/qutebrowser/mainwindow/statusbar/widget.py
+++ b/qutebrowser/mainwindow/statusbar/widget.py
@@ -1,0 +1,19 @@
+from abc import ABCMeta, ABC, abstractmethod
+from qutebrowser.qt.widgets import QWidget
+
+
+class QABCMeta(ABCMeta, type(QWidget)):
+    """Meta class that combines ABC and the Qt meta class"""
+    pass
+
+
+class StatusBarWidget(ABC, metaclass=QABCMeta):
+    """Abstract base class for all status bar widgets"""
+
+    @abstractmethod
+    def enable(self):
+        pass
+
+    @abstractmethod
+    def disable(self):
+        pass

--- a/tests/unit/mainwindow/statusbar/test_widget.py
+++ b/tests/unit/mainwindow/statusbar/test_widget.py
@@ -1,0 +1,33 @@
+from qutebrowser.mainwindow.statusbar.widget import StatusBarWidget
+
+import pytest
+
+
+class TestCreateWidget:
+    def test_scroll_raw(self, qtbot, config_stub):
+        segment = 'scroll_raw'
+        widget = StatusBarWidget.from_config(segment)
+
+        # Force immediate update of percentage widget
+        widget._set_text.set_delay(-1)
+        widget.set_perc(0, 50)
+
+        assert widget.text() == '[50]'
+
+    def test_text(self, qtbot, config_stub):
+        segment = 'text:some text'
+        widget = StatusBarWidget.from_config(segment)
+
+        assert widget.text() == 'some text'
+
+    @pytest.mark.parametrize(
+        "segment,format_",
+        [
+            ('clock:%H:%s', '%H:%s'),
+            ('clock', '%X'),
+        ]
+    )
+    def test_clock(self, segment, format_, qtbot, config_stub):
+        widget = StatusBarWidget.from_config(segment)
+
+        assert widget.format == format_


### PR DESCRIPTION
# Disclaimer
I haven't tested any of these changes (despite the ones covered by the added unit tests).
They are very drafty and shall only serve the purpose to gather some feedback before going all-in with this approach.
Watch out for rough edges!

---

Essentially this refactoring consists of two parts:
1. Some sort of factory to create widgets from `config.statusbar.widgets` (here `StatusBarWidget.from_config()`) encapsulating some special setup logic (e.g. `setText()` for `text:` widgets)
2. Handling the enable / disable logic (which can vary from widget to widget) by implementing `enable()` and `disable()` methods

I am a fan of ABCs to enforce interfaces. However, in this case this leads to repeating ourselves quite a bit with `self.show()` and `self.hide()`.

---

Relates to #7407