### PR TITLE
Add line_profiler support to run_profile.py

### DIFF
--- a/scripts/dev/run_profile.py
+++ b/scripts/dev/run_profile.py
@@ -79,11 +79,13 @@ def main():
     # If we have an exception after here, we don't want the qutebrowser
     # exception hook to take over.
     sys.excepthook = sys.__excepthook__
-    profiler.dump_stats(profilefile)
 
     if args.line_profiler:
         profiler.print_stats()
         sys.exit(0)
+
+    profiler.dump_stats(profilefile)
+
     if args.profile_tool == 'none':
         print("Profile data written to {}".format(profilefile))
     elif args.profile_tool == 'gprof2dot':


### PR DESCRIPTION
Closes #1610

This PR adds support for `line_profiler` to the `run_profile.py` script.

**Changes**
* Added a new `--line-profiler` argument.
* Wrapped the `line_profiler` import in a `try/except` block to prevent crashes for users who don't have the module.
* Display stats directly to stdout when using line_profiler.