### PR TITLE
scripts: pick the url and nothing else

### DIFF
--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -3,13 +3,20 @@
 # author: Thore Bödecker (foxxx0)
 
 _url="$(echo $@ | grep -oE '\w+://.+')"
+if [ -z $_url ]; then
+	for _el in $@; do
+		if [ -e $_el ]; then
+			_url=$_el
+		fi
+	done
+fi
 _qb_version='1.0.4'
 _proto_version=1
 _ipc_socket="${XDG_RUNTIME_DIR}/qutebrowser/ipc-$(printf '%s' "$USER" | md5sum | cut -d' ' -f1)"
 _qute_bin="/usr/bin/qutebrowser"
 
 printf '{"args": ["%s"], "target_arg": null, "version": "%s", "protocol_version": %d, "cwd": "%s"}\n' \
-       "${_url}" \
-       "${_qb_version}" \
-       "${_proto_version}" \
-       "${PWD}" | socat -lf /dev/null - UNIX-CONNECT:"${_ipc_socket}" || "$_qute_bin" "$@" &
+	"${_url}" \
+	"${_qb_version}" \
+	"${_proto_version}" \
+	"${PWD}" | socat -lf /dev/null - UNIX-CONNECT:"${_ipc_socket}" || "$_qute_bin" "$@" &

--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -2,7 +2,7 @@
 # initial idea: Florian Bruhin (The-Compiler)
 # author: Thore Bödecker (foxxx0)
 
-_url="$1"
+_url="$(echo $@ | grep -oE '\w+://.+')"
 _qb_version='1.0.4'
 _proto_version=1
 _ipc_socket="${XDG_RUNTIME_DIR}/qutebrowser/ipc-$(printf '%s' "$USER" | md5sum | cut -d' ' -f1)"

--- a/scripts/open_url_in_instance.sh
+++ b/scripts/open_url_in_instance.sh
@@ -2,14 +2,7 @@
 # initial idea: Florian Bruhin (The-Compiler)
 # author: Thore Bödecker (foxxx0)
 
-_url="$(echo $@ | grep -oE '\w+://.+')"
-if [ -z $_url ]; then
-	for _el in $@; do
-		if [ -e $_el ]; then
-			_url=$_el
-		fi
-	done
-fi
+_url="${@: -1}"
 _qb_version='1.0.4'
 _proto_version=1
 _ipc_socket="${XDG_RUNTIME_DIR}/qutebrowser/ipc-$(printf '%s' "$USER" | md5sum | cut -d' ' -f1)"


### PR DESCRIPTION
This prevents other arguments like `--untrusted-args` from being interpreted as an url by the script.

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
