### PR TITLE
Tune the bug report dialog

### DIFF
--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -489,7 +489,7 @@ def _init_modules(*, args):
     log.init.debug("Initializing sessions...")
     sessions.init(objects.qapp)
 
-    if not args.no_err_windows:
+    if config.val.crash_reporter.enabled and not args.no_err_windows:
         crashsignal.crash_handler.display_faulthandler()
 
     log.init.debug("Initializing quickmarks...")

--- a/qutebrowser/app.py
+++ b/qutebrowser/app.py
@@ -489,7 +489,8 @@ def _init_modules(*, args):
     log.init.debug("Initializing sessions...")
     sessions.init(objects.qapp)
 
-    if config.val.crash_reporter.enabled and not args.no_err_windows:
+    if (config.val.crash_reporter.enabled in ("signals", "both") and
+            not args.no_err_windows):
         crashsignal.crash_handler.display_faulthandler()
 
     log.init.debug("Initializing quickmarks...")

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1463,6 +1463,13 @@ completion.use_best_match:
   default: false
   desc: Execute the best-matching command on a partial match.
 
+## crash reporter
+
+crash_reporter.enabled:
+  type: Bool
+  default: true
+  desc: Open the crash reporter dialog automatically after a crash.
+
 ## downloads
 
 downloads.location.directory:

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1466,8 +1466,14 @@ completion.use_best_match:
 ## crash reporter
 
 crash_reporter.enabled:
-  type: Bool
-  default: true
+  type:
+    name: String
+    valid_values:
+      - none: Don't open the crash reporter.
+      - exceptions: After crashes from python exceptions.
+      - signals: After crashes from signals.
+      - both: After crashes from signals and python exceptions.
+  default: both
   desc: Open the crash reporter dialog automatically after a crash.
 
 ## downloads

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -197,14 +197,14 @@ class _CrashDialog(QDialog):
         self._vbox.addWidget(self._btn_box)
 
         self._btn_report = QPushButton("Report")
-        self._btn_report.setDefault(True)
+        self._btn_report.setAutoDefault(False)
         self._btn_report.clicked.connect(self.on_report_clicked)
-        self._btn_box.addButton(self._btn_report, QDialogButtonBox.ButtonRole.AcceptRole)
+        self._btn_box.addButton(self._btn_report, QDialogButtonBox.ButtonRole.YesRole)
 
         self._btn_cancel = QPushButton("Don't report")
         self._btn_cancel.setAutoDefault(False)
         self._btn_cancel.clicked.connect(self.finish)
-        self._btn_box.addButton(self._btn_cancel, QDialogButtonBox.ButtonRole.RejectRole)
+        self._btn_box.addButton(self._btn_cancel, QDialogButtonBox.ButtonRole.NoRole)
 
     def _init_info_text(self):
         """Add an info text encouraging the user to report crashes."""

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -632,7 +632,7 @@ def dump_exception_info(exc, pages, cmdhist, qobjects):
         qobjects: A list of all QObjects as string.
     """
     print(file=sys.stderr)
-    print("\n\n===== Handling exception with --no-err-windows... =====\n\n",
+    print("\n\n===== Handling exception without a dialog... =====\n\n",
           file=sys.stderr)
     print("\n---- Exceptions ----", file=sys.stderr)
     print(''.join(traceback.format_exception(*exc)), file=sys.stderr)

--- a/qutebrowser/misc/crashsignal.py
+++ b/qutebrowser/misc/crashsignal.py
@@ -277,7 +277,8 @@ class CrashHandler(QObject):
         self.is_crashing = True
 
         self._app.closeAllWindows()
-        if self._args.no_err_windows or not config.val.crash_reporter.enabled:
+        if (self._args.no_err_windows or
+                config.val.crash_reporter.enabled not in ("exceptions", "both")):
             crashdialog.dump_exception_info(exc, info.pages, info.cmd_history,
                                             info.objects)
         else:

--- a/qutebrowser/misc/crashsignal.py
+++ b/qutebrowser/misc/crashsignal.py
@@ -24,7 +24,7 @@ from qutebrowser.qt.core import (pyqtSlot, qInstallMessageHandler, QObject,
 from qutebrowser.qt.widgets import QApplication
 
 from qutebrowser.api import cmdutils
-from qutebrowser.config import configfiles, configexc
+from qutebrowser.config import config, configfiles, configexc
 from qutebrowser.misc import earlyinit, crashdialog, ipc, objects
 from qutebrowser.utils import usertypes, standarddir, log, objreg, debug, utils, message
 from qutebrowser.qt import sip
@@ -277,7 +277,7 @@ class CrashHandler(QObject):
         self.is_crashing = True
 
         self._app.closeAllWindows()
-        if self._args.no_err_windows:
+        if self._args.no_err_windows or not config.val.crash_reporter.enabled:
             crashdialog.dump_exception_info(exc, info.pages, info.cmd_history,
                                             info.objects)
         else:


### PR DESCRIPTION
> <CEO_of_Linux> The-Compiler on my system the crash report window has a blue tint on the "Send report" button. i haven't tested it. but to me this suggests that it's the default action for pressing Enter?
<CEO_of_Linux> The-Compiler still a corner case of clicking in the wrong place at the wrong time :)

<img width="360" src="https://github.com/user-attachments/assets/2da705d4-36e8-482a-9682-c5a8f7f7de81" /> ⟶ <img width="360" alt="crash_mod" src="https://github.com/user-attachments/assets/0e092677-ccdb-4dd3-8d8d-0fd9c30bf356" />

A setting to disable the crash reporter: `crash_reporter.enabled`. This has been asked for five times on IRC.