### PR TITLE
use recommended page lifecycle state

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -293,12 +293,12 @@
 |<<prompt.radius,prompt.radius>>|Rounding radius (in pixels) for the edges of prompts.
 |<<qt.args,qt.args>>|Additional arguments to pass to Qt, without leading `--`.
 |<<qt.chromium.experimental_web_platform_features,qt.chromium.experimental_web_platform_features>>|Enables Web Platform features that are in development.
-|<<qt.chromium.lifecycle_state_discard_delay,qt.chromium.lifecycle_state_discard_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
-|<<qt.chromium.lifecycle_state_freeze_delay,qt.chromium.lifecycle_state_freeze_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
+|<<qt.chromium.lifecycle_state.discard_delay,qt.chromium.lifecycle_state.discard_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state. This state is an extreme resource-saving state, where the browsing context of the web view is discarded and the renderer process is shut down. Resource usage is therefore reduced to near-zero. The web page is automatically reloaded when needed.
+|<<qt.chromium.lifecycle_state.enabled,qt.chromium.lifecycle_state.enabled>>|Use recommended page lifecycle state.
+|<<qt.chromium.lifecycle_state.freeze_delay,qt.chromium.lifecycle_state.freeze_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state. This is a low-CPU state, where most DOM event processing, JavaScript execution, and other tasks are suspended.
 |<<qt.chromium.low_end_device_mode,qt.chromium.low_end_device_mode>>|When to use Chromium's low-end device mode.
 |<<qt.chromium.process_model,qt.chromium.process_model>>|Which Chromium process model to use.
 |<<qt.chromium.sandboxing,qt.chromium.sandboxing>>|What sandboxing mechanisms in Chromium to use.
-|<<qt.chromium.use_recommended_page_lifecycle_state,qt.chromium.use_recommended_page_lifecycle_state>>|Use recommended page lifecycle state.
 |<<qt.environ,qt.environ>>|Additional environment variables to set.
 |<<qt.force_platform,qt.force_platform>>|Force a Qt platform to use.
 |<<qt.force_platformtheme,qt.force_platformtheme>>|Force a Qt platformtheme to use.
@@ -3848,25 +3848,41 @@ Valid values:
 
 Default: +pass:[auto]+
 
-[[qt.chromium.lifecycle_state_discard_delay]]
-=== qt.chromium.lifecycle_state_discard_delay
-The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+[[qt.chromium.lifecycle_state.discard_delay]]
+=== qt.chromium.lifecycle_state.discard_delay
+The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state. This state is an extreme resource-saving state, where the browsing context of the web view is discarded and the renderer process is shut down. Resource usage is therefore reduced to near-zero. The web page is automatically reloaded when needed.
+Set to -1 to disable this state.
 
 This setting is only available with the QtWebEngine backend.
 
 Type: <<types,Int>>
 
-Default: +pass:[0]+
+Default: +pass:[600000]+
 
-[[qt.chromium.lifecycle_state_freeze_delay]]
-=== qt.chromium.lifecycle_state_freeze_delay
-The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
+[[qt.chromium.lifecycle_state.enabled]]
+=== qt.chromium.lifecycle_state.enabled
+Use recommended page lifecycle state.
+This puts webpages into one of three lifecycle states: active, frozen, or discarded. Using the recommended lifecycle state lets the browser use less resources by freezing or discarding web views when it's safe to do so.
+This results in significant battery life savings.
+Ongoing page activity is taken into account when determining the recommended lifecycle state, as to not disrupt your browsing.
+This feature is only available on QtWebEngine 6.5+. On older versions this setting is ignored.
+See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Bool>>
+
+Default: +pass:[true]+
+
+[[qt.chromium.lifecycle_state.freeze_delay]]
+=== qt.chromium.lifecycle_state.freeze_delay
+The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state. This is a low-CPU state, where most DOM event processing, JavaScript execution, and other tasks are suspended.
 
 This setting is only available with the QtWebEngine backend.
 
 Type: <<types,Int>>
 
-Default: +pass:[0]+
+Default: +pass:[30000]+
 
 [[qt.chromium.low_end_device_mode]]
 === qt.chromium.low_end_device_mode
@@ -3934,19 +3950,6 @@ Valid values:
  * +disable-all+: Disable all sandboxing (**not recommended!**).
 
 Default: +pass:[enable-all]+
