### PR TITLE
In POSIX sh, echo flags are undefined

### DIFF
--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -5,7 +5,7 @@
 _url="$1"
 _qb_version='1.0.4'
 _proto_version=1
-_ipc_socket="${XDG_RUNTIME_DIR}/qutebrowser/ipc-$(echo -n "$USER" | md5sum | cut -d' ' -f1)"
+_ipc_socket="${XDG_RUNTIME_DIR}/qutebrowser/ipc-$(printf '%s' "$USER" | md5sum | cut -d' ' -f1)"
 _qute_bin="/usr/bin/qutebrowser"
 
 printf '{"args": ["%s"], "target_arg": null, "version": "%s", "protocol_version": %d, "cwd": "%s"}\n' \


### PR DESCRIPTION
In POSIX, "echo" flags are undefined so using "echo -n" may not work on all systems. To avoid this, use printf which is more portable and POSIX compliant.