### PR TITLE
Exclude `open -p` and `open --private` from command history

### DIFF
--- a/qutebrowser/mainwindow/statusbar/command.py
+++ b/qutebrowser/mainwindow/statusbar/command.py
@@ -197,6 +197,9 @@ class Command(misc.CommandLineEdit):
             if not should_exclude:
                 self.history.append(text)
 
+        if not self.prefix() == ':':
+            self.history.append(text)
+
         if not rapid:
             modeman.leave(self._win_id, usertypes.KeyMode.command,
                           'cmd accept')


### PR DESCRIPTION
Closes https://github.com/qutebrowser/qutebrowser/issues/2865

- Commands `:open -p` and `:open --private` are no longer added to the command history
- Commands starting with a space continue to be excluded from history