-
-[[qt.chromium.use_recommended_page_lifecycle_state]]
-=== qt.chromium.use_recommended_page_lifecycle_state
-Use recommended page lifecycle state.
-This puts webpages into one of three lifecycle states: active, frozen, or discarded. Using the recommended lifecycle state lets the browser use less resources by freezing or discarding web views when it's safe to do so.
-This results in significant battery life savings.
-Ongoing page activity is taken into account when determining the recommended lifecycle state, as to not disrupt your browsing.
-
-This setting is only available with the QtWebEngine backend.
-
-Type: <<types,Bool>>
-
-Default: +pass:[false]+
 
 [[qt.environ]]
 === qt.environ

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -3857,7 +3857,7 @@ This setting is only available with the QtWebEngine backend.
 
 Type: <<types,Int>>
 
-Default: +pass:[600000]+
+Default: +pass:[-1]+
 
 [[qt.chromium.lifecycle_state.enabled]]
 === qt.chromium.lifecycle_state.enabled

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -293,9 +293,12 @@
 |<<prompt.radius,prompt.radius>>|Rounding radius (in pixels) for the edges of prompts.
 |<<qt.args,qt.args>>|Additional arguments to pass to Qt, without leading `--`.
 |<<qt.chromium.experimental_web_platform_features,qt.chromium.experimental_web_platform_features>>|Enables Web Platform features that are in development.
+|<<qt.chromium.lifecycle_state_discard_delay,qt.chromium.lifecycle_state_discard_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+|<<qt.chromium.lifecycle_state_freeze_delay,qt.chromium.lifecycle_state_freeze_delay>>|The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
 |<<qt.chromium.low_end_device_mode,qt.chromium.low_end_device_mode>>|When to use Chromium's low-end device mode.
 |<<qt.chromium.process_model,qt.chromium.process_model>>|Which Chromium process model to use.
 |<<qt.chromium.sandboxing,qt.chromium.sandboxing>>|What sandboxing mechanisms in Chromium to use.
+|<<qt.chromium.use_recommended_page_lifecycle_state,qt.chromium.use_recommended_page_lifecycle_state>>|Use recommended page lifecycle state.
 |<<qt.environ,qt.environ>>|Additional environment variables to set.
 |<<qt.force_platform,qt.force_platform>>|Force a Qt platform to use.
 |<<qt.force_platformtheme,qt.force_platformtheme>>|Force a Qt platformtheme to use.
@@ -3845,6 +3848,26 @@ Valid values:
 
 Default: +pass:[auto]+
 
+[[qt.chromium.lifecycle_state_discard_delay]]
+=== qt.chromium.lifecycle_state_discard_delay
+The amount of time (in milliseconds) to wait before transitioning a page to the discarded lifecycle state.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Int>>
+
+Default: +pass:[0]+
+
+[[qt.chromium.lifecycle_state_freeze_delay]]
+=== qt.chromium.lifecycle_state_freeze_delay
+The amount of time (in milliseconds) to wait before transitioning a page to the frozen lifecycle state.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Int>>
+
+Default: +pass:[0]+
+
 [[qt.chromium.low_end_device_mode]]
 === qt.chromium.low_end_device_mode
 When to use Chromium's low-end device mode.
@@ -3911,6 +3934,19 @@ Valid values:
  * +disable-all+: Disable all sandboxing (**not recommended!**).
 
 Default: +pass:[enable-all]+
+
+[[qt.chromium.use_recommended_page_lifecycle_state]]
+=== qt.chromium.use_recommended_page_lifecycle_state
+Use recommended page lifecycle state.
+This puts webpages into one of three lifecycle states: active, frozen, or discarded. Using the recommended lifecycle state lets the browser use less resources by freezing or discarding web views when it's safe to do so.
+This results in significant battery life savings.
+Ongoing page activity is taken into account when determining the recommended lifecycle state, as to not disrupt your browsing.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Bool>>
+
+Default: +pass:[false]+
 
 [[qt.environ]]
 === qt.environ

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1761,6 +1761,9 @@ class WebEngineTab(browsertab.AbstractTab):
         if self._widget.page().lifecycleState() == recommended_state:
             return
 
+        if delay < 0:
+            return
+
         log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
         self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
         self._lifecycle_timer.start(delay)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1750,8 +1750,10 @@ class WebEngineTab(browsertab.AbstractTab):
             delay = config.val.qt.chromium.lifecycle_state_freeze_delay
         elif recommended_state == QWebEnginePage.LifecycleState.Discarded:
             delay = config.val.qt.chromium.lifecycle_state_discard_delay
