### PR TITLE
Add setting to disable Google Hangouts extension

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -19,6 +19,12 @@ breaking changes (such as renamed commands) can happen in minor releases.
 v3.3.0 (unreleased)
 -------------------
 
+Added
+~~~~~
+
+- Added the `qt.workarounds.disable_hangouts_extension` setting,
+  for disabling the Google Hangouts extension built into Chromium/QtWebEngine.
+
 Removed
 ~~~~~~~
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -302,6 +302,7 @@
 |<<qt.force_software_rendering,qt.force_software_rendering>>|Force software rendering for QtWebEngine.
 |<<qt.highdpi,qt.highdpi>>|Turn on Qt HighDPI scaling.
 |<<qt.workarounds.disable_accelerated_2d_canvas,qt.workarounds.disable_accelerated_2d_canvas>>|Disable accelerated 2d canvas to avoid graphical glitches.
+|<<qt.workarounds.disable_hangouts_extension,qt.workarounds.disable_hangouts_extension>>|Disable the Hangouts extension.
 |<<qt.workarounds.locale,qt.workarounds.locale>>|Work around locale parsing issues in QtWebEngine 5.15.3.
 |<<qt.workarounds.remove_service_workers,qt.workarounds.remove_service_workers>>|Delete the QtWebEngine Service Worker directory on every start.
 |<<scrolling.bar,scrolling.bar>>|When/how to show the scrollbar.
@@ -3992,6 +3993,20 @@ Valid values:
  * +never+: Enable accelerated 2d canvas
 
 Default: +pass:[auto]+
+
+[[qt.workarounds.disable_hangouts_extension]]
+=== qt.workarounds.disable_hangouts_extension
+Disable the Hangouts extension.
+The Hangouts extension provides additional APIs for Google domains only.
+Hangouts has been replaced with Meet, which appears to work without this extension.
+
+This setting requires a restart.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Bool>>
+
+Default: +pass:[false]+
 
 [[qt.workarounds.locale]]
 === qt.workarounds.locale

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -3999,6 +3999,7 @@ Default: +pass:[auto]+
 Disable the Hangouts extension.
 The Hangouts extension provides additional APIs for Google domains only.
 Hangouts has been replaced with Meet, which appears to work without this extension.
+Note this setting gets ignored and the Hangouts extension is always disabled to avoid crashes on Qt 6.5.0 to 6.5.3 if dark mode is enabled, as well as on Qt 6.6.0.
 
 This setting requires a restart.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -404,6 +404,19 @@ qt.workarounds.disable_accelerated_2d_canvas:
 
     So far these glitches only occur on some Intel graphics devices.
 
+qt.workarounds.disable_hangouts_extension:
+  type: Bool
+  default: false
+  backend: QtWebEngine
+  restart: true
+  desc: >-
+    Disable the Hangouts extension.
+
+    The Hangouts extension provides additional APIs for Google domains only.
+
+    Hangouts has been replaced with Meet,
+    which appears to work without this extension.
+
 ## auto_save
 
 auto_save.interval:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -417,6 +417,10 @@ qt.workarounds.disable_hangouts_extension:
     Hangouts has been replaced with Meet,
     which appears to work without this extension.
 
+    Note this setting gets ignored and the Hangouts extension is always
+    disabled to avoid crashes on Qt 6.5.0 to 6.5.3 if dark mode is enabled,
+    as well as on Qt 6.6.0.
+
 ## auto_save
 
 auto_save.interval:

--- a/qutebrowser/misc/pakjoy.py
+++ b/qutebrowser/misc/pakjoy.py
@@ -208,6 +208,8 @@ def copy_webengine_resources() -> Optional[pathlib.Path]:
             and versions.webengine < utils.VersionNumber(6, 5, 3)
             and config.val.colors.webpage.darkmode.enabled
         )
+        # https://github.com/qutebrowser/qutebrowser/issues/8257
+        or config.val.qt.workarounds.disable_hangouts_extension
     ):
         # No patching needed
         return None

--- a/qutebrowser/misc/pakjoy.py
+++ b/qutebrowser/misc/pakjoy.py
@@ -38,8 +38,12 @@ from qutebrowser.utils import qtutils, standarddir, version, utils, log
 
 HANGOUTS_MARKER = b"// Extension ID: nkeimhogjdpnpccoofpliimaahmaaome"
 HANGOUTS_IDS = [
-    36197,  # QtWebEngine 6.5, as found by toofar
-    34897,  # QtWebEngine 6.4
+    41262,  # QtWebEngine 6.7
+    36197,  # QtWebEngine 6.6
+    34897,  # QtWebEngine 6.5
+    32707,  # QtWebEngine 6.4
+    27537,  # QtWebEngine 6.3
+    23607,  # QtWebEngine 6.2
 ]
 PAK_VERSION = 5
 RESOURCES_ENV_VAR = "QTWEBENGINE_RESOURCES_PATH"

--- a/qutebrowser/misc/pakjoy.py
+++ b/qutebrowser/misc/pakjoy.py
@@ -38,12 +38,16 @@ from qutebrowser.utils import qtutils, standarddir, version, utils, log
 
 HANGOUTS_MARKER = b"// Extension ID: nkeimhogjdpnpccoofpliimaahmaaome"
 HANGOUTS_IDS = [
+    # Linux
     41262,  # QtWebEngine 6.7
     36197,  # QtWebEngine 6.6
     34897,  # QtWebEngine 6.5
     32707,  # QtWebEngine 6.4
     27537,  # QtWebEngine 6.3
     23607,  # QtWebEngine 6.2
+
+    248,  # macOS
+    381,  # Windows
 ]
 PAK_VERSION = 5
 RESOURCES_ENV_VAR = "QTWEBENGINE_RESOURCES_PATH"

--- a/tests/unit/misc/test_pakjoy.py
+++ b/tests/unit/misc/test_pakjoy.py
@@ -195,6 +195,7 @@ def read_patched_manifest():
 class TestWithRealResourcesFile:
     """Tests that use the real pak file form the Qt installation."""
 
+    @pytest.mark.qt6_only
     def test_happy_path(self):
         # Go through the full patching processes with the real resources file from
         # the current installation. Make sure our replacement string is in it
@@ -254,6 +255,7 @@ class TestWithRealResourcesFile:
             "Not applying quirks. Expected location: "
         )
 
+    @pytest.mark.qt6_only
     def test_hardcoded_ids(self):
         """Make sure we hardcoded the currently valid ID.
 


### PR DESCRIPTION
Fixes #8257.

Hopefully, the extension can eventually be removed from QtWebEngine.

If not, and until then, this setting disables it, using the existing code in `pakjoy.py`.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
