### PR TITLE
Add "quickmarks_reload" command

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1175,6 +1175,12 @@ class CommandDispatcher:
         return runner
 
     @cmdutils.register(instance='command-dispatcher', scope='window')
+    def quickmarks_reload(self):
+        """Reload quickmark list."""
+        quickmark_manager = objreg.get('quickmark-manager')
+        quickmark_manager.reload()
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
     def quickmark_save(self):
         """Save the current page as a quickmark."""
         quickmark_manager = objreg.get('quickmark-manager')

--- a/qutebrowser/browser/urlmarks.py
+++ b/qutebrowser/browser/urlmarks.py
@@ -82,12 +82,8 @@ class UrlMarkManager(QObject):
 
         self.marks: MutableMapping[str, str] = collections.OrderedDict()
 
-        self._init_lineparser()
-        for line in self._lineparser:
-            if not line.strip() or line.startswith('#'):
-                # Ignore empty or whitespace-only lines and comments.
-                continue
-            self._parse_line(line)
+        self.reload()
+
         self._init_savemanager(objreg.get('save-manager'))
 
     def _init_lineparser(self):
@@ -112,6 +108,17 @@ class UrlMarkManager(QObject):
         """
         del self.marks[key]
         self.changed.emit()
+
+    def reload(self):
+        """Reload quickmark list from disk."""
+        self.marks.clear()
+
+        self._init_lineparser()
+        for line in self._lineparser:
+            if not line.strip() or line.startswith('#'):
+                # Ignore empty or whitespace-only lines and comments.
+                continue
+            self._parse_line(line)
 
 
 class QuickmarkManager(UrlMarkManager):


### PR DESCRIPTION
"quickmarks_reload" allows to reload the quickmark list from disk without restarting qutebrowser

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
