### PR TITLE
Update link to match patterns documentation

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -31,7 +31,7 @@ patterns. The link:settings{outfilesuffix}[settings documentation] marks such
 settings with "This setting supports URL patterns.
 
 The syntax is based on Chromium's
-https://developer.chrome.com/docs/extensions/mv3/match_patterns/[URL pattern syntax].
+https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns/[URL pattern syntax].
 As an extension, the scheme and path can be left off as a short-hand syntax, so
 `example.com` is equivalent to `*://example.com/*`.
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -4874,6 +4874,6 @@ See the setting's valid values for more information on allowed values.
 |Url|A URL as a string.
 |UrlPattern|A match pattern for a URL.
 
-See https://developer.chrome.com/apps/match_patterns for the allowed syntax.
+See https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns for the allowed syntax.
 |VerticalPosition|The position of the download bar.
 |==============

--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -1984,8 +1984,9 @@ class UrlPattern(BaseType):
 
     """A match pattern for a URL.
 
-    See https://developer.chrome.com/apps/match_patterns for the allowed
-    syntax.
+    See
+    https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
+    for the allowed syntax.
     """
 
     def to_py(

--- a/qutebrowser/utils/urlmatch.py
+++ b/qutebrowser/utils/urlmatch.py
@@ -5,7 +5,7 @@
 """A Chromium-like URL matching pattern.
 
 See:
-https://developer.chrome.com/apps/match_patterns
+https://developer.chrome.com/docs/extensions/develop/concepts/match-patterns
 https://cs.chromium.org/chromium/src/extensions/common/url_pattern.cc
 https://cs.chromium.org/chromium/src/extensions/common/url_pattern.h
 


### PR DESCRIPTION
The link to match patterns is broken (404).
This pull request updates the link to point to a working location.
