### PR TITLE
Rewrite `.feature` files to use the `"""` syntax

### DIFF
--- a/misc/requirements/requirements-tests.txt
+++ b/misc/requirements/requirements-tests.txt
@@ -14,6 +14,7 @@ exceptiongroup==1.2.2
 execnet==2.1.1
 filelock==3.16.1
 Flask==3.0.3
+gherkin-official==29.0.0
 hunter==3.7.0
 hypothesis==6.115.0
 idna==3.10
@@ -40,7 +41,7 @@ pluggy==1.5.0
 py-cpuinfo==9.0.0
 Pygments==2.18.0
 pytest==8.3.3
-pytest-bdd==7.3.0
+pytest-bdd==8.0.0
 pytest-benchmark==4.0.0
 pytest-cov==5.0.0
 pytest-instafail==0.5.0

--- a/tests/end2end/conftest.py
+++ b/tests/end2end/conftest.py
@@ -139,32 +139,16 @@ def _get_version_tag(tag):
         raise utils.Unreachable(package)
 
 
-def _get_backend_tag(tag):
-    """Handle a @qtwebengine_*/@qtwebkit_skip tag."""
-    pytest_marks = {
-        'qtwebengine_todo': pytest.mark.qtwebengine_todo,
-        'qtwebengine_skip': pytest.mark.qtwebengine_skip,
-        'qtwebkit_skip': pytest.mark.qtwebkit_skip,
-    }
-    if not any(tag.startswith(t + ':') for t in pytest_marks):
-        return None
-    name, desc = tag.split(':', maxsplit=1)
-    return pytest_marks[name](desc)
-
-
 if not getattr(sys, 'frozen', False):
     def pytest_bdd_apply_tag(tag, function):
         """Handle custom tags for BDD tests.
 
-        This tries various functions, and if none knows how to handle this tag,
-        it returns None so it falls back to pytest-bdd's implementation.
+        If we return None, this falls back to pytest-bdd's implementation.
         """
-        funcs = [_get_version_tag, _get_backend_tag]
-        for func in funcs:
-            mark = func(tag)
-            if mark is not None:
-                mark(function)
-                return True
+        mark = _get_version_tag(tag)
+        if mark is not None:
+            mark(function)
+            return True
         return None
 
 

--- a/tests/end2end/features/backforward.feature
+++ b/tests/end2end/features/backforward.feature
@@ -13,14 +13,14 @@ Feature: Going back and forward.
         And I wait until data/backforward/2.txt is loaded
         And I reload
         Then the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - history:
                 - url: http://localhost:*/data/backforward/1.txt
                 - active: true
                   url: http://localhost:*/data/backforward/2.txt
-	    """
+        """
 
     # https://travis-ci.org/qutebrowser/qutebrowser/jobs/157941720
     @qtwebengine_flaky
@@ -31,7 +31,7 @@ Feature: Going back and forward.
         And I run :back -t
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - history:
@@ -43,7 +43,7 @@ Feature: Going back and forward.
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
-	    """
+        """
 
     Scenario: Going back in a new tab without history
         Given I open data/backforward/1.txt
@@ -51,14 +51,14 @@ Feature: Going back and forward.
         And I run :back -t
         Then the error "At beginning of history." should be shown
         Then the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - active: true
                 history:
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
-	    """
+        """
 
     Scenario: Going back in a new background tab
         Given I open data/backforward/1.txt
@@ -67,7 +67,7 @@ Feature: Going back and forward.
         And I run :back -b
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - active: true
@@ -79,7 +79,7 @@ Feature: Going back and forward.
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
-	    """
+        """
 
     @flaky
     Scenario: Going back with count.
@@ -91,7 +91,7 @@ Feature: Going back and forward.
         And I wait until data/backforward/1.txt is loaded
         And I reload
         Then the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - history:
@@ -99,7 +99,7 @@ Feature: Going back and forward.
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
                 - url: http://localhost:*/data/backforward/3.txt
-	    """
+        """
 
     Scenario: Going back too much with count.
         Given I open data/backforward/1.txt
@@ -124,7 +124,7 @@ Feature: Going back and forward.
         And I run :back -w
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - active: true
@@ -140,7 +140,7 @@ Feature: Going back and forward.
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
-	    """
+        """
 
     Scenario: Going back without history
         Given I open data/backforward/1.txt

--- a/tests/end2end/features/backforward.feature
+++ b/tests/end2end/features/backforward.feature
@@ -13,14 +13,14 @@ Feature: Going back and forward.
         And I wait until data/backforward/2.txt is loaded
         And I reload
         Then the session should look like:
-        """
-            windows:
-            - tabs:
-              - history:
-                - url: http://localhost:*/data/backforward/1.txt
-                - active: true
-                  url: http://localhost:*/data/backforward/2.txt
-        """
+            """
+                windows:
+                - tabs:
+                  - history:
+                    - url: http://localhost:*/data/backforward/1.txt
+                    - active: true
+                      url: http://localhost:*/data/backforward/2.txt
+            """
 
     # https://travis-ci.org/qutebrowser/qutebrowser/jobs/157941720
     @qtwebengine_flaky
@@ -31,19 +31,19 @@ Feature: Going back and forward.
         And I run :back -t
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
-        """
-            windows:
-            - tabs:
-              - history:
-                - url: http://localhost:*/data/backforward/1.txt
-                - active: true
-                  url: http://localhost:*/data/backforward/2.txt
-              - active: true
-                history:
-                - active: true
-                  url: http://localhost:*/data/backforward/1.txt
-                - url: http://localhost:*/data/backforward/2.txt
-        """
+            """
+                windows:
+                - tabs:
+                  - history:
+                    - url: http://localhost:*/data/backforward/1.txt
+                    - active: true
+                      url: http://localhost:*/data/backforward/2.txt
+                  - active: true
+                    history:
+                    - active: true
+                      url: http://localhost:*/data/backforward/1.txt
+                    - url: http://localhost:*/data/backforward/2.txt
+            """
 
     Scenario: Going back in a new tab without history
         Given I open data/backforward/1.txt
@@ -51,14 +51,14 @@ Feature: Going back and forward.
         And I run :back -t
         Then the error "At beginning of history." should be shown
         Then the session should look like:
-        """
-            windows:
-            - tabs:
-              - active: true
-                history:
-                - active: true
-                  url: http://localhost:*/data/backforward/1.txt
-        """
+            """
+                windows:
+                - tabs:
+                  - active: true
+                    history:
+                    - active: true
+                      url: http://localhost:*/data/backforward/1.txt
+            """
 
     Scenario: Going back in a new background tab
         Given I open data/backforward/1.txt
@@ -67,19 +67,19 @@ Feature: Going back and forward.
         And I run :back -b
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
-        """
-            windows:
-            - tabs:
-              - active: true
-                history:
-                - url: http://localhost:*/data/backforward/1.txt
-                - active: true
-                  url: http://localhost:*/data/backforward/2.txt
-              - history:
-                - active: true
-                  url: http://localhost:*/data/backforward/1.txt
-                - url: http://localhost:*/data/backforward/2.txt
-        """
+            """
+                windows:
+                - tabs:
+                  - active: true
+                    history:
+                    - url: http://localhost:*/data/backforward/1.txt
+                    - active: true
+                      url: http://localhost:*/data/backforward/2.txt
+                  - history:
+                    - active: true
+                      url: http://localhost:*/data/backforward/1.txt
+                    - url: http://localhost:*/data/backforward/2.txt
+            """
 
     @flaky
     Scenario: Going back with count.
@@ -91,15 +91,15 @@ Feature: Going back and forward.
         And I wait until data/backforward/1.txt is loaded
         And I reload
         Then the session should look like:
-        """
-            windows:
-            - tabs:
-              - history:
-                - active: true
-                  url: http://localhost:*/data/backforward/1.txt
-                - url: http://localhost:*/data/backforward/2.txt
-                - url: http://localhost:*/data/backforward/3.txt
-        """
+            """
+                windows:
+                - tabs:
+                  - history:
+                    - active: true
+                      url: http://localhost:*/data/backforward/1.txt
+                    - url: http://localhost:*/data/backforward/2.txt
+                    - url: http://localhost:*/data/backforward/3.txt
+            """
 
     Scenario: Going back too much with count.
         Given I open data/backforward/1.txt
@@ -124,23 +124,23 @@ Feature: Going back and forward.
         And I run :back -w
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
-        """
-            windows:
-            - tabs:
-              - active: true
-                history:
-                - url: about:blank
-                - url: http://localhost:*/data/backforward/1.txt
-                - active: true
-                  url: http://localhost:*/data/backforward/2.txt
-            - tabs:
-              - active: true
-                history:
-                - url: about:blank
-                - active: true
-                  url: http://localhost:*/data/backforward/1.txt
-                - url: http://localhost:*/data/backforward/2.txt
-        """
+            """
+                windows:
+                - tabs:
+                  - active: true
+                    history:
+                    - url: about:blank
+                    - url: http://localhost:*/data/backforward/1.txt
+                    - active: true
+                      url: http://localhost:*/data/backforward/2.txt
+                - tabs:
+                  - active: true
+                    history:
+                    - url: about:blank
+                    - active: true
+                      url: http://localhost:*/data/backforward/1.txt
+                    - url: http://localhost:*/data/backforward/2.txt
+            """
 
     Scenario: Going back without history
         Given I open data/backforward/1.txt

--- a/tests/end2end/features/backforward.feature
+++ b/tests/end2end/features/backforward.feature
@@ -50,7 +50,7 @@ Feature: Going back and forward.
         When I run :tab-only
         And I run :back -t
         Then the error "At beginning of history." should be shown
-        Then the session should look like:
+        And the session should look like:
             """
                 windows:
                 - tabs:

--- a/tests/end2end/features/backforward.feature
+++ b/tests/end2end/features/backforward.feature
@@ -13,12 +13,14 @@ Feature: Going back and forward.
         And I wait until data/backforward/2.txt is loaded
         And I reload
         Then the session should look like:
+	    """
             windows:
             - tabs:
               - history:
                 - url: http://localhost:*/data/backforward/1.txt
                 - active: true
                   url: http://localhost:*/data/backforward/2.txt
+	    """
 
     # https://travis-ci.org/qutebrowser/qutebrowser/jobs/157941720
     @qtwebengine_flaky
@@ -29,6 +31,7 @@ Feature: Going back and forward.
         And I run :back -t
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
+	    """
             windows:
             - tabs:
               - history:
@@ -40,6 +43,7 @@ Feature: Going back and forward.
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
+	    """
 
     Scenario: Going back in a new tab without history
         Given I open data/backforward/1.txt
@@ -47,12 +51,14 @@ Feature: Going back and forward.
         And I run :back -t
         Then the error "At beginning of history." should be shown
         Then the session should look like:
+	    """
             windows:
             - tabs:
               - active: true
                 history:
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
+	    """
 
     Scenario: Going back in a new background tab
         Given I open data/backforward/1.txt
@@ -61,6 +67,7 @@ Feature: Going back and forward.
         And I run :back -b
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
+	    """
             windows:
             - tabs:
               - active: true
@@ -72,6 +79,7 @@ Feature: Going back and forward.
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
+	    """
 
     @flaky
     Scenario: Going back with count.
@@ -83,6 +91,7 @@ Feature: Going back and forward.
         And I wait until data/backforward/1.txt is loaded
         And I reload
         Then the session should look like:
+	    """
             windows:
             - tabs:
               - history:
@@ -90,6 +99,7 @@ Feature: Going back and forward.
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
                 - url: http://localhost:*/data/backforward/3.txt
+	    """
 
     Scenario: Going back too much with count.
         Given I open data/backforward/1.txt
@@ -114,6 +124,7 @@ Feature: Going back and forward.
         And I run :back -w
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
+	    """
             windows:
             - tabs:
               - active: true
@@ -129,6 +140,7 @@ Feature: Going back and forward.
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
+	    """
 
     Scenario: Going back without history
         Given I open data/backforward/1.txt

--- a/tests/end2end/features/backforward.feature
+++ b/tests/end2end/features/backforward.feature
@@ -162,7 +162,7 @@ Feature: Going back and forward.
         When I run :forward --quiet
         Then "At end of history." should be logged
 
-    @qtwebengine_skip: Getting 'at beginning of history' when going back
+    @qtwebengine_skip  # Getting 'at beginning of history' when going back
     Scenario: Going forward too much with count.
         Given I open data/backforward/1.txt
         When I open data/backforward/2.txt

--- a/tests/end2end/features/caret.feature
+++ b/tests/end2end/features/caret.feature
@@ -53,8 +53,10 @@ Feature: Caret mode
         And I run :selection-follow --tab
         Then data/hello.txt should be loaded
         And the following tabs should be open:
+            """
             - data/caret.html
             - data/hello.txt (active)
+            """
 
     Scenario: :selection-follow with --tab (without JS)
         When I set content.javascript.enabled to false
@@ -65,8 +67,10 @@ Feature: Caret mode
         And I run :selection-follow --tab
         Then data/hello.txt should be loaded
         And the following tabs should be open:
+            """
             - data/caret.html
             - data/hello.txt
