### PR TITLE
feat(tabs): Add option to show tab bar on tab close

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -4511,6 +4511,14 @@ Type: <<types,Int>>
 
 Default: +pass:[800]+
 
+[[tabs.show_on_tab_close]]
+=== tabs.show_on_tab_close
+Show the tab bar for a short duration when a tab is closed, if tabs.show is set to 'switching'.
+
+Type: <<types,Bool>>
+
+Default: +pass:[False]+
+
 [[tabs.tabs_are_windows]]
 === tabs.tabs_are_windows
 Open a new window for every tab.

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2343,6 +2343,13 @@ tabs.show_switching_delay:
   desc: "Duration (in milliseconds) to show the tab bar before hiding it when
     tabs.show is set to 'switching'."
 
+tabs.show_on_tab_close:
+  default: false
+  type: Bool
+  desc: >-
+    Show the tab bar for a short duration when a tab is closed, if
+    tabs.show is set to 'switching'.
+
 tabs.tabs_are_windows:
   default: false
   type: Bool

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -746,7 +746,11 @@ class TabBar(QTabBar):
     def tabRemoved(self, idx):
         """Update visibility when a tab was removed."""
         super().tabRemoved(idx)
-        self.maybe_hide()
+        if config.val.tabs.show_on_tab_close and config.val.tabs.show == 'switching':
+            self.show()
+            self._auto_hide_timer.start()
+        else:
+            self.maybe_hide()
 
     def wheelEvent(self, e):
         """Override wheelEvent to make the action configurable.


### PR DESCRIPTION
This PR introduces tabs.show_on_tab_close, a new boolean option. When enabled
and tabs.show is set to switching, the tab bar will temporarily appear after a
tab is closed. This provides visual feedback and allows for quick interaction
with the tab bar before it hides again, improving usability for users of the
switching tab bar mode.

This feature has been thoroughly tested, and relevant unit tests are included
in this Pull Request.
