### PR TITLE
Remove support for making Qt5 builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,7 +50,7 @@ jobs:
           python-version: '3.10'
       - uses: actions/setup-node@v4
         with:
-          node-version: '16.x'
+          node-version: '20.x'
         if: "matrix.testenv == 'eslint'"
       - name: Set up problem matchers
         run: "python scripts/dev/ci/problemmatchers.py ${{ matrix.testenv }} ${{ runner.temp }}"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,20 +15,6 @@ jobs:
       matrix:
         include:
           - os: macos-12
-            toxenv: build-release-qt5
-            name: qt5-macos
-          - os: windows-2019
-            toxenv: build-release-qt5
-            name: qt5-windows
-          - os: macos-12
-            args: --debug
-            toxenv: build-release-qt5
-            name: qt5-macos-debug
-          - os: windows-2019
-            args: --debug
-            toxenv: build-release-qt5
-            name: qt5-windows-debug
-          - os: macos-12
             toxenv: build-release
             name: macos-intel
           - os: macos-14

--- a/misc/nsis/install.nsh
+++ b/misc/nsis/install.nsh
@@ -435,29 +435,18 @@ Function .onInit
   ${If} ${RunningX64}
     ; https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa#remarks
     GetWinVer $R0 Major
-    !if "${QT5}" == "True"
-      IntCmpU $R0 6 0 _os_check_fail _os_check_pass
-      GetWinVer $R1 Minor
-      IntCmpU $R1 2 _os_check_pass _os_check_fail _os_check_pass
-    !else
-      IntCmpU $R0 10 0 _os_check_fail _os_check_pass
-      GetWinVer $R1 Build
-      ${If} $R1 >= 22000 ; Windows 11 21H2
-        Goto _os_check_pass
-      ${ElseIf} $R1 >= 14393 ; Windows 10 1607
-      ${AndIf} ${IsNativeAMD64} ; Windows 10 has no x86_64 emulation on arm64
-        Goto _os_check_pass
-      ${EndIf}
-    !endif
+    IntCmpU $R0 10 0 _os_check_fail _os_check_pass
+    GetWinVer $R1 Build
+    ${If} $R1 >= 22000 ; Windows 11 21H2
+      Goto _os_check_pass
+    ${ElseIf} $R1 >= 14393 ; Windows 10 1607
+    ${AndIf} ${IsNativeAMD64} ; Windows 10 has no x86_64 emulation on arm64
+      Goto _os_check_pass
+    ${EndIf}
   ${EndIf}
   _os_check_fail:
-  !if "${QT5}" == "True"
-    MessageBox MB_OK|MB_ICONSTOP "This version of ${PRODUCT_NAME} requires a 64-bit$\r$\n\
-      version of Windows 8 or later."
-  !else
-    MessageBox MB_OK|MB_ICONSTOP "This version of ${PRODUCT_NAME} requires a 64-bit$\r$\n\
-      version of Windows 10 1607 or later."
-  !endif
+  MessageBox MB_OK|MB_ICONSTOP "This version of ${PRODUCT_NAME} requires a 64-bit$\r$\n\
+    version of Windows 10 1607 or later."
   Abort
   _os_check_pass:
 

--- a/misc/nsis/install.nsh
+++ b/misc/nsis/install.nsh
@@ -432,19 +432,16 @@ Function .onInit
   StrCpy $KeepReg 1
 
 ; OS version check
-  ${If} ${RunningX64}
-    ; https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa#remarks
-    GetWinVer $R0 Major
-    IntCmpU $R0 10 0 _os_check_fail _os_check_pass
-    GetWinVer $R1 Build
-    ${If} $R1 >= 22000 ; Windows 11 21H2
-      Goto _os_check_pass
-    ${ElseIf} $R1 >= 14393 ; Windows 10 1607
-    ${AndIf} ${IsNativeAMD64} ; Windows 10 has no x86_64 emulation on arm64
-      Goto _os_check_pass
-    ${EndIf}
+  ; https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa#remarks
+  ; https://learn.microsoft.com/en-us/windows/release-health/release-information
+  ; https://learn.microsoft.com/en-us/windows/release-health/windows11-release-information
+  ${If} ${AtLeastWin11}
+    Goto _os_check_pass
+  ${ElseIf} ${IsNativeAMD64} ; Windows 10 has no x86_64 emulation on arm64
+  ${AndIf} ${AtLeastWin10}
+  ${AndIf} ${AtLeastBuild} 14393 ; Windows 10 1607 (also in error message below)
+    Goto _os_check_pass
   ${EndIf}
-  _os_check_fail:
   MessageBox MB_OK|MB_ICONSTOP "This version of ${PRODUCT_NAME} requires a 64-bit$\r$\n\
     version of Windows 10 1607 or later."
   Abort

--- a/misc/nsis/qutebrowser.nsi
+++ b/misc/nsis/qutebrowser.nsi
@@ -131,9 +131,6 @@ ShowUninstDetails hide
   !define /ifndef DIST_DIR ".\..\..\dist\${PRODUCT_NAME}-${VERSION}"
 !endif
 
-; If not defined, assume Qt6 (requires a more recent windows version)
-!define /ifndef QT5 "False"
-
 ; Pack the exe header with upx if UPX is defined.
 !ifdef UPX
   !packhdr "$%TEMP%\exehead.tmp" '"upx" "--ultra-brute" "$%TEMP%\exehead.tmp"'


### PR DESCRIPTION
The Qt5 builds for Windows and macOS are failing because the most recent PyQt5-Qt5 release either has issues with them (macOS) or doesn't support them at all (Windows).

We aren't making new Qt5 builds anyhow, so this PR removes those jobs from the nightly workflow and removes Qt5 support from the build scripts too.

I've ran the nightly builds on this branch [here](https://github.com/qutebrowser/qutebrowser/actions/runs/11189136733) and tested both builds in a VM, no issues spotted.

Closes: #8260