+            """
 
     @flaky
     Scenario: :selection-follow with link tabbing (without JS)

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -80,7 +80,9 @@ Feature: Using completion
         And I wait for "setting text = ':tab-select 0/2', *" in the log
         And I run :completion-item-del
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
+            """
 
     Scenario: Go to tab after moving a tab
         Given I have a fresh instance

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -91,10 +91,10 @@ Feature: Using completion
         And I run :tab-move 1
         And I run :tab-select hello2.txt
         Then the following tabs should be open:
-        """
+            """
             - data/hello2.txt (active)
             - data/hello.txt
-        """
+            """
 
     Scenario: Space updates completion model after selecting full command
         When I run :cmd-set-text :set

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -91,8 +91,10 @@ Feature: Using completion
         And I run :tab-move 1
         And I run :tab-select hello2.txt
         Then the following tabs should be open:
+	    """
             - data/hello2.txt (active)
             - data/hello.txt
+	    """
 
     Scenario: Space updates completion model after selecting full command
         When I run :cmd-set-text :set

--- a/tests/end2end/features/completion.feature
+++ b/tests/end2end/features/completion.feature
@@ -91,10 +91,10 @@ Feature: Using completion
         And I run :tab-move 1
         And I run :tab-select hello2.txt
         Then the following tabs should be open:
-	    """
+        """
             - data/hello2.txt (active)
             - data/hello.txt
-	    """
+        """
 
     Scenario: Space updates completion model after selecting full command
         When I run :cmd-set-text :set

--- a/tests/end2end/features/conftest.py
+++ b/tests/end2end/features/conftest.py
@@ -350,10 +350,9 @@ def fill_clipboard(quteproc, server, what, content):
 
 
 @bdd.when(bdd.parsers.re(r'I put the following lines into the '
-                         r'(?P<what>primary selection|clipboard):\n'
-                         r'(?P<content>.+)$', flags=re.DOTALL))
-def fill_clipboard_multiline(quteproc, server, what, content):
-    fill_clipboard(quteproc, server, what, textwrap.dedent(content))
+                         r'(?P<what>primary selection|clipboard):', flags=re.DOTALL))
+def fill_clipboard_multiline(quteproc, server, what, docstring):
+    fill_clipboard(quteproc, server, what, textwrap.dedent(docstring))
 
 
 @bdd.when(bdd.parsers.parse('I hint with args "{args}"'))
@@ -456,20 +455,20 @@ def path_should_be_requested(server, path):
     server.wait_for(verb='GET', path='/' + path)
 
 
-@bdd.then(bdd.parsers.parse("The requests should be:\n{pages}"))
-def list_of_requests(server, pages):
+@bdd.then(bdd.parsers.parse("The requests should be:"))
+def list_of_requests(server, docstring):
     """Make sure the given requests were done from the webserver."""
     expected_requests = [server.ExpectedRequest('GET', '/' + path.strip())
-                         for path in pages.split('\n')]
+                         for path in docstring.split('\n')]
     actual_requests = server.get_requests()
     assert actual_requests == expected_requests
 
 
-@bdd.then(bdd.parsers.parse("The unordered requests should be:\n{pages}"))
-def list_of_requests_unordered(server, pages):
+@bdd.then(bdd.parsers.parse("The unordered requests should be:"))
+def list_of_requests_unordered(server, docstring):
     """Make sure the given requests were done (in no particular order)."""
     expected_requests = [server.ExpectedRequest('GET', '/' + path.strip())
-                         for path in pages.split('\n')]
+                         for path in docstring.split('\n')]
     actual_requests = server.get_requests()
     # Requests are not hashable, we need to convert to ExpectedRequests
     actual_requests = [server.ExpectedRequest.from_request(req)
@@ -533,21 +532,21 @@ def javascript_message_not_logged(quteproc, message):
                                message='[*] {}'.format(message))
 
 
-@bdd.then(bdd.parsers.parse("The session should look like:\n{expected}"))
-def compare_session(quteproc, expected):
+@bdd.then(bdd.parsers.parse("The session should look like:"))
+def compare_session(quteproc, docstring):
     """Compare the current sessions against the given template.
 
     partial_compare is used, which means only the keys/values listed will be
     compared.
     """
-    quteproc.compare_session(expected)
+    quteproc.compare_session(docstring)
 
 
 @bdd.then(
-    bdd.parsers.parse("The session saved with {flags} should look like:\n{expected}"))
-def compare_session_flags(quteproc, flags, expected):
+    bdd.parsers.parse("The session saved with {flags} should look like:"))
+def compare_session_flags(quteproc, flags, docstring):
     """Compare the current session saved with custom flags."""
-    quteproc.compare_session(expected, flags=flags)
+    quteproc.compare_session(docstring, flags=flags)
 
 
 @bdd.then("no crash should happen")
@@ -600,17 +599,17 @@ def check_not_contents_plain(quteproc, text):
     assert text not in content
 
 
-@bdd.then(bdd.parsers.parse('the json on the page should be:\n{text}'))
-def check_contents_json(quteproc, text):
+@bdd.then(bdd.parsers.parse('the json on the page should be:'))
+def check_contents_json(quteproc, docstring):
     """Check the current page's content as json."""
     content = quteproc.get_content().strip()
-    expected = json.loads(text)
+    expected = json.loads(docstring)
     actual = json.loads(content)
     assert actual == expected
 
 
-@bdd.then(bdd.parsers.parse("the following tabs should be open:\n{tabs}"))
-def check_open_tabs(quteproc, request, tabs):
+@bdd.then(bdd.parsers.parse("the following tabs should be open:"))
+def check_open_tabs(quteproc, docstring):
     """Check the list of open tabs in the session.
 
     This is a lightweight alternative for "The session should look like: ...".
@@ -620,7 +619,7 @@ def check_open_tabs(quteproc, request, tabs):
     session = quteproc.get_session()
     active_suffix = ' (active)'
     pinned_suffix = ' (pinned)'
-    tabs = tabs.splitlines()
+    tabs = docstring.splitlines()
     assert len(session['windows']) == 1
     assert len(session['windows'][0]['tabs']) == len(tabs)
 
@@ -670,9 +669,9 @@ def clipboard_contains(quteproc, server, what, content):
         what, json.dumps(expected)))
 
 
-@bdd.then(bdd.parsers.parse('the clipboard should contain:\n{content}'))
-def clipboard_contains_multiline(quteproc, server, content):
-    expected = textwrap.dedent(content).replace('(port)', str(server.port))
+@bdd.then(bdd.parsers.parse('the clipboard should contain:'))
+def clipboard_contains_multiline(quteproc, server, docstring):
+    expected = textwrap.dedent(docstring).replace('(port)', str(server.port))
     quteproc.wait_for(message='Setting fake clipboard: {}'.format(
         json.dumps(expected)))
 

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -186,8 +186,10 @@ Feature: Downloading things from a website.
         And I run :download-retry
         And I wait for the error "Download error: * - server replied: NOT FOUND"
         Then the requests should be:
+            """
             does-not-exist
             does-not-exist
+            """
 
     @flaky
     Scenario: Retrying with count
@@ -197,9 +199,11 @@ Feature: Downloading things from a website.
         And I run :download-retry with count 2
         And I wait for the error "Download error: * - server replied: NOT FOUND"
         Then the requests should be:
+            """
             data/downloads/download.bin
             does-not-exist
             does-not-exist
+            """
 
     Scenario: Retrying with two failed downloads
         When I run :download http://localhost:(port)/does-not-exist
@@ -209,9 +213,11 @@ Feature: Downloading things from a website.
         And I run :download-retry
         And I wait for the error "Download error: * - server replied: NOT FOUND"
         Then the requests should be:
+            """
             does-not-exist
             does-not-exist-2
             does-not-exist
+            """
 
     Scenario: Retrying a download which does not exist
         When I run :download-retry with count 42

--- a/tests/end2end/features/downloads.feature
+++ b/tests/end2end/features/downloads.feature
@@ -263,14 +263,14 @@ Feature: Downloading things from a website.
         And I wait for "File successfully written." in the log
         Then the downloaded file Test title.mhtml should exist
 
-    @qtwebengine_skip: QtWebEngine refuses to load this
+    @qtwebengine_skip  # QtWebEngine refuses to load this
     Scenario: Downloading as mhtml with non-ASCII headers
         When I open response-headers?Content-Type=text%2Fpl%C3%A4in
         And I run :download --mhtml --dest mhtml-response-headers.mhtml
         And I wait for "File successfully written." in the log
         Then the downloaded file mhtml-response-headers.mhtml should exist
 
-    @qtwebengine_skip: https://github.com/qutebrowser/qutebrowser/issues/2288
+    @qtwebengine_skip  # https://github.com/qutebrowser/qutebrowser/issues/2288
     Scenario: Overwriting existing mhtml file
         When I set downloads.location.prompt to true
         And I open data/title.html
@@ -330,7 +330,7 @@ Feature: Downloading things from a website.
         And "cancelled" should be logged
 
     # https://github.com/qutebrowser/qutebrowser/issues/1535
-    @qtwebengine_todo: :download --mhtml is not implemented yet
+    @qtwebengine_todo  # :download --mhtml is not implemented yet
     Scenario: Cancelling an MHTML download (issue 1535)
         When I open data/downloads/issue1535.html
         And I run :download --mhtml
@@ -669,14 +669,14 @@ Feature: Downloading things from a website.
         Then the downloaded file download.bin should exist
         And the downloaded file download2.bin should not exist
 
-    @qtwebengine_skip: We can't get the UA from the page there
+    @qtwebengine_skip  # We can't get the UA from the page there
     Scenario: user-agent when using :download
         When I open user-agent
         And I run :download --dest user-agent
         And I wait until the download is finished
         Then the downloaded file user-agent should contain Safari/
 
-    @qtwebengine_skip: We can't get the UA from the page there
+    @qtwebengine_skip  # We can't get the UA from the page there
     Scenario: user-agent when using hints
         When I open /
         And I run :hint links download
@@ -684,7 +684,7 @@ Feature: Downloading things from a website.
         And I wait until the download is finished
         Then the downloaded file user-agent should contain Safari/
 
-    @qtwebengine_skip: Handled by QtWebEngine, not by us
+    @qtwebengine_skip  # Handled by QtWebEngine, not by us
     Scenario: Downloading a "Internal server error" with disposition: inline (#2304)
         When I set downloads.location.prompt to false
         And I open 500-inline

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -15,8 +15,10 @@ Feature: Opening external editors
         And I run :edit-url -t
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
+	    """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
+	    """
 
     Scenario: Editing a URL with -rt
         When I set tabs.new_position.related to prev
@@ -26,8 +28,10 @@ Feature: Opening external editors
         And I run :edit-url -rt
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
+	    """
             - data/numbers/2.txt (active)
             - data/numbers/1.txt
+	    """
 
     Scenario: Editing a URL with -b
         When I run :tab-only
@@ -36,8 +40,10 @@ Feature: Opening external editors
         And I run :edit-url -b
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
+	    """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
+	    """
 
     Scenario: Editing a URL with -w
         When I run :window-only
@@ -47,6 +53,7 @@ Feature: Opening external editors
         And I run :edit-url -w
         Then data/numbers/2.txt should be loaded
         And the session should look like:
+	    """
             windows:
             - tabs:
               - active: true
@@ -58,6 +65,7 @@ Feature: Opening external editors
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
+	    """
 
     Scenario: Editing a URL with -p
         When I open data/numbers/1.txt in a new tab
@@ -67,6 +75,7 @@ Feature: Opening external editors
         And I run :edit-url -p
         Then data/numbers/2.txt should be loaded
         And the session should look like:
+	    """
             windows:
             - tabs:
               - active: true
@@ -79,6 +88,7 @@ Feature: Opening external editors
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
               private: true
+	    """
 
     Scenario: Editing a URL with -t and -b
         When I run :edit-url -t -b

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -15,10 +15,10 @@ Feature: Opening external editors
         And I run :edit-url -t
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
-        """
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
-        """
+            """
 
     Scenario: Editing a URL with -rt
         When I set tabs.new_position.related to prev
@@ -28,10 +28,10 @@ Feature: Opening external editors
         And I run :edit-url -rt
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
-        """
+            """
             - data/numbers/2.txt (active)
             - data/numbers/1.txt
-        """
+            """
 
     Scenario: Editing a URL with -b
         When I run :tab-only
