### PR TITLE
Issue #7385 : Add ASCII style for statusbar progress bar

### DIFF
--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2212,6 +2212,16 @@ statusbar.widgets:
   default: ['keypress', 'search_match', 'url', 'scroll', 'history', 'tabs', 'progress']
   desc: "List of widgets displayed in the statusbar."
 
+statusbar.progress.style:
+  type:
+    name: String
+    valid_values:
+      - default: The standard graphical progress bar.
+      - ascii: A text-based progress bar (e.g. [===>   ]).
+  default: default
+  desc: >-
+    Style of the progress bar in the statusbar.
+
 ## tabs
 
 tabs.background:


### PR DESCRIPTION
Issue #7385 : Add ASCII style for statusbar progress bar

Use `:set statusbar.progress.style ascii` to use the ascii progress bar

### Changes
- Added new setting `statusbar.progress.style` with values `default` and `ascii`.

### Impacted files
- `qutebrowser/config/configdata.yml`
- `qutebrowser/mainwindow/statusbar/progress.py`