### PR TITLE
tabs: allow 'tabs.wrap' to work with scroll wheel

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -755,21 +755,18 @@ class TabBar(QTabBar):
             e: The QWheelEvent
         """
         if config.val.tabs.mousewheel_switching:
-            if utils.is_mac:
-                # WORKAROUND for this not being customizable until Qt 6:
-                # https://codereview.qt-project.org/c/qt/qtbase/+/327746
-                index = self.currentIndex()
-                if index == -1:
-                    return
-                dx = e.angleDelta().x()
-                dy = e.angleDelta().y()
-                delta = dx if abs(dx) > abs(dy) else dy
-                offset = -1 if delta > 0 else 1
-                index += offset
-                if 0 <= index < self.count():
-                    self.setCurrentIndex(index)
-            else:
-                super().wheelEvent(e)
+            index = self.currentIndex()
+            if index == -1:
+                return
+            dx = e.angleDelta().x()
+            dy = e.angleDelta().y()
+            delta = dx if abs(dx) > abs(dy) else dy
+            offset = -1 if delta > 0 else 1
+            index += offset
+            if config.val.tabs.wrap:
+                index %= self.count()
+            if 0 <= index < self.count():
+                self.setCurrentIndex(index)
         else:
             tabbed_browser = objreg.get('tabbed-browser', scope='window',
                                         window=self._win_id)


### PR DESCRIPTION
QTabBar doesn't wrap when switching between tabs with the scroll wheel so the 'tabs.wrap' option is only respected in the tab* commands. However, 'wheelEvent' is already being overriden for macos so we might as well override it for all platforms and implement wrapping there.
Fixes #8521

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