@@ -40,10 +40,10 @@ Feature: Opening external editors
         And I run :edit-url -b
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
-        """
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
-        """
+            """
 
     Scenario: Editing a URL with -w
         When I run :window-only
@@ -53,7 +53,7 @@ Feature: Opening external editors
         And I run :edit-url -w
         Then data/numbers/2.txt should be loaded
         And the session should look like:
-        """
+            """
             windows:
             - tabs:
               - active: true
@@ -65,7 +65,7 @@ Feature: Opening external editors
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
-        """
+            """
 
     Scenario: Editing a URL with -p
         When I open data/numbers/1.txt in a new tab
@@ -75,7 +75,7 @@ Feature: Opening external editors
         And I run :edit-url -p
         Then data/numbers/2.txt should be loaded
         And the session should look like:
-        """
+            """
             windows:
             - tabs:
               - active: true
@@ -88,7 +88,7 @@ Feature: Opening external editors
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
               private: true
-        """
+            """
 
     Scenario: Editing a URL with -t and -b
         When I run :edit-url -t -b

--- a/tests/end2end/features/editor.feature
+++ b/tests/end2end/features/editor.feature
@@ -15,10 +15,10 @@ Feature: Opening external editors
         And I run :edit-url -t
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
-	    """
+        """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
-	    """
+        """
 
     Scenario: Editing a URL with -rt
         When I set tabs.new_position.related to prev
@@ -28,10 +28,10 @@ Feature: Opening external editors
         And I run :edit-url -rt
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
-	    """
+        """
             - data/numbers/2.txt (active)
             - data/numbers/1.txt
-	    """
+        """
 
     Scenario: Editing a URL with -b
         When I run :tab-only
@@ -40,10 +40,10 @@ Feature: Opening external editors
         And I run :edit-url -b
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
-	    """
+        """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
-	    """
+        """
 
     Scenario: Editing a URL with -w
         When I run :window-only
@@ -53,7 +53,7 @@ Feature: Opening external editors
         And I run :edit-url -w
         Then data/numbers/2.txt should be loaded
         And the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - active: true
@@ -65,7 +65,7 @@ Feature: Opening external editors
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
-	    """
+        """
 
     Scenario: Editing a URL with -p
         When I open data/numbers/1.txt in a new tab
@@ -75,7 +75,7 @@ Feature: Opening external editors
         And I run :edit-url -p
         Then data/numbers/2.txt should be loaded
         And the session should look like:
-	    """
+        """
             windows:
             - tabs:
               - active: true
@@ -88,7 +88,7 @@ Feature: Opening external editors
                 - active: true
                   url: http://localhost:*/data/numbers/2.txt
               private: true
-	    """
+        """
 
     Scenario: Editing a URL with -t and -b
         When I run :edit-url -t -b

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -34,7 +34,9 @@ Feature: Using hints
         And I hint with args "links current" and follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
+            """
 
     Scenario: Following a hint and allow to open in new tab.
         When I open data/hints/link_blank.html
@@ -58,7 +60,9 @@ Feature: Using hints
         And I hint with args "links current" and follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
+            """
 
     Scenario: Entering and leaving hinting mode (issue 1464)
         When I open data/hints/html/simple.html

--- a/tests/end2end/features/hints.feature
+++ b/tests/end2end/features/hints.feature
@@ -41,8 +41,10 @@ Feature: Using hints
         And I hint with args "links normal" and follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hints/link_blank.html
             - data/hello.txt
+            """
 
     # https://github.com/qutebrowser/qutebrowser/issues/7842
     @qtwebkit_skip
@@ -160,6 +162,7 @@ Feature: Using hints
         # We should check what the active tab is, but for some reason that makes
         # the test flaky
         Then the session should look like:
+          """
           windows:
           - tabs:
             - history:
@@ -168,6 +171,7 @@ Feature: Using hints
               - url: http://localhost:*/data/hello.txt
             - history:
               - url: http://localhost:*/data/hello2.txt
+          """
 
     Scenario: Using hint --rapid to hit multiple buttons
         When I open data/hints/buttons.html
@@ -295,8 +299,10 @@ Feature: Using hints
         And I hint with args "links tab" and follow s
         And I wait until data/hello2.txt is loaded
         Then the following tabs should be open:
+          """
             - data/hints/iframe_target.html (active)
             - data/hello2.txt
+          """
 
     Scenario: Clicking on iframe with :hint all current
         When I open data/hints/iframe.html

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -39,14 +39,14 @@ Feature: Page history
         Then the history should contain:
             http://localhost:(port)/data/%C3%A4%C3%B6%C3%BC.html Chäschüechli
 
-    @flaky @qtwebengine_todo: Error page message is not implemented
+    @flaky @qtwebengine_todo  # Error page message is not implemented
     Scenario: History with an error
         When I run :open file:///does/not/exist
         And I wait for "Error while loading file:///does/not/exist: Error opening /does/not/exist: *" in the log
         Then the history should contain:
             file:///does/not/exist Error loading page: file:///does/not/exist
 
-    @qtwebengine_todo: Error page message is not implemented
+    @qtwebengine_todo  # Error page message is not implemented
     Scenario: History with a 404
         When I open 404 without waiting
         And I wait for "Error while loading http://localhost:*/404: NOT FOUND" in the log

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -17,7 +17,9 @@ Feature: Page history
     Scenario: History item with title
         When I open data/title.html
         Then the history should contain:
+            """
             http://localhost:(port)/data/title.html Test title
+            """
 
     Scenario: History item with redirect
         When I open redirect-to?url=data/title.html without waiting
@@ -31,27 +33,35 @@ Feature: Page history
     Scenario: History item with spaces in URL
         When I open data/title with spaces.html
         Then the history should contain:
+            """
             http://localhost:(port)/data/title%20with%20spaces.html Test title
+            """
 
     @unicode_locale
     Scenario: History item with umlauts
         When I open data/äöü.html
         Then the history should contain:
+            """
             http://localhost:(port)/data/%C3%A4%C3%B6%C3%BC.html Chäschüechli
+            """
 
     @flaky @qtwebengine_todo  # Error page message is not implemented
     Scenario: History with an error
         When I run :open file:///does/not/exist
         And I wait for "Error while loading file:///does/not/exist: Error opening /does/not/exist: *" in the log
         Then the history should contain:
+            """
             file:///does/not/exist Error loading page: file:///does/not/exist
+            """
 
     @qtwebengine_todo  # Error page message is not implemented
     Scenario: History with a 404
         When I open 404 without waiting
         And I wait for "Error while loading http://localhost:*/404: NOT FOUND" in the log
         Then the history should contain:
+            """
             http://localhost:(port)/404 Error loading page: http://localhost:(port)/404
+            """
 
     Scenario: History with invalid URL
         When I run :tab-only

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -9,8 +9,10 @@ Feature: Page history
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt
         Then the history should contain:
+	    """
             http://localhost:(port)/data/numbers/1.txt
             http://localhost:(port)/data/numbers/2.txt
+	    """
 
     Scenario: History item with title
         When I open data/title.html
@@ -21,8 +23,10 @@ Feature: Page history
         When I open redirect-to?url=data/title.html without waiting
         And I wait until data/title.html is loaded
         Then the history should contain:
+	    """
             r http://localhost:(port)/redirect-to?url=data/title.html Test title
             http://localhost:(port)/data/title.html Test title
+	    """
 
     Scenario: History item with spaces in URL
         When I open data/title with spaces.html
@@ -72,8 +76,10 @@ Feature: Page history
         When I open data/hints/html/simple.html
         And I hint with args "--add-history links yank" and follow a
         Then the history should contain:
+	    """
             http://localhost:(port)/data/hints/html/simple.html Simple link
             http://localhost:(port)/data/hello.txt
+	    """
 
     @flaky
     Scenario: Listing history

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -23,10 +23,10 @@ Feature: Page history
         When I open redirect-to?url=data/title.html without waiting
         And I wait until data/title.html is loaded
         Then the history should contain:
-        """
+            """
             r http://localhost:(port)/redirect-to?url=data/title.html Test title
             http://localhost:(port)/data/title.html Test title
-        """
+            """
 
     Scenario: History item with spaces in URL
         When I open data/title with spaces.html
@@ -76,10 +76,10 @@ Feature: Page history
         When I open data/hints/html/simple.html
         And I hint with args "--add-history links yank" and follow a
         Then the history should contain:
-        """
+            """
             http://localhost:(port)/data/hints/html/simple.html Simple link
             http://localhost:(port)/data/hello.txt
-        """
+            """
 
     @flaky
     Scenario: Listing history

--- a/tests/end2end/features/history.feature
+++ b/tests/end2end/features/history.feature
@@ -9,10 +9,10 @@ Feature: Page history
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt
         Then the history should contain:
-	    """
+        """
             http://localhost:(port)/data/numbers/1.txt
             http://localhost:(port)/data/numbers/2.txt
-	    """
+        """
 
     Scenario: History item with title
         When I open data/title.html
@@ -23,10 +23,10 @@ Feature: Page history
         When I open redirect-to?url=data/title.html without waiting
         And I wait until data/title.html is loaded
         Then the history should contain:
-	    """
+        """
             r http://localhost:(port)/redirect-to?url=data/title.html Test title
             http://localhost:(port)/data/title.html Test title
-	    """
+        """
 
     Scenario: History item with spaces in URL
         When I open data/title with spaces.html
@@ -76,10 +76,10 @@ Feature: Page history
         When I open data/hints/html/simple.html
         And I hint with args "--add-history links yank" and follow a
         Then the history should contain:
-	    """
+        """
             http://localhost:(port)/data/hints/html/simple.html Simple link
             http://localhost:(port)/data/hello.txt
-	    """
+        """
 
     @flaky
     Scenario: Listing history

--- a/tests/end2end/features/invoke.feature
+++ b/tests/end2end/features/invoke.feature
@@ -17,14 +17,17 @@ Feature: Invoking a new process
         And I open data/title.html
         And I open data/search.html as a URL
         Then the following tabs should be open:
+            """
             - data/title.html (active)
             - data/search.html
+            """
 
     Scenario: Using new_instance_open_target = window
         When I set new_instance_open_target to window
         And I open data/title.html
         And I open data/search.html as a URL
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -33,12 +36,14 @@ Feature: Invoking a new process
             - tabs:
               - history:
                 - url: http://localhost:*/data/search.html
+            """
 
     Scenario: Using new_instance_open_target = private-window
         When I set new_instance_open_target to private-window
         And I open data/title.html
         And I open data/search.html as a URL
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -48,6 +53,7 @@ Feature: Invoking a new process
               tabs:
               - history:
                 - url: http://localhost:*/data/search.html
+            """
 
     Scenario: Using new_instance_open_target_window = last-opened
         When I set new_instance_open_target to tab
@@ -56,6 +62,7 @@ Feature: Invoking a new process
         And I open data/search.html in a new window
         And I open data/hello.txt as a URL
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -66,6 +73,7 @@ Feature: Invoking a new process
                 - url: http://localhost:*/data/search.html
               - history:
                 - url: http://localhost:*/data/hello.txt
+            """
 
     Scenario: Using new_instance_open_target_window = first-opened
         When I set new_instance_open_target to tab
@@ -74,6 +82,7 @@ Feature: Invoking a new process
         And I open data/search.html in a new window
         And I open data/hello.txt as a URL
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -84,6 +93,7 @@ Feature: Invoking a new process
             - tabs:
               - history:
                 - url: http://localhost:*/data/search.html
+            """
 
     # issue #1060
 
@@ -96,6 +106,7 @@ Feature: Invoking a new process
         And I wait until data/search.html is loaded
         And I open data/hello.txt as a URL
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -106,6 +117,7 @@ Feature: Invoking a new process
             - tabs:
               - history:
                 - url: http://localhost:*/data/search.html
+            """
 
     Scenario: Opening a new qutebrowser instance with no parameters
         When I set new_instance_open_target to tab
@@ -114,6 +126,7 @@ Feature: Invoking a new process
         And I spawn a new window
         And I wait until data/hello.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -122,3 +135,4 @@ Feature: Invoking a new process
             - tabs:
               - history:
                 - url: http://localhost:*/data/hello.txt
+            """

--- a/tests/end2end/features/invoke.feature
+++ b/tests/end2end/features/invoke.feature
@@ -9,8 +9,10 @@ Feature: Invoking a new process
         And I open data/title.html
         And I open data/search.html as a URL
         Then the following tabs should be open:
+            """
             - data/title.html
             - data/search.html (active)
+            """
 
     Scenario: Using new_instance_open_target = tab-bg
         When I set new_instance_open_target to tab-bg

--- a/tests/end2end/features/javascript.feature
+++ b/tests/end2end/features/javascript.feature
@@ -17,7 +17,9 @@ Feature: Javascript stuff
         And I wait for "[*] window closed" in the log
         Then "Focus object changed: *" should be logged
         And the following tabs should be open:
+            """
             - data/javascript/window_open.html (active)
+            """
 
     @skip   # Too flaky
     Scenario: Opening/closing a modal window via JS
@@ -31,7 +33,9 @@ Feature: Javascript stuff
         Then "Focus object changed: *" should be logged
         And "Web*Dialog requested, but we don't support that!" should be logged
         And the following tabs should be open:
+            """
             - data/javascript/window_open.html (active)
+            """
 
     # https://github.com/qutebrowser/qutebrowser/issues/906
 

--- a/tests/end2end/features/marks.feature
+++ b/tests/end2end/features/marks.feature
@@ -71,7 +71,7 @@ Feature: Setting positional marks
         And I run :jump-mark b
         Then the error "Mark b is not set" should be shown
 
-    @qtwebengine_skip: Does not emit loaded signal for fragments?
+    @qtwebengine_skip  # Does not emit loaded signal for fragments?
     Scenario: Jumping to a local mark after changing fragments
         When I open data/marks.html#top
         And I run :scroll 'top'
@@ -84,7 +84,7 @@ Feature: Setting positional marks
         And I wait until the scroll position changed to 10/10
         Then the page should be scrolled to 10 10
 
-    @qtwebengine_skip: Does not emit loaded signal for fragments?
+    @qtwebengine_skip  # Does not emit loaded signal for fragments?
     Scenario: Jumping back after following a link
         When I hint with args "links normal" and follow s
         And I wait until data/marks.html#bottom is loaded

