### PR TITLE
Bugfix: correctly set focus when hiding cmd in statusbar

### DIFF
--- a/qutebrowser/mainwindow/mainwindow.py
+++ b/qutebrowser/mainwindow/mainwindow.py
@@ -562,7 +562,7 @@ class MainWindow(QWidget):
             self._completion.on_clear_completion_selection)
         self.status.cmd.hide_completion.connect(
             self._completion.hide)
-        self.status.cmd.hide_cmd.connect(self.tabbed_browser.on_release_focus)
+        self.status.connect_slot_to_hide_cmd(self.tabbed_browser.on_release_focus)
 
     def _set_decoration(self, hidden):
         """Set the visibility of the window decoration via Qt."""

--- a/qutebrowser/mainwindow/statusbar/bar.py
+++ b/qutebrowser/mainwindow/statusbar/bar.py
@@ -194,6 +194,17 @@ class StatusBar(QWidget):
         config.instance.changed.connect(self._on_config_changed)
         QTimer.singleShot(0, self.maybe_hide)
 
+    def connect_slot_to_hide_cmd(self, slot):
+        """Connect slot to signal cmd.hide_cmd.
+
+        This method makes sure the slot is called before
+        the widget cmd gets hides.
+        This allows to set focus where we need to before
+        the focus is changed automatically by hiding cmd."""
+        self.cmd.hide_cmd.disconnect(self._hide_cmd_widget)
+        self.cmd.hide_cmd.connect(slot)
+        self.cmd.hide_cmd.connect(self._hide_cmd_widget)
+
     def __repr__(self):
         return utils.get_repr(self)
 


### PR DESCRIPTION
The problem was that in Qt, slots are called in the order of connection, so even though there's a code that tries to set up the focus correctly, it's run after the cmd widget is hidden and hence the focus is already moved and it doesn't work as expected. This PR merely makes sure that the slot is run before the widget is hidden.

I suppose this behaviour occurs only under these specific conditions, because in other cases, like when suggestions are shown, the focus is set somewhere else/differently, but that's just a speculation.

Fixes #8223 