### PR TITLE
Drop Python 3.9 from tox/CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,10 +137,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          ### PyQt 5.15.2 (Python 3.9)
-          - testenv: py39-pyqt5152
+          ### PyQt 5.15.2 (Python 3.10)
+          - testenv: py310-pyqt5152
             os: ubuntu-22.04
-            python: "3.9"
+            python: "3.10"
           ### PyQt 5.15 (Python 3.10, with coverage)
           # FIXME:qt6
           # - testenv: py310-pyqt515-cov
@@ -150,18 +150,18 @@ jobs:
           - testenv: py311-pyqt515
             os: ubuntu-22.04
             python: "3.11"
-          ### PyQt 6.2 (Python 3.9)
-          - testenv: py39-pyqt62
+          ### PyQt 6.2 (Python 3.10)
+          - testenv: py310-pyqt62
             os: ubuntu-22.04
-            python: "3.9"
-          ### PyQt 6.3 (Python 3.9)
-          - testenv: py39-pyqt63
+            python: "3.10"
+          ### PyQt 6.3 (Python 3.10)
+          - testenv: py310-pyqt63
             os: ubuntu-22.04
-            python: "3.9"
-          ## PyQt 6.4 (Python 3.9)
-          - testenv: py39-pyqt64
+            python: "3.10"
+          ## PyQt 6.4 (Python 3.10)
+          - testenv: py310-pyqt64
             os: ubuntu-22.04
-            python: "3.9"
+            python: "3.10"
           ### PyQt 6.5 (Python 3.10)
           - testenv: py310-pyqt65
             os: ubuntu-22.04

--- a/.github/workflows/recompile-requirements.yml
+++ b/.github/workflows/recompile-requirements.yml
@@ -21,10 +21,10 @@ jobs:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v6
         with:
-          python-version: '3.9'
+          python-version: '3.10'
       - name: Recompile requirements
         run: "python3 scripts/dev/recompile_requirements.py ${{ github.event.input.environments }}"
         id: requirements

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ on:
         default: '3.14'
         type: choice
         options:
-          - '3.9'
           - '3.10'
           - '3.11'
           - '3.12'

--- a/doc/contributing.asciidoc
+++ b/doc/contributing.asciidoc
@@ -111,9 +111,9 @@ unittests and several linters/checkers.
 Currently, the following tox environments are available:
 
 * Tests using https://www.pytest.org[pytest]:
-  - `py39`, `py310`, ...: Run pytest for python 3.9/3.10/... with the system-wide PyQt.
-  - `py39-pyqt515`, ..., `py39-pyqt65`: Run pytest with the given PyQt version (`py310-*` etc. also works).
-  - `py39-pyqt515-cov`: Run with coverage support (other Python/PyQt versions work too).
+  - `py310`, `py311`, ...: Run pytest for python 3.10/3.11/... with the system-wide PyQt.
+  - `py310-pyqt515`, ..., `py310-pyqt65`: Run pytest with the given PyQt version (`py311-*` etc. also works).
+  - `py310-pyqt515-cov`: Run with coverage support (other Python/PyQt versions work too).
 * `flake8`: Run various linting checks via https://pypi.python.org/pypi/flake8[flake8].
 * `vulture`: Run https://pypi.python.org/pypi/vulture[vulture] to find
   unused code portions.
@@ -169,16 +169,16 @@ Examples:
 
 ----
 # run only pytest tests which failed in last run:
-tox -e py39 -- --lf
+tox -e py310 -- --lf
 
 # run only the end2end feature tests:
-tox -e py39 -- tests/end2end/features
+tox -e py310 -- tests/end2end/features
 
 # run everything with undo in the generated name, based on the scenario text
-tox -e py39 -- tests/end2end/features/test_tabs_bdd.py -k undo
+tox -e py310 -- tests/end2end/features/test_tabs_bdd.py -k undo
 
 # run coverage test for specific file (updates htmlcov/index.html)
-tox -e py39-cov -- tests/unit/browser/test_webelem.py
+tox -e py310-cov -- tests/unit/browser/test_webelem.py
 ----
 
 Specifying the backend for tests
@@ -649,7 +649,7 @@ The hierarchy of widgets when QtWebEngine is involved looks like this:
 - The `WebEngineTab` has a `_widget` attribute, which is the https://doc.qt.io/qt-6/qwebengineview.html[QWebEngineView]
 - That view has a https://doc.qt.io/qt-6/qwebenginepage.html[QWebEnginePage] for everything which doesn't require rendering.
 - The view also has a layout with exactly one element (which also is its `focusProxy()`).
-    - Qt 5: That element is the https://code.qt.io/cgit/qt/qtwebengine.git/tree/src/webenginewidgets/render_widget_host_view_qt_delegate_widget.cpp?h=5.15[RenderWidgetHostViewQtDelegateWidget] (it inherits https://doc.qt.io/qt-6/qquickwidget.html[QQuickWidget]) - also often referred to as RWHV or RWHVQDW. 
+    - Qt 5: That element is the https://code.qt.io/cgit/qt/qtwebengine.git/tree/src/webenginewidgets/render_widget_host_view_qt_delegate_widget.cpp?h=5.15[RenderWidgetHostViewQtDelegateWidget] (it inherits https://doc.qt.io/qt-6/qquickwidget.html[QQuickWidget]) - also often referred to as RWHV or RWHVQDW.
       It can be obtained via `sip.cast(tab._widget.focusProxy(), QQuickWidget)`.
     - Qt 6: That element is the https://code.qt.io/cgit/qt/qtwebengine.git/tree/src/webenginewidgets/api/qwebengineview.cpp[WebEngineQuickWidget] (it inherits https://doc.qt.io/qt-6/qquickwidget.html[QQuickWidget]).
       It can be obtained via `tab._widget.focusProxy()`.

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py39-pyqt515-cov,mypy-pyqt5,misc,vulture,flake8,pylint,pyroma,eslint,yamllint,actionlint
+envlist = py310-pyqt515-cov,mypy-pyqt5,misc,vulture,flake8,pylint,pyroma,eslint,yamllint,actionlint
 distshare = {toxworkdir}
 skipsdist = true
 minversion = 3.20
@@ -36,7 +36,6 @@ passenv =
 basepython =
     py: {env:PYTHON:python3}
     py3: {env:PYTHON:python3}
-    py39: {env:PYTHON:python3.9}
     py310: {env:PYTHON:python3.10}
     py311: {env:PYTHON:python3.11}
     py312: {env:PYTHON:python3.12}


### PR DESCRIPTION
Udapte by using this commit :https://github.com/qutebrowser/qutebrowser/commit/bd3774dfc82e679d64e708022bbc8b484214d7ab Drop Python 3.8 from tox/CI

All the occurences of 3.9 are replaced by 3.10