### PR TITLE
sessions: introduce save/restore hooks for window positioning

### DIFF
--- a/doc/userscripts.asciidoc
+++ b/doc/userscripts.asciidoc
@@ -57,6 +57,7 @@ In `command` mode:
 - `QUTE_SELECTED_TEXT`: The text currently selected on the page.
 - `QUTE_COUNT`: The `count` from the spawn command running the userscript.
 - `QUTE_TAB_INDEX`: The current tab's index.
+- `QUTE_WIN_ID`: The internal window ID of the current window.
 
 In `hints` mode:
 

--- a/misc/userscripts/README.md
+++ b/misc/userscripts/README.md
@@ -40,6 +40,8 @@ The following userscripts are included in the current directory.
 - [kodi](./kodi): Play videos in Kodi.
 - [add-nextcloud-bookmarks](./add-nextcloud-bookmarks): Create bookmarks in Nextcloud's Bookmarks app.
 - [add-nextcloud-cookbook](./add-nextcloud-cookbook): Add recipes to Nextcloud's Cookbook app.
+- [qb-sway-session](./qb-sway-session): Save and restore window positions
+  and layouts on the Sway compositor (Wayland).
 
 [castnow]: https://github.com/xat/castnow
 [youtube-dl]: https://rg3.github.io/youtube-dl/

--- a/misc/userscripts/README.md
+++ b/misc/userscripts/README.md
@@ -42,6 +42,10 @@ The following userscripts are included in the current directory.
 - [add-nextcloud-cookbook](./add-nextcloud-cookbook): Add recipes to Nextcloud's Cookbook app.
 - [qb-sway-session](./qb-sway-session): Save and restore window positions
   and layouts on the Sway compositor (Wayland).
