### PR TITLE
Name the devtool window

### DIFF
--- a/qutebrowser/browser/inspector.py
+++ b/qutebrowser/browser/inspector.py
@@ -158,6 +158,7 @@ class AbstractWebInspector(QWidget):
         self._position = position
 
         self._widget.show()
+        self.setWindowTitle("Web Inspector")
         self.show()
 
     def toggle(self) -> None:


### PR DESCRIPTION
When the devtool widget is invoked with "window", it appears in its own window. Currently the window title is "qutebrowser", preventing dedicated compositor configuration. We fix this by naming it "Web Inspector".

fix: https://github.com/qutebrowser/qutebrowser/issues/8246