### PR TITLE
Debounce search-in-document

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -50,6 +50,16 @@ changelog_after_upgrade:
 ignore_case:
   renamed: search.ignore_case
 
+search.delay:
+  type:
+    name: Int
+    minval: 0
+    maxval: maxint
+  default: 400
+  desc: Delay (in milliseconds) between last keystroke when searching and the
+    search being submitted. Larger values produce fewer redundant searches but
+    also delay receiving search results.
+
 search.ignore_case:
   type: IgnoreCase
   default: smart


### PR DESCRIPTION
Closes #8134

Adds a new config entry `search.delay` which is an interval to wait since the last keystroke during search (`/`/`?`) before submitting the search. This helps the search experience on large documents with more constrained hardware as we don't end up searching the document for each prefix of the entered leading up to the full query. 

I selected 400ms based on a very unscientific source at the top of a web search suggesting the average typist types 200 characters per minute, or roughly a character every 333ms so by this (shaky) logic that gives a little buffer to ensure an average typist can complete their search query before a search is executed. Subjectively this delay is definitely perceptible, but not particularly sluggish feeling. I'm happy to change it to whatever seems reasonable, maybe the strongest argument is for a value of 0 since that's effectively what it was previously.