### PR TITLE
Fix #8863: fixed caret selection mode resetting find position

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1662,6 +1662,23 @@ class CommandDispatcher:
             tab.search.search(window_text, **window_options)
             count -= 1
 
+        elif window_text is not None and not tab.search.search_displayed:
+            # Restore a temporarily hidden search (e.g. after entering/leaving
+            # caret mode), then continue navigation from the current context.
+            restore_match_current = None
+
+            if hasattr(tab.search, 'take_restore_match_current'):
+                restore_match_current = tab.search.take_restore_match_current()
+
+                if restore_match_current is not None:
+                    tab.search.search(window_text, **window_options)
+
+                    if restore_match_current > 1:
+                        # Restore search state
+                        wrap = config.val.search.wrap
+                        for _ in range(restore_match_current - 1):
+                            tab.search.next_result(wrap=wrap)
+
         if count == 0:
             return
 

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -150,6 +150,17 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._pending_searches = 0
         self.match = browsertab.SearchMatch()
         self._old_match = browsertab.SearchMatch()
+        self._restore_match_current = None
+
+    def keep_match_for_restore(self):
+        """Remember current match on the next clear()."""
+        self._restore_match_current = self.match.current
+
+    def take_restore_match_current(self):
+        """Get and clear a stored pre-clear match index."""
+        current = self._restore_match_current
+        self._restore_match_current = None
+        return current
 
     def _store_flags(self, reverse, ignore_case):
         self._flags.case_sensitive = self._is_case_sensitive(ignore_case)
@@ -304,6 +315,7 @@ class WebEngineCaret(browsertab.AbstractCaret):
         if self._tab.search.search_displayed:
             # We are currently in search mode.
             # convert the search to a blue selection so we can operate on it
+            self._tab.search.keep_match_for_restore()
             self._tab.search.clear()
 
         self._tab.run_js_async(

--- a/tests/unit/browser/test_caret.py
+++ b/tests/unit/browser/test_caret.py
@@ -7,11 +7,12 @@
 import textwrap
 
 import pytest
+from types import SimpleNamespace
 from qutebrowser.qt.core import QUrl
 
 from qutebrowser.qt import machinery
 from qutebrowser.utils import utils, usertypes
-from qutebrowser.browser import browsertab
+from qutebrowser.browser import browsertab, commands
 
 
 @pytest.fixture
@@ -345,6 +346,49 @@ class TestSearch:
 
         caret.move_to_end_of_line()
         selection.check('wei drei')
+
+    @pytest.mark.no_xvfb
+    def test_search_next_after_caret_mode_continues_from_previous_match(self, webengine_tab, mode_manager,
+                                                                        qtbot, config_stub,):
+        webengine_tab.container.expose()
+
+        with qtbot.wait_signal(webengine_tab.load_finished, timeout=10000):
+            webengine_tab.load_url(QUrl('qute://testdata/data/caret.html'))
+
+        with qtbot.wait_callback() as callback:
+            webengine_tab.search.search('w', result_cb=callback)
+        callback.assert_called_with(True)
+
+        with qtbot.wait_callback() as callback:
+            webengine_tab.search.next_result(callback=callback)
+        callback.assert_called_with(browsertab.SearchNavigationResult.found)
+
+        before = webengine_tab.search.match.current
+        total = webengine_tab.search.match.total
+        expected = before + 1 if before < total else 1
+
+        with qtbot.wait_signal(webengine_tab.caret.selection_toggled):
+            mode_manager.enter(usertypes.KeyMode.caret)
+        mode_manager.leave(usertypes.KeyMode.caret)
+
+        dispatcher = commands.CommandDispatcher(
+            win_id=0,
+            tabbed_browser=SimpleNamespace(
+                search_text='w',
+                search_options={
+                    'ignore_case': config_stub.val.search.ignore_case,
+                    'reverse': False,
+                },
+            ),
+        )
+        dispatcher._current_widget = lambda: webengine_tab
+
+        dispatcher.search_next()
+
+        qtbot.wait_until(
+            lambda: webengine_tab.search.match.current == expected,
+            timeout=10000,
+        )
 
 
 class TestFollowSelected:


### PR DESCRIPTION
When the caret selection mode is activated while the find mode is enabled, it used to reset its position to the first match instead of the one it left at. This happened because activating caret mode with find mode open invoked _tab.search.clear(), which erased the previous find mode state.

The fix consists of saving the previous find mode state when caret mode is enabled. Leaving caret mode and resuming match finding now restores the state saved when entering caret mode.

I also included a new test for this case.

Closes #8863
