### PR TITLE
Tree tabs: Make `select_on_remove=prev` select previous sibling

### DIFF
--- a/tests/end2end/features/treetabs.feature
+++ b/tests/end2end/features/treetabs.feature
@@ -356,3 +356,43 @@ Feature: Tree tab management
           - about:blank?grandparent
             - about:blank?parent (active)
           """
+
+    Scenario: Tabs.select_on_remove prev selects previous sibling
+        When I open about:blank?one
+        And I open about:blank?two in a new related tab
+        And I open about:blank?three in a new tab
+        And I run :set tabs.select_on_remove prev
+        And I run :tab-close
+        And I run :config-unset tabs.select_on_remove
+        Then the following tabs should be open:
+          """
+          - about:blank?one (active)
+            - about:blank?two
+          """
+
+    Scenario: Tabs.select_on_remove prev selects parent
+        When I open about:blank?one
+        And I open about:blank?two in a new related tab
+        And I open about:blank?three in a new sibling tab
+        And I run :set tabs.select_on_remove prev
+        And I run :tab-close
+        And I run :config-unset tabs.select_on_remove
+        Then the following tabs should be open:
+          """
+          - about:blank?one (active)
+            - about:blank?two
+          """
+
+    Scenario: Tabs.select_on_remove prev can be overridden
+        When I open about:blank?one
+        And I open about:blank?two in a new related tab
+        And I open about:blank?three in a new tab
+        And I run :tab-select ?two
+        And I run :set tabs.select_on_remove prev
+        And I run :tab-close --next
+        And I run :config-unset tabs.select_on_remove
+        Then the following tabs should be open:
+          """
+          - about:blank?one
+          - about:blank?three (active)
+          """


### PR DESCRIPTION
Updates `tabs.select_on_remove=prev` for tree tab windows so that the previous sibling is selected, instead of the previous tab in the tab bar. I've found that the selected tab descending to the rightmost leaf node of a tab group when I close a top level tab is never what I want.

(I'm doing a couple of nice-to-have features on the tree tabs branch to motivate myself before I jump into type hints, then writing up proposed setting changes and such I guess. I'll probably merge this myself in a few days, just opening for visibility)

It may have been more respectful of people's preferences and habits to add a "previous-sibling" option for the `tabs.select_on_remove` option, but that would be a fair bit of work. Turning that option into strings and mapping them to QTabBar enum values at the only place they are used wouldn't be so bad, but then there would be another place where non-tree code would have to deal with a tree specific option. So I figured I would be bold and change the default behaviour and see if anyone complained.

This was raised [here](https://github.com/qutebrowser/qutebrowser/issues/8075#issuecomment-1937875686), and I got one thumbs up emoji!

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
