### PR TITLE
doc: Correct Arch Linux links

### DIFF
--- a/doc/faq.asciidoc
+++ b/doc/faq.asciidoc
@@ -141,7 +141,7 @@ The comma prefix is used to make sure user-defined bindings don't conflict with
 the built-in ones.
 +
 Note that you might need an additional package (e.g.
-https://www.archlinux.org/packages/community/any/youtube-dl/[youtube-dl] on
+https://archlinux.org/packages/extra/any/yt-dlp/[yt-dlp] on
 Archlinux) to play web videos with mpv.
 +
 There is a very useful script for mpv, which emulates "unique application"

--- a/qutebrowser/html/no_pdfjs.html
+++ b/qutebrowser/html/no_pdfjs.html
@@ -92,7 +92,7 @@ li {
             the required packages for pdf.js are also installed.
             <br/>
             The package is named
-            <a href="https://archlinux.org/packages/community/any/pdfjs/"><b>pdfjs</b></a> on Archlinux
+            <a href="https://archlinux.org/packages/extra/any/pdfjs-legacy/"><b>pdfjs-legacy</b></a> on Archlinux
             and <a href="https://packages.debian.org/bullseye/libjs-pdf"><b>libjs-pdf</b></a> on Debian.
           </li>
 


### PR DESCRIPTION
Arch hasn't been using the `[community]` repository [for 9 months now][1], correct the links for that.
Also, [`youtube-dl`][2] has been replaced in `[extra]` by [`yt-dlp`][3], unsure when -- I think this was in 2023?
Finally (and the trigger for this commit), given #8332, correct the guidance on Arch Linux to point to `pdfjs-legacy` instead of `pdfjs`.

[1]: https://archlinux.org/news/cleaning-up-old-repositories/
[2]: https://aur.archlinux.org/packages/youtube-dl
[3]: https://archlinux.org/packages/extra/any/yt-dlp/