--- a/tests/end2end/features/misc.feature
+++ b/tests/end2end/features/misc.feature
@@ -162,12 +162,14 @@ Feature: Various utility commands.
         And I run :debug-webaction Back
         And I wait until data/backforward/1.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
                 - active: true
                   url: http://localhost:*/data/backforward/1.txt
                 - url: http://localhost:*/data/backforward/2.txt
+            """
 
     Scenario: :debug-webaction with invalid value
         When I open data/hello.txt
@@ -212,8 +214,10 @@ Feature: Various utility commands.
         And I open redirect-later-continue in a new tab
         And I wait 1s
         Then the unordered requests should be:
+            """
             redirect-later-continue
             redirect-later?delay=-1
+            """
         # no request on / because we stopped the redirect
 
     Scenario: :stop with wrong count
@@ -227,8 +231,10 @@ Feature: Various utility commands.
         And I run :reload
         And I wait until data/reload.txt is loaded
         Then the requests should be:
+            """
             data/reload.txt
             data/reload.txt
+            """
 
     Scenario: :reload with force
         When I open headers
@@ -251,6 +257,7 @@ Feature: Various utility commands.
         When I run :tab-only
         And I run :view-source
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -258,6 +265,7 @@ Feature: Various utility commands.
                   url: http://localhost:*/data/hello.txt
               - active: true
                 history: []
+            """
         And the page should contain the html "/* Literal.Number.Integer */"
 
     # Flaky due to :view-source being async?
@@ -438,11 +446,13 @@ Feature: Various utility commands.
         And I wait for "Closing window *" in the log
         And I wait for "removed: main-window" in the log
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
                 history:
                 - url: http://localhost:*/data/hello3.txt
+            """
 
     ## :click-element
 
@@ -467,8 +477,10 @@ Feature: Various utility commands.
         And I run :click-element id link --target=tab
         Then data/hello.txt should be loaded
         And the following tabs should be open:
+            """
             - data/click_element.html
             - data/hello.txt (active)
+            """
 
     Scenario: Clicking an element by CSS selector
         When I open data/click_element.html

--- a/tests/end2end/features/navigate.feature
+++ b/tests/end2end/features/navigate.feature
@@ -73,7 +73,7 @@ Feature: Using :navigate
 
     # increment/decrement
 
-    @qtwebengine_todo: Doesn't find any elements
+    @qtwebengine_todo  # Doesn't find any elements
     Scenario: Navigating multiline links
         When I open data/navigate/multilinelinks.html
         And I run :navigate next

--- a/tests/end2end/features/notifications.feature
+++ b/tests/end2end/features/notifications.feature
@@ -12,7 +12,8 @@ Feature: Notifications
         When I run :click-element id show-button
         Then the javascript message "notification shown" should be logged
         And 1 notification should be presented
-        And the notification should have image dimensions 64x64  # qutebrowser logo
+        # qutebrowser logo
+        And the notification should have image dimensions 64x64
 
     Scenario: Notification containing escaped characters
         Given the notification server supports body markup
@@ -90,7 +91,8 @@ Feature: Notifications
         And the javascript message "i=3 notification shown" should be logged
         And "Ignoring notification tag 'counter' due to PyQt bug" should be logged
         And 3 notifications should be presented
-        And the notification should have title "i=3"  # last one
+        # last one
+        And the notification should have title "i=3"
 
     @pyqtwebengine>=5.15.0
     Scenario: User closes presented notification

--- a/tests/end2end/features/notifications.feature
+++ b/tests/end2end/features/notifications.feature
@@ -123,9 +123,11 @@ Feature: Notifications
         And I click the notification
         Then the javascript message "notification clicked" should be logged
         And the following tabs should be open:
+         """
          - about:blank
          - data/javascript/notifications.html (active)
          - about:blank
+         """
 
     @pyqtwebengine<5.15.0
     Scenario: User clicks presented notification (old Qt)

--- a/tests/end2end/features/open.feature
+++ b/tests/end2end/features/open.feature
@@ -6,6 +6,7 @@ Feature: Opening pages
         And I wait until data/numbers/1.txt is loaded
         And I run :tab-only
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -13,6 +14,7 @@ Feature: Opening pages
                 - url: about:blank
                 - active: true
                   url: http://localhost:*/data/numbers/1.txt
+            """
 
     Scenario: :open without URL
         When I set url.default_page to http://localhost:(port)/data/numbers/11.txt
@@ -46,8 +48,10 @@ Feature: Opening pages
         And I run :open -t http://localhost:(port)/data/numbers/4.txt
         And I wait until data/numbers/4.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/numbers/4.txt (active)
+            """
 
     Scenario: Opening in a new background tab
         Given I open about:blank
@@ -55,8 +59,10 @@ Feature: Opening pages
         And I run :open -b http://localhost:(port)/data/numbers/5.txt
         And I wait until data/numbers/5.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank (active)
             - data/numbers/5.txt
+            """
 
     Scenario: :open with count
         Given I open about:blank
@@ -65,6 +71,7 @@ Feature: Opening pages
         And I run :open http://localhost:(port)/data/numbers/6.txt with count 2
         And I wait until data/numbers/6.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -74,6 +81,7 @@ Feature: Opening pages
                 - url: about:blank
                 - active: true
                   url: http://localhost:*/data/numbers/6.txt
+            """
 
     Scenario: Opening in a new tab (unrelated)
         Given I open about:blank
@@ -83,8 +91,10 @@ Feature: Opening pages
         And I run :open -t http://localhost:(port)/data/numbers/7.txt
         And I wait until data/numbers/7.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/numbers/7.txt (active)
+            """
 
     Scenario: Opening in a new tab (related)
         Given I open about:blank
@@ -94,8 +104,10 @@ Feature: Opening pages
         And I run :open -t --related http://localhost:(port)/data/numbers/8.txt
         And I wait until data/numbers/8.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/8.txt (active)
             - about:blank
+            """
 
     Scenario: Opening in a new window
         Given I open about:blank
@@ -103,6 +115,7 @@ Feature: Opening pages
         And I run :open -w http://localhost:(port)/data/numbers/9.txt
         And I wait until data/numbers/9.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -114,6 +127,7 @@ Feature: Opening pages
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/9.txt
+            """
 
     Scenario: Opening a quickmark
         When I run :quickmark-add http://localhost:(port)/data/numbers/10.txt quickmarktest

--- a/tests/end2end/features/private.feature
+++ b/tests/end2end/features/private.feature
@@ -73,6 +73,7 @@ Feature: Using private browsing
         And I run :navigate -w increment
         And I wait until data/numbers/2.txt is loaded
         Then the session should look like:
+            """
             windows:
             - private: True
               tabs:
@@ -82,6 +83,7 @@ Feature: Using private browsing
               tabs:
               - history:
                 - url: http://localhost:*/data/numbers/2.txt
+            """
 
     Scenario: Opening private window with :navigate next
         # Private window handled in navigate.py
@@ -90,6 +92,7 @@ Feature: Using private browsing
         And I run :navigate -w next
         And I wait until data/navigate/next.html is loaded
         Then the session should look like:
+            """
             windows:
             - private: True
               tabs:
@@ -99,6 +102,7 @@ Feature: Using private browsing
               tabs:
               - history:
                 - url: http://localhost:*/data/navigate/next.html
+            """
 
     Scenario: Opening private window with :tab-clone
         When I open data/hello.txt in a private window
@@ -106,6 +110,7 @@ Feature: Using private browsing
         And I run :tab-clone -w
         And I wait until data/hello.txt is loaded
         Then the session should look like:
+            """
             windows:
             - private: True
               tabs:
@@ -115,6 +120,7 @@ Feature: Using private browsing
               tabs:
               - history:
                 - url: http://localhost:*/data/hello.txt
+            """
 
     Scenario: Opening private window via :click-element
         When I open data/click_element.html in a private window
@@ -122,6 +128,7 @@ Feature: Using private browsing
         And I run :click-element --target window id link
         And I wait until data/hello.txt is loaded
         Then the session should look like:
+            """
             windows:
             - private: True
               tabs:
@@ -131,6 +138,7 @@ Feature: Using private browsing
               tabs:
               - history:
                 - url: http://localhost:*/data/hello.txt
+            """
 
     Scenario: Skipping private window when saving session
         When I open data/hello.txt in a private window
@@ -163,12 +171,14 @@ Feature: Using private browsing
         And I run :quickmark-load two
         And I wait until data/numbers/2.txt is loaded
         Then the session should look like:
+            """
             windows:
             - private: True
               tabs:
               - history:
                 - url: http://localhost:*/data/numbers/1.txt
                 - url: http://localhost:*/data/numbers/2.txt
+            """
 
   @skip  # Too flaky
   Scenario: Saving a private session with only-active-window
@@ -188,6 +198,7 @@ Feature: Using private browsing
         And I run :session-load -c window_session_name
         And I wait until data/numbers/5.txt is loaded
         Then the session should look like:
+            """
             windows:
                 - tabs:
                     - history:
@@ -197,6 +208,7 @@ Feature: Using private browsing
                     - history:
                         - active: true
                           url: http://localhost:*/data/numbers/5.txt
+            """
 
     # https://github.com/qutebrowser/qutebrowser/issues/5810
 

--- a/tests/end2end/features/private.feature
+++ b/tests/end2end/features/private.feature
@@ -153,7 +153,7 @@ Feature: Using private browsing
         Then the javascript message "console.log works!" should not be logged
 
     # Probably needs qutewm to work properly...
-    @qtwebkit_skip: Only applies to QtWebEngine @xfail_norun
+    @qtwebkit_skip  # Only applies to QtWebEngine @xfail_norun
     Scenario: Make sure local storage is isolated with private browsing
         When I open data/hello.txt in a private window
         And I run :jseval localStorage.qute_private_test = 42

--- a/tests/end2end/features/private.feature
+++ b/tests/end2end/features/private.feature
@@ -153,7 +153,7 @@ Feature: Using private browsing
         Then the javascript message "console.log works!" should not be logged
 
     # Probably needs qutewm to work properly...
-    @qtwebkit_skip  # Only applies to QtWebEngine @xfail_norun
+    @qtwebkit_skip  @xfail_norun  # Only applies to QtWebEngine 
     Scenario: Make sure local storage is isolated with private browsing
         When I open data/hello.txt in a private window
         And I run :jseval localStorage.qute_private_test = 42

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -62,7 +62,7 @@ Feature: Prompts
 
     # Multiple prompts
 
-    @qtwebengine_skip: QtWebEngine refuses to load anything with a JS question
+    @qtwebengine_skip  # QtWebEngine refuses to load anything with a JS question
     Scenario: Blocking question interrupted by blocking one
         When I set content.javascript.alert to true
         And I open data/prompt/jsalert.html
@@ -78,7 +78,7 @@ Feature: Prompts
         Then the javascript message "confirm reply: true" should be logged
         And the javascript message "Alert done" should be logged
 
-    @qtwebengine_skip: QtWebEngine refuses to load anything with a JS question
+    @qtwebengine_skip  # QtWebEngine refuses to load anything with a JS question
     Scenario: Blocking question interrupted by async one
         Given I have a fresh instance
         When I set content.javascript.alert to true
@@ -503,7 +503,7 @@ Feature: Prompts
         Then "Added quickmark prompt-in-command-mode for *" should be logged
 
     # https://github.com/qutebrowser/qutebrowser/issues/1093
-    @qtwebengine_skip: QtWebEngine doesn't open the second page/prompt
+    @qtwebengine_skip  # QtWebEngine doesn't open the second page/prompt
     Scenario: Keyboard focus with multiple auth prompts
         When I open basic-auth/user5/password5 without waiting
         And I open basic-auth/user6/password6 in a new tab without waiting

--- a/tests/end2end/features/prompts.feature
+++ b/tests/end2end/features/prompts.feature
@@ -372,10 +372,12 @@ Feature: Prompts
         And I run :prompt-accept
         And I wait until basic-auth/user1/password1 is loaded
         Then the json on the page should be:
+            """
             {
               "authenticated": true,
               "user": "user1"
             }
+            """
 
     Scenario: Authentication with :prompt-accept value
         When I open about:blank in a new tab
@@ -384,10 +386,12 @@ Feature: Prompts
         And I run :prompt-accept user2:password2
         And I wait until basic-auth/user2/password2 is loaded
         Then the json on the page should be:
+            """
             {
               "authenticated": true,
               "user": "user2"
             }
+            """
 
     Scenario: Authentication with invalid :prompt-accept value
         When I open about:blank in a new tab
@@ -410,10 +414,12 @@ Feature: Prompts
         And I run :prompt-accept
         And I wait until basic-auth/user4/password4 is loaded
         Then the json on the page should be:
+            """
             {
               "authenticated": true,
               "user": "user4"
             }
+            """
 
     @qtwebengine_skip
     Scenario: Cancelling webpage authentication with QtWebKit
@@ -517,10 +523,12 @@ Feature: Prompts
         And I wait until basic-auth/user5/password5 is loaded
         # We're on the second page
         Then the json on the page should be:
+            """
             {
               "authenticated": true,
               "user": "user6"
             }
+            """
 
     # https://github.com/qutebrowser/qutebrowser/issues/1249#issuecomment-175205531
     # https://github.com/qutebrowser/qutebrowser/pull/2054#issuecomment-258285544

