### PR TITLE
Make 'tox -e mypy' work again in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -213,14 +213,14 @@ deps =
 allowlist_externals = bash
 commands = bash scripts/dev/run_shellcheck.sh {posargs}
 
-[testenv:mypy-{pyqt5,pyqt6}]
+[testenv:mypy{,-pyqt5,-pyqt6}]
 basepython = {env:PYTHON:python3}
 passenv =
     TERM
     MYPY_FORCE_TERMINAL_WIDTH
 setenv =
     # See qutebrowser/qt/machinery.py
-    pyqt6: QUTE_CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6 --always-true=IS_PYQT --always-false=IS_PYSIDE
+    !pyqt5: QUTE_CONSTANTS_ARGS=--always-true=USE_PYQT6 --always-false=USE_PYQT5 --always-false=USE_PYSIDE6 --always-false=IS_QT5 --always-true=IS_QT6 --always-true=IS_PYQT --always-false=IS_PYSIDE
     pyqt5: QUTE_CONSTANTS_ARGS=--always-false=USE_PYQT6 --always-true=USE_PYQT5 --always-false=USE_PYSIDE6 --always-true=IS_QT5 --always-false=IS_QT6 --always-true=IS_PYQT --always-false=IS_PYSIDE
 deps =
     -r{toxinidir}/requirements.txt


### PR DESCRIPTION
Fix #8344
