### PR TITLE
fix: change fullscreen state when switching tab

### DIFF
--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -926,6 +926,7 @@ class TabbedBrowser(QWidget):
                         .format(current_mode.name, mode_on_change))
         self._now_focused = tab
         self.current_tab_changed.emit(tab)
+        self.cur_fullscreen_requested.emit(tab.data.fullscreen)
         self.cur_search_match_changed.emit(tab.search.match)
         QTimer.singleShot(0, self._update_window_title)
         self._tab_insert_idx_left = self.widget.currentIndex()


### PR DESCRIPTION
Closes #5283

After switching from a fullscreen tab to a normal tab, the whole window state should be restored. Also, switching from a normal tab to a fullscreen tab should make the window fullscreen as well.
