### PR TITLE
Allow null username/password in bw script

### DIFF
--- a/misc/userscripts/qute-bitwarden
+++ b/misc/userscripts/qute-bitwarden
@@ -224,7 +224,7 @@ def main(arguments):
     if len(candidates) == 1:
         selection = candidates.pop()
     else:
-        choices = ['{:s} | {:s}'.format(c['name'], c['login']['username']) for c in candidates]
+        choices = ['{:s} | {:s}'.format(c['name'] or "?", c['login']['username'] or "?") for c in candidates]
         choice = dmenu(choices, arguments.dmenu_invocation, arguments.io_encoding)
         choice_tokens = choice.split('|')
         choice_name = choice_tokens[0].strip()


### PR DESCRIPTION
As in the title. Otherwise it gives an error like this for me when some field is nonexistent

```
Process stderr:
Traceback (most recent call last):
  File "/home/user202729/qutebrowser/misc/userscripts/qute-bitwarden", line 291, in <module>
    sys.exit(main(arguments))
             ~~~~^^^^^^^^^^^
  File "/home/user202729/qutebrowser/misc/userscripts/qute-bitwarden", line 227, in main
    choices = ['{:s} | {:s}'.format(c['name'], c['login']['username']) for c in candidates]
               ~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: unsupported format string passed to NoneType.__format__
```