### PR TITLE
📝 Mention `kerberos` USE-flag on Gentoo

### DIFF
--- a/doc/install.asciidoc
+++ b/doc/install.asciidoc
@@ -162,6 +162,13 @@ need to turn off the `bindist` flag for `dev-qt/qtwebengine`.
 See the https://wiki.gentoo.org/wiki/Qutebrowser#USE_flags[Gentoo Wiki] for
 more information.
 
+To be able to use Kerberos authentication, you will need to turn on the
+`kerberos` USE-flag system-wide and re-emerge `dev-qt/qtwebengine` after that.
+
+See the
+https://wiki.gentoo.org/wiki/Qutebrowser#Kerberos_authentication_does_not_work[
+Troubleshooting section in Gentoo Wiki] for more information.
+
 On Void Linux
 -------------
 


### PR DESCRIPTION
This flag is vital for the allow-list configuration to be picked up. It should be set globally and `dev-qt/qtwebengine` should be recompiled after it's enabled.

Ref #8313.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