--- a/tests/end2end/features/qutescheme.feature
+++ b/tests/end2end/features/qutescheme.feature
@@ -11,7 +11,9 @@ Feature: Special qute:// pages
         And I run :help
         And I wait until qute://help/index.html is loaded
         Then the following tabs should be open:
+            """
             - qute://help/index.html (active)
+            """
 
     Scenario: :help with invalid topic
         When I run :help foo
@@ -23,7 +25,9 @@ Feature: Special qute:// pages
         And I run :help :back
         And I wait until qute://help/commands.html#back is loaded
         Then the following tabs should be open:
+            """
             - qute://help/commands.html#back (active)
+            """
 
     Scenario: :help with invalid command
         When I run :help :foo
@@ -35,7 +39,9 @@ Feature: Special qute:// pages
         And I run :help editor.command
         And I wait until qute://help/settings.html#editor.command is loaded
         Then the following tabs should be open:
+            """
             - qute://help/settings.html#editor.command (active)
+            """
 
     Scenario: :help with -t
         When the documentation is up to date
@@ -98,7 +104,9 @@ Feature: Special qute:// pages
         And I run :history
         And I wait until qute://history/ is loaded
         Then the following tabs should be open:
+            """
             - qute://history/ (active)
+            """
 
     Scenario: :history with -t
         When I run :tab-only

--- a/tests/end2end/features/qutescheme.feature
+++ b/tests/end2end/features/qutescheme.feature
@@ -43,8 +43,10 @@ Feature: Special qute:// pages
         And I run :help -t
         And I wait until qute://help/index.html is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - qute://help/index.html (active)
+            """
 
     # https://github.com/qutebrowser/qutebrowser/issues/2513
     Scenario: Opening link with qute:help
@@ -103,8 +105,10 @@ Feature: Special qute:// pages
         And I run :history -t
         And I wait until qute://history/ is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - qute://history/ (active)
+            """
 
     # qute://settings
 

--- a/tests/end2end/features/scroll.feature
+++ b/tests/end2end/features/scroll.feature
@@ -305,7 +305,9 @@ Feature: Scrolling
         And I wait until the scroll position changed
         And I run :scroll-page --bottom-navigate next 0 1
         Then the following tabs should be open:
+            """
             - data/scroll/simple.html
+            """
 
     Scenario: :scroll-page with --top-navigate
         When I run :scroll-page --top-navigate prev 0 -1

--- a/tests/end2end/features/scroll.feature
+++ b/tests/end2end/features/scroll.feature
@@ -223,7 +223,7 @@ Feature: Scrolling
         When I run :scroll-to-perc with count 50
         Then the page should be scrolled vertically
 
-    @qtwebengine_skip: Causes memory leak...
+    @qtwebengine_skip  # Causes memory leak...
     Scenario: :scroll-to-perc with a very big value
         When I run :scroll-to-perc 99999999999
         Then no crash should happen
@@ -311,7 +311,7 @@ Feature: Scrolling
         When I run :scroll-page --top-navigate prev 0 -1
         Then data/hello3.txt should be loaded
 
-    @qtwebengine_skip: Causes memory leak...
+    @qtwebengine_skip  # Causes memory leak...
     Scenario: :scroll-page with a very big value
         When I run :scroll-page 99999999999 99999999999
         Then the error "Numeric argument is too large for internal int representation." should be shown

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -344,8 +344,10 @@ Feature: Searching on a page
         And I run :selection-follow -t
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/search.html
             - data/hello.txt (active)
+            """
 
     Scenario: Don't follow searched text
         When I run :window-only
@@ -374,8 +376,10 @@ Feature: Searching on a page
         And I run :selection-follow -t
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/search.html
             - data/hello.txt (active)
+            """
 
     @qtwebkit_skip: Not supported in qtwebkit @skip
     Scenario: Follow a searched link in an iframe
@@ -397,8 +401,10 @@ Feature: Searching on a page
         And I run :selection-follow -t
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/iframe_search.html
             - data/hello.txt (active)
+            """
 
     Scenario: Closing a tab during a search
         When I run :open -b about:blank

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -355,7 +355,9 @@ Feature: Searching on a page
         And I wait for "search found foo" in the log
         And I run :selection-follow
         Then the following tabs should be open:
+            """
             - data/search.html (active)
+            """
 
     Scenario: Don't follow searched text in a new tab
         When I run :window-only
@@ -363,7 +365,9 @@ Feature: Searching on a page
         And I wait for "search found foo" in the log
         And I run :selection-follow -t
         Then the following tabs should be open:
+            """
             - data/search.html (active)
+            """
 
     Scenario: Follow a manually selected link
         When I run :jseval --file (testdata)/search_select.js

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -381,7 +381,7 @@ Feature: Searching on a page
             - data/hello.txt (active)
             """
 
-    @qtwebkit_skip: Not supported in qtwebkit @skip
+    @qtwebkit_skip @skip  # Not supported in qtwebkit 
     Scenario: Follow a searched link in an iframe
         When I open data/iframe_search.html
         And I wait for "* search loaded" in the log
@@ -391,7 +391,7 @@ Feature: Searching on a page
         And I run :selection-follow
         Then "navigation request: url http://localhost:*/data/hello.txt (current http://localhost:*/data/iframe_search.html), type link_clicked, is_main_frame False" should be logged
 
-    @qtwebkit_skip: Not supported in qtwebkit @skip
+    @qtwebkit_skip @skip  # Not supported in qtwebkit 
     Scenario: Follow a tabbed searched link in an iframe
         When I open data/iframe_search.html
         And I wait for "* search loaded" in the log

--- a/tests/end2end/features/search.feature
+++ b/tests/end2end/features/search.feature
@@ -113,7 +113,8 @@ Feature: Searching on a page
         When I set search.ignore_case to smart
         And I run :search Foo
         And I wait for "search found Foo with flags FindCaseSensitively" in the log
-        Then "Foo" should be found  # even though foo was first
+        # even though foo was first
+        Then "Foo" should be found
 
     ## :search-next
 

--- a/tests/end2end/features/sessions.feature
+++ b/tests/end2end/features/sessions.feature
@@ -7,6 +7,7 @@ Feature: Saving and loading sessions
     When I open data/hello.txt
     And I open data/title.html in a new tab
     Then the session should look like:
+      """
       windows:
         - active: true
           tabs:
@@ -19,12 +20,14 @@ Feature: Saving and loading sessions
               - active: true
                 url: http://localhost:*/data/title.html
                 title: Test title
+      """
 
   @qtwebengine_skip
   Scenario: Zooming (qtwebkit)
     When I open data/hello.txt
     And I run :zoom 50
     Then the session should look like:
+      """
       windows:
         - tabs:
           - history:
@@ -32,6 +35,7 @@ Feature: Saving and loading sessions
               zoom: 1.0
             - url: http://localhost:*/data/hello.txt
               zoom: 0.5
+      """
 
   # The zoom level is only stored for the newest element for QtWebEngine.
   @qtwebkit_skip
@@ -39,18 +43,21 @@ Feature: Saving and loading sessions
     When I open data/hello.txt
     And I run :zoom 50
     Then the session should look like:
+      """
       windows:
         - tabs:
           - history:
             - url: about:blank
             - url: http://localhost:*/data/hello.txt
               zoom: 0.5
+      """
 
   @qtwebengine_skip
   Scenario: Scrolling (qtwebkit)
     When I open data/scroll/simple.html
     And I run :scroll-px 10 20
     Then the session should look like:
+      """
       windows:
         - tabs:
           - history:
@@ -62,6 +69,7 @@ Feature: Saving and loading sessions
               scroll-pos:
                 x: 10
                 y: 20
+      """
 
   # The scroll position is only stored for the newest element for QtWebEngine.
   @qtwebkit_skip
@@ -70,6 +78,7 @@ Feature: Saving and loading sessions
     And I run :scroll-px 10 20
     And I wait until the scroll position changed to 10/20
     Then the session should look like:
+      """
       windows:
         - tabs:
           - history:
@@ -78,10 +87,12 @@ Feature: Saving and loading sessions
               scroll-pos:
                 x: 10
                 y: 20
+      """
   Scenario: Redirect
     When I open redirect-to?url=data/title.html without waiting
     And I wait until data/title.html is loaded
     Then the session should look like:
+      """
       windows:
         - tabs:
           - history:
@@ -90,16 +101,19 @@ Feature: Saving and loading sessions
               url: http://localhost:*/data/title.html
               original-url: http://localhost:*/redirect-to?url=data/title.html
               title: Test title
+      """
 
   Scenario: Valid UTF-8 data
     When I open data/sessions/snowman.html
     Then the session should look like:
+      """
       windows:
       - tabs:
         - history:
           - url: about:blank
           - url: http://localhost:*/data/sessions/snowman.html
             title: snow☃man
+      """
 
   @qtwebengine_skip
   Scenario: Long output comparison (qtwebkit)
@@ -109,6 +123,7 @@ Feature: Saving and loading sessions
     And I open data/numbers/3.txt in a new window
     # Full output apart from "geometry:" and the active window (needs qutewm)
     Then the session should look like:
+      """
       windows:
       - tabs:
         - history:
@@ -150,6 +165,7 @@ Feature: Saving and loading sessions
             title: ''
             url: http://localhost:*/data/numbers/3.txt
             zoom: 1.0
+      """
 
   # FIXME:qtwebengine what's up with the titles there?
   @qtwebkit_skip
@@ -160,6 +176,7 @@ Feature: Saving and loading sessions
     And I open data/numbers/3.txt in a new window
     # Full output apart from "geometry:" and the active window (needs qutewm)
     Then the session should look like:
+      """
       windows:
       - tabs:
         - history:
@@ -193,26 +210,31 @@ Feature: Saving and loading sessions
             title: localhost:*/data/numbers/3.txt
             url: http://localhost:*/data/numbers/3.txt
             zoom: 1.0
+      """
 
   Scenario: Saving with --no-history
     When I open data/numbers/1.txt
     And I open data/numbers/2.txt
     And I open data/numbers/3.txt
     Then the session saved with --no-history should look like:
+      """
       windows:
       - tabs:
         - history:
           - url: http://localhost:*/data/numbers/3.txt
+      """
 
   Scenario: Saving with --no-history and --only-active-window
     When I open data/numbers/1.txt
     And I open data/numbers/2.txt
     And I open data/numbers/3.txt
     Then the session saved with --no-history --only-active-window should look like:
+      """
       windows:
       - tabs:
         - history:
           - url: http://localhost:*/data/numbers/3.txt
+      """
 
   # https://github.com/qutebrowser/qutebrowser/issues/879
 
@@ -220,6 +242,7 @@ Feature: Saving and loading sessions
     When I open data/sessions/history_replace_state.html without waiting
     Then the javascript message "Called history.replaceState" should be logged
     And the session should look like:
+      """
       windows:
       - tabs:
         - history:
@@ -227,6 +250,7 @@ Feature: Saving and loading sessions
           - active: true
             url: http://localhost:*/data/sessions/history_replace_state.html?state=2
             title: Test title
+      """
 
   @qtwebengine_skip
   Scenario: Saving a session with a page using history.replaceState() and navigating away (qtwebkit)
@@ -234,6 +258,7 @@ Feature: Saving and loading sessions
     And I open data/hello.txt
     Then the javascript message "Called history.replaceState" should be logged
     And the session should look like:
+      """
       windows:
       - tabs:
         - history:
@@ -244,6 +269,7 @@ Feature: Saving and loading sessions
             title: http://localhost:*/data/sessions/history_replace_state.html?state=2
           - active: true
             url: http://localhost:*/data/hello.txt
+      """
 
   # Seems like that bug is fixed upstream in QtWebEngine
   @skip  # Too flaky
@@ -252,6 +278,7 @@ Feature: Saving and loading sessions
     And I wait for "* Called history.replaceState" in the log
     And I open data/hello.txt
     Then the session should look like:
+      """
       windows:
       - tabs:
         - history:
@@ -260,6 +287,7 @@ Feature: Saving and loading sessions
             title: Test title
           - active: true
             url: http://localhost:*/data/hello.txt
+      """
 
   # :session-save
 
@@ -314,6 +342,7 @@ Feature: Saving and loading sessions
     And I wait until data/numbers/4.txt is loaded
     And I wait until data/numbers/5.txt is loaded
     Then the session should look like:
+      """
       windows:
         - tabs:
             - history:
@@ -327,6 +356,7 @@ Feature: Saving and loading sessions
             - history:
                 - active: true
                   url: http://localhost:*/data/numbers/5.txt
+      """
 
   # https://github.com/qutebrowser/qutebrowser/issues/7696
   @qtwebkit_skip
@@ -339,6 +369,7 @@ Feature: Saving and loading sessions
     And I run :session-load --clear current
     And I wait until data/downloads/downloads.html is loaded
     Then the session should look like:
+      """
       windows:
         - tabs:
           - history:
@@ -347,6 +378,7 @@ Feature: Saving and loading sessions
               url: http://localhost:*/data/downloads/downloads.html
           - active: true
             history: []
+      """
 
   # :session-delete
 
