### PR TITLE
Add option to configure audio/mute icon

### DIFF
--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -344,8 +344,8 @@
 |<<tabs.show_switching_delay,tabs.show_switching_delay>>|Duration (in milliseconds) to show the tab bar before hiding it when tabs.show is set to 'switching'.
 |<<tabs.tabs_are_windows,tabs.tabs_are_windows>>|Open a new window for every tab.
 |<<tabs.title.alignment,tabs.title.alignment>>|Alignment of the text inside of tabs.
-|<<tabs.title.audio.muted,tabs.title.audio.muted>>|String or a symbol to indicate that tab has been muted. See `tabs.title.format` for how to display this in the tab title.
-|<<tabs.title.audio.playing,tabs.title.audio.playing>>|String or a symbol to indicate that audio is playing in a tab. See `tabs.title.format` for how to display this in the tab title.
+|<<tabs.title.audio.muted,tabs.title.audio.muted>>|String or symbol to indicate that tab has been muted. See `tabs.title.format` for how to display this in the tab title.
+|<<tabs.title.audio.playing,tabs.title.audio.playing>>|String or symbol to indicate that audio is playing in a tab. See `tabs.title.format` for how to display this in the tab title.
 |<<tabs.title.elide,tabs.title.elide>>|Position of ellipsis in truncated title of tabs.
 |<<tabs.title.format,tabs.title.format>>|Format to use for the tab title.
 |<<tabs.title.format_pinned,tabs.title.format_pinned>>|Format to use for the tab title for pinned tabs. The same placeholders like for `tabs.title.format` are defined.
@@ -4557,7 +4557,7 @@ Default: +pass:[left]+
 
 [[tabs.title.audio.muted]]
 === tabs.title.audio.muted
-String or a symbol to indicate that tab has been muted. See `tabs.title.format` for how to display this in the tab title.
+String or symbol to indicate that tab has been muted. See `tabs.title.format` for how to display this in the tab title.
 
 Type: <<types,String>>
 
@@ -4565,7 +4565,7 @@ Default: +pass:[[M\] ]+
 
 [[tabs.title.audio.playing]]
 === tabs.title.audio.playing
-String or a symbol to indicate that audio is playing in a tab. See `tabs.title.format` for how to display this in the tab title.
+String or symbol to indicate that audio is playing in a tab. See `tabs.title.format` for how to display this in the tab title.
 
 Type: <<types,String>>
 

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -344,6 +344,8 @@
 |<<tabs.show_switching_delay,tabs.show_switching_delay>>|Duration (in milliseconds) to show the tab bar before hiding it when tabs.show is set to 'switching'.
 |<<tabs.tabs_are_windows,tabs.tabs_are_windows>>|Open a new window for every tab.
 |<<tabs.title.alignment,tabs.title.alignment>>|Alignment of the text inside of tabs.
+|<<tabs.title.audio.muted,tabs.title.audio.muted>>|String or a symbol to indicate that tab has been muted. See `tabs.title.format` for how to display this in the tab title.
+|<<tabs.title.audio.playing,tabs.title.audio.playing>>|String or a symbol to indicate that audio is playing in a tab. See `tabs.title.format` for how to display this in the tab title.
 |<<tabs.title.elide,tabs.title.elide>>|Position of ellipsis in truncated title of tabs.
 |<<tabs.title.format,tabs.title.format>>|Format to use for the tab title.
 |<<tabs.title.format_pinned,tabs.title.format_pinned>>|Format to use for the tab title for pinned tabs. The same placeholders like for `tabs.title.format` are defined.
@@ -4552,6 +4554,22 @@ Valid values:
  * +center+
 
 Default: +pass:[left]+
+
+[[tabs.title.audio.muted]]
+=== tabs.title.audio.muted
+String or a symbol to indicate that tab has been muted. See `tabs.title.format` for how to display this in the tab title.
+
+Type: <<types,String>>
+
+Default: +pass:[[M\] ]+
+
+[[tabs.title.audio.playing]]
+=== tabs.title.audio.playing
+String or a symbol to indicate that audio is playing in a tab. See `tabs.title.format` for how to display this in the tab title.
+
+Type: <<types,String>>
+
+Default: +pass:[[A\] ]+
 
 [[tabs.title.elide]]
 === tabs.title.elide

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2373,12 +2373,12 @@ tabs.title.alignment:
 tabs.title.audio.playing:
   default: '[A] '
   type: String
-  desc: "String or a symbol to indicate that audio is playing in a tab. See
+  desc: "String or symbol to indicate that audio is playing in a tab. See
     `tabs.title.format` for how to display this in the tab title."
 tabs.title.audio.muted:
   default: '[M] '
   type: String
-  desc: "String or a symbol to indicate that tab has been muted. See
+  desc: "String or symbol to indicate that tab has been muted. See
     `tabs.title.format` for how to display this in the tab title."
 
 tabs.title.elide:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -2370,6 +2370,17 @@ tabs.title.alignment:
   type: TextAlignment
   desc: Alignment of the text inside of tabs.
 
+tabs.title.audio.playing:
+  default: '[A] '
+  type: String
+  desc: "String or a symbol to indicate that audio is playing in a tab. See
+    `tabs.title.format` for how to display this in the tab title."
+tabs.title.audio.muted:
+  default: '[M] '
+  type: String
+  desc: "String or a symbol to indicate that tab has been muted. See
+    `tabs.title.format` for how to display this in the tab title."
+
 tabs.title.elide:
   default: right
   type: ElidePosition

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -4,6 +4,7 @@
 
 """The tab widget used for TabbedBrowser from browser.py."""
 
+import enum
 import functools
 import contextlib
 import dataclasses
@@ -35,10 +36,6 @@ class TabWidget(QTabWidget):
 
     tab_index_changed = pyqtSignal(int, int)
     new_tab_requested = pyqtSignal('QUrl', bool, bool)
-
-    # Strings for controlling the mute/audible text
-    MUTE_STRING = '[M] '
-    AUDIBLE_STRING = '[A] '
 
     def __init__(self, win_id, parent=None):
         super().__init__(parent)
@@ -178,9 +175,9 @@ class TabWidget(QTabWidget):
         fields['private'] = ' [Private Mode] ' if tab.is_private else ''
         try:
             if tab.audio.is_muted():
-                fields['audio'] = TabWidget.MUTE_STRING
+                fields['audio'] = config.cache['tabs.title.audio.muted']
             elif tab.audio.is_recently_audible():
-                fields['audio'] = TabWidget.AUDIBLE_STRING
+                fields['audio'] = config.cache['tabs.title.audio.playing']
             else:
                 fields['audio'] = ''
         except browsertab.WebTabError:

--- a/qutebrowser/mainwindow/tabwidget.py
+++ b/qutebrowser/mainwindow/tabwidget.py
@@ -4,7 +4,6 @@
 
 """The tab widget used for TabbedBrowser from browser.py."""
 
-import enum
 import functools
 import contextlib
 import dataclasses


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
This PR adds an option to configure audio/mute indicators used in formatting the tab title.

Example with some nerdfonts icons:
<img width="660" height="49" alt="image" src="https://github.com/user-attachments/assets/a30d17f3-4b82-4166-b8fd-ef3274d2c162" />