+- [qb-hyprland-session](./qb-hyprland-session): Save and restore window
+  positions and layouts on the Hyprland compositor (Wayland).  Supports
+  basic mode (workspace/monitor/floating) and full tiling tree
+  reconstruction with the [Hy3](https://github.com/outfoxxed/hy3) plugin.
 
 [castnow]: https://github.com/xat/castnow
 [youtube-dl]: https://rg3.github.io/youtube-dl/

--- a/misc/userscripts/qb-hyprland-session
+++ b/misc/userscripts/qb-hyprland-session
@@ -1,0 +1,1131 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: Simon Désaulniers (sim590) <sim.desaulniers@gmail.com>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Session save/restore helper for qutebrowser on Hyprland (Wayland).
+
+This script is designed to be invoked via qutebrowser's
+``session.after_save_command`` and ``session.after_load_command`` config
+options.
+
+Usage::
+
+    # In qutebrowser config.py:
+    c.session.after_save_command = (
+        'qb-hyprland-session save {session_path}'
+    )
+    c.session.after_load_command = (
+        'qb-hyprland-session restore {session_path}'
+    )
+
+File layout
+-----------
+
+The session YAML written by qutebrowser is **never modified** by this
+script.  All Hyprland-specific data is stored in a companion *sidecar*
+file in a ``hyprland/`` subdirectory next to the session file::
+
+    data/sessions/default.yml            ← written by qutebrowser (untouched)
+    data/sessions/hyprland/default.yml   ← written by this script
+
+The sidecar is written atomically (temp-file + ``os.replace``) so it is
+either fully written or not written at all — a crash can never corrupt
+the session file.
+
+Modes
+-----
+
+The script supports two modes of operation depending on whether the
+Hy3 plugin (https://github.com/outfoxxed/hy3) is loaded:
+
+**With Hy3** (full reconstruction):
+    Hy3 provides an i3/Sway-like manual tiling layout with an explicit
+    container tree (splith, splitv, tabbed).  The script parses the
+    ``hy3:debugnodes`` output to save and reconstruct the full tiling
+    hierarchy, including proportional window sizes and tabbed groups.
+
+**Without Hy3** (basic mode):
+    Only workspace assignment, monitor placement, and floating window
+    positions are restored.  The tiling layout (dwindle/master) is
+    managed automatically by Hyprland and cannot be reconstructed.
+
+**save**
+    Reads the session YAML (read-only) and queries Hyprland via
+    ``hyprctl`` to find qutebrowser windows.  Correlates them via
+    temporary title markers (``__qb_save_<win_id>__``) that qutebrowser
+    sets on each window right before running this command, giving
+    exact 1:1 matching even with duplicate page titles.  Writes the
+    sidecar with per-window data and (if Hy3 is active) the container
+    tree.
+
+**restore**
+    Reads the session YAML (for ``restore_id`` marker titles) and the
+    sidecar (for Hyprland positions and tree data), then restores the
+    layout.
+
+Dependencies
+------------
+
+- Python >= 3.9 (standard library only, plus PyYAML)
+- ``hyprctl`` in ``$PATH``
+- Optional: Hy3 plugin for full tiling tree reconstruction
+"""
+
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("qb-hyprland-session: PyYAML is required. Install it with: "
+          "pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+WINDOW_CLASS = "org.qutebrowser.qutebrowser"
+MARKER_PREFIX = "__qb_restore_"
+MARKER_SUFFIX = "__"
+SAVE_MARKER_RE = re.compile(r"^__qb_save_(\d+)__$")
+# How long to wait for windows to appear (seconds)
+RESTORE_TIMEOUT = 4.0
+RESTORE_POLL_INTERVAL = 0.3
+
+
+# ---------------------------------------------------------------------------
+# Hyprland helpers
+# ---------------------------------------------------------------------------
+
+def _hyprctl_json(command):
+    """Run ``hyprctl -j <command>`` and return parsed JSON."""
+    result = subprocess.run(
+        ["hyprctl", "-j", command],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def _hyprctl_dispatch(dispatcher, args=""):
+    """Run ``hyprctl dispatch <dispatcher> <args>``."""
+    cmd = f"{dispatcher} {args}".strip() if args else dispatcher
+    try:
+        subprocess.run(
+            ["hyprctl", "dispatch", cmd],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"qb-hyprland-session: hyprctl dispatch error: {e.stderr}",
+              file=sys.stderr)
+
+
+def _hyprctl_dispatch_batch(commands):
+    """Run multiple dispatch commands in a single IPC call via --batch."""
+    if not commands:
+        return
+    batch = " ; ".join(f"dispatch {c}" for c in commands)
+    try:
+        subprocess.run(
+            ["hyprctl", "--batch", batch],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"qb-hyprland-session: hyprctl batch error: {e.stderr}",
+              file=sys.stderr)
+
+
+def get_hypr_clients():
+    """Return a list of all windows from ``hyprctl -j clients``."""
+    return _hyprctl_json("clients")
+
+
+def get_hypr_monitors():
+    """Return a list of monitors from ``hyprctl -j monitors``."""
+    return _hyprctl_json("monitors")
+
+
+def get_hypr_workspaces():
+    """Return a list of workspaces from ``hyprctl -j workspaces``."""
+    return _hyprctl_json("workspaces")
+
+
+def find_qb_windows(clients, window_class=WINDOW_CLASS):
+    """Filter clients to qutebrowser windows only."""
+    return [c for c in clients if c.get("class") == window_class]
+
+
+# ---------------------------------------------------------------------------
+# Hy3 detection and tree parsing
+# ---------------------------------------------------------------------------
+
+def _is_hy3_active():
+    """Check if the Hy3 plugin is loaded."""
+    try:
+        result = subprocess.run(
+            ["hyprctl", "plugin", "list"],
+            capture_output=True, text=True, check=True,
+        )
+        return "hy3" in result.stdout.lower()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+
+
+def _get_hy3_debug_nodes():
+    """Run ``hy3:debugnodes`` and capture output from hyprctl.
+
+    ``hy3:debugnodes`` writes its output to Hyprland's log, but it also
+    returns the tree via the dispatch command's stdout.  We capture the
+    output from the dispatch command directly.
+    """
+    try:
+        result = subprocess.run(
+            ["hyprctl", "dispatch", "hy3:debugnodes"],
+            capture_output=True, text=True, check=True,
+        )
+        output = result.stdout.strip()
+        if output and output != "ok":
+            return output
+    except subprocess.CalledProcessError:
+        pass
+
+    # Fallback: read from Hyprland's log
+    return _read_debug_nodes_from_log()
+
+
+def _read_debug_nodes_from_log():
+    """Read hy3:debugnodes output from Hyprland's log file."""
+    sig = os.environ.get("HYPRLAND_INSTANCE_SIGNATURE", "")
+    if not sig:
+        return None
+
+    log_path = Path(f"/tmp/hypr/{sig}/hyprland.log")
+    if not log_path.exists():
+        # Try XDG_RUNTIME_DIR
+        runtime = os.environ.get("XDG_RUNTIME_DIR", "")
+        if runtime:
+            log_path = Path(runtime) / "hypr" / sig / "hyprland.log"
+        if not log_path.exists():
+            return None
+
+    try:
+        with open(log_path, encoding="utf-8", errors="replace") as f:
+            lines = f.readlines()
+    except OSError:
+        return None
+
+    # Find the last debugnodes output block — lines containing
+    # "group(" or "window(" patterns, preceded by a hy3 log prefix
+    debug_lines = []
+    in_block = False
+    for line in reversed(lines):
+        stripped = line.strip()
+        # hy3:debugnodes output lines start with group( or |-
+        if ("group(" in stripped or "window(" in stripped
+                or stripped.startswith("|-")):
+            debug_lines.append(stripped)
+            in_block = True
+        elif in_block:
+            break
+
+    if not debug_lines:
+        return None
+
+    debug_lines.reverse()
+    return "\n".join(debug_lines)
+
+
+# Regex patterns for parsing hy3:debugnodes output
+_HY3_GROUP_RE = re.compile(
+    r"group\(0x[0-9a-f]+ of (?:0x[0-9a-f]*|0)\)\s+"
+    r"\[(\w+(?:\s+\d+)?)\]\s+size ratio:\s*([\d.]+)"
+)
+_HY3_WINDOW_RE = re.compile(
+    r"window\(0x[0-9a-f]+ of 0x[0-9a-f]+\)\s+"
+    r"\[hypr\s+(0x[0-9a-f]+)\]\s+size ratio:\s*([\d.]+)"
+)
+
+
+def _parse_hy3_tree(text):
+    """Parse the textual output of ``hy3:debugnodes`` into a tree.
+
+    Returns a list of root nodes (one per workspace).  Each node is
+    either::
+
+        {"type": "group", "layout": "splith|splitv|tab",
+         "workspace": N_or_None, "ratio": float,
+         "children": [...]}
+
+    or::
+
+        {"type": "window", "address": "0x...", "ratio": float}
+
+    The indentation is 2 spaces per ``|-`` prefix per nesting level.
+    """
+    if not text:
+        return []
+
+    lines = text.strip().splitlines()
+    roots = []
+    stack = []  # (indent_level, node)
+
+    for line in lines:
+        # Determine indentation level.
+        # Root nodes have no prefix (level 0).
+        # Children are prefixed by "|-" with 2 spaces per additional
+        # nesting level:
+        #   group(... of 0) [root 6] ...        ← level 0
+        #   |-group(... of 0x...) [splith] ...  ← level 1
+        #     |-window(...)                     ← level 2
+        stripped = line.lstrip()
+        leading = len(line) - len(stripped)
+        if stripped.startswith("|-"):
+            indent = (leading // 2) + 1
+            stripped = stripped[2:]
+        else:
+            indent = leading // 2
+
+        gm = _HY3_GROUP_RE.match(stripped)
+        wm = _HY3_WINDOW_RE.match(stripped)
+
+        if gm:
+            group_type = gm.group(1)
+            ratio = float(gm.group(2))
+
+            # Parse group type
+            workspace = None
+            if group_type.startswith("root"):
+                parts = group_type.split()
+                layout = "root"
+                if len(parts) > 1:
+                    workspace = parts[1]
+            else:
+                layout = group_type
+
+            node = {
+                "type": "group",
+                "layout": layout,
+                "ratio": ratio,
+                "children": [],
+            }
+            if workspace is not None:
+                node["workspace"] = workspace
+
+            # Find parent in stack
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+
+            if stack:
+                stack[-1][1]["children"].append(node)
+            else:
+                roots.append(node)
+
+            stack.append((indent, node))
+
+        elif wm:
+            address = wm.group(1)
+            ratio = float(wm.group(2))
+
+            node = {
+                "type": "window",
+                "address": address,
+                "ratio": ratio,
+            }
+
+            while stack and stack[-1][0] >= indent:
+                stack.pop()
+
+            if stack:
+                stack[-1][1]["children"].append(node)
+            else:
+                roots.append(node)
+
+    return roots
+
+
+def _prune_hy3_tree(node, addr_to_restore_id):
+    """Prune an Hy3 tree to contain only qutebrowser windows.
+
+    Similar to the Sway version's ``_prune_node()``.
+
+    Returns:
+        ``{"restore_id": N, "ratio": float}`` for a leaf window,
+        ``{"layout": "...", "ratio": float, "children": [...]}``
+        for a container, or ``None`` if no qb windows found.
+    """
+    if node["type"] == "window":
+        restore_id = addr_to_restore_id.get(node["address"])
+        if restore_id is not None:
+            return {"restore_id": restore_id, "ratio": node["ratio"]}
+        return None
+
+    # Group node: recurse into children
+    pruned_children = []
+    for child in node.get("children", []):
+        pruned = _prune_hy3_tree(child, addr_to_restore_id)
+        if pruned is not None:
+            pruned_children.append(pruned)
+
+    if not pruned_children:
+        return None
+
+    if len(pruned_children) == 1:
+        return pruned_children[0]  # collapse single-child container
+
+    layout = node.get("layout", "splith")
+    # Skip "root" layout — it's just a wrapper
+    if layout == "root":
+        layout = "splith"
+
+    return {
+        "layout": layout,
+        "ratio": node.get("ratio", 1.0),
+        "children": pruned_children,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Sidecar file helpers
+# ---------------------------------------------------------------------------
+
+def _sidecar_path(session_path):
+    """Derive the sidecar file path from the session file path.
+
+    ``data/sessions/default.yml`` → ``data/sessions/hyprland/default.yml``
+    """
+    p = Path(session_path)
+    return p.parent / "hyprland" / p.name
+
+
+def _atomic_write_yaml(path, data):
+    """Write *data* as YAML to *path* atomically.
+
+    Creates parent directories if needed.
+    """
+    path = Path(path)
+    os.makedirs(path.parent, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=path.parent, suffix=".tmp", prefix=path.name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Save mode
+# ---------------------------------------------------------------------------
+
+def do_save(session_path):
+    """Write Hyprland geometry and tree info to a sidecar file.
+
+    The session YAML is read but **never modified**.
+    """
+    path = Path(session_path)
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if data is None or "windows" not in data:
+        return
+
+    clients = get_hypr_clients()
+    qb_windows = find_qb_windows(clients)
+
+    # Build win_id -> hyprland window via save markers in the title.
+    # qutebrowser sets each window's title to __qb_save_<win_id>__
+    # right before running after_save_command.  On Hyprland the title
+    # update may not have reached the compositor yet, so we poll
+    # briefly if no markers are found on the first try.
+    hypr_by_win_id = {}
+    for attempt in range(10):
+        if attempt > 0:
+            time.sleep(0.1)
+            clients = get_hypr_clients()
+            qb_windows = find_qb_windows(clients)
+
+        hypr_by_win_id.clear()
+        for qw in qb_windows:
+            title = qw.get("title", "")
+            m = SAVE_MARKER_RE.match(title)
+            if m:
+                hypr_by_win_id[int(m.group(1))] = qw
+
+        if hypr_by_win_id:
+            break
+
+    # Build monitor ID -> monitor name mapping
+    monitors = get_hypr_monitors()
+    monitor_id_to_name = {m["id"]: m["name"] for m in monitors}
+
+    # Build win_id -> hyprland window via save markers in the title
+    hypr_by_win_id = {}
+    for qw in qb_windows:
+        title = qw.get("title", "")
+        m = SAVE_MARKER_RE.match(title)
+        if m:
+            hypr_by_win_id[int(m.group(1))] = qw
+
+    # address -> restore_id for tree pruning
+    addr_to_restore_id = {}
+
+    # Build sidecar data — keyed by restore_id
+    sidecar_windows = {}
+    for win in data["windows"]:
+        win_id = win.get("win_id")
+        restore_id = win.get("restore_id")
+        if win_id is None or restore_id is None:
+            continue
+
+        qw = hypr_by_win_id.get(win_id)
+        if qw is None:
+            continue
+
+        monitor_name = monitor_id_to_name.get(qw.get("monitor"))
+        ws_name = str(qw.get("workspace", {}).get("name", ""))
+
+        sidecar_windows[restore_id] = {
+            "floating": qw.get("floating", False),
+            "at": qw.get("at"),
+            "size": qw.get("size"),
+        }
+        if ws_name:
+            sidecar_windows[restore_id]["workspace"] = ws_name
+        if monitor_name:
+            sidecar_windows[restore_id]["monitor"] = monitor_name
+
+        if not qw.get("floating", False):
+            addr_to_restore_id[qw["address"]] = restore_id
+
+    # Build per-workspace pruned trees (Hy3 only)
+    hy3_trees = {}
+    hy3_active = _is_hy3_active()
+    if hy3_active:
+        debug_text = _get_hy3_debug_nodes()
+        if debug_text:
+            roots = _parse_hy3_tree(debug_text)
+            for root in roots:
+                ws = root.get("workspace")
+                if not ws:
+                    continue
+                pruned = _prune_hy3_tree(root, addr_to_restore_id)
+                if pruned is not None:
+                    hy3_trees[ws] = pruned
+
+    if not sidecar_windows and not hy3_trees:
+        return
+
+    sidecar = {"windows": sidecar_windows}
+    if hy3_trees:
+        sidecar["hy3_trees"] = hy3_trees
+
+    _atomic_write_yaml(_sidecar_path(path), sidecar)
+
+
+# ---------------------------------------------------------------------------
+# Restore mode — basic (no Hy3)
+# ---------------------------------------------------------------------------
+
+def _move_to_workspace(address, workspace, ws_to_monitor, monitors):
+    """Move a window to a workspace, ensuring correct monitor placement.
+
+    Hyprland creates new workspaces on the currently focused monitor.
+    To ensure the workspace ends up on the right monitor, we:
+
+    1. Focus the target monitor.
+    2. Move the window to the workspace.
+    3. Explicitly move the workspace to the correct monitor if it
+       ended up on the wrong one.
+    """
+    monitor = ws_to_monitor.get(workspace)
+    if monitor:
+        _hyprctl_dispatch("focusmonitor", monitor)
+    _hyprctl_dispatch("movetoworkspacesilent",
+                      f"{workspace},address:{address}")
+    # Belt and suspenders: force the workspace onto the right monitor
+    # in case focusmonitor wasn't enough (e.g. with
+    # split-monitor-workspaces plugin).
+    if monitor:
+        _hyprctl_dispatch("moveworkspacetomonitor", f"{workspace} {monitor}")
+
+
+def _restore_floating(address, info, ws_to_monitor, monitors):
+    """Restore a floating window to its exact saved position and size."""
+    workspace = info.get("workspace")
+    if workspace:
+        _move_to_workspace(address, workspace, ws_to_monitor, monitors)
+
+    at = info.get("at")
+    size = info.get("size")
+
+    cmds = [f"togglefloating address:{address}"]
+    if at:
+        cmds.append(f"movewindowpixel exact {at[0]} {at[1]},address:{address}")
+    if size:
+        cmds.append(
+            f"resizewindowpixel exact {size[0]} {size[1]},address:{address}")
+
+    _hyprctl_dispatch_batch(cmds)
+
+
+# ---------------------------------------------------------------------------
+# Restore mode — Hy3 tree reconstruction
+# ---------------------------------------------------------------------------
+
+def _restore_hy3_tree(node, id_to_addr, workspace, ws_to_monitor, monitors,
+                      is_first_in_workspace=True, sidecar_windows=None):
+    """Recursively restore the Hy3 tiling tree.
+
+    Strategy:
+    1. Move the first leaf to the target workspace.
+    2. Focus it.
+    3. For subsequent children in a group: focus the previous sibling,
+       use ``hy3:makegroup`` to set the split direction, then move
+       the next window into the workspace (it will join the group).
+
+    Returns the address of the last placed window, or None.
+    """
+    if "restore_id" in node:
+        # Leaf window
+        address = id_to_addr.get(node["restore_id"])
+        if address is None:
+            return None
+
+        if is_first_in_workspace:
+            _move_to_workspace(address, workspace, ws_to_monitor, monitors)
+        else:
+            # Move to workspace — Hy3 will auto-tile it next to focused
+            _hyprctl_dispatch("movetoworkspacesilent",
+                              f"{workspace},address:{address}")
+
+        # Ensure it's tiled
+        clients = get_hypr_clients()
+        for c in clients:
+            if c["address"] == address and c.get("floating"):
+                _hyprctl_dispatch("togglefloating", f"address:{address}")
+                break
+
+        return address
+
+    # Group node: process children
+    layout = node.get("layout", "splith")
+    children = node.get("children", [])
+
+    if not children:
+        return None
+
+    last_placed = None
+    for i, child in enumerate(children):
+        if i == 0:
+            # First child: place it
+            last_placed = _restore_hy3_tree(
+                child, id_to_addr, workspace, ws_to_monitor, monitors,
+                is_first_in_workspace=is_first_in_workspace,
+                sidecar_windows=sidecar_windows)
+
+            # Set the group direction after the first child is placed
+            if last_placed is not None and len(children) > 1:
+                _hyprctl_dispatch("focuswindow", f"address:{last_placed}")
+                hy3_dir = {"splith": "h", "splitv": "v",
+                           "tab": "tab"}.get(layout, "h")
+                _hyprctl_dispatch("hy3:makegroup", hy3_dir)
+        else:
+            # Subsequent children: focus the last placed window first
+            if last_placed is not None:
+                _hyprctl_dispatch("focuswindow", f"address:{last_placed}")
+
+            result = _restore_hy3_tree(
+                child, id_to_addr, workspace, ws_to_monitor, monitors,
+                is_first_in_workspace=False,
+                sidecar_windows=sidecar_windows)
+            if result is not None:
+                last_placed = result
+
+    # Resize children proportionally based on saved pixel sizes
+    if last_placed is not None and len(children) > 1:
+        _resize_hy3_children(children, layout, id_to_addr,
+                             sidecar_windows or {})
+
+    return last_placed
+
+
+def _first_leaf_address(node, id_to_addr):
+    """Return the address of the first leaf in a tree node."""
+    if "restore_id" in node:
+        return id_to_addr.get(node["restore_id"])
+    for child in node.get("children", []):
+        result = _first_leaf_address(child, id_to_addr)
+        if result is not None:
+            return result
+    return None
+
+
+def _resize_hy3_children(children, layout, id_to_addr, sidecar_windows):
+    """Resize children proportionally based on saved pixel sizes.
+
+    Uses the ``at`` and ``size`` data from the sidecar to compute
+    the target proportion of each child, then applies ``resizeactive``
+    to the first N-1 children.  The last child takes the remaining
+    space automatically.
+
+    For ``splith``: proportions are computed from ``size[0]`` (width).
+    For ``splitv``: proportions are computed from ``size[1]`` (height).
+    For ``tab``: no resizing (children overlap).
+    """
+    if layout not in ("splith", "splitv"):
+        return
+
+    dim_idx = 0 if layout == "splith" else 1
+
+    # Collect saved sizes for each child (via first leaf's restore_id)
+    saved_sizes = []
+    for child in children:
+        rid = _first_leaf_restore_id(child)
+        if rid is None:
+            saved_sizes.append(None)
+            continue
+        win_data = sidecar_windows.get(rid, {})
+        sz = win_data.get("size")
+        at = win_data.get("at")
+        if sz:
+            saved_sizes.append(sz[dim_idx])
+        else:
+            saved_sizes.append(None)
+
+    # For containers (non-leaf children), the saved size of a single
+    # leaf isn't the container's full size.  We need to compute the
+    # container extent from the leftmost/topmost to rightmost/bottommost
+    # leaf.
+    for i, child in enumerate(children):
+        if "restore_id" not in child and child.get("children"):
+            extent = _container_extent(child, dim_idx, sidecar_windows)
+            if extent is not None:
+                saved_sizes[i] = extent
+
+    valid = [s for s in saved_sizes if s is not None]
+    if len(valid) < 2:
+        return
+
+    total = sum(s for s in saved_sizes if s is not None)
+    if total <= 0:
+        return
+
+    # Read current sizes from hyprctl
+    clients = get_hypr_clients()
+    addr_to_current = {}
+    for c in clients:
+        addr_to_current[c["address"]] = c
+
+    # Resize all children except the last.  Focus a leaf in the
+    # child, then use resizeactive to adjust.
+    for child in children[:-1]:
+        target_size = saved_sizes[children.index(child)]
+        if target_size is None:
+            continue
+
+        target_pct = target_size / total
+        addr = _first_leaf_address(child, id_to_addr)
+        if addr is None:
+            continue
+
+        # Get current size of this leaf
+        current = addr_to_current.get(addr)
+        if current is None:
+            continue
+
+        current_size = current["size"][dim_idx]
+
+        # Compute what this child's size SHOULD be.
+        # We need the total workspace dimension.  Approximate from
+        # current window positions.
+        # Better approach: compute target delta from proportions.
+        # Current total ≈ sum of all children's current sizes.
+        current_total = 0
+        for c2 in children:
+            a2 = _first_leaf_address(c2, id_to_addr)
+            if a2 and a2 in addr_to_current:
+                c2_size = addr_to_current[a2]["size"][dim_idx]
+                if "restore_id" not in c2 and c2.get("children"):
+                    ext = _current_container_extent(
+                        c2, dim_idx, id_to_addr, addr_to_current)
+                    if ext is not None:
+                        c2_size = ext
+                current_total += c2_size
+
+        if current_total <= 0:
+            continue
+
+        desired = round(target_pct * current_total)
+        # For containers, use the container extent as current_size
+        if "restore_id" not in child and child.get("children"):
+            ext = _current_container_extent(
+                child, dim_idx, id_to_addr, addr_to_current)
+            if ext is not None:
+                current_size = ext
+
+        delta = desired - current_size
+        if abs(delta) < 2:
+            continue
+
+        _hyprctl_dispatch("focuswindow", f"address:{addr}")
+        if layout == "splith":
+            _hyprctl_dispatch("resizeactive", f"{delta} 0")
+        else:
+            _hyprctl_dispatch("resizeactive", f"0 {delta}")
+
+
+def _first_leaf_restore_id(node):
+    """Return the restore_id of the first leaf in a tree node."""
+    if "restore_id" in node:
+        return node["restore_id"]
+    for child in node.get("children", []):
+        result = _first_leaf_restore_id(child)
+        if result is not None:
+            return result
+    return None
+
+
+def _container_extent(node, dim_idx, sidecar_windows):
+    """Compute a container's extent along a dimension from saved data.
+
+    For splith (dim_idx=0): sum of all children's widths.
+    For splitv (dim_idx=1): sum of all children's heights.
+    For the orthogonal direction: max of children.
+
+    This returns the extent along the parent's split dimension.
+    """
+    if "restore_id" in node:
+        win_data = sidecar_windows.get(node["restore_id"], {})
+        sz = win_data.get("size")
+        return sz[dim_idx] if sz else None
+
+    layout = node.get("layout", "splith")
+    child_dim_idx = 0 if layout == "splith" else 1
+
+    # If this container splits along the SAME axis as the parent,
+    # its extent is the sum of its children.
+    # If it splits along the OTHER axis, its extent is the max.
+    extents = []
+    for child in node.get("children", []):
+        ext = _container_extent(child, dim_idx, sidecar_windows)
+        if ext is not None:
+            extents.append(ext)
+
+    if not extents:
+        return None
+
+    if (layout == "splith" and dim_idx == 0) or \
+       (layout == "splitv" and dim_idx == 1):
+        return sum(extents)
+    else:
+        return max(extents)
+
+
+def _current_container_extent(node, dim_idx, id_to_addr, addr_to_current):
+    """Compute a container's current extent from live hyprctl data."""
+    if "restore_id" in node:
+        addr = id_to_addr.get(node["restore_id"])
+        if addr and addr in addr_to_current:
+            return addr_to_current[addr]["size"][dim_idx]
+        return None
+
+    layout = node.get("layout", "splith")
+    extents = []
+    for child in node.get("children", []):
+        ext = _current_container_extent(
+            child, dim_idx, id_to_addr, addr_to_current)
+        if ext is not None:
+            extents.append(ext)
+
+    if not extents:
+        return None
+
+    if (layout == "splith" and dim_idx == 0) or \
+       (layout == "splitv" and dim_idx == 1):
+        return sum(extents)
+    else:
+        return max(extents)
+
+
+# ---------------------------------------------------------------------------
+# Restore mode
+# ---------------------------------------------------------------------------
+
+def do_restore(session_path):
+    """Restore qutebrowser windows to their saved Hyprland layout."""
+    path = Path(session_path)
+    sc_path = _sidecar_path(path)
+
+    # ---- read sidecar (hyprland-specific data) ------------------------
+    if not sc_path.exists():
+        return
+
+    with open(sc_path, encoding="utf-8") as f:
+        sidecar = yaml.safe_load(f)
+
+    if not sidecar or "windows" not in sidecar:
+        return
+
+    sidecar_windows = sidecar.get("windows", {})
+
+    # ---- read session YAML (for restore_ids) --------------------------
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if data is None or "windows" not in data:
+        return
+
+    # ---- build expected markers → window info -------------------------
+    expected = {}
+    for win in data["windows"]:
+        restore_id = win.get("restore_id")
+        if restore_id is None:
+            continue
+
+        sw_data = sidecar_windows.get(restore_id)
+        if sw_data is None:
+            continue
+
+        workspace = sw_data.get("workspace")
+        if workspace is None:
+            continue
+
+        marker = f"{MARKER_PREFIX}{restore_id}{MARKER_SUFFIX}"
+        expected[marker] = {
+            "restore_id": restore_id,
+            "workspace": workspace,
+            "monitor": sw_data.get("monitor"),
+            "floating": sw_data.get("floating", False),
+            "at": sw_data.get("at"),
+            "size": sw_data.get("size"),
+        }
+
+    if not expected:
+        return
+
+    # ---- build workspace → monitor mapping ----------------------------
+    ws_to_monitor = {}
+    for info in expected.values():
+        ws = info.get("workspace")
+        monitor = info.get("monitor")
+        if ws and monitor:
+            ws_to_monitor.setdefault(ws, monitor)
+
+    monitors = get_hypr_monitors()
+
+    # Remember current workspace
+    original_ws = None
+    for m in monitors:
+        if m.get("focused"):
+            original_ws = str(m["activeWorkspace"]["name"])
+            break
+
+    # Poll until windows appear or timeout
+    found = _poll_for_windows(expected)
+
+    # Build restore_id -> address mapping
+    id_to_addr = {
+        info["restore_id"]: info["address"]
+        for info in found.values()
+    }
+
+    # Restore floating windows (exact position)
+    for info in found.values():
+        if info["floating"]:
+            _restore_floating(info["address"], info, ws_to_monitor, monitors)
+
+    # Restore tiled windows
+    hy3_trees = sidecar.get("hy3_trees")
+    if hy3_trees:
+        # Hy3 tree-based reconstruction
+        for workspace, tree_node in hy3_trees.items():
+            _restore_hy3_tree(tree_node, id_to_addr, workspace,
+                              ws_to_monitor, monitors,
+                              sidecar_windows=sidecar_windows)
+        # Nudge windows toward their saved positions.  When
+        # non-qutebrowser windows occupy the same workspace, the
+        # tree reconstruction may place qb windows at the wrong
+        # position within the tree.  This phase repeatedly pushes
+        # each misplaced window in the direction of its saved
+        # coordinates using hy3:movewindow.
+        _nudge_windows(found, sidecar_windows, id_to_addr)
+    else:
+        # Basic mode: simple workspace placement
+        for info in found.values():
+            if not info["floating"]:
+                _move_to_workspace(info["address"], info["workspace"],
+                                   ws_to_monitor, monitors)
+
+    # Restore focus to original workspace
+    if original_ws:
+        _hyprctl_dispatch("workspace", original_ws)
+
+
+def _nudge_windows(found, sidecar_windows, id_to_addr):
+    """Push tiled qb windows toward their saved positions.
+
+    After tree reconstruction, windows that share a workspace with
+    non-qutebrowser windows may end up at the wrong position in the
+    tiling tree.  This function iteratively moves each misplaced
+    window using ``hy3:movewindow`` until its position is close enough
+    to the saved coordinates, or a maximum number of iterations is
+    reached.
+
+    The heuristic is simple: compare the window's current ``at``
+    (top-left corner) with the saved ``at``.  If it's too far to the
+    left of the target, push it right, etc.  A tolerance of 50 pixels
+    is used to account for gaps/borders.
+
+    Oscillation detection: if a window returns to a position it has
+    already visited, it means no further progress can be made (e.g.
+    because the number of windows in the workspace has changed since
+    the save).  In that case, the window is moved back to the position
+    that minimises the distance to the target and excluded from
+    further nudging.
+    """
+    TOLERANCE = 50
+    MAX_MOVES = 20
+
+    tiled = []
+    for info in found.values():
+        if info["floating"]:
+            continue
+        rid = info["restore_id"]
+        sw = sidecar_windows.get(rid, {})
+        saved_at = sw.get("at")
+        if saved_at is None:
+            continue
+        tiled.append({
+            "address": info["address"],
+            "saved_x": saved_at[0],
+            "saved_y": saved_at[1],
+            "history": [],     # list of (x, y) positions visited
+            "settled": False,  # True once converged or oscillating
+        })
+
+    if not tiled:
+        return
+
+    for _ in range(MAX_MOVES):
+        clients = get_hypr_clients()
+        addr_to_client = {c["address"]: c for c in clients}
+
+        moved_any = False
+        for win in tiled:
+            if win["settled"]:
+                continue
+
+            c = addr_to_client.get(win["address"])
+            if c is None:
+                win["settled"] = True
+                continue
+
+            cur_x, cur_y = c["at"]
+            dx = win["saved_x"] - cur_x
+            dy = win["saved_y"] - cur_y
+
+            # Close enough — converged.
+            if abs(dx) <= TOLERANCE and abs(dy) <= TOLERANCE:
+                win["settled"] = True
+                continue
+
+            cur_pos = (cur_x, cur_y)
+
+            # Oscillation detection: we've been here before.
+            if cur_pos in win["history"]:
+                # Find the best position among all visited positions
+                # (the one closest to the target).
+                best_pos = min(
+                    win["history"],
+                    key=lambda p: abs(p[0] - win["saved_x"])
+                                + abs(p[1] - win["saved_y"]),
+                )
+                # Move back to the best position if we're not there.
+                best_dx = best_pos[0] - cur_x
+                best_dy = best_pos[1] - cur_y
+                if abs(best_dx) > TOLERANCE or abs(best_dy) > TOLERANCE:
+                    _hyprctl_dispatch(
+                        "focuswindow", f"address:{win['address']}")
+                    if abs(best_dx) > TOLERANCE:
+                        direction = "r" if best_dx > 0 else "l"
+                        _hyprctl_dispatch("hy3:movewindow", direction)
+                win["settled"] = True
+                continue
+
+            win["history"].append(cur_pos)
+
+            _hyprctl_dispatch("focuswindow",
+                              f"address:{win['address']}")
+
+            # Move in the axis with the largest delta first
+            if abs(dx) > TOLERANCE:
+                direction = "r" if dx > 0 else "l"
+                _hyprctl_dispatch("hy3:movewindow", direction)
+                moved_any = True
+            elif abs(dy) > TOLERANCE:
+                direction = "d" if dy > 0 else "u"
+                _hyprctl_dispatch("hy3:movewindow", direction)
+                moved_any = True
+
+        if not moved_any:
+            break
+
+
+def _poll_for_windows(expected):
+    """Poll hyprctl clients until expected marker windows appear or timeout."""
+    deadline = time.monotonic() + RESTORE_TIMEOUT
+    remaining = dict(expected)
+    found = {}
+
+    while remaining and time.monotonic() < deadline:
+        clients = get_hypr_clients()
+        qb_windows = find_qb_windows(clients)
+
+        for qw in qb_windows:
+            title = qw.get("title", "")
+            if title in remaining:
+                info = remaining.pop(title)
+                info["address"] = qw["address"]
+                found[title] = info
+
+        if remaining:
+            time.sleep(RESTORE_POLL_INTERVAL)
+
+    return found
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} (save|restore) <session_path>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    mode = sys.argv[1]
+    session_path = sys.argv[2]
+
+    if mode == "save":
+        do_save(session_path)
+    elif mode == "restore":
+        do_restore(session_path)
+    else:
+        print(f"qb-hyprland-session: unknown mode '{mode}'",
+              file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/userscripts/qb-hyprland-session
+++ b/misc/userscripts/qb-hyprland-session
@@ -103,6 +103,124 @@ RESTORE_POLL_INTERVAL = 0.3
 # Hyprland helpers
 # ---------------------------------------------------------------------------
 
+# Config provider detection: "lua" or "hyprlang".
+# In Hyprland >= 0.55 with a Lua config, ``hyprctl dispatch`` routes all
+# arguments through the Lua evaluator, which breaks plugin dispatchers that
+# contain colons (e.g. ``hy3:makegroup``).  We detect Lua mode once at
+# startup and use ``hyprctl eval`` with the structured Lua API instead.
+_CONFIG_PROVIDER = None  # set by _detect_config_provider()
+
+
+def _detect_config_provider():
+    """Detect whether Hyprland uses Lua or hyprlang config.
+
+    Returns ``"lua"`` if ``hyprctl eval "return 'ok'"`` succeeds and
+    returns ``"ok"``, otherwise ``"hyprlang"``.
+    """
+    try:
+        result = subprocess.run(
+            ["hyprctl", "eval", "return 'ok'"],
+            capture_output=True, text=True, check=True,
+        )
+        if result.stdout.strip() == "ok":
+            return "lua"
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    return "hyprlang"
+
+
+def _dispatch_to_lua(dispatcher, args=""):
+    """Translate a hyprlang-style dispatch call to a Lua API expression.
+
+    Returns a Lua expression string suitable for ``hyprctl eval``.
+    """
+    # --- Hy3 plugin dispatchers ---
+    if dispatcher == "hy3:makegroup":
+        return f"hl.dispatch(hl.plugin.hy3.make_group('{args}'))"
+    if dispatcher == "hy3:movewindow":
+        return f"hl.dispatch(hl.plugin.hy3.move_window('{args}'))"
+    if dispatcher == "hy3:debugnodes":
+        return "hl.dispatch(hl.plugin.hy3.debug_nodes())"
+
+    # --- Built-in dispatchers ---
+    if dispatcher == "focuswindow":
+        # args: "address:0x..."
+        return f"hl.dispatch(hl.dsp.focus({{window='{args}'}}))"
+    if dispatcher == "focusmonitor":
+        # args: monitor name e.g. "DP-1"
+        return f"hl.dispatch(hl.dsp.focus({{monitor='{args}'}}))"
+    if dispatcher == "workspace":
+        # args: workspace name/number
+        return f"hl.dispatch(hl.dsp.focus({{workspace='{args}'}}))"
+    if dispatcher == "movetoworkspacesilent":
+        # args: "WS,address:0x..." or "WS,title:..."
+        parts = args.split(",", 1)
+        ws = parts[0]
+        if len(parts) > 1:
+            win = parts[1]
+            return (f"hl.dispatch(hl.dsp.window.move("
+                    f"{{workspace='{ws}', window='{win}', silent=true}}))")
+        return (f"hl.dispatch(hl.dsp.window.move("
+                f"{{workspace='{ws}', silent=true}}))")
+    if dispatcher == "togglefloating":
+        # args: "address:0x..."
+        if args:
+            return f"hl.dispatch(hl.dsp.window.float({{window='{args}'}}))"
+        return "hl.dispatch(hl.dsp.window.float({}))"
+    if dispatcher == "moveworkspacetomonitor":
+        # args: "WS MON"
+        parts = args.split(None, 1)
+        ws = parts[0] if parts else ""
+        mon = parts[1] if len(parts) > 1 else ""
+        return (f"hl.dispatch(hl.dsp.workspace.move("
+                f"{{name='{ws}', monitor='{mon}'}}))")
+    if dispatcher == "resizeactive":
+        # args: "X Y" — relative resize of the focused window
+        parts = args.split()
+        x = parts[0] if parts else "0"
+        y = parts[1] if len(parts) > 1 else "0"
+        return f"hl.dispatch(hl.dsp.window.resize({{x={x}, y={y}, relative=true}}))"
+    if dispatcher == "movewindowpixel":
+        # args: "exact X Y,address:0x..."
+        # Parse: "exact <X> <Y>,<window>"
+        m = re.match(r"exact\s+(\d+)\s+(\d+),(.+)", args)
+        if m:
+            x, y, win = m.group(1), m.group(2), m.group(3)
+            return (f"hl.dispatch(hl.dsp.window.move("
+                    f"{{x={x}, y={y}, window='{win}'}}))")
+        return f"hl.dispatch(hl.dsp.window.move({{x=0, y=0}}))"
+    if dispatcher == "resizewindowpixel":
+        # args: "exact W H,address:0x..."
+        m = re.match(r"exact\s+(\d+)\s+(\d+),(.+)", args)
+        if m:
+            w, h, win = m.group(1), m.group(2), m.group(3)
+            return (f"hl.dispatch(hl.dsp.window.resize("
+                    f"{{x={w}, y={h}, relative=false, window='{win}'}}))")
+        return f"hl.dispatch(hl.dsp.window.resize({{x=0, y=0, relative=false}}))"
+
+    # Fallback: generic string dispatch (may fail in Lua mode for
+    # unhandled dispatchers, but at least logs the attempt)
+    print(f"qb-hyprland-session: WARNING: no Lua mapping for dispatcher "
+          f"'{dispatcher}' with args '{args}'", file=sys.stderr)
+    return f"hl.dispatch(hl.dsp.exec_raw('{dispatcher} {args}'))"
+
+
+def _dispatch_batch_to_lua(commands):
+    """Translate a list of hyprlang-style dispatch strings to a single Lua
+    expression containing multiple ``hl.dispatch()`` calls.
+
+    Each command in *commands* is a string like ``"focuswindow address:0x..."``
+    or ``"togglefloating address:0x..."``.
+    """
+    lua_parts = []
+    for cmd in commands:
+        parts = cmd.split(None, 1)
+        dispatcher = parts[0]
+        args = parts[1] if len(parts) > 1 else ""
+        lua_parts.append(_dispatch_to_lua(dispatcher, args))
+    return "; ".join(lua_parts)
+
+
 def _hyprctl_json(command):
     """Run ``hyprctl -j <command>`` and return parsed JSON."""
     result = subprocess.run(
@@ -112,8 +230,30 @@ def _hyprctl_json(command):
     return json.loads(result.stdout)
 
 
+def _hyprctl_eval(lua_code):
+    """Run ``hyprctl eval <lua_code>`` and return stdout."""
+    try:
+        result = subprocess.run(
+            ["hyprctl", "eval", lua_code],
+            capture_output=True, text=True, check=True,
+        )
+        return result.stdout.strip()
+    except subprocess.CalledProcessError as e:
+        print(f"qb-hyprland-session: hyprctl eval error: {e.stderr}",
+              file=sys.stderr)
+        return None
+
+
 def _hyprctl_dispatch(dispatcher, args=""):
-    """Run ``hyprctl dispatch <dispatcher> <args>``."""
+    """Run ``hyprctl dispatch <dispatcher> <args>``.
+
+    In Lua mode, translates to the structured Lua API and uses
+    ``hyprctl eval`` instead.
+    """
+    if _CONFIG_PROVIDER == "lua":
+        lua_code = _dispatch_to_lua(dispatcher, args)
+        _hyprctl_eval(lua_code)
+        return
     cmd = f"{dispatcher} {args}".strip() if args else dispatcher
     try:
         subprocess.run(
@@ -126,8 +266,16 @@ def _hyprctl_dispatch(dispatcher, args=""):
 
 
 def _hyprctl_dispatch_batch(commands):
-    """Run multiple dispatch commands in a single IPC call via --batch."""
+    """Run multiple dispatch commands in a single IPC call.
+
+    In Lua mode, joins all translated Lua calls into a single
+    ``hyprctl eval`` invocation.  In hyprlang mode, uses ``--batch``.
+    """
     if not commands:
+        return
+    if _CONFIG_PROVIDER == "lua":
+        lua_code = _dispatch_batch_to_lua(commands)
+        _hyprctl_eval(lua_code)
         return
     batch = " ; ".join(f"dispatch {c}" for c in commands)
     try:
@@ -177,12 +325,18 @@ def _is_hy3_active():
 
 
 def _get_hy3_debug_nodes():
-    """Run ``hy3:debugnodes`` and capture output from hyprctl.
+    """Run ``hy3:debugnodes`` and capture output.
 
-    ``hy3:debugnodes`` writes its output to Hyprland's log, but it also
-    returns the tree via the dispatch command's stdout.  We capture the
-    output from the dispatch command directly.
+    In hyprlang mode, the dispatch command returns the tree on stdout.
+    In Lua mode, stdout is not available from ``hyprctl eval``, so we
+    trigger the dispatch and then read the output from Hyprland's log.
     """
+    if _CONFIG_PROVIDER == "lua":
+        # Trigger debugnodes via Lua API; output goes to Hyprland log
+        _hyprctl_eval("hl.dispatch(hl.plugin.hy3.debug_nodes())")
+        time.sleep(0.05)  # brief pause for log flush
+        return _read_debug_nodes_from_log()
+
     try:
         result = subprocess.run(
             ["hyprctl", "dispatch", "hy3:debugnodes"],
@@ -348,10 +502,15 @@ def _parse_hy3_tree(text):
     return roots
 
 
-def _prune_hy3_tree(node, addr_to_restore_id):
+def _prune_hy3_tree(node, addr_to_restore_id, addr_to_client=None):
     """Prune an Hy3 tree to contain only qutebrowser windows.
 
     Similar to the Sway version's ``_prune_node()``.
+
+    The *addr_to_client* dict maps window addresses to hyprctl client
+    dicts (with ``at`` and ``size``).  This is used to infer the real
+    layout direction because ``hy3:debugnodes`` always reports
+    ``[splith]`` regardless of the actual split direction.
 
     Returns:
         ``{"restore_id": N, "ratio": float}`` for a leaf window,
@@ -367,7 +526,7 @@ def _prune_hy3_tree(node, addr_to_restore_id):
     # Group node: recurse into children
     pruned_children = []
     for child in node.get("children", []):
-        pruned = _prune_hy3_tree(child, addr_to_restore_id)
+        pruned = _prune_hy3_tree(child, addr_to_restore_id, addr_to_client)
         if pruned is not None:
             pruned_children.append(pruned)
 
@@ -382,11 +541,52 @@ def _prune_hy3_tree(node, addr_to_restore_id):
     if layout == "root":
         layout = "splith"
 
+    # Infer the real layout direction from window positions, because
+    # hy3:debugnodes incorrectly reports [splith] for splitv groups.
+    if layout == "splith" and addr_to_client and len(pruned_children) >= 2:
+        inferred = _infer_layout_from_children(
+            pruned_children, addr_to_restore_id, addr_to_client)
+        if inferred:
+            layout = inferred
+
     return {
         "layout": layout,
         "ratio": node.get("ratio", 1.0),
         "children": pruned_children,
     }
+
+
+def _infer_layout_from_children(pruned_children, addr_to_restore_id,
+                                addr_to_client):
+    """Infer splith vs splitv from the positions of the first two leaves."""
+    def _first_leaf_addr(node, a2r):
+        """Find the address of the first leaf in a pruned node."""
+        if "restore_id" in node:
+            # Reverse lookup: restore_id -> address
+            for addr, rid in a2r.items():
+                if rid == node["restore_id"]:
+                    return addr
+            return None
+        for child in node.get("children", []):
+            result = _first_leaf_addr(child, a2r)
+            if result is not None:
+                return result
+        return None
+
+    addr1 = _first_leaf_addr(pruned_children[0], addr_to_restore_id)
+    addr2 = _first_leaf_addr(pruned_children[1], addr_to_restore_id)
+    if not addr1 or not addr2:
+        return None
+    c1 = addr_to_client.get(addr1)
+    c2 = addr_to_client.get(addr2)
+    if not c1 or not c2:
+        return None
+
+    dx = abs(c1["at"][0] - c2["at"][0])
+    dy = abs(c1["at"][1] - c2["at"][1])
+    if dy > dx:
+        return "splitv"
+    return "splith"
 
 
 # ---------------------------------------------------------------------------
@@ -518,7 +718,10 @@ def do_save(session_path):
                 ws = root.get("workspace")
                 if not ws:
                     continue
-                pruned = _prune_hy3_tree(root, addr_to_restore_id)
+                # Build addr -> client dict for layout inference
+                addr_to_client = {c["address"]: c for c in clients}
+                pruned = _prune_hy3_tree(root, addr_to_restore_id,
+                                         addr_to_client)
                 if pruned is not None:
                     hy3_trees[ws] = pruned
 
@@ -663,11 +866,6 @@ def _restore_hy3_tree(node, id_to_addr, workspace, ws_to_monitor, monitors,
             if result is not None:
                 last_placed = result
 
-    # Resize children proportionally based on saved pixel sizes
-    if last_placed is not None and len(children) > 1:
-        _resize_hy3_children(children, layout, id_to_addr,
-                             sidecar_windows or {})
-
     return last_placed
 
 
@@ -680,6 +878,42 @@ def _first_leaf_address(node, id_to_addr):
         if result is not None:
             return result
     return None
+
+
+def _resize_tree_pass(node, id_to_addr, sidecar_windows):
+    """Recursively apply proportional resize to a placed tree."""
+    if "restore_id" in node:
+        return  # leaf, nothing to resize
+    children = node.get("children", [])
+    layout = node.get("layout", "splith")
+    if len(children) > 1:
+        _wait_for_stable_sizes(children, id_to_addr)
+        _resize_hy3_children(children, layout, id_to_addr,
+                             sidecar_windows or {})
+    for child in children:
+        _resize_tree_pass(child, id_to_addr, sidecar_windows)
+
+
+def _wait_for_stable_sizes(children, id_to_addr, timeout=2.0, interval=0.15):
+    """Wait until window sizes stop changing (Hy3 has settled)."""
+    def _get_sizes():
+        clients = get_hypr_clients()
+        addr_map = {c["address"]: c for c in clients}
+        sizes = {}
+        for child in children:
+            addr = _first_leaf_address(child, id_to_addr)
+            if addr and addr in addr_map:
+                sizes[addr] = tuple(addr_map[addr]["size"])
+        return sizes
+
+    prev = _get_sizes()
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        time.sleep(interval)
+        curr = _get_sizes()
+        if curr == prev and curr:
+            return
+        prev = curr
 
 
 def _resize_hy3_children(children, layout, id_to_addr, sidecar_windows):
@@ -790,6 +1024,7 @@ def _resize_hy3_children(children, layout, id_to_addr, sidecar_windows):
             continue
 
         _hyprctl_dispatch("focuswindow", f"address:{addr}")
+        time.sleep(0.1)
         if layout == "splith":
             _hyprctl_dispatch("resizeactive", f"{delta} 0")
         else:
@@ -969,11 +1204,43 @@ def do_restore(session_path):
     # Restore tiled windows
     hy3_trees = sidecar.get("hy3_trees")
     if hy3_trees:
-        # Hy3 tree-based reconstruction
+        # Filter id_to_addr per workspace to avoid placing windows in the
+        # wrong workspace when the tree data is stale or incomplete.
+        placed_ids = set()
         for workspace, tree_node in hy3_trees.items():
-            _restore_hy3_tree(tree_node, id_to_addr, workspace,
+            # Build a restricted mapping: only include windows that
+            # actually belong to this workspace according to sidecar_windows
+            ws_id_to_addr = {}
+            for rid, addr in id_to_addr.items():
+                win_info = sidecar_windows.get(rid, {})
+                if str(win_info.get("workspace", "")) == str(workspace):
+                    ws_id_to_addr[rid] = addr
+            _restore_hy3_tree(tree_node, ws_id_to_addr, workspace,
                               ws_to_monitor, monitors,
                               sidecar_windows=sidecar_windows)
+            placed_ids.update(ws_id_to_addr.keys())
+
+        # Place any tiled windows whose workspace differs from all
+        # tree workspaces (e.g. windows on a workspace with no tree).
+        for info in found.values():
+            rid = info.get("restore_id")
+            if rid is not None and rid not in placed_ids and not info["floating"]:
+                ws = info.get("workspace", "")
+                if not ws.startswith("special:"):
+                    _move_to_workspace(info["address"], ws,
+                                       ws_to_monitor, monitors)
+
+        # Second pass: resize after all windows are in their correct
+        # workspaces.  Wait for Hy3 to settle, then apply proportional
+        # resize per tree.
+        time.sleep(0.3)
+        for workspace, tree_node in hy3_trees.items():
+            ws_id_to_addr = {}
+            for rid, addr in id_to_addr.items():
+                win_info = sidecar_windows.get(rid, {})
+                if str(win_info.get("workspace", "")) == str(workspace):
+                    ws_id_to_addr[rid] = addr
+            _resize_tree_pass(tree_node, ws_id_to_addr, sidecar_windows)
         # Nudge windows toward their saved positions.  When
         # non-qutebrowser windows occupy the same workspace, the
         # tree reconstruction may place qb windows at the wrong
@@ -1135,10 +1402,13 @@ def _poll_for_windows(expected):
 # ---------------------------------------------------------------------------
 
 def main():
+    global _CONFIG_PROVIDER
     if len(sys.argv) < 3:
         print(f"Usage: {sys.argv[0]} (save|restore) <session_path>",
               file=sys.stderr)
         sys.exit(1)
+
+    _CONFIG_PROVIDER = _detect_config_provider()
 
     mode = sys.argv[1]
     session_path = sys.argv[2]

--- a/misc/userscripts/qb-hyprland-session
+++ b/misc/userscripts/qb-hyprland-session
@@ -504,7 +504,7 @@ def do_save(session_path):
         if monitor_name:
             sidecar_windows[restore_id]["monitor"] = monitor_name
 
-        if not qw.get("floating", False):
+        if not qw.get("floating", False) and not ws_name.startswith("special:"):
             addr_to_restore_id[qw["address"]] = restore_id
 
     # Build per-workspace pruned trees (Hy3 only)
@@ -546,17 +546,29 @@ def _move_to_workspace(address, workspace, ws_to_monitor, monitors):
     2. Move the window to the workspace.
     3. Explicitly move the workspace to the correct monitor if it
        ended up on the wrong one.
+
+    Special workspaces (scratchpad, e.g. ``special:magic``) are handled
+    separately: they are not bound to a specific monitor and do not
+    need monitor focusing or workspace-to-monitor moves.
     """
-    monitor = ws_to_monitor.get(workspace)
-    if monitor:
-        _hyprctl_dispatch("focusmonitor", monitor)
+    is_special = workspace.startswith("special:")
+
+    if not is_special:
+        monitor = ws_to_monitor.get(workspace)
+        if monitor:
+            _hyprctl_dispatch("focusmonitor", monitor)
+
     _hyprctl_dispatch("movetoworkspacesilent",
                       f"{workspace},address:{address}")
-    # Belt and suspenders: force the workspace onto the right monitor
-    # in case focusmonitor wasn't enough (e.g. with
-    # split-monitor-workspaces plugin).
-    if monitor:
-        _hyprctl_dispatch("moveworkspacetomonitor", f"{workspace} {monitor}")
+
+    if not is_special:
+        # Belt and suspenders: force the workspace onto the right monitor
+        # in case focusmonitor wasn't enough (e.g. with
+        # split-monitor-workspaces plugin).
+        monitor = ws_to_monitor.get(workspace)
+        if monitor:
+            _hyprctl_dispatch("moveworkspacetomonitor",
+                              f"{workspace} {monitor}")
 
 
 def _restore_floating(address, info, ws_to_monitor, monitors):
@@ -944,6 +956,16 @@ def do_restore(session_path):
         if info["floating"]:
             _restore_floating(info["address"], info, ws_to_monitor, monitors)
 
+    # Restore windows in special workspaces (scratchpad, etc.)
+    # These are not part of the Hy3 tiling tree and just need to be
+    # moved to the correct special workspace.
+    special_restore_ids = set()
+    for info in found.values():
+        ws = info.get("workspace", "")
+        if ws.startswith("special:") and not info["floating"]:
+            _move_to_workspace(info["address"], ws, ws_to_monitor, monitors)
+            special_restore_ids.add(info["restore_id"])
+
     # Restore tiled windows
     hy3_trees = sidecar.get("hy3_trees")
     if hy3_trees:
@@ -999,6 +1021,10 @@ def _nudge_windows(found, sidecar_windows, id_to_addr):
     tiled = []
     for info in found.values():
         if info["floating"]:
+            continue
+        # Skip windows in special workspaces (scratchpad, etc.)
+        ws = info.get("workspace", "")
+        if ws.startswith("special:"):
             continue
         rid = info["restore_id"]
         sw = sidecar_windows.get(rid, {})

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -1,0 +1,276 @@
+#!/usr/bin/env python3
+
+# SPDX-FileCopyrightText: sim590
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Session save/restore helper for qutebrowser on Sway (Wayland).
+
+This script is designed to be invoked via qutebrowser's
+``session.after_save_command`` and ``session.after_load_command`` config
+options.
+
+Usage::
+
+    # In qutebrowser config.py:
+    c.session.after_save_command = (
+        'qb-sway-session save {session_path}'
+    )
+    c.session.after_load_command = (
+        'qb-sway-session restore {session_path}'
+    )
+
+Modes
+-----
+
+**save**
+    Reads the session YAML written by qutebrowser, queries the Sway tree
+    (``swaymsg -t get_tree``) to find qutebrowser windows, correlates them
+    by ``window_title``, and enriches each window entry with Sway-specific
+    data:
+
+    - ``sway_rect``: window geometry (x, y, width, height)
+    - ``sway_workspace``: workspace name
+    - ``sway_floating``: whether the window was floating
+    - ``sway_parent_layout``: parent container layout (splith, splitv,
+      tabbed, stacked)
+
+**restore**
+    Reads the (enriched) session YAML, queries the Sway tree to find
+    qutebrowser windows bearing temporary title markers
+    (``__qb_restore_<N>__``), and restores them:
+
+    - **Floating windows**: moved to saved workspace, set floating,
+      positioned and resized to exact saved coordinates.
+    - **Tiled windows**: moved to saved workspace, kept tiled.
+      The parent layout (splith/splitv/tabbed/stacked) is applied so
+      the split direction matches the original.
+
+Dependencies
+------------
+
+- Python >= 3.9 (standard library only, plus PyYAML)
+- ``swaymsg`` in ``$PATH``
+"""
+
+import json
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    print("qb-sway-session: PyYAML is required. Install it with: "
+          "pip install pyyaml", file=sys.stderr)
+    sys.exit(1)
+
+
+APP_ID = "org.qutebrowser.qutebrowser"
+MARKER_PREFIX = "__qb_restore_"
+MARKER_SUFFIX = "__"
+# How long to wait for windows to appear (seconds)
+RESTORE_TIMEOUT = 4.0
+RESTORE_POLL_INTERVAL = 0.3
+
+
+def get_sway_tree():
+    """Return the parsed JSON tree from ``swaymsg -t get_tree``."""
+    result = subprocess.run(
+        ["swaymsg", "-t", "get_tree"],
+        capture_output=True, text=True, check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def find_qb_windows(tree, app_id=APP_ID):
+    """Recursively find all qutebrowser windows with context info.
+
+    Returns a list of dicts with keys:
+        - All original keys from the Sway tree node
+        - ``is_floating``: whether the window is in a floating container
+        - ``parent_layout``: layout of the parent container
+        - ``workspace``: name of the containing workspace
+    """
+    results = []
+    _collect_qb_windows(tree, app_id, results,
+                        parent_layout=None, is_floating=False,
+                        workspace=None)
+    return results
+
+
+def _collect_qb_windows(node, app_id, results,
+                        parent_layout, is_floating, workspace):
+    """Recursive helper for find_qb_windows."""
+    if node.get("type") == "workspace":
+        workspace = node.get("name")
+
+    if node.get("app_id") == app_id:
+        node["is_floating"] = is_floating
+        node["parent_layout"] = parent_layout
+        node["workspace"] = workspace
+        results.append(node)
+        return
+
+    for child in node.get("nodes", []):
+        _collect_qb_windows(child, app_id, results,
+                            parent_layout=node.get("layout"),
+                            is_floating=False,
+                            workspace=workspace)
+    for child in node.get("floating_nodes", []):
+        _collect_qb_windows(child, app_id, results,
+                            parent_layout=node.get("layout"),
+                            is_floating=True,
+                            workspace=workspace)
+
+
+def swaymsg_cmd(command):
+    """Run a swaymsg command, logging errors."""
+    try:
+        subprocess.run(
+            ["swaymsg", command],
+            capture_output=True, text=True, check=True,
+        )
+    except subprocess.CalledProcessError as e:
+        print(f"qb-sway-session: swaymsg error: {e.stderr}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Save mode
+# ---------------------------------------------------------------------------
+
+def do_save(session_path):
+    """Enrich the session YAML with Sway geometry info."""
+    path = Path(session_path)
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if data is None or "windows" not in data:
+        return
+
+    tree = get_sway_tree()
+    sway_windows = find_qb_windows(tree)
+
+    # Build a lookup by window title
+    sway_by_title = {}
+    for sw in sway_windows:
+        title = sw.get("name", "")
+        if title:
+            sway_by_title[title] = sw
+
+    enriched = False
+    for win in data["windows"]:
+        title = win.get("window_title", "")
+        sw = sway_by_title.get(title)
+        if sw is not None:
+            win["sway_rect"] = sw["rect"]
+            win["sway_floating"] = sw["is_floating"]
+            if sw.get("workspace") is not None:
+                win["sway_workspace"] = sw["workspace"]
+            enriched = True
+
+    if enriched:
+        with open(path, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+
+
+# ---------------------------------------------------------------------------
+# Restore mode
+# ---------------------------------------------------------------------------
+
+def do_restore(session_path):
+    """Move/resize qutebrowser windows to their saved Sway positions."""
+    path = Path(session_path)
+    with open(path, encoding="utf-8") as f:
+        data = yaml.safe_load(f)
+
+    if data is None or "windows" not in data:
+        return
+
+    # Build expected markers -> saved info
+    expected = {}
+    for win in data["windows"]:
+        restore_id = win.get("restore_id")
+        if restore_id is None:
+            continue
+        # We need at least a workspace to do anything useful
+        workspace = win.get("sway_workspace")
+        if workspace is None:
+            continue
+        marker = f"{MARKER_PREFIX}{restore_id}{MARKER_SUFFIX}"
+        expected[marker] = {
+            "rect": win.get("sway_rect"),
+            "workspace": workspace,
+            "floating": win.get("sway_floating", False),
+        }
+
+    if not expected:
+        return
+
+    # Poll for windows with markers
+    deadline = time.monotonic() + RESTORE_TIMEOUT
+    remaining = dict(expected)
+
+    while remaining and time.monotonic() < deadline:
+        tree = get_sway_tree()
+        sway_windows = find_qb_windows(tree)
+
+        for sw in sway_windows:
+            title = sw.get("name", "")
+            if title in remaining:
+                info = remaining.pop(title)
+                _restore_window(sw["id"], info)
+
+        if remaining:
+            time.sleep(RESTORE_POLL_INTERVAL)
+
+
+def _restore_window(con_id, info):
+    """Restore a single window to its saved state."""
+    workspace = info["workspace"]
+    is_floating = info["floating"]
+    rect = info.get("rect")
+
+    # Move to the correct workspace
+    swaymsg_cmd(
+        f'[con_id={con_id}] move container to workspace "{workspace}"'
+    )
+
+    if is_floating and rect:
+        # Floating window: restore exact position and size
+        commands = [
+            f"[con_id={con_id}] floating enable",
+            f'[con_id={con_id}] move position {rect["x"]} {rect["y"]}',
+            f'[con_id={con_id}] resize set {rect["width"]} {rect["height"]}',
+        ]
+        swaymsg_cmd(", ".join(commands))
+    else:
+        # Tiled window: ensure it's not floating, let Sway handle tiling
+        swaymsg_cmd(f"[con_id={con_id}] floating disable")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} (save|restore) <session_path>",
+              file=sys.stderr)
+        sys.exit(1)
+
+    mode = sys.argv[1]
+    session_path = sys.argv[2]
+
+    if mode == "save":
+        do_save(session_path)
+    elif mode == "restore":
+        do_restore(session_path)
+    else:
+        print(f"qb-sway-session: unknown mode '{mode}'", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -26,25 +26,24 @@ Modes
 **save**
     Reads the session YAML written by qutebrowser, queries the Sway tree
     (``swaymsg -t get_tree``) to find qutebrowser windows, correlates them
-    by ``window_title``, and enriches each window entry with Sway-specific
-    data:
+    by ``window_title``, and enriches the session file with:
 
-    - ``sway_rect``: window geometry (x, y, width, height)
-    - ``sway_workspace``: workspace name
-    - ``sway_floating``: whether the window was floating
-    - ``sway_parent_layout``: parent container layout (splith, splitv,
-      tabbed, stacked)
+    - Per-window: ``sway_rect``, ``sway_workspace``, ``sway_floating``
+    - Global: ``sway_trees`` — a pruned tiling tree per workspace that
+      captures the container hierarchy (split directions) between
+      qutebrowser windows.
 
 **restore**
-    Reads the (enriched) session YAML, queries the Sway tree to find
-    qutebrowser windows bearing temporary title markers
-    (``__qb_restore_<N>__``), and restores them:
+    Reads the enriched session YAML and restores window layout:
 
-    - **Floating windows**: moved to saved workspace, set floating,
-      positioned and resized to exact saved coordinates.
-    - **Tiled windows**: moved to saved workspace, kept tiled.
-      The parent layout (splith/splitv/tabbed/stacked) is applied so
-      the split direction matches the original.
+    - **Floating windows**: exact position and size via ``swaymsg``.
+    - **Tiled windows**: reconstructs the container hierarchy from
+      ``sway_trees`` using Sway's ``mark`` + ``move container to mark``
+      mechanism, preserving split directions (splith, splitv, tabbed,
+      stacked).
+
+    Falls back to simple workspace placement if ``sway_trees`` is absent
+    (backward compatibility).
 
 Dependencies
 ------------
@@ -57,6 +56,7 @@ import json
 import subprocess
 import sys
 import time
+from collections import defaultdict
 from pathlib import Path
 
 try:
@@ -70,10 +70,15 @@ except ImportError:
 APP_ID = "org.qutebrowser.qutebrowser"
 MARKER_PREFIX = "__qb_restore_"
 MARKER_SUFFIX = "__"
+LAYOUT_MARK = "__qb_layout_ref__"
 # How long to wait for windows to appear (seconds)
 RESTORE_TIMEOUT = 4.0
 RESTORE_POLL_INTERVAL = 0.3
 
+
+# ---------------------------------------------------------------------------
+# Sway helpers
+# ---------------------------------------------------------------------------
 
 def get_sway_tree():
     """Return the parsed JSON tree from ``swaymsg -t get_tree``."""
@@ -87,53 +92,97 @@ def get_sway_tree():
 def find_qb_windows(tree, app_id=APP_ID):
     """Recursively find all qutebrowser windows with context info.
 
-    Returns a list of dicts with keys:
-        - All original keys from the Sway tree node
-        - ``is_floating``: whether the window is in a floating container
-        - ``parent_layout``: layout of the parent container
-        - ``workspace``: name of the containing workspace
+    Returns a list of dicts with added keys:
+        ``is_floating``, ``workspace``
     """
     results = []
     _collect_qb_windows(tree, app_id, results,
-                        parent_layout=None, is_floating=False,
-                        workspace=None)
+                        is_floating=False, workspace=None)
     return results
 
 
-def _collect_qb_windows(node, app_id, results,
-                        parent_layout, is_floating, workspace):
+def _collect_qb_windows(node, app_id, results, is_floating, workspace):
     """Recursive helper for find_qb_windows."""
     if node.get("type") == "workspace":
         workspace = node.get("name")
 
     if node.get("app_id") == app_id:
         node["is_floating"] = is_floating
-        node["parent_layout"] = parent_layout
         node["workspace"] = workspace
         results.append(node)
         return
 
     for child in node.get("nodes", []):
         _collect_qb_windows(child, app_id, results,
-                            parent_layout=node.get("layout"),
-                            is_floating=False,
-                            workspace=workspace)
+                            is_floating=False, workspace=workspace)
     for child in node.get("floating_nodes", []):
         _collect_qb_windows(child, app_id, results,
-                            parent_layout=node.get("layout"),
-                            is_floating=True,
-                            workspace=workspace)
+                            is_floating=True, workspace=workspace)
 
 
 def swaymsg_cmd(command):
-    """Run a swaymsg command, logging errors."""
+    """Run a swaymsg command, logging errors to stderr."""
     try:
         subprocess.run(
             ["swaymsg", command],
             capture_output=True, text=True, check=True,
         )
     except subprocess.CalledProcessError as e:
-        print(f"qb-sway-session: swaymsg error: {e.stderr}", file=sys.stderr)
+        print(f"qb-sway-session: swaymsg error: {e.stderr}",
+              file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Tree pruning (save)
+# ---------------------------------------------------------------------------
+
+def _find_workspaces(node):
+    """Recursively find all workspace nodes in the Sway tree."""
+    workspaces = []
+    if node.get("type") == "workspace":
+        workspaces.append(node)
+    for child in node.get("nodes", []) + node.get("floating_nodes", []):
+        workspaces.extend(_find_workspaces(child))
+    return workspaces
+
+
+def _prune_node(node, sway_id_to_restore_id):
+    """Build a pruned tree containing only tiled qutebrowser windows.
+
+    Returns:
+        ``{"restore_id": N}`` for a leaf window,
+        ``{"layout": "...", "children": [...]}`` for a container,
+        or ``None`` if no qb windows found in this subtree.
+
+    Single-child containers are collapsed (the child is returned
+    directly) since a lone window fills its container regardless
+    of layout.
+    """
+    # Leaf: qutebrowser window
+    if node.get("app_id") == APP_ID:
+        sway_id = node.get("id")
+        restore_id = sway_id_to_restore_id.get(sway_id)
+        if restore_id is not None:
+            return {"restore_id": restore_id}
+        return None
+
+    # Container: recurse into tiled children only (skip floating_nodes)
+    pruned_children = []
+    for child in node.get("nodes", []):
+        pruned = _prune_node(child, sway_id_to_restore_id)
+        if pruned is not None:
+            pruned_children.append(pruned)
+
+    if not pruned_children:
+        return None
+
+    if len(pruned_children) == 1:
+        return pruned_children[0]  # collapse single-child container
+
+    return {
+        "layout": node.get("layout", "splith"),
+        "children": pruned_children,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -141,7 +190,7 @@ def swaymsg_cmd(command):
 # ---------------------------------------------------------------------------
 
 def do_save(session_path):
-    """Enrich the session YAML with Sway geometry info."""
+    """Enrich the session YAML with Sway geometry and tree info."""
     path = Path(session_path)
     with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
@@ -152,35 +201,170 @@ def do_save(session_path):
     tree = get_sway_tree()
     sway_windows = find_qb_windows(tree)
 
-    # Build a lookup by window title
-    sway_by_title = {}
+    # Build title -> list of sway windows (handles duplicate titles)
+    sway_by_title = defaultdict(list)
     for sw in sway_windows:
         title = sw.get("name", "")
         if title:
-            sway_by_title[title] = sw
+            sway_by_title[title].append(sw)
+
+    # sway con_id -> restore_id for tree pruning (unique, no collision)
+    sway_id_to_restore_id = {}
 
     enriched = False
     for win in data["windows"]:
         title = win.get("window_title", "")
-        sw = sway_by_title.get(title)
-        if sw is not None:
-            win["sway_rect"] = sw["rect"]
-            win["sway_floating"] = sw["is_floating"]
-            if sw.get("workspace") is not None:
-                win["sway_workspace"] = sw["workspace"]
-            enriched = True
+        candidates = sway_by_title.get(title, [])
+        if not candidates:
+            continue
+        sw = candidates.pop(0)
 
-    if enriched:
+        win["sway_rect"] = sw["rect"]
+        win["sway_floating"] = sw["is_floating"]
+        if sw.get("workspace") is not None:
+            win["sway_workspace"] = sw["workspace"]
+
+        if not sw["is_floating"] and win.get("restore_id") is not None:
+            sway_id_to_restore_id[sw["id"]] = win["restore_id"]
+
+        enriched = True
+
+    # Build per-workspace pruned trees for tiled windows
+    sway_trees = {}
+    for ws in _find_workspaces(tree):
+        ws_name = ws.get("name")
+        if not ws_name:
+            continue
+        pruned = _prune_node(ws, sway_id_to_restore_id)
+        if pruned is not None:
+            sway_trees[ws_name] = pruned
+
+    if sway_trees:
+        data["sway_trees"] = sway_trees
+
+    if enriched or sway_trees:
         with open(path, "w", encoding="utf-8") as f:
             yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+
+
+# ---------------------------------------------------------------------------
+# Tree reconstruction (restore)
+# ---------------------------------------------------------------------------
+
+def _apply_layout(con_id, layout):
+    """Set the split/layout direction for the container around con_id.
+
+    For splith/splitv: uses the ``split`` command which creates a new
+    container around the window (if it has siblings) with the given
+    orientation.
+
+    For tabbed/stacked: first creates a container with ``split``, then
+    changes its layout.  This ensures we don't accidentally change the
+    parent workspace's layout.
+    """
+    swaymsg_cmd(f'[con_id={con_id}] focus')
+    if layout in ("splith", "splitv"):
+        swaymsg_cmd(layout)
+    elif layout == "tabbed":
+        swaymsg_cmd("splith")
+        swaymsg_cmd("layout tabbed")
+    elif layout == "stacked":
+        swaymsg_cmd("splith")
+        swaymsg_cmd("layout stacking")
+    else:
+        swaymsg_cmd("splith")
+
+
+def _restore_tree_node(node, id_to_con, workspace, reference_con_id):
+    """Recursively restore tiled windows according to saved tree structure.
+
+    The algorithm uses Sway's ``mark`` mechanism:
+
+    - The first child of a container is placed using either
+      ``move container to workspace`` (root level) or
+      ``move container to mark`` (nested — placed next to the reference
+      window, entering its parent container).
+    - After placing the first child, ``split`` is applied to set the
+      container's layout direction.
+    - Subsequent children use ``move container to mark`` on the
+      previously placed sibling, entering the same container.
+
+    Args:
+        node: saved tree node — either ``{"restore_id": N}`` (leaf) or
+              ``{"layout": "...", "children": [...]}`` (container).
+        id_to_con: mapping of ``restore_id`` → sway ``con_id``.
+        workspace: target workspace name.
+        reference_con_id: if set, place next to this window via mark.
+            ``None`` means place at the workspace root.
+
+    Returns:
+        ``con_id`` of the last leaf window placed, or ``None`` if no
+        windows could be placed.
+    """
+    if "restore_id" in node:
+        # Leaf: place the window
+        con_id = id_to_con.get(node["restore_id"])
+        if con_id is None:
+            return None
+
+        if reference_con_id is not None:
+            swaymsg_cmd(
+                f'[con_id={reference_con_id}] mark --add {LAYOUT_MARK}')
+            swaymsg_cmd(
+                f'[con_id={con_id}] move container to mark {LAYOUT_MARK}')
+            swaymsg_cmd(f'unmark {LAYOUT_MARK}')
+        else:
+            swaymsg_cmd(
+                f'[con_id={con_id}] move container to workspace "{workspace}"')
+
+        swaymsg_cmd(f'[con_id={con_id}] floating disable')
+        return con_id
+
+    # Container: process children recursively
+    layout = node.get("layout", "splith")
+    children = node.get("children", [])
+
+    last_placed = None
+    for i, child in enumerate(children):
+        if i == 0:
+            # First child inherits the reference (or workspace root)
+            last_placed = _restore_tree_node(
+                child, id_to_con, workspace, reference_con_id)
+            # Set the layout direction for this container
+            if last_placed is not None and len(children) > 1:
+                _apply_layout(last_placed, layout)
+        else:
+            # Subsequent children: reference is the last placed window
+            result = _restore_tree_node(
+                child, id_to_con, workspace, last_placed)
+            if result is not None:
+                last_placed = result
+
+    return last_placed
 
 
 # ---------------------------------------------------------------------------
 # Restore mode
 # ---------------------------------------------------------------------------
 
+def _get_focused_workspace():
+    """Get the currently focused workspace name."""
+    try:
+        result = subprocess.run(
+            ["swaymsg", "-t", "get_workspaces"],
+            capture_output=True, text=True, check=True,
+        )
+        workspaces = json.loads(result.stdout)
+        for ws in workspaces:
+            if ws.get("focused"):
+                return ws["name"]
+    except (subprocess.CalledProcessError, json.JSONDecodeError):
+        pass
+    return None
+
+
 def do_restore(session_path):
-    """Move/resize qutebrowser windows to their saved Sway positions."""
+    """Restore qutebrowser windows to their saved Sway layout."""
     path = Path(session_path)
     with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
@@ -188,18 +372,16 @@ def do_restore(session_path):
     if data is None or "windows" not in data:
         return
 
-    # Build expected markers -> saved info
+    # Build expected markers -> window info
     expected = {}
     for win in data["windows"]:
         restore_id = win.get("restore_id")
-        if restore_id is None:
-            continue
-        # We need at least a workspace to do anything useful
         workspace = win.get("sway_workspace")
-        if workspace is None:
+        if restore_id is None or workspace is None:
             continue
         marker = f"{MARKER_PREFIX}{restore_id}{MARKER_SUFFIX}"
         expected[marker] = {
+            "restore_id": restore_id,
             "rect": win.get("sway_rect"),
             "workspace": workspace,
             "floating": win.get("sway_floating", False),
@@ -208,9 +390,59 @@ def do_restore(session_path):
     if not expected:
         return
 
-    # Poll for windows with markers
+    # Remember current workspace to restore focus at the end
+    original_ws = _get_focused_workspace()
+
+    # Poll until windows appear or timeout
+    found = _poll_for_windows(expected)
+
+    # Build restore_id -> con_id mapping
+    id_to_con = {
+        info["restore_id"]: info["con_id"]
+        for info in found.values()
+    }
+
+    # Restore floating windows (exact position)
+    for info in found.values():
+        if info["floating"] and info.get("rect"):
+            _restore_floating(info["con_id"], info)
+
+    # Restore tiled windows
+    sway_trees = data.get("sway_trees")
+    if sway_trees:
+        # Tree-based reconstruction
+        for workspace, tree_node in sway_trees.items():
+            _restore_tree_node(tree_node, id_to_con, workspace,
+                               reference_con_id=None)
+    else:
+        # Fallback: simple workspace placement (no tree data)
+        for info in found.values():
+            if not info["floating"]:
+                swaymsg_cmd(
+                    f'[con_id={info["con_id"]}] move container to '
+                    f'workspace "{info["workspace"]}"')
+                swaymsg_cmd(
+                    f'[con_id={info["con_id"]}] floating disable')
+
+    # Restore focus to the workspace the user was on before restore.
+    # After moving containers during restore, the workspace's focus
+    # may be stuck at a parent container level (as if "focus parent"
+    # had been pressed repeatedly).  We switch back to the original
+    # workspace and then descend the focus to a leaf window.
+    if original_ws:
+        swaymsg_cmd(f'workspace "{original_ws}"')
+    # Descend focus to a leaf window.  "focus child" descends one
+    # level; repeating it enough times reaches a leaf from any depth.
+    # It is a no-op when already at a leaf, so extra calls are harmless.
+    for _ in range(10):
+        swaymsg_cmd('focus child')
+
+
+def _poll_for_windows(expected):
+    """Poll the Sway tree until expected marker windows appear or timeout."""
     deadline = time.monotonic() + RESTORE_TIMEOUT
     remaining = dict(expected)
+    found = {}
 
     while remaining and time.monotonic() < deadline:
         tree = get_sway_tree()
@@ -220,34 +452,25 @@ def do_restore(session_path):
             title = sw.get("name", "")
             if title in remaining:
                 info = remaining.pop(title)
-                _restore_window(sw["id"], info)
+                info["con_id"] = sw["id"]
+                found[title] = info
 
         if remaining:
             time.sleep(RESTORE_POLL_INTERVAL)
 
+    return found
 
-def _restore_window(con_id, info):
-    """Restore a single window to its saved state."""
+
+def _restore_floating(con_id, info):
+    """Restore a floating window to its exact saved position and size."""
+    rect = info["rect"]
     workspace = info["workspace"]
-    is_floating = info["floating"]
-    rect = info.get("rect")
-
-    # Move to the correct workspace
     swaymsg_cmd(
-        f'[con_id={con_id}] move container to workspace "{workspace}"'
-    )
-
-    if is_floating and rect:
-        # Floating window: restore exact position and size
-        commands = [
-            f"[con_id={con_id}] floating enable",
-            f'[con_id={con_id}] move position {rect["x"]} {rect["y"]}',
-            f'[con_id={con_id}] resize set {rect["width"]} {rect["height"]}',
-        ]
-        swaymsg_cmd(", ".join(commands))
-    else:
-        # Tiled window: ensure it's not floating, let Sway handle tiling
-        swaymsg_cmd(f"[con_id={con_id}] floating disable")
+        f'[con_id={con_id}] move container to workspace "{workspace}"')
+    swaymsg_cmd(
+        f'[con_id={con_id}] floating enable, '
+        f'[con_id={con_id}] move position {rect["x"]} {rect["y"]}, '
+        f'[con_id={con_id}] resize set {rect["width"]} {rect["height"]}')
 
 
 # ---------------------------------------------------------------------------

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -46,7 +46,7 @@ Modes
     the sidecar with:
 
     - Per-window (keyed by ``restore_id``): ``sway_rect``,
-      ``sway_workspace``, ``sway_floating``
+      ``sway_workspace``, ``sway_output``, ``sway_floating``
     - ``sway_trees`` — a pruned tiling tree per workspace that captures
       the container hierarchy (split directions) between qutebrowser
       windows.
@@ -55,6 +55,10 @@ Modes
     Reads the session YAML (for ``restore_id`` marker titles) and the
     sidecar (for Sway positions and tree data), then restores the layout:
 
+    - **Multi-monitor**: focuses the correct output immediately before
+      each ``move container to workspace`` command so that sway creates
+      the workspace on the right monitor, even when the workspace does
+      not exist yet at restore time.
     - **Floating windows**: exact position and size via ``swaymsg``.
     - **Tiled windows**: reconstructs the container hierarchy from
       ``sway_trees`` using Sway's ``mark`` + ``move container to mark``
@@ -117,31 +121,37 @@ def find_qb_windows(tree, app_id=APP_ID):
     """Recursively find all qutebrowser windows with context info.
 
     Returns a list of dicts with added keys:
-        ``is_floating``, ``workspace``
+        ``is_floating``, ``workspace``, ``output``
     """
     results = []
     _collect_qb_windows(tree, app_id, results,
-                        is_floating=False, workspace=None)
+                        is_floating=False, workspace=None, output=None)
     return results
 
 
-def _collect_qb_windows(node, app_id, results, is_floating, workspace):
+def _collect_qb_windows(node, app_id, results, is_floating, workspace,
+                        output):
     """Recursive helper for find_qb_windows."""
+    if node.get("type") == "output":
+        output = node.get("name")
     if node.get("type") == "workspace":
         workspace = node.get("name")
 
     if node.get("app_id") == app_id:
         node["is_floating"] = is_floating
         node["workspace"] = workspace
+        node["output"] = output
         results.append(node)
         return
 
     for child in node.get("nodes", []):
         _collect_qb_windows(child, app_id, results,
-                            is_floating=False, workspace=workspace)
+                            is_floating=False, workspace=workspace,
+                            output=output)
     for child in node.get("floating_nodes", []):
         _collect_qb_windows(child, app_id, results,
-                            is_floating=True, workspace=workspace)
+                            is_floating=True, workspace=workspace,
+                            output=output)
 
 
 def swaymsg_cmd(command):
@@ -302,6 +312,8 @@ def do_save(session_path):
         }
         if sw.get("workspace") is not None:
             sidecar_windows[restore_id]["sway_workspace"] = sw["workspace"]
+        if sw.get("output") is not None:
+            sidecar_windows[restore_id]["sway_output"] = sw["output"]
 
         if not sw["is_floating"]:
             sway_id_to_restore_id[sw["id"]] = restore_id
@@ -324,6 +336,25 @@ def do_save(session_path):
         sidecar["sway_trees"] = sway_trees
 
     _atomic_write_yaml(_sidecar_path(path), sidecar)
+
+
+# ---------------------------------------------------------------------------
+# Multi-monitor helper
+# ---------------------------------------------------------------------------
+
+def _focus_output_for_workspace(workspace, ws_to_output):
+    """Focus the output where *workspace* should live.
+
+    When a workspace does not exist yet, sway creates it on whichever
+    output currently has focus.  By focusing the correct output right
+    before a ``move container to workspace`` command, we ensure the
+    workspace (and thus the window) ends up on the right monitor.
+
+    This is a no-op if *workspace* is not in *ws_to_output*.
+    """
+    output = ws_to_output.get(workspace)
+    if output:
+        swaymsg_cmd(f'focus output "{output}"')
 
 
 # ---------------------------------------------------------------------------
@@ -354,7 +385,8 @@ def _apply_layout(con_id, layout):
         swaymsg_cmd("splith")
 
 
-def _restore_tree_node(node, id_to_con, workspace, reference_con_id):
+def _restore_tree_node(node, id_to_con, workspace, reference_con_id,
+                       ws_to_output=None):
     """Recursively restore tiled windows according to saved tree structure.
 
     The algorithm uses Sway's ``mark`` mechanism:
@@ -368,6 +400,10 @@ def _restore_tree_node(node, id_to_con, workspace, reference_con_id):
     - Subsequent children use ``move container to mark`` on the
       previously placed sibling, entering the same container.
 
+    For multi-monitor support, ``focus output`` is issued immediately
+    before any ``move container to workspace`` command (root level only)
+    to ensure sway creates the workspace on the correct output.
+
     Args:
         node: saved tree node — either ``{"restore_id": N}`` (leaf) or
               ``{"layout": "...", "children": [...]}`` (container).
@@ -375,11 +411,16 @@ def _restore_tree_node(node, id_to_con, workspace, reference_con_id):
         workspace: target workspace name.
         reference_con_id: if set, place next to this window via mark.
             ``None`` means place at the workspace root.
+        ws_to_output: mapping of workspace → output name for
+            multi-monitor placement.
 
     Returns:
         ``con_id`` of the last leaf window placed, or ``None`` if no
         windows could be placed.
     """
+    if ws_to_output is None:
+        ws_to_output = {}
+
     if "restore_id" in node:
         # Leaf: place the window
         con_id = id_to_con.get(node["restore_id"])
@@ -393,6 +434,7 @@ def _restore_tree_node(node, id_to_con, workspace, reference_con_id):
                 f'[con_id={con_id}] move container to mark {LAYOUT_MARK}')
             swaymsg_cmd(f'unmark {LAYOUT_MARK}')
         else:
+            _focus_output_for_workspace(workspace, ws_to_output)
             swaymsg_cmd(
                 f'[con_id={con_id}] move container to workspace "{workspace}"')
 
@@ -408,14 +450,16 @@ def _restore_tree_node(node, id_to_con, workspace, reference_con_id):
         if i == 0:
             # First child inherits the reference (or workspace root)
             last_placed = _restore_tree_node(
-                child, id_to_con, workspace, reference_con_id)
+                child, id_to_con, workspace, reference_con_id,
+                ws_to_output=ws_to_output)
             # Set the layout direction for this container
             if last_placed is not None and len(children) > 1:
                 _apply_layout(last_placed, layout)
         else:
             # Subsequent children: reference is the last placed window
             result = _restore_tree_node(
-                child, id_to_con, workspace, last_placed)
+                child, id_to_con, workspace, last_placed,
+                ws_to_output=ws_to_output)
             if result is not None:
                 last_placed = result
 
@@ -491,6 +535,7 @@ def do_restore(session_path):
             "restore_id": restore_id,
             "rect": sw_data.get("sway_rect"),
             "workspace": workspace,
+            "output": sw_data.get("sway_output"),
             "floating": sw_data.get("sway_floating", False),
         }
 
@@ -499,6 +544,18 @@ def do_restore(session_path):
 
     # Remember current workspace to restore focus at the end
     original_ws = _get_focused_workspace()
+
+    # ---- build workspace → output mapping ------------------------------
+    # Used by restoration functions to focus the correct output
+    # immediately before each ``move container to workspace`` command.
+    # This ensures sway creates the workspace on the correct monitor
+    # even if it doesn't exist yet.
+    ws_to_output = {}
+    for info in expected.values():
+        ws = info.get("workspace")
+        output = info.get("output")
+        if ws and output:
+            ws_to_output.setdefault(ws, output)
 
     # Poll until windows appear or timeout
     found = _poll_for_windows(expected)
@@ -512,7 +569,7 @@ def do_restore(session_path):
     # Restore floating windows (exact position)
     for info in found.values():
         if info["floating"] and info.get("rect"):
-            _restore_floating(info["con_id"], info)
+            _restore_floating(info["con_id"], info, ws_to_output)
 
     # Restore tiled windows
     sway_trees = sidecar.get("sway_trees")
@@ -520,11 +577,14 @@ def do_restore(session_path):
         # Tree-based reconstruction
         for workspace, tree_node in sway_trees.items():
             _restore_tree_node(tree_node, id_to_con, workspace,
-                               reference_con_id=None)
+                               reference_con_id=None,
+                               ws_to_output=ws_to_output)
     else:
         # Fallback: simple workspace placement (no tree data)
         for info in found.values():
             if not info["floating"]:
+                _focus_output_for_workspace(
+                    info["workspace"], ws_to_output)
                 swaymsg_cmd(
                     f'[con_id={info["con_id"]}] move container to '
                     f'workspace "{info["workspace"]}"')
@@ -568,10 +628,13 @@ def _poll_for_windows(expected):
     return found
 
 
-def _restore_floating(con_id, info):
+def _restore_floating(con_id, info, ws_to_output=None):
     """Restore a floating window to its exact saved position and size."""
+    if ws_to_output is None:
+        ws_to_output = {}
     rect = info["rect"]
     workspace = info["workspace"]
+    _focus_output_for_workspace(workspace, ws_to_output)
     swaymsg_cmd(
         f'[con_id={con_id}] move container to workspace "{workspace}"')
     swaymsg_cmd(

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 
-# SPDX-FileCopyrightText: sim590
+# SPDX-FileCopyrightText: Simon Désaulniers (sim590) <sim.desaulniers@gmail.com>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -48,8 +48,8 @@ Modes
     - Per-window (keyed by ``restore_id``): ``sway_rect``,
       ``sway_workspace``, ``sway_output``, ``sway_floating``
     - ``sway_trees`` — a pruned tiling tree per workspace that captures
-      the container hierarchy (split directions) between qutebrowser
-      windows.
+      the container hierarchy (split directions and pixel dimensions)
+      between qutebrowser windows.
 
 **restore**
     Reads the session YAML (for ``restore_id`` marker titles) and the
@@ -63,7 +63,7 @@ Modes
     - **Tiled windows**: reconstructs the container hierarchy from
       ``sway_trees`` using Sway's ``mark`` + ``move container to mark``
       mechanism, preserving split directions (splith, splitv, tabbed,
-      stacked).
+      stacked) and proportional sizes via ``resize set … ppt``.
 
     Falls back to simple workspace placement if ``sway_trees`` is absent
     (backward compatibility).  If the sidecar file is missing the script
@@ -184,20 +184,30 @@ def _prune_node(node, sway_id_to_restore_id):
     """Build a pruned tree containing only tiled qutebrowser windows.
 
     Returns:
-        ``{"restore_id": N}`` for a leaf window,
-        ``{"layout": "...", "children": [...]}`` for a container,
-        or ``None`` if no qb windows found in this subtree.
+        ``{"restore_id": N, "rect": {...}}`` for a leaf window,
+        ``{"layout": "...", "children": [...], "rect": {...}}``
+        for a container, or ``None`` if no qb windows found in this
+        subtree.
+
+    Each node includes its ``rect`` (pixel dimensions from the Sway
+    tree) when available, which is used during restore to compute
+    proportional sizes (see :func:`_resize_children`).
 
     Single-child containers are collapsed (the child is returned
     directly) since a lone window fills its container regardless
     of layout.
     """
+    rect = node.get("rect")
+
     # Leaf: qutebrowser window
     if node.get("app_id") == APP_ID:
         sway_id = node.get("id")
         restore_id = sway_id_to_restore_id.get(sway_id)
         if restore_id is not None:
-            return {"restore_id": restore_id}
+            result = {"restore_id": restore_id}
+            if rect:
+                result["rect"] = rect
+            return result
         return None
 
     # Container: recurse into tiled children only (skip floating_nodes)
@@ -213,10 +223,13 @@ def _prune_node(node, sway_id_to_restore_id):
     if len(pruned_children) == 1:
         return pruned_children[0]  # collapse single-child container
 
-    return {
+    result = {
         "layout": node.get("layout", "splith"),
         "children": pruned_children,
     }
+    if rect:
+        result["rect"] = rect
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +398,101 @@ def _apply_layout(con_id, layout):
         swaymsg_cmd("splith")
 
 
+def _first_leaf_con_id(node, id_to_con):
+    """Return the ``con_id`` of the first leaf descendant of *node*.
+
+    Returns ``None`` if no leaf with a known ``con_id`` is found.
+    """
+    if "restore_id" in node:
+        return id_to_con.get(node["restore_id"])
+    for child in node.get("children", []):
+        result = _first_leaf_con_id(child, id_to_con)
+        if result is not None:
+            return result
+    return None
+
+
+def _tree_depth(node):
+    """Return the depth from *node* to its first leaf descendant.
+
+    A leaf node (``restore_id`` present) has depth 0.  A container's
+    depth is 1 + depth of its first child.
+    """
+    if "restore_id" in node:
+        return 0
+    children = node.get("children", [])
+    if not children:
+        return 0
+    return 1 + _tree_depth(children[0])
+
+
+def _resize_children(children, layout, id_to_con):
+    """Resize children proportionally based on saved ``rect`` data.
+
+    For ``splith``: proportions are computed from ``rect.width``.
+    For ``splitv``: proportions are computed from ``rect.height``.
+    For ``tabbed``/``stacked``: no resizing (children overlap).
+
+    Each child except the last is resized to its saved proportion
+    (in ppt — percentage points).  The last child automatically
+    takes the remaining space.
+
+    For container children (not direct leaves), focuses a leaf
+    descendant first, then uses ``focus parent`` to reach the
+    container level before resizing.
+    """
+    if layout not in ("splith", "splitv"):
+        return
+
+    dim = "width" if layout == "splith" else "height"
+
+    # Collect sizes for children that have rect data
+    sizes = []
+    for child in children:
+        rect = child.get("rect")
+        if rect and dim in rect:
+            sizes.append(rect[dim])
+        else:
+            sizes.append(None)
+
+    # Need at least 2 children with valid sizes to compute proportions
+    valid = [s for s in sizes if s is not None]
+    if len(valid) < 2:
+        return
+
+    total = sum(s for s in sizes if s is not None)
+    if total <= 0:
+        return
+
+    # Resize all children except the last
+    for i, child in enumerate(children[:-1]):
+        if sizes[i] is None:
+            continue
+
+        ppt = round(sizes[i] / total * 100)
+        if ppt <= 0 or ppt >= 100:
+            continue
+
+        # Find a focusable con_id for this child
+        if "restore_id" in child:
+            con_id = id_to_con.get(child["restore_id"])
+            if con_id is None:
+                continue
+            swaymsg_cmd(f'[con_id={con_id}] focus')
+        else:
+            # Container child: focus a leaf descendant, then ascend
+            leaf_con_id = _first_leaf_con_id(child, id_to_con)
+            if leaf_con_id is None:
+                continue
+            swaymsg_cmd(f'[con_id={leaf_con_id}] focus')
+            depth = _tree_depth(child)
+            for _ in range(depth):
+                swaymsg_cmd('focus parent')
+
+        resize_dim = "width" if layout == "splith" else "height"
+        swaymsg_cmd(f'resize set {resize_dim} {ppt} ppt')
+
+
 def _restore_tree_node(node, id_to_con, workspace, reference_con_id,
                        ws_to_output=None):
     """Recursively restore tiled windows according to saved tree structure.
@@ -462,6 +570,10 @@ def _restore_tree_node(node, id_to_con, workspace, reference_con_id,
                 ws_to_output=ws_to_output)
             if result is not None:
                 last_placed = result
+
+    # Restore proportional sizes from saved rect data
+    if last_placed is not None and len(children) > 1:
+        _resize_children(children, layout, id_to_con)
 
     return last_placed
 

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -20,21 +20,37 @@ Usage::
         'qb-sway-session restore {session_path}'
     )
 
+File layout
+-----------
+
+The session YAML written by qutebrowser is **never modified** by this
+script.  All Sway-specific data is stored in a companion *sidecar* file
+next to the session file::
+
+    data/sessions/default.yml        ← written by qutebrowser (untouched)
+    data/sessions/default.sway.yml   ← written by this script
+
+The sidecar is written atomically (temp-file + ``os.replace``) so it is
+either fully written or not written at all — a crash can never corrupt
+the session file.
+
 Modes
 -----
 
 **save**
-    Reads the session YAML written by qutebrowser, queries the Sway tree
-    (``swaymsg -t get_tree``) to find qutebrowser windows, correlates them
-    by ``window_title``, and enriches the session file with:
+    Reads the session YAML (read-only) and queries the Sway tree
+    (``swaymsg -t get_tree``) to find qutebrowser windows.  Correlates
+    them by ``window_title`` and writes the sidecar with:
 
-    - Per-window: ``sway_rect``, ``sway_workspace``, ``sway_floating``
-    - Global: ``sway_trees`` — a pruned tiling tree per workspace that
-      captures the container hierarchy (split directions) between
-      qutebrowser windows.
+    - Per-window (keyed by ``restore_id``): ``sway_rect``,
+      ``sway_workspace``, ``sway_floating``
+    - ``sway_trees`` — a pruned tiling tree per workspace that captures
+      the container hierarchy (split directions) between qutebrowser
+      windows.
 
 **restore**
-    Reads the enriched session YAML and restores window layout:
+    Reads the session YAML (for ``restore_id`` marker titles) and the
+    sidecar (for Sway positions and tree data), then restores the layout:
 
     - **Floating windows**: exact position and size via ``swaymsg``.
     - **Tiled windows**: reconstructs the container hierarchy from
@@ -43,7 +59,9 @@ Modes
       stacked).
 
     Falls back to simple workspace placement if ``sway_trees`` is absent
-    (backward compatibility).
+    (backward compatibility).  If the sidecar file is missing the script
+    exits silently — the session loads normally, just without position
+    restoration.
 
 Dependencies
 ------------
@@ -53,8 +71,10 @@ Dependencies
 """
 
 import json
+import os
 import subprocess
 import sys
+import tempfile
 import time
 from collections import defaultdict
 from pathlib import Path
@@ -186,11 +206,51 @@ def _prune_node(node, sway_id_to_restore_id):
 
 
 # ---------------------------------------------------------------------------
+# Sidecar file helpers
+# ---------------------------------------------------------------------------
+
+def _sidecar_path(session_path):
+    """Derive the sidecar file path from the session file path.
+
+    ``default.yml`` → ``default.sway.yml``
+    """
+    p = Path(session_path)
+    return p.with_name(p.stem + ".sway.yml")
+
+
+def _atomic_write_yaml(path, data):
+    """Write *data* as YAML to *path* atomically.
+
+    Uses a temporary file in the same directory followed by
+    ``os.replace()`` (atomic on POSIX) so the file is either fully
+    written or not touched at all.
+    """
+    path = Path(path)
+    fd, tmp_path = tempfile.mkstemp(
+        dir=path.parent, suffix=".tmp", prefix=path.name)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
 # Save mode
 # ---------------------------------------------------------------------------
 
 def do_save(session_path):
-    """Enrich the session YAML with Sway geometry and tree info."""
+    """Write Sway geometry and tree info to a sidecar file.
+
+    The session YAML is read but **never modified**.  All Sway-specific
+    data is written to a companion ``.sway.yml`` file next to the
+    session file, keyed by ``restore_id``.
+    """
     path = Path(session_path)
     with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
@@ -211,23 +271,28 @@ def do_save(session_path):
     # sway con_id -> restore_id for tree pruning (unique, no collision)
     sway_id_to_restore_id = {}
 
-    enriched = False
+    # Build sidecar data — keyed by restore_id
+    sidecar_windows = {}
     for win in data["windows"]:
         title = win.get("window_title", "")
+        restore_id = win.get("restore_id")
+        if restore_id is None:
+            continue
+
         candidates = sway_by_title.get(title, [])
         if not candidates:
             continue
         sw = candidates.pop(0)
 
-        win["sway_rect"] = sw["rect"]
-        win["sway_floating"] = sw["is_floating"]
+        sidecar_windows[restore_id] = {
+            "sway_rect": sw["rect"],
+            "sway_floating": sw["is_floating"],
+        }
         if sw.get("workspace") is not None:
-            win["sway_workspace"] = sw["workspace"]
+            sidecar_windows[restore_id]["sway_workspace"] = sw["workspace"]
 
-        if not sw["is_floating"] and win.get("restore_id") is not None:
-            sway_id_to_restore_id[sw["id"]] = win["restore_id"]
-
-        enriched = True
+        if not sw["is_floating"]:
+            sway_id_to_restore_id[sw["id"]] = restore_id
 
     # Build per-workspace pruned trees for tiled windows
     sway_trees = {}
@@ -239,12 +304,14 @@ def do_save(session_path):
         if pruned is not None:
             sway_trees[ws_name] = pruned
 
-    if sway_trees:
-        data["sway_trees"] = sway_trees
+    if not sidecar_windows and not sway_trees:
+        return
 
-    if enriched or sway_trees:
-        with open(path, "w", encoding="utf-8") as f:
-            yaml.dump(data, f, default_flow_style=False, allow_unicode=True)
+    sidecar = {"windows": sidecar_windows}
+    if sway_trees:
+        sidecar["sway_trees"] = sway_trees
+
+    _atomic_write_yaml(_sidecar_path(path), sidecar)
 
 
 # ---------------------------------------------------------------------------
@@ -364,27 +431,55 @@ def _get_focused_workspace():
 
 
 def do_restore(session_path):
-    """Restore qutebrowser windows to their saved Sway layout."""
+    """Restore qutebrowser windows to their saved Sway layout.
+
+    Reads the session YAML (for ``restore_id`` values used as marker
+    titles) and the companion ``.sway.yml`` sidecar (for Sway-specific
+    positions and tree data).  The session file is never modified.
+    """
     path = Path(session_path)
+    sc_path = _sidecar_path(path)
+
+    # ---- read sidecar (sway-specific data) ----------------------------
+    if not sc_path.exists():
+        return
+
+    with open(sc_path, encoding="utf-8") as f:
+        sidecar = yaml.safe_load(f)
+
+    if not sidecar or "windows" not in sidecar:
+        return
+
+    sidecar_windows = sidecar.get("windows", {})
+
+    # ---- read session YAML (for restore_ids) --------------------------
     with open(path, encoding="utf-8") as f:
         data = yaml.safe_load(f)
 
     if data is None or "windows" not in data:
         return
 
-    # Build expected markers -> window info
+    # ---- build expected markers → window info -------------------------
     expected = {}
     for win in data["windows"]:
         restore_id = win.get("restore_id")
-        workspace = win.get("sway_workspace")
-        if restore_id is None or workspace is None:
+        if restore_id is None:
             continue
+
+        sw_data = sidecar_windows.get(restore_id)
+        if sw_data is None:
+            continue
+
+        workspace = sw_data.get("sway_workspace")
+        if workspace is None:
+            continue
+
         marker = f"{MARKER_PREFIX}{restore_id}{MARKER_SUFFIX}"
         expected[marker] = {
             "restore_id": restore_id,
-            "rect": win.get("sway_rect"),
+            "rect": sw_data.get("sway_rect"),
             "workspace": workspace,
-            "floating": win.get("sway_floating", False),
+            "floating": sw_data.get("sway_floating", False),
         }
 
     if not expected:
@@ -408,7 +503,7 @@ def do_restore(session_path):
             _restore_floating(info["con_id"], info)
 
     # Restore tiled windows
-    sway_trees = data.get("sway_trees")
+    sway_trees = sidecar.get("sway_trees")
     if sway_trees:
         # Tree-based reconstruction
         for workspace, tree_node in sway_trees.items():

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -40,7 +40,10 @@ Modes
 **save**
     Reads the session YAML (read-only) and queries the Sway tree
     (``swaymsg -t get_tree``) to find qutebrowser windows.  Correlates
-    them by ``window_title`` and writes the sidecar with:
+    them via temporary title markers (``__qb_save_<win_id>__``) that
+    qutebrowser sets on each window right before running this command,
+    giving exact 1:1 matching even with duplicate page titles.  Writes
+    the sidecar with:
 
     - Per-window (keyed by ``restore_id``): ``sway_rect``,
       ``sway_workspace``, ``sway_floating``
@@ -72,11 +75,11 @@ Dependencies
 
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
 import time
-from collections import defaultdict
 from pathlib import Path
 
 try:
@@ -90,6 +93,7 @@ except ImportError:
 APP_ID = "org.qutebrowser.qutebrowser"
 MARKER_PREFIX = "__qb_restore_"
 MARKER_SUFFIX = "__"
+SAVE_MARKER_RE = re.compile(r"^__qb_save_(\d+)__$")
 LAYOUT_MARK = "__qb_layout_ref__"
 # How long to wait for windows to appear (seconds)
 RESTORE_TIMEOUT = 4.0
@@ -250,6 +254,12 @@ def do_save(session_path):
     The session YAML is read but **never modified**.  All Sway-specific
     data is written to a companion ``.sway.yml`` file next to the
     session file, keyed by ``restore_id``.
+
+    Correlation between session windows and Sway windows is done via
+    temporary title markers (``__qb_save_<win_id>__``) that qutebrowser
+    sets on each window just before running this command.  This gives
+    exact 1:1 matching even when multiple windows share the same page
+    title.
     """
     path = Path(session_path)
     with open(path, encoding="utf-8") as f:
@@ -261,12 +271,15 @@ def do_save(session_path):
     tree = get_sway_tree()
     sway_windows = find_qb_windows(tree)
 
-    # Build title -> list of sway windows (handles duplicate titles)
-    sway_by_title = defaultdict(list)
+    # Build win_id -> sway window via save markers in the title.
+    # qutebrowser sets each window's title to __qb_save_<win_id>__
+    # right before running after_save_command.
+    sway_by_win_id = {}
     for sw in sway_windows:
         title = sw.get("name", "")
-        if title:
-            sway_by_title[title].append(sw)
+        m = SAVE_MARKER_RE.match(title)
+        if m:
+            sway_by_win_id[int(m.group(1))] = sw
 
     # sway con_id -> restore_id for tree pruning (unique, no collision)
     sway_id_to_restore_id = {}
@@ -274,15 +287,14 @@ def do_save(session_path):
     # Build sidecar data — keyed by restore_id
     sidecar_windows = {}
     for win in data["windows"]:
-        title = win.get("window_title", "")
+        win_id = win.get("win_id")
         restore_id = win.get("restore_id")
-        if restore_id is None:
+        if win_id is None or restore_id is None:
             continue
 
-        candidates = sway_by_title.get(title, [])
-        if not candidates:
+        sw = sway_by_win_id.get(win_id)
+        if sw is None:
             continue
-        sw = candidates.pop(0)
 
         sidecar_windows[restore_id] = {
             "sway_rect": sw["rect"],

--- a/misc/userscripts/qb-sway-session
+++ b/misc/userscripts/qb-sway-session
@@ -25,10 +25,10 @@ File layout
 
 The session YAML written by qutebrowser is **never modified** by this
 script.  All Sway-specific data is stored in a companion *sidecar* file
-next to the session file::
+in a ``sway/`` subdirectory next to the session file::
 
     data/sessions/default.yml        ← written by qutebrowser (untouched)
-    data/sessions/default.sway.yml   ← written by this script
+    data/sessions/sway/default.yml   ← written by this script
 
 The sidecar is written atomically (temp-file + ``os.replace``) so it is
 either fully written or not written at all — a crash can never corrupt
@@ -239,20 +239,21 @@ def _prune_node(node, sway_id_to_restore_id):
 def _sidecar_path(session_path):
     """Derive the sidecar file path from the session file path.
 
-    ``default.yml`` → ``default.sway.yml``
+    ``data/sessions/default.yml`` → ``data/sessions/sway/default.yml``
     """
     p = Path(session_path)
-    return p.with_name(p.stem + ".sway.yml")
+    return p.parent / "sway" / p.name
 
 
 def _atomic_write_yaml(path, data):
     """Write *data* as YAML to *path* atomically.
 
-    Uses a temporary file in the same directory followed by
-    ``os.replace()`` (atomic on POSIX) so the file is either fully
-    written or not touched at all.
+    Creates parent directories if needed.  Uses a temporary file in the
+    same directory followed by ``os.replace()`` (atomic on POSIX) so the
+    file is either fully written or not touched at all.
     """
     path = Path(path)
+    os.makedirs(path.parent, exist_ok=True)
     fd, tmp_path = tempfile.mkstemp(
         dir=path.parent, suffix=".tmp", prefix=path.name)
     try:
@@ -275,8 +276,8 @@ def do_save(session_path):
     """Write Sway geometry and tree info to a sidecar file.
 
     The session YAML is read but **never modified**.  All Sway-specific
-    data is written to a companion ``.sway.yml`` file next to the
-    session file, keyed by ``restore_id``.
+    data is written to a companion sidecar file in a ``sway/``
+    subdirectory (e.g. ``sway/default.yml``), keyed by ``restore_id``.
 
     Correlation between session windows and Sway windows is done via
     temporary title markers (``__qb_save_<win_id>__``) that qutebrowser
@@ -602,8 +603,9 @@ def do_restore(session_path):
     """Restore qutebrowser windows to their saved Sway layout.
 
     Reads the session YAML (for ``restore_id`` values used as marker
-    titles) and the companion ``.sway.yml`` sidecar (for Sway-specific
-    positions and tree data).  The session file is never modified.
+    titles) and the companion sidecar in the ``sway/`` subdirectory
+    (for Sway-specific positions and tree data).  The session file is
+    never modified.
     """
     path = Path(session_path)
     sc_path = _sidecar_path(path)

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1158,6 +1158,7 @@ class CommandDispatcher:
         env = {
             'QUTE_MODE': 'command',
             'QUTE_SELECTED_TEXT': selection,
+            'QUTE_WIN_ID': str(self._win_id),
         }
 
         if count is not None:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -130,6 +130,36 @@ session.lazy_restore:
   default: false
   desc: Load a restored tab as soon as it takes focus.
 
+session.after_save_command:
+  type:
+    name: String
+    none_ok: true
+  default: null
+  desc: >-
+    Command to run after a session is saved.
+
+    The placeholder `{session_path}` is replaced with the path to the saved
+    session file. The command is executed asynchronously (fire-and-forget).
+
+    This can be used for window manager integration, e.g. saving window
+    positions alongside the session data.
+
+session.after_load_command:
+  type:
+    name: String
+    none_ok: true
+  default: null
+  desc: >-
+    Command to run after a session is loaded and all windows are created.
+
+    The placeholder `{session_path}` is replaced with the path to the session
+    file. The command is executed asynchronously.
+
+    When this is set, windows are created with temporary title markers
+    (`+__qb_restore_<N>__+`) to allow the external command to identify and
+    reposition them. The markers are automatically replaced by normal window
+    titles after a few seconds.
+
 backend:
   type:
     name: String

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -25,6 +25,7 @@ from qutebrowser.browser import signalfilter, browsertab, history
 from qutebrowser.utils import (log, usertypes, utils, qtutils,
                                urlutils, message, jinja, version)
 from qutebrowser.misc import quitter, objects
+from qutebrowser.qt import sip
 
 
 @dataclasses.dataclass
@@ -327,6 +328,34 @@ class TabbedBrowser(QWidget):
         title = utils.elide(title, 1024)
 
         self._window().setWindowTitle(title)
+
+    def suppress_title_update(self, marker_title, timeout_ms=5000):
+        """Temporarily suppress automatic title updates and set a marker.
+
+        Used during session restore so that external scripts (e.g. a
+        window-manager integration) can identify windows by a known
+        marker title before the real page title overwrites it.
+
+        Args:
+            marker_title: The temporary title to set on the window.
+            timeout_ms: How long (in milliseconds) to keep the marker
+                before restoring automatic title updates.  Defaults to
+                5 000 ms (5 seconds).
+        """
+        self._title_update_suppressed = True
+        self._window().setWindowTitle(marker_title)
+        QTimer.singleShot(timeout_ms, self._unsuppress_title_update)
+
+    def _unsuppress_title_update(self):
+        """Re-enable automatic window title updates after a marker timeout."""
+        if sip.isdeleted(self):
+            return
+        self._title_update_suppressed = False
+        self._update_window_title()
+
+    def refresh_window_title(self):
+        """Force-refresh the window title from current tab state."""
+        self._update_window_title()
 
     def _connect_tab_signals(self, tab):
         """Set up the needed signals for tab."""

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -241,6 +241,7 @@ class TabbedBrowser(QWidget):
         self._global_marks: MutableMapping[str, tuple[QPoint, QUrl]] = {}
         self.default_window_icon = self._window().windowIcon()
         self.is_private = private
+        self._title_update_suppressed = False
         self.tab_deque = TabDeque()
         config.instance.changed.connect(self._on_config_changed)
         quitter.instance.shutting_down.connect(self.shutdown)
@@ -306,6 +307,9 @@ class TabbedBrowser(QWidget):
             field: A field name which was updated. If given, the title
                    is only set if the given field is in the template.
         """
+        if self._title_update_suppressed:
+            return
+
         title_format = config.cache['window.title_format']
         if field is not None and ('{' + field + '}') not in title_format:
             return

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -356,6 +356,30 @@ class SessionManager(QObject):
 
         after_save = config.val.session.after_save_command
         if after_save:
+            # Temporarily replace window titles with unique markers so the
+            # external script can correlate session windows with Sway (or
+            # other WM) windows by win_id instead of the page title.
+            # The after_save_command runs synchronously, so the markers are
+            # only visible for the duration of the external command.
+            save_marker_prefix = "__qb_save_"
+            save_marker_suffix = "__"
+            for wid in objreg.window_registry:
+                try:
+                    mw = objreg.get('main-window', scope='window',
+                                    window=wid)
+                    if not sip.isdeleted(mw):
+                        mw.setWindowTitle(
+                            f"{save_marker_prefix}{wid}"
+                            f"{save_marker_suffix}")
+                except KeyError:
+                    pass
+
+            # Flush pending Wayland/X11 requests so the compositor sees
+            # the new titles before the external command queries the
+            # window tree.
+            from qutebrowser.qt.widgets import QApplication
+            QApplication.processEvents()
+
             cmd = after_save.replace('{session_path}', str(path))
             try:
                 subprocess.run(shlex.split(cmd), timeout=10)
@@ -365,6 +389,16 @@ class SessionManager(QObject):
             except OSError as e:
                 log.sessions.error(
                     "Failed to run after_save_command: {}".format(e))
+            finally:
+                # Restore real window titles
+                for wid in objreg.window_registry:
+                    try:
+                        tb = objreg.get('tabbed-browser', scope='window',
+                                        window=wid)
+                        if not sip.isdeleted(tb):
+                            tb._update_window_title()
+                    except KeyError:
+                        pass
 
         return name
 

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -7,6 +7,8 @@
 import os
 import os.path
 import itertools
+import shlex
+import subprocess
 import urllib
 import shutil
 import pathlib
@@ -282,6 +284,9 @@ class SessionManager(QObject):
             if getattr(active_window, 'win_id', None) == win_id:
                 win_data['active'] = True
             win_data['geometry'] = bytes(main_window.saveGeometry())
+            win_data['win_id'] = win_id
+            win_data['window_title'] = main_window.windowTitle()
+            win_data['restore_id'] = len(data['windows'])
             win_data['tabs'] = []
             if tabbed_browser.is_private:
                 win_data['private'] = True
@@ -348,6 +353,19 @@ class SessionManager(QObject):
 
         if load_next_time:
             configfiles.state['general']['session'] = name
+
+        after_save = config.val.session.after_save_command
+        if after_save:
+            cmd = after_save.replace('{session_path}', str(path))
+            try:
+                subprocess.run(shlex.split(cmd), timeout=10)
+            except subprocess.TimeoutExpired:
+                log.sessions.warning(
+                    "after_save_command timed out after 10s")
+            except OSError as e:
+                log.sessions.error(
+                    "Failed to run after_save_command: {}".format(e))
+
         return name
 
     def _save_autosave(self):
@@ -473,9 +491,27 @@ class SessionManager(QObject):
         if tab_to_focus is not None:
             tabbed_browser.widget.setCurrentIndex(tab_to_focus)
 
+        # Set temporary title marker for external restore scripts.
+        # The restore_id lets the script correlate session data with
+        # the actual window on the compositor side.
+        restore_id = win.get('restore_id')
+        if restore_id is not None:
+            marker = '__qb_restore_{}__'.format(restore_id)
+            tabbed_browser._title_update_suppressed = True
+            window.setWindowTitle(marker)
+            QTimer.singleShot(
+                5000,
+                lambda tb=tabbed_browser: self._unsuppress_title(tb))
+
         window.show()
         if win.get('active', False):
             QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
+
+    @staticmethod
+    def _unsuppress_title(tabbed_browser):
+        """Re-enable automatic window title updates after restore."""
+        tabbed_browser._title_update_suppressed = False
+        tabbed_browser._update_window_title()
 
     def load(self, name, temp=False):
         """Load a named session.
@@ -507,6 +543,15 @@ class SessionManager(QObject):
             self.did_load = True
         if not name.startswith('_') and not temp:
             self.current = name
+
+        after_load = config.val.session.after_load_command
+        if after_load:
+            cmd = after_load.replace('{session_path}', str(path))
+            try:
+                subprocess.Popen(shlex.split(cmd))
+            except OSError as e:
+                log.sessions.error(
+                    "Failed to run after_load_command: {}".format(e))
 
     def delete(self, name):
         """Delete a session."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -356,51 +356,53 @@ class SessionManager(QObject):
 
         after_save = config.val.session.after_save_command
         if after_save:
-            # Temporarily replace window titles with unique markers so the
-            # external script can correlate session windows with Sway (or
-            # other WM) windows by win_id instead of the page title.
-            # The after_save_command runs synchronously, so the markers are
-            # only visible for the duration of the external command.
-            save_marker_prefix = "__qb_save_"
-            save_marker_suffix = "__"
-            for wid in objreg.window_registry:
-                try:
-                    mw = objreg.get('main-window', scope='window',
-                                    window=wid)
-                    if not sip.isdeleted(mw):
-                        mw.setWindowTitle(
-                            f"{save_marker_prefix}{wid}"
-                            f"{save_marker_suffix}")
-                except KeyError:
-                    pass
-
-            # Flush pending Wayland/X11 requests so the compositor sees
-            # the new titles before the external command queries the
-            # window tree.
-            from qutebrowser.qt.widgets import QApplication
-            QApplication.processEvents()
-
-            cmd = after_save.replace('{session_path}', str(path))
-            try:
-                subprocess.run(shlex.split(cmd), timeout=10)
-            except subprocess.TimeoutExpired:
-                log.sessions.warning(
-                    "after_save_command timed out after 10s")
-            except OSError as e:
-                log.sessions.error(
-                    "Failed to run after_save_command: {}".format(e))
-            finally:
-                # Restore real window titles
-                for wid in objreg.window_registry:
-                    try:
-                        tb = objreg.get('tabbed-browser', scope='window',
-                                        window=wid)
-                        if not sip.isdeleted(tb):
-                            tb._update_window_title()
-                    except KeyError:
-                        pass
+            self._run_after_save_command(after_save, path)
 
         return name
+
+    def _run_after_save_command(self, after_save, path):
+        """Run the after_save_command with temporary title markers.
+
+        Temporarily replaces window titles with unique markers so the
+        external script can correlate session windows with compositor
+        windows by win_id.  The command runs synchronously, so the
+        markers are only visible for its duration.
+        """
+        for wid in objreg.window_registry:
+            try:
+                mw = objreg.get('main-window', scope='window',
+                                window=wid)
+                if not sip.isdeleted(mw):
+                    mw.setWindowTitle(
+                        f"__qb_save_{wid}__")
+            except KeyError:
+                pass
+
+        # Flush pending Wayland/X11 requests so the compositor sees
+        # the new titles before the external command queries the
+        # window tree.
+        from qutebrowser.qt.widgets import QApplication
+        QApplication.processEvents()
+
+        cmd = after_save.replace('{session_path}', str(path))
+        try:
+            subprocess.run(shlex.split(cmd), check=False, timeout=10)
+        except subprocess.TimeoutExpired:
+            log.sessions.warning(
+                "after_save_command timed out after 10s")
+        except OSError as e:
+            log.sessions.error(
+                "Failed to run after_save_command: {}".format(e))
+        finally:
+            # Restore real window titles
+            for wid in objreg.window_registry:
+                try:
+                    tb = objreg.get('tabbed-browser', scope='window',
+                                    window=wid)
+                    if not sip.isdeleted(tb):
+                        tb.refresh_window_title()
+                except KeyError:
+                    pass
 
     def _save_autosave(self):
         """Save the autosave session."""
@@ -531,21 +533,11 @@ class SessionManager(QObject):
         restore_id = win.get('restore_id')
         if restore_id is not None:
             marker = '__qb_restore_{}__'.format(restore_id)
-            tabbed_browser._title_update_suppressed = True
-            window.setWindowTitle(marker)
-            QTimer.singleShot(
-                5000,
-                lambda tb=tabbed_browser: self._unsuppress_title(tb))
+            tabbed_browser.suppress_title_update(marker)
 
         window.show()
         if win.get('active', False):
             QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
-
-    @staticmethod
-    def _unsuppress_title(tabbed_browser):
-        """Re-enable automatic window title updates after restore."""
-        tabbed_browser._title_update_suppressed = False
-        tabbed_browser._update_window_title()
 
     def load(self, name, temp=False):
         """Load a named session.
@@ -581,11 +573,12 @@ class SessionManager(QObject):
         after_load = config.val.session.after_load_command
         if after_load:
             cmd = after_load.replace('{session_path}', str(path))
-            try:
-                subprocess.Popen(shlex.split(cmd))
-            except OSError as e:
-                log.sessions.error(
-                    "Failed to run after_load_command: {}".format(e))
+            parts = shlex.split(cmd)
+            # Lazy import to avoid circular dependency:
+            # sessions -> guiprocess -> apitypes -> browsertab -> sessions
+            from qutebrowser.misc import guiprocess
+            proc = guiprocess.GUIProcess('after-load-command')
+            proc.start(parts[0], parts[1:])
 
     def delete(self, name):
         """Delete a session."""

--- a/qutebrowser/misc/sessions.py
+++ b/qutebrowser/misc/sessions.py
@@ -510,7 +510,7 @@ class SessionManager(QObject):
         except ValueError as e:
             raise SessionError(e)
 
-    def _load_window(self, win):
+    def _load_window(self, win, no_hooks=False):
         """Turn yaml data into windows."""
         window = mainwindow.MainWindow(geometry=win['geometry'],
                                        private=win.get('private', None))
@@ -530,21 +530,24 @@ class SessionManager(QObject):
         # Set temporary title marker for external restore scripts.
         # The restore_id lets the script correlate session data with
         # the actual window on the compositor side.
-        restore_id = win.get('restore_id')
-        if restore_id is not None:
-            marker = '__qb_restore_{}__'.format(restore_id)
-            tabbed_browser.suppress_title_update(marker)
+        if not no_hooks:
+            restore_id = win.get('restore_id')
+            if restore_id is not None:
+                marker = '__qb_restore_{}__'.format(restore_id)
+                tabbed_browser.suppress_title_update(marker)
 
         window.show()
         if win.get('active', False):
             QTimer.singleShot(0, tabbed_browser.widget.activateWindow)
 
-    def load(self, name, temp=False):
+    def load(self, name, temp=False, no_hooks=False):
         """Load a named session.
 
         Args:
             name: The name of the session to load.
             temp: If given, don't set the current session.
+            no_hooks: If given, don't run after_load_command and don't
+                inject title markers.
         """
         path = self._get_session_path(name, check_exists=True)
         try:
@@ -563,22 +566,23 @@ class SessionManager(QObject):
                                    "in single process mode.")
 
         for win in data['windows']:
-            self._load_window(win)
+            self._load_window(win, no_hooks=no_hooks)
 
         if data['windows']:
             self.did_load = True
         if not name.startswith('_') and not temp:
             self.current = name
 
-        after_load = config.val.session.after_load_command
-        if after_load:
-            cmd = after_load.replace('{session_path}', str(path))
-            parts = shlex.split(cmd)
-            # Lazy import to avoid circular dependency:
-            # sessions -> guiprocess -> apitypes -> browsertab -> sessions
-            from qutebrowser.misc import guiprocess
-            proc = guiprocess.GUIProcess('after-load-command')
-            proc.start(parts[0], parts[1:])
+        if not no_hooks:
+            after_load = config.val.session.after_load_command
+            if after_load:
+                cmd = after_load.replace('{session_path}', str(path))
+                parts = shlex.split(cmd)
+                # Lazy import to avoid circular dependency:
+                # sessions -> guiprocess -> apitypes -> browsertab -> sessions
+                from qutebrowser.misc import guiprocess
+                proc = guiprocess.GUIProcess('after-load-command')
+                proc.start(parts[0], parts[1:])
 
     def delete(self, name):
         """Delete a session."""
@@ -604,7 +608,8 @@ def session_load(name: str, *,
                  clear: bool = False,
                  temp: bool = False,
                  force: bool = False,
-                 delete: bool = False) -> None:
+                 delete: bool = False,
+                 no_hooks: bool = False) -> None:
     """Load a session.
 
     Args:
@@ -613,13 +618,15 @@ def session_load(name: str, *,
         temp: Don't set the current session for :session-save.
         force: Force loading internal sessions (starting with an underline).
         delete: Delete the saved session once it has loaded.
+        no_hooks: Don't run session.after_load_command and don't inject
+            title markers for external restore scripts.
     """
     if name.startswith('_') and not force:
         raise cmdutils.CommandError("{} is an internal session, use --force "
                                     "to load anyways.".format(name))
     old_windows = list(objreg.window_registry.values())
     try:
