### PR TITLE
Fix zero division bug in tab-move +

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1048,7 +1048,7 @@ class CommandDispatcher:
                 new_idx += delta
 
             if config.val.tabs.wrap:
-                new_idx %= self._count()
+                new_idx %= max(1, self._count())
         else:
             # pylint: disable=else-if-used
             # absolute moving

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -868,10 +868,6 @@ class CommandDispatcher:
         Args:
             count: How many tabs to switch back.
         """
-        if self._count() == 0:
-            # Running :tab-prev after last tab was closed
-            # See https://github.com/qutebrowser/qutebrowser/issues/1448
-            return
         newidx = self._current_index() - count
         if newidx >= 0:
             self._set_current_index(newidx)
@@ -888,10 +884,6 @@ class CommandDispatcher:
         Args:
             count: How many tabs to switch forward.
         """
-        if self._count() == 0:
-            # Running :tab-next after last tab was closed
-            # See https://github.com/qutebrowser/qutebrowser/issues/1448
-            return
         newidx = self._current_index() + count
         if newidx < self._count():
             self._set_current_index(newidx)
@@ -1172,7 +1164,7 @@ class CommandDispatcher:
         if count is not None:
             env['QUTE_COUNT'] = str(count)
 
-        idx = self._current_index()
+        idx = self._tabbed_browser.widget.currentIndex()
         if idx != -1:
             env['QUTE_TAB_INDEX'] = str(idx + 1)
             env['QUTE_TITLE'] = self._tabbed_browser.widget.page_title(idx)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -60,7 +60,7 @@ class CommandDispatcher:
     def _count(self) -> int:
         """Convenience method to get the widget count."""
         count = self._tabbed_browser.widget.count()
-        if count <= 0:
+        if count < 0:
             raise cmdutils.CommandError("No WebView available yet!")
         return count
 
@@ -72,7 +72,7 @@ class CommandDispatcher:
     def _current_index(self):
         """Convenience method to get the current widget index."""
         current_index = self._tabbed_browser.widget.currentIndex()
-        if current_index <= 0:
+        if current_index < 0:
             raise cmdutils.CommandError("No WebView available yet!")
         return current_index
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -59,10 +59,7 @@ class CommandDispatcher:
 
     def _count(self) -> int:
         """Convenience method to get the widget count."""
-        count = self._tabbed_browser.widget.count()
-        if count < 0:
-            raise cmdutils.CommandError("No WebView available yet!")
-        return count
+        return self._tabbed_browser.widget.count()
 
     def _set_current_index(self, idx):
         """Convenience method to set the current widget index."""
@@ -72,7 +69,7 @@ class CommandDispatcher:
     def _current_index(self):
         """Convenience method to get the current widget index."""
         current_index = self._tabbed_browser.widget.currentIndex()
-        if current_index < 0:
+        if current_index == -1:
             raise cmdutils.CommandError("No WebView available yet!")
         return current_index
 

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -59,7 +59,10 @@ class CommandDispatcher:
 
     def _count(self) -> int:
         """Convenience method to get the widget count."""
-        return self._tabbed_browser.widget.count()
+        count = self._tabbed_browser.widget.count()
+        if count <= 0:
+            raise cmdutils.CommandError("No WebView available yet!")
+        return count
 
     def _set_current_index(self, idx):
         """Convenience method to set the current widget index."""
@@ -68,7 +71,10 @@ class CommandDispatcher:
 
     def _current_index(self):
         """Convenience method to get the current widget index."""
-        return self._tabbed_browser.widget.currentIndex()
+        current_index = self._tabbed_browser.widget.currentIndex()
+        if current_index <= 0:
+            raise cmdutils.CommandError("No WebView available yet!")
+        return current_index
 
     def _current_url(self):
         """Convenience method to get the current url."""
@@ -1048,7 +1054,7 @@ class CommandDispatcher:
                 new_idx += delta
 
             if config.val.tabs.wrap:
-                new_idx %= max(1, self._count())
+                new_idx %= self._count()
         else:
             # pylint: disable=else-if-used
             # absolute moving

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1469,14 +1469,16 @@ Feature: Tab management
         When I set tabs.last_close to close
         And I run :tab-only
         And I run :tab-close ;; tab-next
-        Then qutebrowser should quit
+        Then the error "No WebView available yet!" should be shown
+        And qutebrowser should quit
         And no crash should happen
 
     Scenario: Using :tab-prev after closing last tab (#1448)
         When I set tabs.last_close to close
         And I run :tab-only
         And I run :tab-close ;; tab-prev
-        Then qutebrowser should quit
+        Then the error "No WebView available yet!" should be shown
+        And qutebrowser should quit
         And no crash should happen
 
     Scenario: Opening link with tabs_are_windows set (#2162)


### PR DESCRIPTION
Do the modulo by 1 incase self._count() is 0 or negative. 

1, 0 or -1 would all lead to 0 with `% 1`

Starting the browser with 
`qutebrowser --temp-basedir --debug ":tab-move +"` 
now  returns 
`qutebrowser.api.cmdutils.CommandError: Can't move tab to position 1!`
which is also displayed in the statusbar.

Closes #7966 

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