-        else:
+        elif recommended_state == QWebEnginePage.LifecycleState.Active:
             delay = 0
+        else:
+            raise utils.Unreachable(recommended_state)
 
         try:
             self._lifecycle_timer.timeout.disconnect()

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1753,8 +1753,15 @@ class WebEngineTab(browsertab.AbstractTab):
         else:
             delay = 0
 
-        self._lifecycle_timer.timeout.disconnect()
-        log.webview.debug(f"Setting lifecycle state {recommended_state} in {delay}ms")
+        try:
+            self._lifecycle_timer.timeout.disconnect()
+        except TypeError:
+            pass
+
+        if self._widget.page().lifecycleState() == recommended_state:
+            return
+
+        log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
         self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
         self._lifecycle_timer.start(delay)
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1764,6 +1764,9 @@ class WebEngineTab(browsertab.AbstractTab):
         if delay < 0:
             return
 
+        if self.data.pinned and recommended_state != QWebEnginePage.LifecycleState.Active:
+            return
+
         log.webview.debug(f"Scheduling recommended lifecycle change {delay=} {recommended_state=} tab={self}")
         self._lifecycle_timer.timeout.connect(lambda: self._set_lifecycle_state(recommended_state))
         self._lifecycle_timer.start(delay)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1754,11 +1754,11 @@ class WebEngineTab(browsertab.AbstractTab):
         timers = {
             QWebEnginePage.LifecycleState.Frozen: (
                 self._lifecycle_timer_freeze,
-                config.val.qt.chromium.lifecycle_state_freeze_delay,
+                config.val.qt.chromium.lifecycle_state.freeze_delay,
             ),
             QWebEnginePage.LifecycleState.Discarded: (
                 self._lifecycle_timer_discard,
-                config.val.qt.chromium.lifecycle_state_discard_delay,
+                config.val.qt.chromium.lifecycle_state.discard_delay,
             ),
         }
 
@@ -1786,7 +1786,7 @@ class WebEngineTab(browsertab.AbstractTab):
             self._schedule_lifecycle_transition(None)
             return
 
-        disabled = not config.val.qt.chromium.use_recommended_page_lifecycle_state
+        disabled = not config.val.qt.chromium.lifecycle_state.enabled
 
         if recommended_state == QWebEnginePage.LifecycleState.Active:
             self._schedule_lifecycle_transition(None)

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -1791,7 +1791,8 @@ class WebEngineTab(browsertab.AbstractTab):
         page.printRequested.connect(self._on_print_requested)
         page.selectClientCertificate.connect(self._on_select_client_certificate)
 
-        page.recommendedStateChanged.connect(self._on_recommended_state_changed)
+        if version.qtwebengine_versions().webengine >= utils.VersionNumber(6, 5):
+            page.recommendedStateChanged.connect(self._on_recommended_state_changed)
 
         view.titleChanged.connect(self.title_changed)
         view.urlChanged.connect(self._on_url_changed)

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -345,9 +345,9 @@ qt.chromium.experimental_web_platform_features:
     Chromium. By default, this is enabled with Qt 5 to maximize compatibility
     despite an aging Chromium base.
 
-qt.chromium.use_recommended_page_lifecycle_state:
+qt.chromium.lifecycle_state.enabled:
   type: Bool
-  default: false
+  default: true
   backend: QtWebEngine
   # yamllint disable rule:line-length
   desc: >-
@@ -368,27 +368,33 @@ qt.chromium.use_recommended_page_lifecycle_state:
     See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
   # yamllint enable rule:line-length
 
-qt.chromium.lifecycle_state_freeze_delay:
+qt.chromium.lifecycle_state.freeze_delay:
   type:
     name: Int
     minval: 0
     maxval: maxint
-  default: 0
+  default: 30_000
   backend: QtWebEngine
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the frozen lifecycle state.
+    This is a low-CPU state, where most DOM event processing, JavaScript
+    execution, and other tasks are suspended.
 
-qt.chromium.lifecycle_state_discard_delay:
+qt.chromium.lifecycle_state.discard_delay:
   type:
     name: Int
     minval: -1
     maxval: maxint
