### PR TITLE
password_fill: dispatch "input" event to make some websites happy

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -361,12 +361,14 @@ cat <<EOF
                 input.focus();
                 input.value = "$(javascript_escape "${username}")";
                 input.dispatchEvent(new Event('change'));
+                input.dispatchEvent(new Event('input'));
                 input.blur();
             }
             if (input.type == "password") {
                 input.focus();
                 input.value = "$(javascript_escape "${password}")";
                 input.dispatchEvent(new Event('change'));
+                input.dispatchEvent(new Event('input'));
                 input.blur();
             }
         }


### PR DESCRIPTION
This change follows from #2111. It seems like #5234 did not fix all websites. I'm adding another event here to fix some other websites that I use. It seems the event `input` makes the form happy.