@@ -436,7 +468,9 @@ Feature: Saving and loading sessions
       And I open data/numbers/4.txt
       Then the message "Tab is pinned! Opening in new tab." should be shown
       And the following tabs should be open:
+        """
         - data/numbers/1.txt
         - data/numbers/2.txt (active) (pinned)
         - data/numbers/4.txt
         - data/numbers/3.txt
+        """

--- a/tests/end2end/features/spawn.feature
+++ b/tests/end2end/features/spawn.feature
@@ -54,8 +54,10 @@ Feature: :spawn
         And I run :spawn -u (testdata)/userscripts/open_current_url
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt
             - data/hello.txt (active)
+            """
 
     @posix
     Scenario: Running :spawn with userscript and count
@@ -75,8 +77,10 @@ Feature: :spawn
         And I run :spawn -u (testdata)/userscripts/open_current_url.bat
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+           """
             - data/hello.txt
             - data/hello.txt (active)
+           """
 
     @posix
     Scenario: Running :spawn with userscript that expects the stdin getting closed

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1193,7 +1193,7 @@ Feature: Tab management
     # tabs.last_close
 
     # FIXME:qtwebengine
-    @qtwebengine_skip: Waits for an earlier about:blank and fails
+    @qtwebengine_skip  # Waits for an earlier about:blank and fails
     Scenario: tabs.last_close = blank
         When I open data/hello.txt
         And I set tabs.last_close to blank

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -164,7 +164,9 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-only
         Then the following tabs should be open:
+            """
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-only with --prev
         When I open data/numbers/1.txt
@@ -937,7 +939,9 @@ Feature: Tab management
         And I run :undo
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
+            """
 
     @qtwebengine_flaky
     Scenario: Undo with auto-created last tab, with history
@@ -950,7 +954,9 @@ Feature: Tab management
         And I run :undo
         And I wait until data/hello2.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello2.txt (active)
+            """
 
     Scenario: Undo with auto-created last tab (startpage)
         When I open data/hello.txt
@@ -962,7 +968,9 @@ Feature: Tab management
         And I run :undo
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
+            """
 
     Scenario: Undo with auto-created last tab (default-page)
         When I open data/hello.txt
@@ -974,7 +982,9 @@ Feature: Tab management
         And I run :undo
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
+            """
 
     @skip  # Too flaky
     Scenario: Double-undo with single tab on tabs.last_close default page
@@ -1201,7 +1211,9 @@ Feature: Tab management
         And I run :tab-close
         And I wait until about:blank is loaded
         Then the following tabs should be open:
+            """
             - about:blank (active)
+            """
 
     Scenario: tabs.last_close = startpage
         When I set url.start_pages to ["http://localhost:(port)/data/numbers/7.txt", "http://localhost:(port)/data/numbers/8.txt"]
@@ -1225,7 +1237,9 @@ Feature: Tab management
         And I run :tab-close
         And I wait until data/numbers/9.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/9.txt (active)
+            """
 
     Scenario: tabs.last_close = close
         When I open data/hello.txt
@@ -1481,13 +1495,17 @@ Feature: Tab management
         When I open data/title.html
         And I run :tab-select /
         Then the following tabs should be open:
+            """
             - data/title.html (active)
+            """
 
     Scenario: :tab-select with wrong argument (//)
         When I open data/title.html
         And I run :tab-select //
         Then the following tabs should be open:
+            """
             - data/title.html (active)
+            """
 
     Scenario: :tab-select with wrong argument (0/x)
         When I open data/title.html
@@ -1746,7 +1764,9 @@ Feature: Tab management
         And I wait for "*want to close a pinned tab*" in the log
         And I run :prompt-accept yes
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
+            """
 
     Scenario: Pinned :tab-close prompt no
         When I open data/numbers/1.txt
@@ -1772,7 +1792,9 @@ Feature: Tab management
         And I wait for "*want to close pinned tabs*" in the log
         And I run :prompt-accept yes
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
+            """
 
     Scenario: Pinned :tab-only prompt no
         When I open data/numbers/1.txt
@@ -1795,7 +1817,9 @@ Feature: Tab management
         And I run :tab-pin
         And I run :tab-only
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt (active) (pinned)
+            """
 
     Scenario: Pinned :tab-only --pinned close
         When I open data/numbers/1.txt
@@ -1805,7 +1829,9 @@ Feature: Tab management
         And I run :tab-next
         And I run :tab-only --pinned close
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
+            """
 
     Scenario: Pinned :tab-only --pinned keep
         When I open data/numbers/1.txt
@@ -1846,7 +1872,9 @@ Feature: Tab management
         And I run :tab-pin
         And I open data/numbers/2.txt
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt (active) (pinned)
+            """
 
     Scenario: :home on a pinned tab
         When I open data/numbers/1.txt
@@ -1854,7 +1882,9 @@ Feature: Tab management
         And I run :home
         Then the message "Tab is pinned!" should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
+            """
 
     Scenario: :home on a pinned tab with tabs.pinned.frozen = false
         When I set url.start_pages to ["http://localhost:(port)/data/numbers/2.txt"]
@@ -1864,7 +1894,9 @@ Feature: Tab management
         And I run :home
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
+            """
             - data/numbers/2.txt (active) (pinned)
+            """
 
     Scenario: Cloning a pinned tab
         When I open data/numbers/1.txt

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -14,8 +14,10 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-close
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
+            """
 
     Scenario: :tab-close with count
         When I open data/numbers/1.txt
@@ -23,8 +25,10 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-close with count 1
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-close with invalid count
         When I open data/numbers/1.txt
@@ -32,9 +36,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-close with count 23
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = next
         When I set tabs.select_on_remove to next
@@ -44,8 +50,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = prev
         When I set tabs.select_on_remove to prev
@@ -55,8 +63,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = last-used
         When I set tabs.select_on_remove to last-used
@@ -67,9 +77,11 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt
             - data/numbers/4.txt (active)
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = prev and --next
         When I set tabs.select_on_remove to prev
@@ -79,8 +91,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close --next
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = next and --prev
         When I set tabs.select_on_remove to next
@@ -90,8 +104,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close --prev
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = prev and --opposite
         When I set tabs.select_on_remove to prev
@@ -101,8 +117,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close --opposite
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = next and --opposite
         When I set tabs.select_on_remove to next
@@ -112,8 +130,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close --opposite
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-close with tabs.select_on_remove = last-used and --opposite
         When I set tabs.select_on_remove to last-used
@@ -131,8 +151,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-close
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/4.txt (active)
+            """
 
     # :tab-only
 
@@ -151,8 +173,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-only --prev
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
+            """
 
     Scenario: :tab-only with --next
         When I open data/numbers/1.txt
@@ -161,8 +185,10 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :tab-only --next
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-only with --prev and --next
         When I run :tab-only --prev --next
@@ -180,9 +206,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-focus without index/count
         When I open data/numbers/1.txt
@@ -192,9 +220,11 @@ Feature: Tab management
         And I run :tab-focus
         Then the warning "Using :tab-focus without count is deprecated, use :tab-next instead." should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-focus with invalid index
         When I run :tab-focus 23
@@ -210,9 +240,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-focus with count and index
         When I open data/numbers/1.txt
@@ -220,9 +252,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus 4 with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-focus last
         When I open data/numbers/1.txt
@@ -232,9 +266,11 @@ Feature: Tab management
         And I run :tab-focus 3
         And I run :tab-focus last
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-focus with current tab number
         When I open data/numbers/1.txt
@@ -244,9 +280,11 @@ Feature: Tab management
         And I run :tab-focus 3
         And I run :tab-focus 3
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-focus with current tab number and --no-last
         When I open data/numbers/1.txt
@@ -256,9 +294,11 @@ Feature: Tab management
         And I run :tab-focus 3
         And I run :tab-focus --no-last 3
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-focus with -1
         When I open data/numbers/1.txt
@@ -267,9 +307,11 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-focus -1
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-focus negative index
         When I open data/numbers/1.txt
@@ -277,9 +319,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-focus -2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-focus with invalid negative index
         When I open data/numbers/1.txt
@@ -305,11 +349,13 @@ Feature: Tab management
         And I run :tab-focus 3
         And I run :cmd-repeat 2 tab-focus stack-prev
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
             - data/numbers/4.txt
             - data/numbers/5.txt
+            """
 
     Scenario: :tab-focus next stacking
         When I open data/numbers/1.txt
@@ -325,11 +371,13 @@ Feature: Tab management
         And I run :cmd-repeat 3 tab-focus stack-prev
         And I run :cmd-repeat 2 tab-focus stack-next
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt
             - data/numbers/4.txt (active)
             - data/numbers/5.txt
+            """
 
     Scenario: :tab-focus stacking limit
         When I set tabs.focus_stack_size to 1
@@ -349,11 +397,13 @@ Feature: Tab management
         And I run :cmd-repeat 4 tab-focus stack-prev
         Then the error "Could not find requested tab!" should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
             - data/numbers/4.txt
             - data/numbers/5.txt
+            """
 
     Scenario: :tab-focus stacking and last
         When I open data/numbers/1.txt
@@ -369,11 +419,13 @@ Feature: Tab management
         And I run :cmd-repeat 2 tab-focus stack-prev
         And I run :cmd-repeat 3 tab-focus last
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt
             - data/numbers/4.txt (active)
             - data/numbers/5.txt
+            """
 
 
     Scenario: :tab-focus last after moving current tab
@@ -383,9 +435,11 @@ Feature: Tab management
         And I run :tab-move 2
         And I run :tab-focus last
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt
             - data/numbers/2.txt (active)
+            """
 
     Scenario: :tab-focus last after closing a lower number tab
         When I open data/numbers/1.txt
@@ -394,8 +448,10 @@ Feature: Tab management
         And I run :tab-close with count 1
         And I run :tab-focus last
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     # tab-prev/tab-next
 
@@ -404,8 +460,10 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new tab
         And I run :tab-prev
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-next
         When I open data/numbers/1.txt
@@ -413,8 +471,10 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-next
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
+            """
 
     Scenario: :tab-prev with count
         When I open data/numbers/1.txt
@@ -422,9 +482,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-prev with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-next with count
         When I open data/numbers/1.txt
@@ -433,9 +495,11 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-next with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-prev on first tab without wrap
         When I set tabs.wrap to false
@@ -457,9 +521,11 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-prev
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-next with last tab with wrap
         When I set tabs.wrap to true
@@ -468,9 +534,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-next
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-next with last tab, wrap and count
         When I set tabs.wrap to true
@@ -479,9 +547,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-next with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (active)
             - data/numbers/3.txt
+            """
 
     # :tab-move
 
@@ -491,9 +561,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move
         Then the following tabs should be open:
+            """
             - data/numbers/3.txt (active)
             - data/numbers/1.txt
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with absolute position and count.
         When I open data/numbers/1.txt
@@ -501,9 +573,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with absolute position and invalid count.
         When I open data/numbers/1.txt
@@ -512,9 +586,11 @@ Feature: Tab management
         And I run :tab-move with count 23
         Then the error "Can't move tab to position 23!" should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-move with index.
         When I open data/numbers/1.txt
@@ -522,9 +598,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with negative index.
         When I open data/numbers/1.txt
@@ -532,9 +610,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move -3
         Then the following tabs should be open:
+            """
             - data/numbers/3.txt (active)
             - data/numbers/1.txt
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with invalid index.
         When I open data/numbers/1.txt
@@ -543,9 +623,11 @@ Feature: Tab management
         And I run :tab-move -5
         Then the error "Can't move tab to position -1!" should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-move with index and count.
         When I open data/numbers/1.txt
@@ -553,9 +635,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move 1 with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with index and invalid count.
         When I open data/numbers/1.txt
@@ -564,9 +648,11 @@ Feature: Tab management
         And I run :tab-move -2 with count 4
         Then the error "Can't move tab to position 4!" should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-move with relative position (negative).
         When I open data/numbers/1.txt
@@ -574,9 +660,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move -
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with relative position (positive).
         When I open data/numbers/1.txt
@@ -585,9 +673,11 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-move +
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-move with relative position (negative) and count.
         When I open data/numbers/1.txt
@@ -595,9 +685,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move - with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/3.txt (active)
             - data/numbers/1.txt
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with relative position and too big count.
         When I set tabs.wrap to false
@@ -615,9 +707,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move +
         Then the following tabs should be open:
+            """
             - data/numbers/3.txt (active)
             - data/numbers/1.txt
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-move with relative position (negative), wrap and count
         When I set tabs.wrap to true
@@ -627,9 +721,11 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-move - with count 8
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
+            """
 
     Scenario: :tab-move with absolute position
         When I open data/numbers/1.txt
@@ -638,9 +734,11 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-move end
         Then the following tabs should be open:
+            """
             - data/numbers/2.txt
             - data/numbers/3.txt
             - data/numbers/1.txt (active)
+            """
 
     Scenario: :tab-move with absolute position
         When I open data/numbers/1.txt
@@ -648,9 +746,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-move start
         Then the following tabs should be open:
+            """
             - data/numbers/3.txt (active)
             - data/numbers/1.txt
             - data/numbers/2.txt
+            """
 
     Scenario: Make sure :tab-move retains metadata
         When I open data/title.html
@@ -658,6 +758,7 @@ Feature: Tab management
         And I run :tab-focus 1
         And I run :tab-move +
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -667,6 +768,7 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/title.html
                   title: Test title
+            """
 
     # :tab-clone
 