-  default: 0
+  default: 600_000
   backend: QtWebEngine
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the discarded lifecycle state.
+    This state is an extreme resource-saving state, where the browsing context
+    of the web view is discarded and the renderer process is shut down.
+    Resource usage is therefore reduced to near-zero. The web page is
+    automatically reloaded when needed.
 
     Set to -1 to disable this state.
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -349,6 +349,7 @@ qt.chromium.use_recommended_page_lifecycle_state:
   type: Bool
   default: false
   backend: QtWebEngine
+  # yamllint disable rule:line-length
   desc: >-
     Use recommended page lifecycle state.
 
@@ -361,6 +362,9 @@ qt.chromium.use_recommended_page_lifecycle_state:
     Ongoing page activity is taken into account when determining the
     recommended lifecycle state, as to not disrupt your browsing.
 
+    See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
+  # yamllint enable rule:line-length
+
 qt.chromium.lifecycle_state_freeze_delay:
   type: Int
   default: 0
@@ -369,6 +373,8 @@ qt.chromium.lifecycle_state_freeze_delay:
     The amount of time (in milliseconds) to wait before transitioning a page to
     the frozen lifecycle state.
 
+    Set to -1 to disable this state (will also disable the discard state).
+
 qt.chromium.lifecycle_state_discard_delay:
   type: Int
   default: 0
@@ -376,6 +382,8 @@ qt.chromium.lifecycle_state_discard_delay:
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the discarded lifecycle state.
+
+    Set to -1 to disable this state.
 
 qt.highdpi:
   type: Bool

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -362,6 +362,9 @@ qt.chromium.use_recommended_page_lifecycle_state:
     Ongoing page activity is taken into account when determining the
     recommended lifecycle state, as to not disrupt your browsing.
 
+    This feature is only available on QtWebEngine 6.5+. On older versions
+    this setting is ignored.
+
     See the Qt documentation for more details: https://doc.qt.io/qt-6/qtwebengine-features.html#page-lifecycle-api
   # yamllint enable rule:line-length
 

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -345,6 +345,38 @@ qt.chromium.experimental_web_platform_features:
     Chromium. By default, this is enabled with Qt 5 to maximize compatibility
     despite an aging Chromium base.
 
+qt.chromium.use_recommended_page_lifecycle_state:
+  type: Bool
+  default: false
+  backend: QtWebEngine
+  desc: >-
+    Use recommended page lifecycle state.
+
+    This puts webpages into one of three lifecycle states: active, frozen, or
+    discarded. Using the recommended lifecycle state lets the browser use less
+    resources by freezing or discarding web views when it's safe to do so.
+
+    This results in significant battery life savings.
+
+    Ongoing page activity is taken into account when determining the
+    recommended lifecycle state, as to not disrupt your browsing.
+
+qt.chromium.lifecycle_state_freeze_delay:
+  type: Int
+  default: 0
+  backend: QtWebEngine
+  desc: >-
+    The amount of time (in milliseconds) to wait before transitioning a page to
+    the frozen lifecycle state.
+
+qt.chromium.lifecycle_state_discard_delay:
+  type: Int
+  default: 0
+  backend: QtWebEngine
+  desc: >-
+    The amount of time (in milliseconds) to wait before transitioning a page to
+    the discarded lifecycle state.
+
 qt.highdpi:
   type: Bool
   default: false

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -369,17 +369,21 @@ qt.chromium.use_recommended_page_lifecycle_state:
   # yamllint enable rule:line-length
 
 qt.chromium.lifecycle_state_freeze_delay:
-  type: Int
+  type:
+    name: Int
+    minval: 0
+    maxval: maxint
   default: 0
   backend: QtWebEngine
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to
     the frozen lifecycle state.
 
-    Set to -1 to disable this state (will also disable the discard state).
-
 qt.chromium.lifecycle_state_discard_delay:
-  type: Int
+  type:
+    name: Int
+    minval: -1
+    maxval: maxint
   default: 0
   backend: QtWebEngine
   desc: >-

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -386,7 +386,7 @@ qt.chromium.lifecycle_state.discard_delay:
     name: Int
     minval: -1
     maxval: maxint
-  default: 600_000
+  default: -1
   backend: QtWebEngine
   desc: >-
     The amount of time (in milliseconds) to wait before transitioning a page to

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1998,4 +1998,3 @@ Feature: Tab management
         And I run :tab-prev
         Then "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Frozen" should be logged
         And "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Discarded" should be logged
-        And I run :set qt.chromium.use_recommended_page_lifecycle_state false

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1992,7 +1992,9 @@ Feature: Tab management
 
     @qt>=6.5
     Scenario: Lifecycle change on tab switch
