### PR TITLE
Fixes issue #8246: fix window title for Web Inspector

### DIFF
--- a/qutebrowser/browser/inspector.py
+++ b/qutebrowser/browser/inspector.py
@@ -94,10 +94,10 @@ class AbstractWebInspector(QWidget):
         self._child_event_filter = eventfilter.ChildEventFilter(
             eventfilter=self._event_filter,
             parent=self)
+        self.setWindowTitle("Web Inspector")
 
     def _set_widget(self, widget: _WidgetType) -> None:
         self._widget = widget
-        self._widget.setWindowTitle("Web Inspector")
         self._widget.installEventFilter(self._child_event_filter)
         self._layout.wrap(self, self._widget)
 

--- a/tests/unit/browser/test_inspector.py
+++ b/tests/unit/browser/test_inspector.py
@@ -138,3 +138,7 @@ def test_detach_after_toggling(hidden_again, needs_recreate,
             fake_inspector.set_position(inspector.Position.window)
         assert fake_inspector.isVisible()
         assert fake_inspector.isWindow()
+
+
+def test_window_title(fake_inspector):
+    assert fake_inspector.windowTitle() == "Web Inspector"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
Fixes issue https://github.com/qutebrowser/qutebrowser/issues/8246, changes self._widget.setWindowTitle to self.setWindowTitle and adds a test for it. Based on #8292