### PR TITLE
Fix Issue #7290 Mac Icon larger than other apps.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ TODO
 /misc/nsis/include
 /misc/nsis/plugins
 /wheels
+.DS_Store

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -168,6 +168,8 @@ def init(*, args: argparse.Namespace) -> None:
 
 def _init_icon():
     """Initialize the icon of qutebrowser."""
+    if utils.is_mac:
+        return
     fallback_icon = QIcon()
     for size in [16, 24, 32, 48, 64, 96, 128, 256, 512]:
         filename = 'icons/qutebrowser-{size}x{size}.png'.format(size=size)


### PR DESCRIPTION
The Qutebrowser icon is larger than the ones of other applications.

Kate handles this by exiting early on icon setting for macOS.

Tested the same approach on (arm64) mac successfully.

Closes#7290

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
