### PR TITLE
Allow newlines in configuration values

### DIFF
--- a/qutebrowser/config/configtypes.py
+++ b/qutebrowser/config/configtypes.py
@@ -226,7 +226,7 @@ class BaseType:
     @functools.lru_cache(maxsize=2**9)
     def _basic_str_validation_cache(value: str) -> None:
         """Cache validation result to prevent looping over strings."""
-        if any(ord(c) < 32 or ord(c) == 0x7f for c in value):
+        if any(ord(c) != 10 and (ord(c) < 32 or ord(c) == 0x7f) for c in value):
             raise configexc.ValidationError(
                 value, "may not contain unprintable chars!")
 


### PR DESCRIPTION
There are valid uses for configuration strings with newline characters. For instance, to :open multiple urls in different tabs requires they be separated by a newline character.

This patch relaxes the restriction on valid configuration values to permit '\n'.