-        session_manager.load(name, temp=temp)
+        session_manager.load(name, temp=temp, no_hooks=no_hooks)
     except SessionNotFoundError:
         raise cmdutils.CommandError("Session {} not found!".format(name))
     except SessionError as e:


### PR DESCRIPTION
## Summary

Add `session.after_save_command` and `session.after_load_command` config
options that run external commands after session save/load, enabling
window managers to save and restore window positions.

### Core changes (qutebrowser)

- On save, enrich session data with `win_id`, `window_title` and
  `restore_id`.  Temporarily set each window's title to
  `__qb_save_<win_id>__` before running the synchronous
  (`subprocess.run`, timeout 10 s) `after_save_command`, so external
  scripts can correlate session windows with WM windows.  Flush title
  changes to the compositor via `QApplication.processEvents()` before
  launching the command.  Restore real titles in a finally block via
  `TabbedBrowser.refresh_window_title()`.
- On load, inject temporary title markers (`__qb_restore_<N>__`) via
  `TabbedBrowser.suppress_title_update()`, which suppresses automatic
  title updates for 5 s so external scripts can identify windows before
  normal titles are set.  The `after_load_command` runs asynchronously
  via `GUIProcess`.
- The `:session-load` command accepts a `--no-hooks` flag to skip
  marker injection and `after_load_command` execution, useful when
  loading single-window sessions without repositioning.
- Expose `QUTE_WIN_ID` environment variable to userscripts.

### Userscript: qb-sway-session

Include `qb-sway-session`, a helper script for Sway/Wayland that saves
and restores window geometry, workspace placement and container layout
(splith/splitv/tabbed/stacked) via swaymsg, including proportional
window sizes within tiled containers.  The script never modifies
the session YAML; all Sway-specific data is written to an atomic sidecar
file in a `sway/` subdirectory (e.g. `sway/default.yml`).  Multi-monitor
setups are supported by focusing the correct output before each workspace
move.

Closes: #8917