### PR TITLE
Add Solarized theme

### DIFF
--- a/doc/help/configuring.asciidoc
+++ b/doc/help/configuring.asciidoc
@@ -416,6 +416,7 @@ Pre-built colorschemes
 - https://github.com/gicrisf/qute-city-lights[City Lights (matte dark)]
 - https://github.com/catppuccin/qutebrowser[Catppuccin]
 - https://github.com/iruzo/matrix-qutebrowser[Matrix]
+- https://github.com/harmtemolder/qutebrowser-solarized[Solarized]
 
 Avoiding flake8 errors
 ^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
I stumbled upon <https://www.reddit.com/r/qutebrowser/comments/77eqiq/solarized_or_base16_color_theme_for_qutebrowser/> and <https://bitbucket.org/kartikynwa/dotty2hotty/src/1a9ba9b80f07e1f63b740da5e6970dc5a97f1037/qutebrowser.py> and decided to build that into a proper theme that can be downloaded and applied easily. This PR adds a link to its repo to the docs