### PR TITLE
Adjust linters for dropping Python 3.9

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -59,7 +59,7 @@ ignore =
     PT004,
     PT011,
     PT012
-min-version = 3.9.0
+min-version = 3.10.0
 max-complexity = 12
 per-file-ignores =
     qutebrowser/api/hook.py : N801

--- a/.mypy.ini
+++ b/.mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.9
+python_version = 3.10
 
 ### --strict
 warn_unused_configs = True

--- a/.pylintrc
+++ b/.pylintrc
@@ -16,7 +16,7 @@ load-plugins=qute_pylint.config,
              pylint.extensions.dunder
 
 persistent=n
-py-version=3.9
+py-version=3.10
 
 [MESSAGES CONTROL]
 enable=all


### PR DESCRIPTION
Udapte by using this commit :https://github.com/qutebrowser/qutebrowser/commit/5337882657de995a639cab7a0cea5464f8443886 Adjust linters for dropping Python 3.8