@@ -679,6 +781,7 @@ Feature: Tab management
         And I run :tab-clone
         And I wait until data/title.html is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -690,6 +793,7 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/title.html
                   title: Test title
+            """
 
     Scenario: Cloning zoom value
         When I open data/hello.txt
@@ -697,6 +801,7 @@ Feature: Tab management
         And I run :tab-clone
         And I wait until data/hello.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -708,20 +813,24 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/hello.txt
                   zoom: 1.2
+            """
 
     Scenario: Cloning to background tab
         When I open data/hello2.txt
         And I run :tab-clone -b
         And I wait until data/hello2.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello2.txt (active)
             - data/hello2.txt
+            """
 
     Scenario: Cloning to new window
         When I open data/title.html
         And I run :tab-clone -w
         And I wait until data/title.html is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -735,6 +844,7 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/title.html
                   title: Test title
+            """
 
     Scenario: Cloning with tabs_are_windows = true
         When I open data/title.html
@@ -742,6 +852,7 @@ Feature: Tab management
         And I run :tab-clone
         And I wait until data/title.html is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -755,12 +866,14 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/title.html
                   title: Test title
+            """
 
     Scenario: Cloning to private window
         When I open data/title.html
         And I run :tab-clone -p
         And I wait until data/title.html is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -775,6 +888,7 @@ Feature: Tab management
                 - url: about:blank
                 - url: http://localhost:*/data/title.html
                   title: Test title
+            """
 
     # https://github.com/qutebrowser/qutebrowser/issues/2289
 
@@ -801,6 +915,7 @@ Feature: Tab management
         And I run :undo
         And I wait until data/numbers/3.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -810,6 +925,7 @@ Feature: Tab management
                 history:
                 - url: http://localhost:*/data/numbers/2.txt
                 - url: http://localhost:*/data/numbers/3.txt
+            """
 
     @qtwebengine_flaky
     Scenario: Undo with auto-created last tab
@@ -878,9 +994,11 @@ Feature: Tab management
         And I run :tab-close with count 1
         And I run :undo
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: Undo a tab closed after switching tabs
         When I open data/numbers/1.txt
@@ -890,9 +1008,11 @@ Feature: Tab management
         And I run :tab-focus 2
         And I run :undo
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: Undo a tab closed after rearranging tabs
         When I open data/numbers/1.txt
@@ -902,9 +1022,11 @@ Feature: Tab management
         And I run :tab-move with count 1
         And I run :undo
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/3.txt
             - data/numbers/2.txt
+            """
 
     @flaky
     Scenario: Undo a tab closed after new tab opened
@@ -915,9 +1037,11 @@ Feature: Tab management
         And I run :undo
         And I wait until data/numbers/1.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: Undo the closing of tabs using :tab-only
         When I open data/numbers/1.txt
@@ -927,9 +1051,11 @@ Feature: Tab management
         And I run :tab-only
         And I run :undo
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
             - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     # :undo --window
 
@@ -942,6 +1068,7 @@ Feature: Tab management
         And I run :undo -w
         And I wait for "Focus object changed: *" in the log
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -953,6 +1080,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/numbers/2.txt
+            """
 
     Scenario: Undo the closing of a window with multiple tabs
         Given I clear the log
@@ -964,6 +1092,7 @@ Feature: Tab management
         And I run :undo -w
         And I wait for "Focus object changed: *" in the log
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -977,6 +1106,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/numbers/3.txt
+            """
 
     Scenario: Undo the closing of a window with multiple tabs with undo stack
         Given I clear the log
@@ -990,6 +1120,7 @@ Feature: Tab management
         And I run :undo
         And I wait for "Focus object changed: *" in the log
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -1003,6 +1134,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/numbers/3.txt
+            """
 
     Scenario: Undo the closing of a window with tabs are windows
         Given I clear the log
@@ -1015,6 +1147,7 @@ Feature: Tab management
         And I run :undo -w
         And I wait for "Focus object changed: *" in the log
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -1025,6 +1158,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/numbers/2.txt
+            """
 
     # :undo with count
 
@@ -1036,8 +1170,10 @@ Feature: Tab management
         And I run :tab-close
         And I run :undo with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: Undo with a too-high count
         When I open data/numbers/1.txt
@@ -1076,8 +1212,10 @@ Feature: Tab management
         And I wait until data/numbers/7.txt is loaded
         And I wait until data/numbers/8.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/7.txt
             - data/numbers/8.txt (active)
+            """
 
     Scenario: tabs.last_close = default-page
         When I set url.default_page to http://localhost:(port)/data/numbers/9.txt
@@ -1104,8 +1242,10 @@ Feature: Tab management
         And I hint with args "all tab" and follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hints/html/simple.html (active)
             - data/hello.txt
+            """
 
     Scenario: opening tab with tabs.new_position.related prev
         When I set tabs.new_position.related to prev
@@ -1115,9 +1255,11 @@ Feature: Tab management
         And I run :click-element id link --target=tab
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/hello.txt (active)
             - data/hints/html/simple.html
+            """
 
     Scenario: opening tab with tabs.new_position.related next
         When I set tabs.new_position.related to next
@@ -1127,9 +1269,11 @@ Feature: Tab management
         And I run :click-element id link --target=tab
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/hints/html/simple.html
             - data/hello.txt (active)
+            """
 
     Scenario: opening tab with tabs.new_position.related first
         When I set tabs.new_position.related to first
@@ -1139,9 +1283,11 @@ Feature: Tab management
         And I run :click-element id link --target=tab
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hello.txt (active)
             - about:blank
             - data/hints/html/simple.html
+            """
 
     Scenario: opening tab with tabs.new_position.related last
         When I set tabs.new_position.related to last
@@ -1152,9 +1298,11 @@ Feature: Tab management
         And I run :click-element id link --target=tab
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - data/hints/html/simple.html
             - about:blank
             - data/hello.txt (active)
+            """
 
     # stacking tabs
     Scenario: stacking tabs opening tab with tabs.new_position.related next
@@ -1168,10 +1316,12 @@ Feature: Tab management
         And I wait until data/navigate/prev.html is loaded
         And I wait until data/navigate/next.html is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/navigate/index.html (active)
             - data/navigate/prev.html
             - data/navigate/next.html
+            """
 
     Scenario: stacking tabs opening tab with tabs.new_position.related prev
         When I set tabs.new_position.related to prev
@@ -1184,10 +1334,12 @@ Feature: Tab management
         And I wait until data/navigate/prev.html is loaded
         And I wait until data/navigate/next.html is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/navigate/next.html
             - data/navigate/prev.html
             - data/navigate/index.html (active)
+            """
 
     Scenario: no stacking tabs opening tab with tabs.new_position.related next
         When I set tabs.new_position.related to next
@@ -1200,10 +1352,12 @@ Feature: Tab management
         And I wait until data/navigate/prev.html is loaded
         And I wait until data/navigate/next.html is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/navigate/index.html (active)
             - data/navigate/next.html
             - data/navigate/prev.html
+            """
 
     Scenario: no stacking tabs opening tab with tabs.new_position.related prev
         When I set tabs.new_position.related to prev
@@ -1216,10 +1370,12 @@ Feature: Tab management
         And I wait until data/navigate/prev.html is loaded
         And I wait until data/navigate/next.html is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/navigate/prev.html
             - data/navigate/next.html
             - data/navigate/index.html (active)
+            """
 
     # :tab-select
 
@@ -1234,9 +1390,11 @@ Feature: Tab management
         And I run :tab-select Searching text
         And I wait for "Current tab changed, focusing <qutebrowser.browser.* tab_id=* url='http://localhost:*/data/search.html'>" in the log
         Then the following tabs should be open:
+            """
             - data/title.html
             - data/search.html (active)
             - data/scroll/simple.html
+            """
 
     Scenario: :tab-select with no matching title
         When I run :tab-select invalid title
@@ -1252,6 +1410,7 @@ Feature: Tab management
         And I run :tab-select Scrolling
         And I wait for "Focus object changed: *" in the log
         Then the session should look like:
+            """
             windows:
             - active: true
               tabs:
@@ -1269,6 +1428,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/paste_primary.html
+            """
 
     Scenario: :tab-select with no matching index
         When I open data/title.html
@@ -1292,6 +1452,7 @@ Feature: Tab management
         And I run :tab-select 0/2
         And I wait for "Focus object changed: *" in the log
         Then the session should look like:
+            """
             windows:
             - active: true
               tabs:
@@ -1309,6 +1470,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/paste_primary.html
+            """
 
     Scenario: :tab-select with wrong argument (-1)
         When I open data/title.html
@@ -1346,6 +1508,7 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new window
         And I run :tab-take 0/1
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -1355,6 +1518,7 @@ Feature: Tab management
                 - url: http://localhost:*/data/numbers/2.txt
               - history:
                 - url: http://localhost:*/data/numbers/1.txt
+            """
 
     Scenario: Take a tab from the same window
         Given I have a fresh instance
@@ -1379,6 +1543,7 @@ Feature: Tab management
         And I run :tab-take 1/1
         And I wait until data/numbers/2.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -1387,6 +1552,7 @@ Feature: Tab management
               - active: true
                 history:
                 - url: http://localhost:*/data/numbers/2.txt
+            """
 
     # :tab-give
 
@@ -1397,6 +1563,7 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new window
         And I run :tab-give 0
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -1406,6 +1573,7 @@ Feature: Tab management
             - tabs:
               - history:
                 - url: about:blank
+            """
 
     Scenario: Give a tab to the same window
         Given I have a fresh instance
@@ -1419,6 +1587,7 @@ Feature: Tab management
         And I run :tab-give
         And I wait until data/numbers/2.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -1427,6 +1596,7 @@ Feature: Tab management
             - tabs:
               - history:
                 - url: http://localhost:*/data/numbers/2.txt
+            """
 
     Scenario: Give a tab from window with only one tab
         When I open data/hello.txt
@@ -1455,6 +1625,7 @@ Feature: Tab management
         And I run :tab-give 1
         And I wait until data/numbers/1.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -1462,6 +1633,7 @@ Feature: Tab management
                 - url: http://localhost:*/data/numbers/2.txt
               - history:
                 - url: http://localhost:*/data/numbers/1.txt
+            """
 
     # Other
 
@@ -1485,6 +1657,7 @@ Feature: Tab management
         And I hint with args "all tab-fg" and follow a
         And I wait until data/hello.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - history:
@@ -1493,6 +1666,7 @@ Feature: Tab management
             - tabs:
               - history:
                 - url: http://localhost:*/data/hello.txt
+            """
 
     Scenario: Closing tab with tabs_are_windows
         When I set tabs.tabs_are_windows to true
@@ -1502,12 +1676,14 @@ Feature: Tab management
         And I run :tab-close
         And I wait for "removed: tabbed-browser" in the log
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
                 history:
                 - url: about:blank
                 - url: http://localhost:*/data/numbers/1.txt
+            """
 
     # :tab-pin
 
@@ -1517,9 +1693,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-pin
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active) (pinned)
+            """
 
     Scenario: :tab-pin unpin
         When I open data/numbers/1.txt
@@ -1529,9 +1707,11 @@ Feature: Tab management
         And I run :tab-pin
         And I run :tab-pin
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (pinned)
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-pin to index 2
         When I open data/numbers/1.txt
@@ -1539,9 +1719,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-pin with count 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (pinned)
             - data/numbers/3.txt (active)
+            """
 
     Scenario: :tab-pin with an invalid count
         When I open data/numbers/1.txt
@@ -1549,9 +1731,11 @@ Feature: Tab management
         And I open data/numbers/3.txt in a new tab
         And I run :tab-pin with count 23
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt
             - data/numbers/3.txt (active)
+            """
 
     Scenario: Pinned :tab-close prompt yes
         When I open data/numbers/1.txt
@@ -1573,8 +1757,10 @@ Feature: Tab management
         And I wait for "*want to close a pinned tab*" in the log
         And I run :prompt-accept no
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (pinned)
             - data/numbers/2.txt (active) (pinned)
+            """
 
     Scenario: Pinned :tab-only prompt yes
         When I open data/numbers/1.txt
@@ -1598,8 +1784,10 @@ Feature: Tab management
         And I wait for "*want to close pinned tabs*" in the log
         And I run :prompt-accept no
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
             - data/numbers/2.txt (pinned)
+            """
 
     Scenario: Pinned :tab-only close all but pinned tab
         When I open data/numbers/1.txt
@@ -1627,8 +1815,10 @@ Feature: Tab management
         And I run :tab-next
         And I run :tab-only --pinned keep
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
             - data/numbers/2.txt (pinned)
+            """
 
     Scenario: Pinned :tab-only --pinned prompt
         When I open data/numbers/1.txt
@@ -1645,8 +1835,10 @@ Feature: Tab management
         And I open data/numbers/2.txt
         Then the message "Tab is pinned! Opening in new tab." should be shown
         And the following tabs should be open:
+            """
             - data/numbers/1.txt (active) (pinned)
             - data/numbers/2.txt