-        When I set qt.chromium.use_recommended_page_lifecycle_state to true
+        When I set qt.chromium.lifecycle_state.enabled to true
+        And I set qt.chromium.lifecycle_state.freeze_delay to 0
+        And I set qt.chromium.lifecycle_state.discard_delay to 0
         And I open about:blank?1
         And I open about:blank?2 in a new tab
         And I run :tab-prev

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1990,6 +1990,7 @@ Feature: Tab management
         And I run :tab-prev
         Then "Entering mode KeyMode.insert (reason: mode_override)" should be logged
 
+    @qt>=6.5
     Scenario: Lifecycle change on tab switch
         When I set qt.chromium.use_recommended_page_lifecycle_state to true
         And I open about:blank?1

--- a/tests/end2end/features/tabs.feature
+++ b/tests/end2end/features/tabs.feature
@@ -1989,3 +1989,12 @@ Feature: Tab management
         And I open data/numbers/2.txt in a new tab
         And I run :tab-prev
         Then "Entering mode KeyMode.insert (reason: mode_override)" should be logged
+
+    Scenario: Lifecycle change on tab switch
+        When I set qt.chromium.use_recommended_page_lifecycle_state to true
+        And I open about:blank?1
+        And I open about:blank?2 in a new tab
+        And I run :tab-prev
+        Then "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Frozen" should be logged
+        And "Setting page lifecycle state of <qutebrowser.browser.webengine.webenginetab.WebEngineTab tab_id=* url='about:blank?2'> to LifecycleState.Discarded" should be logged
+        And I run :set qt.chromium.use_recommended_page_lifecycle_state false

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -352,9 +352,9 @@ class TestPageLifecycle:
         """For negative delay values, the timer shouldn't be scheduled."""
         self.set_config(
             config_stub,
-            freeze_delay=-1,
+            discard_delay=-1,
         )
