### PR TITLE
Feat/8077 remove tree code from commands.py

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -487,7 +487,7 @@ class CommandDispatcher:
         tabbed_browser.widget.setCurrentWidget(new_tab_map[current_node.uid])
         if not keep:
             self._tabbed_browser.close_tab(
-                node.value,
+                current_node.value,
                 add_undo=False,
                 transfer=True,
                 recursive=True,

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1133,7 +1133,11 @@ class CommandDispatcher:
     @cmdutils.register(instance="command-dispatcher", scope="window")
     @cmdutils.argument("index", choices=["+", "-", "start", "end"])
     @cmdutils.argument("count", value=cmdutils.Value.count)
-    def tab_move(self, index: Union[str, int] = None, count: int = None) -> None:
+    def tab_move(  # noqa: C901
+        self,
+        index: Union[str, int] = None,
+        count: int = None,
+    ) -> None:
         """Move the current tab according to the argument and [count].
 
         If neither is given, move it to the first position.

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -466,61 +466,6 @@ class CommandDispatcher:
         if not keep:
             tabbed_browser.close_tab(tab, add_undo=False, transfer=True)
 
-    def _tree_tab_give_onepass(self, tabbed_browser, keep):
-        """Recursive tab-give, move current tab and children to tabbed_browser."""
-        seen_nodes = []
-        new_tabs = []
-        root_idx = None
-        for idx, node in enumerate(
-            self._current_widget().node.traverse(
-                notree.TraverseOrder.PRE,
-                render_collapsed=True
-            )
-        ):
-            related=False
-            sibling=False
-
-            if not seen_nodes:  # first node, top level
-                pass
-            elif node.parent == seen_nodes[-1].parent:  # going through siblings
-                sibling = True
-            elif node.parent == seen_nodes[-1]:  # first child, going down a level
-                related = True
-            else:  # next subtree, walk back up to find the parent
-                related = True
-                for count, parent in enumerate(reversed(seen_nodes), start=1):
-                    if node.parent == parent:
-                        tabbed_browser.widget.setCurrentWidget(new_tabs[-count])
-                        break
-                else:
-                    assert False, f"Unknown tree structure in tab-give: node={node}"
-
-            # Open each new tab in the foreground so that the sibling and
-            # related settings above will apply to the previously opened one.
-            tab = tabbed_browser.tabopen(
-                node.value.url(),
-                background=False,
-                idx=None if root_idx is None else root_idx + idx,
-                related=related,
-                sibling=sibling,
-            )
-            if node.collapsed:
-                tab.node.collapsed = True
-            if root_idx == None:
-                root_idx = tabbed_browser.widget.currentIndex()
-
-            seen_nodes.append(node)
-            new_tabs.append(tab)
-
-        if not keep:
-            self._tabbed_browser.close_tab(
-                self._current_widget(),
-                add_undo=False,
-                transfer=True,
-                recursive=True,
-            )
-        tabbed_browser.widget.setCurrentWidget(new_tabs[0])
-
     def _tree_tab_give(self, tabbed_browser, keep):
         """Recursive tab-give, move current tab and children to tabbed_browser."""
         new_tab_map = {}  # old_uid -> new tab

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -488,7 +488,7 @@ class TabbedBrowser(QWidget):
         else:
             yes_action()
 
-    def close_tab(self, tab, *, add_undo=True, new_undo=True, transfer=False):
+    def close_tab(self, tab, *, add_undo=True, new_undo=True, transfer=False, recursive=False):
         """Close a tab.
 
         Args:
@@ -507,7 +507,7 @@ class TabbedBrowser(QWidget):
         if last_close == 'ignore' and count == 1:
             return
 
-        self._remove_tab(tab, add_undo=add_undo, new_undo=new_undo)
+        self._remove_tab(tab, add_undo=add_undo, new_undo=new_undo, recursive=recursive)
 
         if count == 1:  # We just closed the last tab above.
             if last_close == 'close':
@@ -520,7 +520,15 @@ class TabbedBrowser(QWidget):
             elif last_close == 'default-page':
                 self.load_url(config.val.url.default_page, newtab=True)
 
-    def _remove_tab(self, tab, *, add_undo=True, new_undo=True, crashed=False):
+    def _remove_tab(
+        self,
+        tab,
+        *,
+        add_undo=True,
+        new_undo=True,
+        crashed=False,
+        recursive=False,  # pylint: disable=unused-argument
+    ):
         """Remove a tab from the tab list and delete it properly.
 
         Args:

--- a/qutebrowser/mainwindow/treetabbedbrowser.py
+++ b/qutebrowser/mainwindow/treetabbedbrowser.py
@@ -283,7 +283,8 @@ class TreeTabbedBrowser(TabbedBrowser):
             pos = config.val.tabs.new_position.tree.new_toplevel
             parent = self.widget.tree_root
 
-        self._position_tab(cur_tab.node, tab.node, pos, parent, sibling, related, background)
+        self._position_tab(cur_tab.node, tab.node, pos, parent, sibling,
+                           related, background, idx)
 
         return tab
 
@@ -296,6 +297,7 @@ class TreeTabbedBrowser(TabbedBrowser):
         sibling: bool = False,
         related: bool = True,
         background: bool = None,
+        idx: int = None,
     ) -> None:
         toplevel = not sibling and not related
         siblings = list(parent.children)
@@ -304,7 +306,14 @@ class TreeTabbedBrowser(TabbedBrowser):
             # potentially adding it as a duplicate later.
             siblings.remove(new_node)
 
-        if pos == 'first':
+        if idx:
+            sibling_indices = [self.widget.indexOf(node.value) for node in siblings]
+            assert sibling_indices == sorted(sibling_indices)
+            sibling_indices.append(idx)
+            sibling_indices = sorted(sibling_indices)
+            rel_idx = sibling_indices.index(idx)
+            siblings.insert(rel_idx, new_node)
+        elif pos == 'first':
             rel_idx = 0
             if config.val.tabs.new_position.stacking and related:
                 rel_idx += self._tree_tab_child_rel_idx

--- a/qutebrowser/misc/notree.py
+++ b/qutebrowser/misc/notree.py
@@ -228,13 +228,11 @@ class Node(Generic[T]):
 
     def traverse(self, order: TraverseOrder = TraverseOrder.PRE,
                  render_collapsed: bool = True) -> Iterable['Node']:
-        """Generator for all descendants of `self`.
+        """Generator for `self` and all descendants.
 
         Args:
             order: a TraverseOrder object. See TraverseOrder documentation.
             render_collapsed: whether to yield children of collapsed nodes
-            Even if render_collapsed is False, collapsed nodes are be rendered.
-            It's their children that won't.
         """
         if order == TraverseOrder.PRE:
             yield self

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -83,7 +83,9 @@ Feature: Tree tab management
         And I wait for "Asking question *" in the log
         And I run :prompt-accept yes
         Then the following tabs should be open:
+            """
             - data/numbers/4.txt
+            """
 
     Scenario: :tab-close --recursive with collapsed subtree
         When I open data/numbers/1.txt
@@ -95,7 +97,9 @@ Feature: Tree tab management
         And I run :tab-focus 1
         And I run :tab-close --recursive
         Then the following tabs should be open:
+            """
             - data/numbers/4.txt
+            """
 
     Scenario: :tab-give --recursive with collapsed subtree
         When I open data/numbers/1.txt
@@ -110,10 +114,12 @@ Feature: Tree tab management
         And I run :window-only
         And I wait until data/numbers/4.txt is loaded
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt (active)
               - data/numbers/3.txt (collapsed)
                 - data/numbers/4.txt
               - data/numbers/2.txt
+            """
 
     Scenario: Open a child tab
         When I open data/numbers/1.txt
@@ -146,10 +152,12 @@ Feature: Tree tab management
         And I open data/numbers/4.txt in a new related tab
         And I run :tab-move 2
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
               - data/numbers/4.txt
               - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: Move a tab within siblings
         When I open data/numbers/1.txt
@@ -157,9 +165,11 @@ Feature: Tree tab management
         And I open data/numbers/3.txt in a new sibling tab
         And I run :tab-move +
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
               - data/numbers/2.txt
               - data/numbers/3.txt
+            """
 
     Scenario: Move a tab to end
         When I open data/numbers/1.txt
@@ -169,10 +179,12 @@ Feature: Tree tab management
         And I run :tab-focus 2
         And I run :tab-move end
         Then the following tabs should be open:
+            """
             - data/numbers/1.txt
             - data/numbers/3.txt
               - data/numbers/4.txt
               - data/numbers/2.txt
+            """
 
     Scenario: Move a tab to start
         When I open data/numbers/1.txt
@@ -181,10 +193,12 @@ Feature: Tree tab management
         And I open data/numbers/4.txt in a new related tab
         And I run :tab-move start
         Then the following tabs should be open:
+            """
             - data/numbers/4.txt
             - data/numbers/1.txt
               - data/numbers/2.txt
             - data/numbers/3.txt
+            """
 
     Scenario: Collapse a subtree
         When I open data/numbers/1.txt

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -124,7 +124,7 @@ Feature: Tree tab management
               - data/numbers/2.txt (active)
             """
 
-    Scenario: Move a tab to the given index
+    Scenario: Move a tab down to the given index
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab
         And I open data/numbers/3.txt in a new tab
@@ -138,6 +138,53 @@ Feature: Tree tab management
             - data/numbers/1.txt
               - data/numbers/2.txt
             """
+
+    Scenario: Move a tab up to given index
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new tab
+        And I open data/numbers/4.txt in a new related tab
+        And I run :tab-move 2
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+              - data/numbers/4.txt
+              - data/numbers/2.txt
+            - data/numbers/3.txt
+
+    Scenario: Move a tab within siblings
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new sibling tab
+        And I run :tab-move +
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+              - data/numbers/2.txt
+              - data/numbers/3.txt
+
+    Scenario: Move a tab to end
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new tab
+        And I open data/numbers/4.txt in a new related tab
+        And I run :tab-focus 2
+        And I run :tab-move end
+        Then the following tabs should be open:
+            - data/numbers/1.txt
+            - data/numbers/3.txt
+              - data/numbers/4.txt
+              - data/numbers/2.txt
+
+    Scenario: Move a tab to start
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new tab
+        And I open data/numbers/4.txt in a new related tab
+        And I run :tab-move start
+        Then the following tabs should be open:
+            - data/numbers/4.txt
+            - data/numbers/1.txt
+              - data/numbers/2.txt
+            - data/numbers/3.txt
 
     Scenario: Collapse a subtree
         When I open data/numbers/1.txt

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -97,6 +97,24 @@ Feature: Tree tab management
         Then the following tabs should be open:
             - data/numbers/4.txt
 
+    Scenario: :tab-give --recursive with collapsed subtree
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new sibling tab
+        And I open data/numbers/4.txt in a new related tab
+        And I open data/numbers/5.txt in a new tab
+        And I run :tab-focus 2
+        And I run :tree-tab-toggle-hide
+        And I run :tab-focus 1
+        And I run :tab-give --recursive
+        And I run :window-only
+        And I wait until data/numbers/4.txt is loaded
+        Then the following tabs should be open:
+            - data/numbers/1.txt (active)
+              - data/numbers/3.txt (collapsed)
+                - data/numbers/4.txt
+              - data/numbers/2.txt
+
     Scenario: Open a child tab
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -72,6 +72,31 @@ Feature: Tree tab management
             - data/numbers/4.txt
             """
 
+    Scenario: :tab-close --recursive with pinned tab
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I open data/numbers/4.txt in a new tab
+        And I run :tab-focus 1
+        And I run :cmd-run-with-count 2 tab-pin
+        And I run :tab-close --recursive
+        And I wait for "Asking question *" in the log
+        And I run :prompt-accept yes
+        Then the following tabs should be open:
+            - data/numbers/4.txt
+
+    Scenario: :tab-close --recursive with collapsed subtree
+        When I open data/numbers/1.txt
+        And I open data/numbers/2.txt in a new related tab
+        And I open data/numbers/3.txt in a new related tab
+        And I open data/numbers/4.txt in a new tab
+        And I run :tab-focus 2
+        And I run :tree-tab-toggle-hide
+        And I run :tab-focus 1
+        And I run :tab-close --recursive
+        Then the following tabs should be open:
+            - data/numbers/4.txt
+
     Scenario: Open a child tab
         When I open data/numbers/1.txt
         And I open data/numbers/2.txt in a new related tab

--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -111,9 +111,25 @@ Feature: Tree tab management
         And I run :tree-tab-toggle-hide
         And I run :tab-focus 1
         And I run :tab-give --recursive
-        And I run :window-only
         And I wait until data/numbers/4.txt is loaded
-        Then the following tabs should be open:
+        Then the session should look like:
+            """
+            windows:
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/5.txt
+            - tabs:
+              - history:
+                - url: http://localhost:*/data/numbers/1.txt
+              - history:
+                - url: http://localhost:*/data/numbers/3.txt
+              - history:
+                - url: http://localhost:*/data/numbers/4.txt
+              - history:
+                - url: http://localhost:*/data/numbers/2.txt
+            """
+        And I run :window-only
+        And the following tabs should be open:
             """
             - data/numbers/1.txt (active)
               - data/numbers/3.txt (collapsed)

--- a/tests/unit/misc/test_notree.py
+++ b/tests/unit/misc/test_notree.py
@@ -172,10 +172,13 @@ def test_demote_to_last(tree):
     assert n6.children[-1] is n11
 
 
-def test_traverse(node):
-    len_traverse = len(list(node.traverse()))
-    len_render = len(node.render())
-    assert len_traverse == len_render
+def test_traverse(tree):
+    n1, n2, n3, n4, n5, n6, n7, n8, n9, n10, n11 = tree
+    actual = list(n1.traverse())
+    rendered = n1.render()
+    assert len(actual) == len(rendered)
+    print("\n".join('\t'.join((str(t[0]), t[1][0] + str(t[1][1]))) for t in zip(actual, rendered)))
+    assert actual == [n1, n2, n4, n5, n3, n6, n7, n8, n9, n10, n11]
 
 
 def test_traverse_postorder(tree):


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
Overall this was less eventful than the [tabbedbrowser](https://github.com/qutebrowser/qutebrowser/pull/8122) and [session](https://github.com/qutebrowser/qutebrowser/pull/8084) passes. There is a fair bit of tree specific code in the commands.py class, but it's all fairly clearly delineated from non-tree code. So hopefully the cognitive load for maintainers who don't have tree stuff in their heads isn't too bad.

The main chunks of this PR is reducing the complexity of the `_tree_tab_give()` and calling the `TreeTabbedBrowser.close_tab()` method instead of iterating over the tree and handing the details in commands.py.

My main takeaways:
* Having to support tree specific flags (like `--recursive` and `--sibling`) in methods and commands that may not know anything about tabs is "smelly". Commands.py itself isn't so bad, by plumbing them through the TabbedBrowser base class when the implementation is in TreeTabbedBrowser is disconcerting. It seems like it breaks the LSP. Still more food for though here thinking about how an extension would handle this use case.
* There is lots of code in commands.py that just acts on tabs or tabbed browser. I feel pretty strongly that this behaviour should be on TabWidget and TabbedBrowser. For example, when we add tabs and windows/tabbedbrowsers into the extension APIs, callers will want to do things like `tab.close()` or `tabbedbrowser.tab_next()`. Having to dispatch commands seems like incidental complexity from that point of view (also, as it stands now calling commands from extensions is not an intuitive API).
* tbh my appetite to continue polishing on this PR was tempered but how unclear an abstraction this commands.py file is currently, it doesn't paint a clear direction for me to refactor down. I think there's a lot of scope to move complexity down into TabWidget, TabbedBrowser or notree.py, but I think that'll required restructuring some APIs, which I'm treating as out of scope of this "reduce maintenance burden" work. I'll probably revisit that in [review: unify methods of traversing tree · Tree Tabs Integration](https://github.com/orgs/qutebrowser/projects/3/views/1?pane=issue&itemId=49902415) at some point, or the work to add tabs to the extension API (but I don't want to distract myself from getting tree tabs ready as-is though_.

Closes: https://github.com/qutebrowser/qutebrowser/issues/8077