### PR TITLE
fix: allow fake-key <Modifier+{<,>}> 

### DIFF
--- a/qutebrowser/keyinput/keyutils.py
+++ b/qutebrowser/keyinput/keyutils.py
@@ -273,14 +273,19 @@ def _parse_keystring(keystr: str) -> Iterator[str]:
     for c in keystr:
         if c == '>':
             if special:
-                yield _parse_special_key(key)
-                key = ''
-                special = False
+                if key.endswith('+'):
+                    key += '>'
+                else:
+                    yield _parse_special_key(key)
+                    key = ''
+                    special = False
             else:
-                yield '>'
-                assert not key, key
+                yield _parse_single_key('>')
         elif c == '<':
-            special = True
+            if special:
+                key += '<'
+            else:
+                special = True
         elif special:
             key += c
         else:


### PR DESCRIPTION
When viewing youtube videos on youtube.com, changing playback speed requires you to enter insert mode first. 
Just binding :bind > fake-key > does not make the youtube player change speed, fake-key <Shift+>> is required.

When binding:
		bind < fake-key <Shift+<>
		bind > fake-key <Shift+>>
	or
		config.bind("<", "fake-key <Shift+<>", mode="normal")
		config.bind(">", "fake-key <Shift+>>", mode="normal")

Got these errors:
		Could not parse '<Shift+>>': Got invalid key!
		Could not parse '<Shift+<>': Got invalid key!

Changes tested on debian 13 stable.