### PR TITLE
Fix #8650: tabs no longer get stuck switching when drag fails

### DIFF
--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -477,9 +477,10 @@ class TabBar(QTabBar):
         """Hide the tab bar if needed."""
         show = config.val.tabs.show
         tab = self._current_tab()
-        if (show in ['never', 'switching'] or
+        # Ensure the tab bar remains visible during drag-and-drop operations.
+        if ((show in ['never', 'switching'] or
                 (show == 'multiple' and self.count() == 1) or
-                (tab and tab.data.fullscreen)):
+                (tab and tab.data.fullscreen)) and not self.drag_in_progress):
             self.hide()
         else:
             self.show()

--- a/tests/unit/mainwindow/test_tabwidget.py
+++ b/tests/unit/mainwindow/test_tabwidget.py
@@ -182,6 +182,29 @@ class TestTabWidget:
 
         benchmark(_run_bench)
 
+    def test_maybe_hide_respects_drag (self, widget, config_stub):
+        """`maybe_hide()` should not hide the tab bar if a drag is in progress.
+        
+        Set `tabs.show` to "never" to ensure that the default behavior 
+        of hiding the tab bar is in place; when `tab_bar._drag_in_progress` is true,
+        the bar must be visible. 
+        """
+
+        bar = widget.tabBar()
+        assert bar.isVisible()
+
+        config_stub.val.tabs.show = "never"
+
+        # when dragging, the tab bar should remain visible
+        bar.drag_in_progress = True
+        bar.maybe_hide()
+        assert bar.isVisible()
+
+        # when not dragging, the tab bar should be hidden
+        bar.drag_in_progress = False
+        bar.maybe_hide()
+        assert not bar.isVisible()
+
     def test_tab_pinned_benchmark(self, benchmark, widget, fake_web_tab):
         """Benchmark for _tab_pinned."""
         widget.addTab(fake_web_tab(), 'foobar')


### PR DESCRIPTION
When the `tabs.show` setting is set to `switching`, the tab bar disappears after a timeout,
even during an active drag-and-drop operation.
This causes tab-switching commands and keybindings to become unresponsive until the tab bar is manually reset to `always`. This patch introduces a check for the `drag_in_progress` flag in the `maybe_hide` method to ensure the tab bar remains visible during drag-and-drop operations.
A unit test has been added to verify this behaviour.

This PR closes issue #8650.