### PR TITLE
Unify librarry loading for X11/Wayland wmname

### DIFF
--- a/qutebrowser/misc/wmname.py
+++ b/qutebrowser/misc/wmname.py
@@ -26,12 +26,20 @@ class _WaylandDisplayStruct(ctypes.Structure):
 _WaylandDisplay = NewType("_WaylandDisplay", "ctypes._Pointer[_WaylandDisplayStruct]")
 
 
+def _load_library(name: str) -> ctypes.CDLL:
+    lib = ctypes.util.find_library(name)
+    if lib is None:
+        raise Error(f"{name} library not found")
+
+    try:
+        return ctypes.CDLL(lib)
+    except OSError as e:
+        raise Error(f"Failed to load {name} library: {e}")
+
+
 def _load_libwayland_client() -> ctypes.CDLL:
     """Load the Wayland client library."""
-    try:
-        return ctypes.CDLL("libwayland-client.so")
-    except OSError as e:
-        raise Error(f"Failed to load libwayland-client: {e}")
+    return _load_library("wayland-client")
 
 
 def _pid_from_fd(fd: int) -> int:
@@ -138,14 +146,7 @@ _X11Window = NewType("_X11Window", int)
 
 def _x11_load_lib() -> ctypes.CDLL:
     """Load the X11 library."""
-    lib = ctypes.util.find_library("X11")
-    if lib is None:
-        raise Error("X11 library not found")
-
-    try:
-        return ctypes.CDLL(lib)
-    except OSError as e:
-        raise Error(f"Failed to load X11 library: {e}")
+    return _load_library("X11")
 
 
 @contextlib.contextmanager

--- a/tests/unit/misc/test_wmname.py
+++ b/tests/unit/misc/test_wmname.py
@@ -28,9 +28,10 @@ def test_load_libwayland_client():
 
 def test_load_libwayland_client_error(mocker: pytest_mock.MockerFixture):
     """Test that an error in loading the Wayland client library raises an error."""
+    mocker.patch.object(ctypes.util, "find_library", return_value="libwayland-client.so.6")
     mocker.patch("ctypes.CDLL", side_effect=OSError("Library not found"))
 
-    with pytest.raises(wmname.Error, match="Failed to load libwayland-client"):
+    with pytest.raises(wmname.Error, match="Failed to load wayland-client"):
         wmname._load_libwayland_client()
 
 


### PR DESCRIPTION
libwayland-client.so is development symlink used during linking and there's no need to have it installed (usually shipped in -devel/-dev packages) on user's machines. Instead of hardcoding library file name, use same mechanism as in libX11 which let's Python figure the details and share common logic between X11 and Wayland.

Closes #8771

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
