### PR TITLE
Handle UnicodeDecodeError when loading scripts

### DIFF
--- a/qutebrowser/browser/greasemonkey.py
+++ b/qutebrowser/browser/greasemonkey.py
@@ -334,6 +334,10 @@ class GreasemonkeyManager(QObject):
                         successful.append(script)
                 except OSError as e:
                     errors.append((os.path.basename(script_filename), str(e)))
+                except UnicodeDecodeError as e:
+                    log.greasemonkey.warning(
+                        f"Failed to decode {os.path.basename(script_filename)}: {e}")
+                    errors.append((os.path.basename(script_filename), str(e)))
 
         self.scripts_reloaded.emit()
         return LoadResults(successful=successful, errors=errors)


### PR DESCRIPTION
Catch UnicodeDecodeError during Greasemonkey script loading to prevent any kind of load failures

Log a warning with the script filename and error and add the failure to the errors list so the loading can continue for the remaining scripts

<!-- Thanks for submitting a pull request! Please pick a descriptive title (not just "issue 12345"). If there is an open issue associated to your PR, please add a line like "Closes #12345" somewhere in the PR description (outside of this comment) -->
