### PR TITLE
WIP initial pyproject toml support for build tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "qutebrowser"
+description = "A keyboard-driven, vim-like browser based on Python and Qt."
 # What about the other libs in requirements.txt?
 dependencies = [
   "jinja2",
@@ -41,7 +42,6 @@ classifiers = [
 # https://discuss.python.org/t/please-make-package-version-go-away/58501/11
 dynamic = [
   "version",
-  "description",
 ]
 
 [project.urls]
@@ -57,8 +57,10 @@ funding = "https://github.com/qutebrowser/qutebrowser/blob/main/README.asciidoc#
 qutebrowser = "qutebrowser.qutebrowser:main"
 
 [tool.setuptools.dynamic]
-version = {attr = "qutebrowser.__version__"}
-description = {attr = "qutebrowser.__description__"}
+# We can't import a variable from qutebrowser/__init__.py because when we put
+# "qutebrowser" here setuptools resolves that to "qutebrowser/qutebrowser.py".
+# So just import the attribute from that qutebrowser.py file.
+version = {attr = "qutebrowser.qutebrowser.__version__"}
 
 [tool.setuptools.packages.find]
 include = ["qutebrowser", "qutebrowser.*"]  # package names should match these glob patterns (["*"] by default)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,64 @@
+[build-system]
+requires = ["setuptools >= 42.0.0"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "qutebrowser"
+# What about the other libs in requirements.txt?
+dependencies = [
+  "jinja2",
+  "pyyaml",
+]
+requires-python = ">=3.9"
+authors = [
+  {name = "Florian Bruhin", email = "mail@qutebrowser.org"},
+]
+readme = {file = "README.asciidoc", content-type = "text/asciidoc"}
+license = "GPL-3.0-or-later"
+license-files = ["LICENSE"]
+keywords = ["pyqt", "browser", "web", "qt", "webkit", "qtwebkit", "qtwebengine"]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: X11 Applications :: Qt",
+  "Intended Audience :: End Users/Desktop",
+  "Natural Language :: English",
+  "Operating System :: Microsoft :: Windows",
+  "Operating System :: POSIX :: Linux",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX :: BSD",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.9",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Topic :: Internet",
+  "Topic :: Internet :: WWW/HTTP",
+  "Topic :: Internet :: WWW/HTTP :: Browsers",
+]
+# TODO: reconsider making the application files the authoritative source of
+# these values, see discussion:
+# https://discuss.python.org/t/please-make-package-version-go-away/58501/11
+dynamic = [
+  "version",
+  "description",
+]
+
+[project.urls]
+homepage = "https://www.qutebrowser.org/"
+documentation = "https://www.qutebrowser.org/doc/help/"
+repository = "https://github.com/qutebrowser/qutebrowser.git"
+issues = "https://github.com/qutebrowser/qutebrowser/issues"
+changelog = "https://www.qutebrowser.org/doc/changelog.html"
+download = "https://github.com/qutebrowser/qutebrowser/releases"
+funding = "https://github.com/qutebrowser/qutebrowser/blob/main/README.asciidoc#donating"
+
+[project.gui-scripts]
+qutebrowser = "qutebrowser.qutebrowser:main"
+
+[tool.setuptools.dynamic]
+version = {attr = "qutebrowser.__version__"}
+description = {attr = "qutebrowser.__description__"}
+
+[tool.setuptools.packages.find]
+include = ["qutebrowser", "qutebrowser.*"]  # package names should match these glob patterns (["*"] by default)

--- a/qutebrowser/qutebrowser.py
+++ b/qutebrowser/qutebrowser.py
@@ -23,6 +23,7 @@ import sys
 import json
 
 import qutebrowser
+from qutebrowser import __version__
 try:
     from qutebrowser.misc.checkpyver import check_python_version
 except ImportError:

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ import setuptools
 # * version=_get_constant('version'),
 #   * dynamic in setuptools
 # * description=_get_constant('description'),
-#   * dynamic option in setuptools
+#   * support reading from file, but not attribute
 # * author=_get_constant('author'),
 # * author_email=_get_constant('email'),
 #   * both not dynamic and don't change much, duplicate or move
@@ -48,6 +48,7 @@ import setuptools
 #   * not dynamic, it's also not used anywhere else and doesn't change often
 #   * just duplicate it and leave a comment or move it completely
 #
+# Move duplicated stuff in __init__ to use importlib.metadata?
 
 # Args to setup()
 # https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration

--- a/setup.py
+++ b/setup.py
@@ -10,10 +10,55 @@ import re
 import ast
 import os
 import os.path
+import sys
+
+# Add repo root to path so we can import scripts. Prior to PEP517 support this
+# was the default behavior for setuptools.
+# https://github.com/pypa/setuptools/issues/3939#issuecomment-1573619382
+# > If users want to import local modules they are recommended to explicitly add the current directory to sys.path at the top of setup.py.
+sys.path.append(".")
 
 from scripts import setupcommon as common
 
 import setuptools
+
+# Dynamic stuff in setup.py:
+# * common.write_git_file (and then cleaning it up)
+#   * should be shipped with qutebrowser
+#   * read in version, used in pyinstaller
+#   * couldn't find any good options for this. There are plugins like
+#   setuptools-scm and hatch-vcs that can include git data in the version. But
+#   we want a clean version but to include git info about the build at
+#   runtime. This really seems like it needs a build hook, which for
+#   setuptools I think is setup.py (there are entry points you can set, but
+#   they say something about the application needing to be installed before
+#   they can run, not sure if that means they aren't usable or what). I think
+#   hatch has build hooks you can specify in pyproject.toml
+# * long_description=read_file('README.asciidoc')
+#   * dynamic `readme` key in setuptools
+#   * but docs say to just put the file name anyhow? https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#readme
+# * version=_get_constant('version'),
+#   * dynamic in setuptools
+# * description=_get_constant('description'),
+#   * dynamic option in setuptools
+# * author=_get_constant('author'),
+# * author_email=_get_constant('email'),
+#   * both not dynamic and don't change much, duplicate or move
+# * license=_get_constant('license'),
+#   * not dynamic, it's also not used anywhere else and doesn't change often
+#   * just duplicate it and leave a comment or move it completely
+#
+
+# Args to setup()
+# https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration
+# * packages=setuptools.find_namespace_packages(include=['qutebrowser', 'qutebrowser.*']),
+#    * [tool.setuptools.packages.find]
+# * include_package_data=True,
+#    * true by default when using pyproject.toml
+# * entry_points={'gui_scripts': ['qutebrowser = qutebrowser.qutebrowser:main']},
+#    * https://setuptools.pypa.io/en/latest/userguide/entry_point.html#gui-scripts
+# * zip_safe=True,
+#    * obsolete
 
 
 try:
@@ -51,43 +96,44 @@ def _get_constant(name):
 try:
     common.write_git_file()
     setuptools.setup(
-        packages=setuptools.find_namespace_packages(include=['qutebrowser',
-                                                             'qutebrowser.*']),
-        include_package_data=True,
-        entry_points={'gui_scripts':
-                      ['qutebrowser = qutebrowser.qutebrowser:main']},
-        zip_safe=True,
-        install_requires=['jinja2', 'PyYAML'],
-        python_requires='>=3.9',
-        name='qutebrowser',
-        version=_get_constant('version'),
-        description=_get_constant('description'),
-        long_description=read_file('README.asciidoc'),
-        long_description_content_type='text/plain',
-        url='https://www.qutebrowser.org/',
-        author=_get_constant('author'),
-        author_email=_get_constant('email'),
-        license=_get_constant('license'),
-        classifiers=[
-            'Development Status :: 5 - Production/Stable',
-            'Environment :: X11 Applications :: Qt',
-            'Intended Audience :: End Users/Desktop',
-            'Natural Language :: English',
-            'Operating System :: Microsoft :: Windows',
-            'Operating System :: POSIX :: Linux',
-            'Operating System :: MacOS',
-            'Operating System :: POSIX :: BSD',
-            'Programming Language :: Python :: 3',
-            'Programming Language :: Python :: 3.9',
-            'Programming Language :: Python :: 3.10',
-            'Programming Language :: Python :: 3.11',
-            'Programming Language :: Python :: 3.12',
-            'Programming Language :: Python :: 3.13',
-            'Topic :: Internet',
-            'Topic :: Internet :: WWW/HTTP',
-            'Topic :: Internet :: WWW/HTTP :: Browsers',
-        ],
-        keywords='pyqt browser web qt webkit qtwebkit qtwebengine',
+        #packages=setuptools.find_namespace_packages(include=['qutebrowser',
+        #                                                     'qutebrowser.*']),
+        #include_package_data=True,
+        #entry_points={'gui_scripts':
+        #              ['qutebrowser = qutebrowser.qutebrowser:main']},
+        #zip_safe=True,
+
+        #install_requires=['jinja2', 'PyYAML'],
+        #python_requires='>=3.9',
+        #name='qutebrowser',
+        #version=_get_constant('version'),
+        #description=_get_constant('description'),
+        #long_description=read_file('README.asciidoc'),
+        #long_description_content_type='text/plain',
+        #url='https://www.qutebrowser.org/',
+        #author=_get_constant('author'),
+        #author_email=_get_constant('email'),
+        #license=_get_constant('license'),
+        #classifiers=[
+        #    'Development Status :: 5 - Production/Stable',
+        #    'Environment :: X11 Applications :: Qt',
+        #    'Intended Audience :: End Users/Desktop',
+        #    'Natural Language :: English',
+        #    'Operating System :: Microsoft :: Windows',
+        #    'Operating System :: POSIX :: Linux',
+        #    'Operating System :: MacOS',
+        #    'Operating System :: POSIX :: BSD',
+        #    'Programming Language :: Python :: 3',
+        #    'Programming Language :: Python :: 3.9',
+        #    'Programming Language :: Python :: 3.10',
+        #    'Programming Language :: Python :: 3.11',
+        #    'Programming Language :: Python :: 3.12',
+        #    'Programming Language :: Python :: 3.13',
+        #    'Topic :: Internet',
+        #    'Topic :: Internet :: WWW/HTTP',
+        #    'Topic :: Internet :: WWW/HTTP :: Browsers',
+        #],
+        #keywords='pyqt browser web qt webkit qtwebkit qtwebengine',
     )
 finally:
     if BASEDIR is not None:


### PR DESCRIPTION
WIP branch playing around with moving from setup.py to pyproject.toml. I'll probably look at setuptools and hatch as backends (setuptools is what we use now, hatch seems popular and non-opinionated). I don't think I'll look at moving any tool config into pyproject.toml beyond what's required for building.

Closes: #3526 (partially at least)