### PR TITLE
Save screenshots when end2end tests fail

### DIFF
--- a/.github/workflows/bleeding.yml
+++ b/.github/workflows/bleeding.yml
@@ -42,6 +42,21 @@ jobs:
         if: "endsWith(matrix.image, '-qt6')"
       - name: Run tox
         run: dbus-run-session tox -e ${{ matrix.testenv }}
+      - name: Gather info
+        id: info
+        run: |
+            echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+            echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        if: failure()
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: "end2end-screenshots-${{ steps.info.outputs.date }}-${{ steps.info.outputs.sha_short }}-${{ matrix.image }}"
+          path: |
+            ${{ runner.temp }}/pytest-screenshots/*.png
+          if-no-files-found: ignore
+        if: failure()
   irc:
     timeout-minutes: 2
     continue-on-error: true

--- a/.github/workflows/bleeding.yml
+++ b/.github/workflows/bleeding.yml
@@ -27,6 +27,7 @@ jobs:
         PY_COLORS: "1"
         DOCKER: "${{ matrix.image }}"
         CI: true
+        TMPDIR: "${{ runner.temp }}"
       volumes:
         # Hardcoded because we can't use ${{ runner.temp }} here apparently.
         - /home/runner/work/_temp/:/home/runner/work/_temp/
@@ -54,7 +55,7 @@ jobs:
         with:
           name: "end2end-screenshots-${{ steps.info.outputs.date }}-${{ steps.info.outputs.sha_short }}-${{ matrix.image }}"
           path: |
-            ${{ runner.temp }}/pytest-screenshots/*.png
+            ${{ runner.temp }}/pytest-of-user/pytest-current/pytest-screenshots/*.png
           if-no-files-found: ignore
         if: failure()
   irc:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,21 @@ jobs:
         run: "python scripts/dev/ci/problemmatchers.py tests ${{ runner.temp }}"
       - name: Run tox
         run: "dbus-run-session -- tox -e ${{ matrix.testenv }}"
+      - name: Gather info
+        id: info
+        run: |
+            echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+            echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        if: failure()
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: "end2end-screenshots-${{ steps.info.outputs.date }}-${{ steps.info.outputs.sha_short }}-${{ matrix.image }}"
+          path: |
+            ${{ runner.temp }}/pytest-screenshots/*.png
+          if-no-files-found: ignore
+        if: failure()
 
   tests:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"
@@ -236,6 +251,21 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           name: "${{ matrix.testenv }}"
+      - name: Gather info
+        id: info
+        run: |
+            echo "date=$(date +'%Y-%m-%d')" >> "$GITHUB_OUTPUT"
+            echo "sha_short=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+        shell: bash
+        if: failure()
+      - name: Upload screenshots
+        uses: actions/upload-artifact@v4
+        with:
+          name: "end2end-screenshots-${{ steps.info.outputs.date }}-${{ steps.info.outputs.sha_short }}-${{ matrix.testenv }}-${{ matrix.os }}"
+          path: |
+            ${{ runner.temp }}/pytest-screenshots/*.png
+          if-no-files-found: ignore
+        if: failure()
 
   codeql:
     if: "!contains(github.event.head_commit.message, '[ci skip]')"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,7 @@ jobs:
         DOCKER: "${{ matrix.image }}"
         CI: true
         PYTEST_ADDOPTS: "--color=yes"
+        TMPDIR: "${{ runner.temp }}"
       volumes:
         # Hardcoded because we can't use ${{ runner.temp }} here apparently.
         - /home/runner/work/_temp/:/home/runner/work/_temp/
@@ -131,7 +132,7 @@ jobs:
         with:
           name: "end2end-screenshots-${{ steps.info.outputs.date }}-${{ steps.info.outputs.sha_short }}-${{ matrix.image }}"
           path: |
-            ${{ runner.temp }}/pytest-screenshots/*.png
+            ${{ runner.temp }}/pytest-of-user/pytest-current/pytest-screenshots/*.png
           if-no-files-found: ignore
         if: failure()
 
@@ -237,6 +238,8 @@ jobs:
       - name: Upgrade 3rd party assets
         run: "tox exec -e ${{ matrix.testenv }} -- python scripts/dev/update_3rdparty.py --gh-token ${{ secrets.GITHUB_TOKEN }}"
         if: "startsWith(matrix.os, 'windows-')"
+      - name: "Set TMPDIR for pytest"
+        run: 'echo "TMPDIR=${{ runner.temp }}" >> "$GITHUB_ENV"'
       - name: "Run ${{ matrix.testenv }}"
         run: "dbus-run-session -- tox -e ${{ matrix.testenv }} -- ${{ matrix.args }}"
         if: "startsWith(matrix.os, 'ubuntu-')"
@@ -263,7 +266,7 @@ jobs:
         with:
           name: "end2end-screenshots-${{ steps.info.outputs.date }}-${{ steps.info.outputs.sha_short }}-${{ matrix.testenv }}-${{ matrix.os }}"
           path: |
-            ${{ runner.temp }}/pytest-screenshots/*.png
+            ${{ runner.temp }}/pytest-of-runner/pytest-current/pytest-screenshots/*.png
           if-no-files-found: ignore
         if: failure()
 

--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -30,6 +30,10 @@ Removed
 
 - Support for macOS 11 Big Sur is dropped. Binaries are now built on macOS 12
   Monterey and are unlikely to still run on older macOS versions.
+- Failed end2end tests will now save screenshots of the browser window when
+  run under xvfb (the default on linux). Screenshots will be under
+  `$TEMP/pytest-current/pytest-screenshots/` or attached to the GitHub actions
+  run as an artifact. (#7625)
 
 Changed
 ~~~~~~~

--- a/misc/requirements/requirements-tests-bleeding.txt
+++ b/misc/requirements/requirements-tests-bleeding.txt
@@ -20,6 +20,7 @@ git+https://github.com/pygments/pygments.git
 git+https://github.com/pytest-dev/pytest-repeat.git
 git+https://github.com/pytest-dev/pytest-cov.git
 git+https://github.com/The-Compiler/pytest-xvfb.git
+git+https://github.com/python-pillow/Pillow.git
 git+https://github.com/pytest-dev/pytest-xdist.git
 git+https://github.com/john-kurkowski/tldextract
 

--- a/misc/requirements/requirements-tests.txt
+++ b/misc/requirements/requirements-tests.txt
@@ -35,6 +35,7 @@ packaging==24.1
 parse==1.20.2
 parse-type==0.6.2
 platformdirs==4.2.2
+pillow==10.4.0
 pluggy==1.5.0
 py-cpuinfo==9.0.0
 Pygments==2.18.0

--- a/misc/requirements/requirements-tests.txt-raw
+++ b/misc/requirements/requirements-tests.txt-raw
@@ -25,6 +25,7 @@ pytest-cov
 # To avoid windows from popping up
 pytest-xvfb
 PyVirtualDisplay
+pillow
 # To run on multiple cores with -n
 pytest-xdist
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -85,3 +85,4 @@ filterwarnings =
     # Python 3.12: https://github.com/ionelmc/pytest-benchmark/issues/240 (fixed but not released)
     ignore:(datetime\.)?datetime\.utcnow\(\) is deprecated and scheduled for removal in a future version\. Use timezone-aware objects to represent datetimes in UTC. (datetime\.)?datetime\.now\(datetime\.UTC\)\.:DeprecationWarning:pytest_benchmark\.utils
 faulthandler_timeout = 90
+xvfb_colordepth = 24

--- a/qutebrowser/utils/standarddir.py
+++ b/qutebrowser/utils/standarddir.py
@@ -10,6 +10,7 @@ import sys
 import contextlib
 import enum
 import argparse
+import tempfile
 from typing import Iterator, Optional, Dict
 
 from qutebrowser.qt.core import QStandardPaths
@@ -311,14 +312,15 @@ def _create(path: str) -> None:
         0700. If the destination directory exists already the permissions
         should not be changed.
     """
-    if APPNAME == 'qute_test' and path.startswith('/home'):  # pragma: no cover
-        for k, v in os.environ.items():
-            if k == 'HOME' or k.startswith('XDG_'):
-                log.init.debug(f"{k} = {v}")
-        raise AssertionError(
-            "Trying to create directory inside /home during "
-            "tests, this should not happen."
-        )
+    if APPNAME == 'qute_test':
+        if path.startswith('/home') and not path.startswith(tempfile.gettempdir()):  # pragma: no cover
+            for k, v in os.environ.items():
+                if k == 'HOME' or k.startswith('XDG_'):
+                    log.init.debug(f"{k} = {v}")
+            raise AssertionError(
+                "Trying to create directory inside /home during "
+                "tests, this should not happen."
+            )
     os.makedirs(path, 0o700, exist_ok=True)
 
 

--- a/scripts/dev/changelog_urls.json
+++ b/scripts/dev/changelog_urls.json
@@ -168,5 +168,6 @@
   "mdurl": "https://github.com/executablebooks/mdurl/commits/master",
   "blinker": "https://blinker.readthedocs.io/en/stable/#changes",
   "exceptiongroup": "https://github.com/agronholm/exceptiongroup/blob/main/CHANGES.rst",
-  "nh3": "https://github.com/messense/nh3/commits/main"
+  "nh3": "https://github.com/messense/nh3/commits/main",
+  "pillow": "https://github.com/python-pillow/Pillow/blob/main/CHANGES.rst"
 }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -399,5 +399,3 @@ def pytest_terminal_summary(terminalreporter):
         terminalreporter.ensure_newline()
         screenshot_dir = screenshots[0].parent
         terminalreporter.section(f"End2end screenshots available in: {screenshot_dir}", sep="-", blue=True, bold=True)
-        for screenshot in screenshots:
-            terminalreporter.line(screenshot.parts[-1])

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -18,10 +18,15 @@ from qutebrowser.qt.core import PYQT_VERSION, QCoreApplication
 pytest.register_assert_rewrite('end2end.fixtures')
 
 # pylint: disable=unused-import
+# Import fixtures that the bdd tests rely on.
 from end2end.fixtures.notificationserver import notification_server
 from end2end.fixtures.webserver import server, server_per_test, server2, ssl_server
-from end2end.fixtures.quteprocess import (quteproc_process, quteproc,
-                                          quteproc_new)
+from end2end.fixtures.quteprocess import (
+    quteproc_process, quteproc,
+    quteproc_new,
+    screenshot_dir,
+    take_x11_screenshot,
+)
 from end2end.fixtures.testprocess import pytest_runtest_makereport
 # pylint: enable=unused-import
 from qutebrowser.utils import qtutils, utils, version

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -415,7 +415,8 @@ class QuteProc(testprocess.Process):
                 '--debug-flag', 'werror',
                 '--debug-flag', 'test-notification-service',
                 '--debug-flag', 'caret',
-                '--qt-flag', 'disable-features=PaintHoldingCrossOrigin']
+                '--qt-flag', 'disable-features=PaintHoldingCrossOrigin',
+                '--qt-arg', 'geometry', '800x600+0+0']
 
         if self.request.config.webengine and testutils.disable_seccomp_bpf_sandbox():
             args += testutils.DISABLE_SECCOMP_BPF_ARGS

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -932,7 +932,7 @@ def screenshot_dir(request, tmp_path_factory):
 
 
 @pytest.fixture
-def take_x11_screenshot(request, screenshot_dir, xvfb):
+def take_x11_screenshot(request, screenshot_dir, record_property, xvfb):
     """Take a screenshot of the current pytest-xvfb display.
 
     Screenshots are saved to the location of the `screenshot_dir` fixture.
@@ -952,13 +952,10 @@ def take_x11_screenshot(request, screenshot_dir, xvfb):
         for char in bad_chars:
             fname = fname.replace(char, "_")
 
-        # TODO:
-        # 1. Log a "screenshot saved to ..." message so that people know where
-        #    to go look for them when running locally? Using pytest-print? Or
-        #    add an FYI to the report summary?
         fpath = screenshot_dir / fname
         img.save(fpath)
 
+        record_property("screenshot", str(fpath))
     return doit
 
 

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -943,16 +943,7 @@ def take_x11_screenshot(request, screenshot_dir, record_property, xvfb):
             return
 
         img = grab(xdisplay=f":{xvfb.display}")
-
-        current_test = request.node.nodeid
-        fname = f"{datetime.datetime.now().isoformat()}-{current_test.replace('/', '_')}.png"
-        # upload-artifacts says it doesn't allow these characters if it sees
-        # one of them.
-        bad_chars = '":<>|*?\r\n'
-        for char in bad_chars:
-            fname = fname.replace(char, "_")
-
-        fpath = screenshot_dir / fname
+        fpath = screenshot_dir / f"{request.node.name}.png"
         img.save(fpath)
 
         record_property("screenshot", str(fpath))

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ passenv =
     QT_QUICK_BACKEND
     FORCE_COLOR
     DBUS_SESSION_BUS_ADDRESS
+    RUNNER_TEMP
     HYPOTHESIS_EXAMPLES_DIR
 basepython =
     py: {env:PYTHON:python3}


### PR DESCRIPTION
* Takes a screen capture of the XVFB screen when an e2e test fails
* It won't take any if you aren't using xvfb
* On local runs it'll put the screenshots in $TEMP/pytest-current/pytest-screenshots/
* On GitHub actions it'll attach any screenshots as run artifacts in a zip file
* Handles multiple test workers running in parallel (eg they don't clobber the output dir)
* Only captures the frontmost window if multiple are open
* Will capture screenshots for tests that are rerun by https://github.com/pytest-dev/pytest-rerunfailures, which is not ideal because we don't get error logs for the failed-by-rerun tests

Example: <https://github.com/qutebrowser/qutebrowser/actions/runs/10537503218?pr=8243#:~:text=Produced%20during%20runtime>

![image](https://github.com/user-attachments/assets/538dd656-12bb-49af-a0b0-076d73a0eabb)