### PR TITLE
docs: update contributing guide with new issue tracker link

### DIFF
--- a/doc/contributing.asciidoc
+++ b/doc/contributing.asciidoc
@@ -41,7 +41,7 @@ If you want to find something useful to do, check the
 https://github.com/qutebrowser/qutebrowser/issues[issue tracker]. Some
 pointers:
 
-* https://github.com/qutebrowser/qutebrowser/labels/easy[Issues which should
+* https://github.com/qutebrowser/qutebrowser/contribute[Issues which should
 be easy to solve]
 * https://github.com/qutebrowser/qutebrowser/labels/component%3A%20docs[Documentation issues which require little/no coding]
 


### PR DESCRIPTION
Use 'contribute' link to list good-first-issue, as 'easy' label is gone.