### PR TITLE
Add qute://blank

### DIFF
--- a/qutebrowser/browser/qutescheme.py
+++ b/qutebrowser/browser/qutescheme.py
@@ -606,3 +606,11 @@ def qute_start(_url: QUrl) -> _HandlerRet:
                         search_url=searchurl,
                         quickmarks=quickmarks)
     return 'text/html', page
+
+
+@add_handler("blank")
+def qute_blank(_url: QUrl) -> _HandlerRet:
+    """Handler for qute://blank."""
+    bgcolor = config.val.colors.webpage.bg
+    return "text/html", \
+        f'<html style="background-color: {bgcolor.name()}"/>'

--- a/tests/unit/browser/test_qutescheme.py
+++ b/tests/unit/browser/test_qutescheme.py
@@ -310,3 +310,17 @@ class TestQuteConfigdiff:
         url = QUrl('qute://configdiff/')
         _mimetype, data = qutescheme.data_for_url(url)
         assert data == b'content.images = false'
+
+
+class TestBlankHandler:
+
+    """Test the qute://blank handler."""
+
+    @pytest.fixture(autouse=True)
+    def prepare_config(self, config_stub):
+        config_stub.set_obj("colors.webpage.bg", "#101010")
+
+    def test_basic(self, config_stub):
+        url = QUrl("qute://blank")
+        _mimetype, data = qutescheme.qute_blank(url)
+        assert data == '<html style="background-color: #101010"/>'


### PR DESCRIPTION
Enabling darkmode I've noticed that `about:blank` background color changes from the one specified in `colors.webpage.bg`. I wasn't able to disable dark mode for this page specifically (using url patterns), so I've devised a `qute://blank` page which explicitly sets the background.