+            """
 
     Scenario: :tab-pin open url with tabs.pinned.frozen = false
         When I set tabs.pinned.frozen to false
@@ -1680,8 +1872,10 @@ Feature: Tab management
         And I run :tab-clone
         And I wait until data/numbers/1.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (pinned)
             - data/numbers/1.txt (pinned) (active)
+            """
 
     Scenario: Undo a pinned tab
         When I open data/numbers/1.txt
@@ -1691,8 +1885,10 @@ Feature: Tab management
         And I run :undo
         And I wait until data/numbers/2.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/2.txt (pinned) (active)
+            """
 
 
     Scenario: Focused webview after clicking link in bg

--- a/tests/end2end/features/test_history_bdd.py
+++ b/tests/end2end/features/test_history_bdd.py
@@ -34,8 +34,8 @@ def check_query(quteproc, name, value):
     assert data[name] == value
 
 
-@bdd.then(bdd.parsers.parse("the history should contain:\n{expected}"))
-def check_history(quteproc, server, tmpdir, expected):
+@bdd.then(bdd.parsers.parse("the history should contain:"))
+def check_history(quteproc, server, tmpdir, docstring):
     quteproc.wait_for(message='INSERT INTO History *', category='sql')
     path = tmpdir / 'history'
     quteproc.send_cmd(':debug-dump-history "{}"'.format(path))
@@ -46,7 +46,7 @@ def check_history(quteproc, server, tmpdir, expected):
         # ignore access times, they will differ in each run
         actual = '\n'.join(re.sub('^\\d+-?', '', line).strip() for line in f)
 
-    expected = expected.replace('(port)', str(server.port))
+    expected = docstring.replace('(port)', str(server.port))
     assert actual == expected
 
 

--- a/tests/end2end/features/test_sessions_bdd.py
+++ b/tests/end2end/features/test_sessions_bdd.py
@@ -15,12 +15,12 @@ def turn_on_scroll_logging(quteproc):
     quteproc.turn_on_scroll_logging()
 
 
-@bdd.when(bdd.parsers.parse('I have a "{name}" session file:\n{contents}'))
-def create_session_file(quteproc, name, contents):
+@bdd.when(bdd.parsers.parse('I have a "{name}" session file:'))
+def create_session_file(quteproc, name, docstring):
     filename = os.path.join(quteproc.basedir, 'data', 'sessions',
                             name + '.yml')
     with open(filename, 'w', encoding='utf-8') as f:
-        f.write(contents)
+        f.write(docstring)
 
 
 @bdd.when(bdd.parsers.parse('I replace "{pattern}" by "{replacement}" in the '

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -42,8 +42,10 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-load -t http://localhost:(port)/data/numbers/2.txt
         Then data/numbers/2.txt should be loaded
         And the following tabs should be open:
+            """
             - about:blank
             - data/numbers/2.txt (active)
+            """
 
     Scenario: Loading a bookmark in a background tab
         Given I open about:blank
@@ -51,8 +53,10 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-load -b http://localhost:(port)/data/numbers/3.txt
         Then data/numbers/3.txt should be loaded
         And the following tabs should be open:
+            """
             - about:blank (active)
             - data/numbers/3.txt
+            """
 
     Scenario: Loading a bookmark in a new window
         Given I open about:blank
@@ -60,6 +64,7 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-load -w http://localhost:(port)/data/numbers/4.txt
         And I wait until data/numbers/4.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -71,6 +76,7 @@ Feature: quickmarks and bookmarks
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/4.txt
+            """
 
     Scenario: Loading a bookmark with -t and -b
         When I run :bookmark-load -t -b about:blank
@@ -177,8 +183,10 @@ Feature: quickmarks and bookmarks
         And I run :quickmark-load -t fourteen
         Then data/numbers/14.txt should be loaded
         And the following tabs should be open:
+            """
             - about:blank
             - data/numbers/14.txt (active)
+            """
 
     Scenario: Loading a quickmark in a background tab
         Given I open about:blank
@@ -187,8 +195,10 @@ Feature: quickmarks and bookmarks
         And I run :quickmark-load -b fifteen
         Then data/numbers/15.txt should be loaded
         And the following tabs should be open:
+            """
             - about:blank (active)
             - data/numbers/15.txt
+            """
 
     Scenario: Loading a quickmark in a new window
         Given I open about:blank
@@ -197,6 +207,7 @@ Feature: quickmarks and bookmarks
         And I run :quickmark-load -w sixteen
         And I wait until data/numbers/16.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -208,6 +219,7 @@ Feature: quickmarks and bookmarks
                 history:
                 - active: true
                   url: http://localhost:*/data/numbers/16.txt
+            """
 
     Scenario: Loading a quickmark which does not exist
         When I run :quickmark-load -b doesnotexist

--- a/tests/end2end/features/urlmarks.feature
+++ b/tests/end2end/features/urlmarks.feature
@@ -34,7 +34,9 @@ Feature: quickmarks and bookmarks
         And I run :bookmark-load http://localhost:(port)/data/numbers/1.txt
         Then data/numbers/1.txt should be loaded
         And the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
+            """
 
     Scenario: Loading a bookmark in a new tab
         Given I open about:blank
@@ -174,7 +176,9 @@ Feature: quickmarks and bookmarks
         And I run :quickmark-load thirteen
         Then data/numbers/13.txt should be loaded
         And the following tabs should be open:
+            """
             - data/numbers/13.txt (active)
+            """
 
     Scenario: Loading a quickmark in a new tab
         Given I open about:blank

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -143,10 +143,10 @@ Feature: Miscellaneous utility commands exposed to the user.
         And I run :hint-follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
-	    """
+        """
             - data/hints/link_blank.html
             - data/hello.txt (active)
-	    """
+        """
 
     ## :debug-log-capacity
 

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -143,10 +143,10 @@ Feature: Miscellaneous utility commands exposed to the user.
         And I run :hint-follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
-        """
+            """
             - data/hints/link_blank.html
             - data/hello.txt (active)
-        """
+            """
 
     ## :debug-log-capacity
 

--- a/tests/end2end/features/utilcmds.feature
+++ b/tests/end2end/features/utilcmds.feature
@@ -143,8 +143,10 @@ Feature: Miscellaneous utility commands exposed to the user.
         And I run :hint-follow a
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+	    """
             - data/hints/link_blank.html
             - data/hello.txt (active)
+	    """
 
     ## :debug-log-capacity
 

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -125,22 +125,27 @@ Feature: Yanking and pasting.
         And I run :open -t {clipboard}
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/hello.txt (active)
+            """
 
     Scenario: Pasting in a background tab
         When I put "http://localhost:(port)/data/hello.txt" into the clipboard
         And I run :open -b {clipboard}
         And I wait until data/hello.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank (active)
             - data/hello.txt
+            """
 
     Scenario: Pasting in a new window
         When I put "http://localhost:(port)/data/hello.txt" into the clipboard
         And I run :open -w {clipboard}
         And I wait until data/hello.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -152,6 +157,7 @@ Feature: Yanking and pasting.
                 history:
                 - active: true
                   url: http://localhost:*/data/hello.txt
+            """
 
     Scenario: Pasting an invalid URL
         When I set url.auto_search to never
@@ -163,72 +169,91 @@ Feature: Yanking and pasting.
     @qtwebengine_flaky
     Scenario: Pasting multiple urls in a new tab
         When I put the following lines into the clipboard:
+            """
             http://localhost:(port)/data/hello.txt
             http://localhost:(port)/data/hello2.txt
             http://localhost:(port)/data/hello3.txt
+            """
         And I run :open -t {clipboard}
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
         And I wait until data/hello3.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/hello.txt (active)
             - data/hello2.txt
             - data/hello3.txt
+            """
 
     Scenario: Pasting multiline text
         When I set url.auto_search to naive
         And I set url.searchengines to {"DEFAULT": "http://localhost:(port)/data/hello.txt?q={}"}
         And I put the following lines into the clipboard:
+            """
             this url:
             http://qutebrowser.org
             should not open
+            """
         And I run :open -t {clipboard}
         And I wait until data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/hello.txt?q=this%20url%3A%0Ahttp%3A//qutebrowser.org%0Ashould%20not%20open (active)
+            """
 
     Scenario: Pasting multiline whose first line looks like a URI
         When I set url.auto_search to naive
         And I set url.searchengines to {"DEFAULT": "http://localhost:(port)/data/hello.txt?q={}"}
         And I put the following lines into the clipboard:
+            """
             text:
             should open
             as search
+            """
         And I run :open -t {clipboard}
         And I wait until data/hello.txt?q=text%3A%0Ashould%20open%0Aas%20search is loaded
         Then the following tabs should be open:
+            """
             - about:blank
             - data/hello.txt?q=text%3A%0Ashould%20open%0Aas%20search (active)
+            """
 
     # https://travis-ci.org/qutebrowser/qutebrowser/jobs/157941726
     @qtwebengine_flaky
     Scenario: Pasting multiple urls in a background tab
         When I put the following lines into the clipboard:
+            """
             http://localhost:(port)/data/hello.txt
             http://localhost:(port)/data/hello2.txt
             http://localhost:(port)/data/hello3.txt
+            """
         And I run :open -b {clipboard}
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
         And I wait until data/hello3.txt is loaded
         Then the following tabs should be open:
+            """
             - about:blank (active)
             - data/hello.txt
             - data/hello2.txt
             - data/hello3.txt
+            """
 
     Scenario: Pasting multiple urls in new windows
         When I put the following lines into the clipboard:
+            """
             http://localhost:(port)/data/hello.txt
             http://localhost:(port)/data/hello2.txt
             http://localhost:(port)/data/hello3.txt
+            """
         And I run :open -w {clipboard}
         And I wait until data/hello.txt is loaded
         And I wait until data/hello2.txt is loaded
         And I wait until data/hello3.txt is loaded
         Then the session should look like:
+            """
             windows:
             - tabs:
               - active: true
@@ -250,6 +275,7 @@ Feature: Yanking and pasting.
                 history:
                 - active: true
                   url: http://localhost:*/data/hello3.txt
+            """
 
     Scenario: Pasting multiple urls with an empty one
         And I put "http://localhost:(port)/data/hello.txt\n\nhttp://localhost:(port)/data/hello2.txt" into the clipboard

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -63,23 +63,23 @@ Feature: Yanking and pasting.
         Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title with spaces.html" should be shown
         And the clipboard should contain "http://localhost:(port)/data/title with spaces.html"
 
-	Scenario: Yanking URL that has = and & in its query string
-		When I open data/title.html?a=b&c=d
-		And I run :yank
-		Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title.html?a=b&c=d" should be shown
-		And the clipboard should contain "http://localhost:(port)/data/title.html?a=b&c=d"
+    Scenario: Yanking URL that has = and & in its query string
+        When I open data/title.html?a=b&c=d
+        And I run :yank
+        Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title.html?a=b&c=d" should be shown
+        And the clipboard should contain "http://localhost:(port)/data/title.html?a=b&c=d"
 
-	Scenario: Yanking URL that has = and ; in its query string
-		When I open data/title.html?a=b;c=d
-		And I run :yank
-		Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title.html?a=b;c=d" should be shown
-		And the clipboard should contain "http://localhost:(port)/data/title.html?a=b;c=d"
+    Scenario: Yanking URL that has = and ; in its query string
+        When I open data/title.html?a=b;c=d
+        And I run :yank
+        Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title.html?a=b;c=d" should be shown
+        And the clipboard should contain "http://localhost:(port)/data/title.html?a=b;c=d"
 
-	Scenario: Yanking URL with both & and ; in its query string
-		When I open data/title.html?a;b&c=d
-		And I run :yank
-		Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title.html?a;b&c=d" should be shown
-		And the clipboard should contain "http://localhost:(port)/data/title.html?a;b&c=d"
+    Scenario: Yanking URL with both & and ; in its query string
+        When I open data/title.html?a;b&c=d
+        And I run :yank
+        Then the message "Yanked URL to clipboard: http://localhost:(port)/data/title.html?a;b&c=d" should be shown
+        And the clipboard should contain "http://localhost:(port)/data/title.html?a;b&c=d"
 
     Scenario: Yanking with --quiet
         When I open data/title.html

--- a/tests/end2end/features/yankpaste.feature
+++ b/tests/end2end/features/yankpaste.feature
@@ -278,12 +278,12 @@ Feature: Yanking and pasting.
             """
 
     Scenario: Pasting multiple urls with an empty one
-        And I put "http://localhost:(port)/data/hello.txt\n\nhttp://localhost:(port)/data/hello2.txt" into the clipboard
+        When I put "http://localhost:(port)/data/hello.txt\n\nhttp://localhost:(port)/data/hello2.txt" into the clipboard
         And I run :open -t {clipboard}
         Then no crash should happen
 
     Scenario: Pasting multiple urls with an almost empty one
-        And I put "http://localhost:(port)/data/hello.txt\n \nhttp://localhost:(port)/data/hello2.txt" into the clipboard
+        When I put "http://localhost:(port)/data/hello.txt\n \nhttp://localhost:(port)/data/hello2.txt" into the clipboard
         And I run :open -t {clipboard}
         Then no crash should happen
 


### PR DESCRIPTION
fixes #8342

This is untested and purely based on the information provided in the referenced issue.
But it looked pretty straightforward to me so I just used a bit of `git grep` + `vim`-foo to insert the `"""` where I understood they would be required now, adjusting the indentation appropriately.

Let me know if I missed anything or messed up in any other way.