### PR TITLE
[webengine] fix intermittent "unknown error while getting elements" on Qt 6.11

### DIFF
--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -780,10 +780,16 @@ class WebEngineElements(browsertab.AbstractElements):
 
     def find_css(self, selector, callback, error_cb, *,
                  only_visible=False):
-        js_code = javascript.assemble('webelem', 'find_css', selector,
-                                      only_visible)
+        init_code = javascript.wrap_global(
+            'scripts',
+            resources.read_file('javascript/scroll.js'),
+            resources.read_file('javascript/webelem.js'),
+            resources.read_file('javascript/caret.js'),
+        )
+        call_code = javascript.assemble('webelem', 'find_css', selector,
+                                        only_visible)
         js_cb = functools.partial(self._js_cb_multiple, callback, error_cb)
-        self._tab.run_js_async(js_code, js_cb)
+        self._tab.run_js_async(init_code + '\n' + call_code, js_cb)
 
     def find_id(self, elem_id, callback):
         js_code = javascript.assemble('webelem', 'find_id', elem_id)


### PR DESCRIPTION
Partial fix for #8925

On Qt 6.11, `window._qutebrowser` is sometimes undefined when `find_css` runs. You can verify it mid-bug with `:jseval --world=application typeof window._qutebrowser` which sometimes returns "undefined". The DocumentCreation injection isn't firing after forward/backward navigation.

Because `find_css` blindly assumes webelem.js has been injected, the JS throws a TypeError which gets handed back by Qt as None.

This fix bundles the `wrap_global` init with the `find_css` call in one runJavaScript instead of relying on the injection having already run, and the init has an initialized["scripts"] guard so it's a no-op if the injection did work.

Note that this only fixes hints. Scroll, stylesheets, and caret are probably broken for the same reason but at different call sites; I'm not sure if you'd rather fix those the same way or go a different direction, but this fix has been working for me.