-        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
+        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Discarded)
         assert not webengine_tab._lifecycle_timer.isActive()
 
     def test_pinned_tabs_untouched(

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -333,6 +333,20 @@ class TestPageLifecycle:
             pass
         set_state_spy.assert_called_once_with(new_state)
 
+    def test_state_disabled(
+        self,
+        webengine_tab: webenginetab.WebEngineTab,
+        monkeypatch,
+        config_stub,
+    ):
+        """For negative delay values, the timer shouldn't be scheduled."""
+        self.set_config(
+            config_stub,
+            freeze_delay=-1,
+        )
+        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
+        assert not webengine_tab._lifecycle_timer.isActive()
+
     def test_timer_interrupted(
         self,
         webengine_tab: webenginetab.WebEngineTab,

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -14,11 +14,13 @@ QWebEngineScriptCollection = QtWebEngineCore.QWebEngineScriptCollection
 QWebEngineScript = QtWebEngineCore.QWebEngineScript
 
 from qutebrowser.browser import greasemonkey
-from qutebrowser.utils import usertypes
+from qutebrowser.utils import usertypes, utils, version
 webenginetab = pytest.importorskip(
     "qutebrowser.browser.webengine.webenginetab")
 
 pytestmark = pytest.mark.usefixtures('greasemonkey_manager')
+
+versions = version.qtwebengine_versions(avoid_init=True)
 
 
 class ScriptsHelper:
@@ -247,6 +249,14 @@ class TestWebEnginePermissions:
 
 
 class TestPageLifecycle:
+
+    @pytest.fixture(autouse=True)
+    def check_version(self):
+        # While the lifecycle feature was introduced in 5.14, PyQt seems to
+        # have trouble connecting to the signal we require on 6.4 and prior.
+        # https://github.com/qutebrowser/qutebrowser/pull/8547#issuecomment-2890997662
+        if versions.webengine < utils.VersionNumber(6, 5):
+            pytest.skip("Lifecycle feature requires Webengine 6.5+")
 
     @pytest.fixture
     def set_state_spy(

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -347,6 +347,17 @@ class TestPageLifecycle:
         webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
         assert not webengine_tab._lifecycle_timer.isActive()
 
+    def test_pinned_tabs_untouched(
+        self,
+        webengine_tab: webenginetab.WebEngineTab,
+        monkeypatch,
+        config_stub,
+    ):
+        """Don't change lifecycle state for a pinned tab."""
+        webengine_tab.set_pinned(True)
+        webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Frozen)
+        assert not webengine_tab._lifecycle_timer.isActive()
+
     def test_timer_interrupted(
         self,
         webengine_tab: webenginetab.WebEngineTab,

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -288,9 +288,9 @@ class TestPageLifecycle:
         discard_delay=0,
         enabled=True,
     ):
-        config_stub.val.qt.chromium.lifecycle_state_freeze_delay = freeze_delay
-        config_stub.val.qt.chromium.lifecycle_state_discard_delay = discard_delay
-        config_stub.val.qt.chromium.use_recommended_page_lifecycle_state = enabled
+        config_stub.val.qt.chromium.lifecycle_state.freeze_delay = freeze_delay
+        config_stub.val.qt.chromium.lifecycle_state.discard_delay = discard_delay
+        config_stub.val.qt.chromium.lifecycle_state.enabled = enabled
 
     def timer_for(self, tab, state):  # pylint: disable=inconsistent-return-statements
         if state == QWebEnginePage.LifecycleState.Frozen:

--- a/tests/unit/browser/webengine/test_webenginetab.py
+++ b/tests/unit/browser/webengine/test_webenginetab.py
@@ -259,25 +259,25 @@ class TestPageLifecycle:
             pytest.skip("Lifecycle feature requires Webengine 6.5+")
 
     @pytest.fixture
-    def set_state_spy(
+    def set_state_mock(
         self,
         webengine_tab: webenginetab.WebEngineTab,
         monkeypatch,
         mocker,
     ):
-        set_state_spy = mocker.Mock()
+        set_state_mock = mocker.Mock()
         monkeypatch.setattr(
             webengine_tab._widget.page(),
             "setLifecycleState",
-            set_state_spy,
+            set_state_mock,
         )
-        return set_state_spy
+        return set_state_mock
 
     @pytest.fixture(autouse=True)
     def set_config_defaults(
         self,
         config_stub,
-        set_state_spy,
+        set_state_mock,
     ):
         self.set_config(config_stub)
 
@@ -295,14 +295,14 @@ class TestPageLifecycle:
     def test_qt_method_is_called(
         self,
         webengine_tab: webenginetab.WebEngineTab,
-        set_state_spy,
+        set_state_mock,
         qtbot,
     ):
         """Basic test to show that we call QT after going through our code."""
         webengine_tab._on_recommended_state_changed(QWebEnginePage.LifecycleState.Discarded)
         with qtbot.wait_signal(webengine_tab._lifecycle_timer.timeout):
             pass
-        set_state_spy.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)
+        set_state_mock.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)
 
     @pytest.mark.parametrize(
         "new_state, freeze_delay, discard_delay",
@@ -316,7 +316,7 @@ class TestPageLifecycle:
         webengine_tab: webenginetab.WebEngineTab,
         monkeypatch,
         mocker,
-        set_state_spy,
+        set_state_mock,
         config_stub,
         qtbot,
         new_state,
@@ -341,7 +341,7 @@ class TestPageLifecycle:
 
         with qtbot.wait_signal(timer.timeout, timeout=100):
             pass
-        set_state_spy.assert_called_once_with(new_state)
+        set_state_mock.assert_called_once_with(new_state)
 
     def test_state_disabled(
         self,
@@ -371,7 +371,7 @@ class TestPageLifecycle:
     def test_timer_interrupted(
         self,
         webengine_tab: webenginetab.WebEngineTab,
-        set_state_spy,
+        set_state_mock,
         config_stub,
         qtbot,
     ):
@@ -390,4 +390,4 @@ class TestPageLifecycle:
 
         with qtbot.wait_signal(webengine_tab._lifecycle_timer.timeout):
             pass
-        set_state_spy.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)
+        set_state_mock.assert_called_once_with(QWebEnginePage.LifecycleState.Discarded)


### PR DESCRIPTION
Hello. This patch adds a setting to enable the use of "recommended page lifecycle states", which lets the web engine freeze or discard[^1] pages, which results in a significant reduction in CPU usage and battery drain.

I have been using it exclusively since September last year, and it has basically been unnoticeable other than a dramatic improvement to battery life on my aging laptop.

Unfortunately I have no hard numbers to back this up, only my own experience from the past ~7 months of being able to use my laptop on campus without bringing a charger.

Maybe someone knows of a good way to measure these things, and could take it for a spin?

Cheers. 

[^1]: Qt docs describe this as "similar to serializing the browsing history of the web view and destroying the view, then creating a new view and restoring its history."