### PR TITLE
Fix tests after year 2036

### DIFF
--- a/tests/unit/browser/webkit/test_cookies.py
+++ b/tests/unit/browser/webkit/test_cookies.py
@@ -14,8 +14,8 @@ from qutebrowser.misc import lineparser, objects
 pytestmark = pytest.mark.usefixtures('data_tmpdir')
 
 
-COOKIE1 = b'foo1=bar; expires=Tue, 01-Jan-2036 08:00:01 GMT'
-COOKIE2 = b'foo2=bar; expires=Tue, 01-Jan-2036 08:00:01 GMT'
+COOKIE1 = b'foo1=bar; expires=Tue, 01-Jan-2999 08:00:01 GMT'
+COOKIE2 = b'foo2=bar; expires=Tue, 01-Jan-2999 08:00:01 GMT'
 SESSION_COOKIE = b'foo3=bar'
 EXPIRED_COOKIE = b'foo4=bar; expires=Sat, 01-Jan-2000 08:00:01 GMT'
 


### PR DESCRIPTION
Background:
As part of my work on reproducible builds for openSUSE, I check that software still gives identical build results in the future. The usual offset is +16 years, because that is how long I expect some software will be used in some places. This showed up failing tests in our package build. See https://reproducible-builds.org/ for why this matters.
