### PR TITLE
Create persistent element zapper mode

### DIFF
--- a/qutebrowser/browser/browsertab.py
+++ b/qutebrowser/browser/browsertab.py
@@ -833,6 +833,25 @@ class AbstractElements:
         raise NotImplementedError
 
 
+class AbstractZapper(QObject):
+    """Hiding selected Elements."""
+
+    def __init__(self, tab: 'AbstractTab', parent: QWidget = None) -> None:
+        super().__init__(parent)
+        self._widget = cast(_WidgetType, None)
+        self._tab = tab
+
+    def zapper_select(self) -> None:
+        """Highlights hovered elements, detects clicks and Enter presses."""
+        raise NotImplementedError
+
+    def save_hidden_elements_setting(self) -> None:
+        raise NotImplementedError
+
+    def reset_hidden_elements_setting(self) -> None:
+        raise NotImplementedError
+
+
 class AbstractAudio(QObject):
 
     """Handling of audio/muting for this tab."""

--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -1900,3 +1900,33 @@ class CommandDispatcher:
 
         log.misc.debug('state before fullscreen: {}'.format(
             debug.qflags_key(Qt, window.state_before_fullscreen)))
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def zapper(self):
+        """Toggle a hover-highlighting mode for the current page.
+
+        Activates/deactivates a tool where:
+        - Hovering highlights elements with a red outline
+        - Clicking adds persistent green highlighting to elements
+        - Pressing Enter hides the currently highlighted element
+        """
+        tab = self._current_widget()
+        tab.zapper.zapper_select()
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def zapper_save(self):
+        """Save zapper settings for the current urls for future visits."""
+        tab = self._current_widget()
+        try:
+            tab.zapper.save_hidden_elements_setting()
+        except Exception as e:
+            message.error('Failed to save zapper settings: {}'.format(e))
+
+    @cmdutils.register(instance='command-dispatcher', scope='window')
+    def zapper_restore(self):
+        """Reset zapper settings for the current url."""
+        tab = self._current_widget()
+        try:
+            tab.zapper.reset_hidden_elements_setting()
+        except Exception as e:
+            message.error('Failed to reset zapper settings: {}'.format(e))

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -15,6 +15,7 @@ from typing import cast, Union, Optional
 from qutebrowser.qt.core import (pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QUrl,
                           QObject, QByteArray, QTimer)
 from qutebrowser.qt.network import QAuthenticator
+from qutebrowser.qt.widgets import QWidget
 from qutebrowser.qt.webenginecore import QWebEnginePage, QWebEngineScript, QWebEngineHistory
 
 from qutebrowser.config import config
@@ -805,6 +806,74 @@ class WebEngineElements(browsertab.AbstractElements):
         self._tab.run_js_async(js_code, js_cb)
 
 
+class WebEngineZapper(browsertab.AbstractZapper):
+    """QtWebEngine implementation for the zapper element selection tool.
+
+    Allows users to hover over and select page elements for hiding.
+    """
+
+    _tab: 'WebEngineTab'
+
+    def __init__(self, tab: 'WebEngineTab', parent: Optional[QWidget] = None) -> None:
+        super().__init__(tab=tab, parent=parent)
+        # Declared for type consistency with other components, but not used
+        self._widget = cast(webview.WebEngineView, None)
+
+    def zapper_select(self) -> None:
+        """Toggle the zapper selection mode.
+
+        Activates/deactivates a mode where hovering highlights elements
+        and clicking adds persistent highlighting. Pressing Enter hides
+        the currently highlighted element.
+        """
+        js_code = resources.read_file('javascript/zapper.js')
+
+        def _show_result(result):
+            if result is None:
+                message.info("Zapper toggled.")
+            else:
+                message.info("{}.".format(str(result).capitalize()))
+
+        self._tab.run_js_async(js_code, _show_result)
+
+    def save_hidden_elements_setting(self) -> None:
+        """Save hidden elements configuration for this URL.
+
+        Collect selectors for elements marked with the zapper persist
+        class and store them in the site's `localStorage` so they are
+        hidden on future visits.
+        """
+        js_code = resources.read_file('javascript/zapper_save.js')
+
+        def _cb(result):
+            try:
+                n = len(result) if result is not None else 0
+            except Exception:
+                n = 0
+            if n:
+                message.info("Hiding {} element(s){}.".format(
+                    n, 's' if n != 1 else ''))
+            else:
+                message.info('No elements saved.')
+
+        self._tab.run_js_async(js_code, _cb)
+
+    def reset_hidden_elements_setting(self) -> None:
+        """Reset hidden elements for this URL by removing the stored
+        selectors from `localStorage` and reloading the page.
+        """
+        js_code = resources.read_file('javascript/zapper_restore.js')
+
+        def _cb(_):
+            message.info('Zapper settings cleared.')
+            try:
+                self._tab.reload()
+            except Exception:
+                pass
+
+        self._tab.run_js_async(js_code, _cb)
+
+
 class WebEngineAudio(browsertab.AbstractAudio):
 
     """QtWebEngine implementations related to audio/muting.
@@ -1304,6 +1373,7 @@ class WebEngineTab(browsertab.AbstractTab):
         self.elements = WebEngineElements(tab=self)
         self.action = WebEngineAction(tab=self)
         self.audio = WebEngineAudio(tab=self, parent=self)
+        self.zapper = WebEngineZapper(tab=self, parent=self)
         self.private_api = WebEngineTabPrivate(mode_manager=mode_manager,
                                                tab=self)
         self._permissions = _WebEnginePermissions(tab=self, parent=self)
@@ -1582,6 +1652,15 @@ class WebEngineTab(browsertab.AbstractTab):
             self.dump_async(functools.partial(
                 self._error_page_workaround,
                 self.settings.test_attribute('content.javascript.enabled')))
+
+        # Inject persisted zapper hiding rules (if any) so saved selectors
+        # are applied automatically on page load.
+        try:
+            if ok and self.settings.test_attribute('content.javascript.enabled'):
+                js_code = resources.read_file('javascript/zapper_load.js')
+                self.run_js_async(js_code)
+        except Exception as e:  # pragma: no cover - defensive
+            log.webview.debug("Failed to run zapper_load.js: {}".format(e))
 
     @pyqtSlot(certificateerror.CertificateErrorWrapper)
     def _on_ssl_errors(self, error):

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -859,17 +859,15 @@ class WebEngineZapper(browsertab.AbstractZapper):
         self._tab.run_js_async(js_code, _cb)
 
     def reset_hidden_elements_setting(self) -> None:
-        """Reset hidden elements for this URL by removing the stored
-        selectors from `localStorage` and reloading the page.
+        """Reset hidden elements for this URL.
+
+        Removes stored selectors from `localStorage` and unhides elements
+        in-place without reloading the page.
         """
         js_code = resources.read_file('javascript/zapper_restore.js')
 
         def _cb(_):
             message.info('Zapper settings cleared.')
-            try:
-                self._tab.reload()
-            except Exception:
-                pass
 
         self._tab.run_js_async(js_code, _cb)
 

--- a/qutebrowser/javascript/zapper.js
+++ b/qutebrowser/javascript/zapper.js
@@ -1,0 +1,235 @@
+"use strict";
+
+(function() {
+    const CLASS = "__qute_zapper_hover";
+    const HIDDEN_CLASS = "__qute_zapper_hidden";
+    const STYLE_ID = "__qute_zapper_style";
+    const STATE_KEY = "__qute_zapper_state";
+    const PERSIST_CLASS = "__qute_zapper_persist";
+
+    if (!window[STATE_KEY]) {
+        window[STATE_KEY] = {
+            enabled: false,
+            current: null,
+            handler: null,
+            clickHandler: null,
+            keyHandler: null,
+            downHandler: null,
+            persisted: [],
+        };
+    }
+    const state = window[STATE_KEY];
+
+    function ensure_style() {
+        if (document.getElementById(STYLE_ID)) {
+            return;
+        }
+
+        const style = document.createElement("style");
+        style.id = STYLE_ID;
+        style.textContent = `
+            .${CLASS} {
+                outline: 2px solid #ff0000 !important;
+                outline-offset: 2px !important;
+                cursor: crosshair !important;
+            }
+            .__qute_zapper_persist {
+                outline: 3px solid #4caf50 !important;
+                outline-offset: 3px !important;
+                cursor: default !important;
+            }
+            .${HIDDEN_CLASS} {
+                display: none !important;
+            }
+        `;
+        (document.head || document.documentElement).appendChild(style);
+    }
+
+    function clear_current() {
+        if (state.current) {
+            state.current.classList.remove(CLASS);
+            state.current = null;
+        }
+    }
+
+    function add_persist(elem) {
+        if (!elem ||
+            elem === document.documentElement ||
+            elem === document.body) {
+            return;
+        }
+        elem.classList.remove(HIDDEN_CLASS);
+        if (state.persisted.indexOf(elem) !== -1) {
+            return;
+        }
+        state.persisted.push(elem);
+        elem.classList.add(PERSIST_CLASS);
+    }
+
+    function remove_persist(elem) {
+        const idx = state.persisted.indexOf(elem);
+        if (idx === -1) {return;}
+        state.persisted.splice(idx, 1);
+        elem.classList.remove(PERSIST_CLASS);
+        elem.classList.remove(HIDDEN_CLASS);
+    }
+
+    function hide_persist(elem) {
+        if (!elem ||
+            elem === document.documentElement ||
+            elem === document.body) {
+            return;
+        }
+        elem.classList.remove(PERSIST_CLASS);
+        elem.classList.add(HIDDEN_CLASS);
+        try {
+            elem.style.setProperty("display", "none", "important");
+        } catch (err) {
+            // ignore
+        }
+    }
+
+    function update_current(elem) {
+        if (elem === state.current) {
+            return;
+        }
+
+        clear_current();
+        if (!elem || elem === document.documentElement ||
+                elem === document.body) {
+            return;
+        }
+
+        state.current = elem;
+        elem.classList.add(CLASS);
+    }
+
+    function cleanup_zapper() {
+        if (state.handler) {
+            window.removeEventListener("mousemove", state.handler, true);
+        }
+        if (state.clickHandler) {
+            window.removeEventListener("click", state.clickHandler, true);
+        }
+        if (state.keyHandler) {
+            window.removeEventListener("keydown", state.keyHandler, true);
+        }
+        if (state.downHandler) {
+            window.removeEventListener("pointerdown", state.downHandler, true);
+            window.removeEventListener("mousedown", state.downHandler, true);
+        }
+        clear_current();
+        state.handler = null;
+        state.clickHandler = null;
+        state.keyHandler = null;
+        state.downHandler = null;
+        state.persisted = [];
+        state.enabled = false;
+    }
+
+    if (state.enabled) {
+        // Hide persisted elements that the user added while zapper was active.
+        // Keeping them in the DOM allows :zapper-save to collect them later.
+        try {
+            for (let i = 0; i < state.persisted.length; i++) {
+                hide_persist(state.persisted[i]);
+            }
+        } catch (err) {
+            // ignore
+        }
+        cleanup_zapper();
+        return "zapper disabled";
+    }
+
+    ensure_style();
+    state.handler = function(event) {
+        const elem = document.elementFromPoint(event.clientX, event.clientY);
+        update_current(elem);
+    };
+
+    state.clickHandler = function(event) {
+        try {
+            const elem = state.current;
+            if (!elem ||
+                elem === document.documentElement ||
+                elem === document.body) {
+                return;
+            }
+            // Toggle persisted highlight on click
+            if (state.persisted.indexOf(elem) !== -1) {
+                remove_persist(elem);
+            } else {
+                add_persist(elem);
+            }
+            event.preventDefault();
+            event.stopPropagation();
+        } catch (err) {
+            // ignore
+        }
+    };
+
+    state.downHandler = function(event) {
+        try {
+            // Prevent activation of buttons/inputs when interacting with zapper
+            event.preventDefault();
+            event.stopPropagation();
+        } catch (err) {
+            // ignore
+        }
+    };
+
+    state.keyHandler = function(event) {
+    try {
+        if (event.key === "Enter" || event.keyCode === 13) {
+            event.preventDefault();
+            event.stopPropagation();
+
+            // Save selectors to localStorage for the restore script
+            try {
+                const selectors = state.persisted
+                    .filter(el => el && el.parentNode)
+                    .map(el => {
+                        if (el.id) {
+                            return `#${ el.id}`;
+                        }
+                        if (el.className) {
+                            const classes = [...el.classList]
+                                .filter(cls => cls !== "__qute_zapper_persist")
+                                .join(".");
+                            return `${el.tagName.toLowerCase() }.${ classes}`;
+                        }
+                        return el.tagName.toLowerCase();
+                    })
+                    .filter(Boolean);
+
+                const url = window.location.origin + window.location.pathname;
+                const encoded = btoa(url)
+                    .replace(/[^a-zA-Z0-9_-]/g, "_")
+                    .slice(0, 50);
+                const key = `__qute_zapper_persist_${ encoded}`;
+                localStorage.setItem(key, JSON.stringify(selectors));
+            } catch (err) {
+                /* ignore */
+            }
+
+            // Hide persisted elements via style
+            for (let i = 0; i < state.persisted.length; i++) {
+                hide_persist(state.persisted[i]);
+            }
+
+            cleanup_zapper();
+        }
+    } catch (err) {
+        /* ignore */
+    }
+};
+
+    window.addEventListener("mousemove", state.handler, true);
+    window.addEventListener("click", state.clickHandler, true);
+    window.addEventListener("keydown", state.keyHandler, true);
+    window.addEventListener("pointerdown", state.downHandler, true);
+    window.addEventListener("mousedown", state.downHandler, true);
+    state.enabled = true;
+    return "zapper enabled";
+})();
+

--- a/qutebrowser/javascript/zapper_load.js
+++ b/qutebrowser/javascript/zapper_load.js
@@ -13,8 +13,17 @@
         return `__qute_zapper_persist_${ encoded}`;
     }
 
-    // Get website zapper settings (selectors for previously hidden elements)
-    const stored = localStorage.getItem(getStorageKey());
+    // data: some URLs disable web storage
+    if (window.location.origin === "null") {
+        return;
+    }
+
+    let stored;
+    try {
+        stored = localStorage.getItem(getStorageKey());
+    } catch (err) {
+        return;
+    }
     if (!stored) {return;}
 
     let selectors;
@@ -33,6 +42,7 @@
     function injectStyle(doc) {
         try {
             const style = doc.createElement("style");
+            style.id = "__qute_zapper_load_style";
             style.textContent = css;
             (doc.head || doc.documentElement).appendChild(style);
         } catch (err) {

--- a/qutebrowser/javascript/zapper_load.js
+++ b/qutebrowser/javascript/zapper_load.js
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Restores previously saved zapper settings for a certain url.
+// Used on website reload, to create hiding persistence.
+"use strict";
+(function() {
+    // Generate the same unique storage key based on the current URL
+    function getStorageKey() {
+        const url = window.location.origin + window.location.pathname;
+        const encoded = btoa(url)
+            .replace(/[^a-zA-Z0-9_-]/g, "_")
+            .slice(0, 50);
+        return `__qute_zapper_persist_${ encoded}`;
+    }
+
+    // Get website zapper settings (selectors for previously hidden elements)
+    const stored = localStorage.getItem(getStorageKey());
+    if (!stored) {return;}
+
+    let selectors;
+    try {
+        selectors = JSON.parse(stored);
+    } catch (err) {
+        return;
+    }
+    if (!Array.isArray(selectors) || selectors.length === 0) {return;}
+
+    // Wrap selectors in hide element rule
+    const css = selectors
+        .map(selector => `${selector} { display: none !important; }`)
+        .join("\n");
+
+    function injectStyle(doc) {
+        try {
+            const style = doc.createElement("style");
+            style.textContent = css;
+            (doc.head || doc.documentElement).appendChild(style);
+        } catch (err) {
+            /* cross-origin, skip */
+        }
+    }
+
+    // Apply to main document
+    injectStyle(document);
+})();
+

--- a/qutebrowser/javascript/zapper_restore.js
+++ b/qutebrowser/javascript/zapper_restore.js
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// Deletes zapper settings for the current URL
+"use strict";
+(function() {
+    // Generate the same unique storage key based on the current URL
+    function getStorageKey() {
+        const url = window.location.origin + window.location.pathname;
+        return `__qute_zapper_persist_${ btoa(url)
+            .replace(/[^a-zA-Z0-9_-]/g, "_")
+            .slice(0, 50)}`;
+    }
+    try {
+        localStorage.removeItem(getStorageKey());
+    } catch (err) {
+        /* ignore */
+    }
+})();
+

--- a/qutebrowser/javascript/zapper_restore.js
+++ b/qutebrowser/javascript/zapper_restore.js
@@ -1,17 +1,36 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 //
-// Deletes zapper settings for the current URL
+// Clears saved zapper settings for the current URL and unhides elements
 "use strict";
 (function() {
-    // Generate the same unique storage key based on the current URL
+    const HIDDEN_CLASS = "__qute_zapper_hidden";
+
     function getStorageKey() {
         const url = window.location.origin + window.location.pathname;
         return `__qute_zapper_persist_${ btoa(url)
             .replace(/[^a-zA-Z0-9_-]/g, "_")
             .slice(0, 50)}`;
     }
+
     try {
         localStorage.removeItem(getStorageKey());
+    } catch (err) {
+        /* ignore */
+    }
+
+    // Remove the injected style
+    const loadStyle = document.getElementById("__qute_zapper_load_style");
+    if (loadStyle) {
+        loadStyle.remove();
+    }
+
+    // Un-hide elements 
+    try {
+        const hiddenElems = document.querySelectorAll(`.${HIDDEN_CLASS}`);
+        for (let i = 0; i < hiddenElems.length; i++) {
+            hiddenElems[i].classList.remove(HIDDEN_CLASS);
+            hiddenElems[i].style.removeProperty("display");
+        }
     } catch (err) {
         /* ignore */
     }

--- a/qutebrowser/javascript/zapper_save.js
+++ b/qutebrowser/javascript/zapper_save.js
@@ -1,0 +1,158 @@
+"use strict";
+
+(function() {
+    // Generate a unique storage key based on the current URL
+    // (origin + pathname). This ensures different websites/pages
+    // have separate settings.
+    function getStorageKey() {
+        const url = window.location.origin + window.location.pathname;
+
+        const encoded = btoa(url)
+            .replace(/[^a-zA-Z0-9_-]/g, "_")
+            .slice(0, 50);
+
+        return `__qute_zapper_persist_${encoded}`;
+    }
+
+    const STORAGE_KEY = getStorageKey();
+    const PERSIST_CLASS = "__qute_zapper_persist";
+    const HIDDEN_CLASS = "__qute_zapper_hidden";
+
+    // Escape an id for use in a selector
+    function escape_id(id) {
+        if (window.CSS && CSS.escape) {
+            return `#${CSS.escape(id)}`;
+        }
+        return `#${id.replace(
+            /([\\"'\s.#>+~:[\]()])/g,
+            "\\$1"
+        )}`;
+    }
+
+    // Create a selector for an element
+    function get_selector(element) {
+        if (!element || element.nodeType !== 1) {
+            return null;
+        }
+        if (element.id) {
+            return escape_id(element.id);
+        }
+
+        const parts = [];
+        let node = element;
+
+        while (
+            node &&
+            node.nodeType === 1 &&
+            node.parentElement
+        ) {
+            const tag = node.tagName.toLowerCase();
+
+            let nth = 1;
+            let sibling = node;
+
+            while (
+                (sibling = sibling.previousElementSibling) !== null
+            ) {
+                if (sibling.tagName === node.tagName) {
+                    nth++;
+                }
+            }
+
+            parts.unshift(`${tag}:nth-of-type(${nth})`);
+            node = node.parentElement;
+        }
+
+        return parts.join(" > ");
+    }
+
+    // Create selectors for elements marked for hiding
+    function collect_selectors(selector) {
+        const nodes = [];
+
+        nodes.push(...document.querySelectorAll(selector));
+
+        const selectors = [];
+        const seen = {};
+
+        for (let index = 0; index < nodes.length; index++) {
+            try {
+                const selectorStr = get_selector(nodes[index]);
+
+                if (selectorStr && !seen[selectorStr]) {
+                    selectors.push(selectorStr);
+                    seen[selectorStr] = true;
+                }
+            } catch (error) {
+                // Ignore invalid node errors
+            }
+        }
+
+        return selectors;
+    }
+
+    // Collect new selectors
+    const persistSelectors = collect_selectors(
+        `.${PERSIST_CLASS}`
+    );
+
+    const hiddenSelectors = collect_selectors(
+        `.${HIDDEN_CLASS}`
+    );
+
+    // Merge with existing selectors
+    let allSelectors = persistSelectors.concat(hiddenSelectors);
+
+    try {
+        const existing = localStorage.getItem(STORAGE_KEY);
+
+        if (existing) {
+            const existingSelectors = JSON.parse(existing);
+
+            if (Array.isArray(existingSelectors)) {
+                // Combine and deduplicate
+                const combined = {};
+
+                for (
+                    let index = 0;
+                    index < existingSelectors.length;
+                    index++
+                ) {
+                    combined[existingSelectors[index]] = true;
+                }
+
+                for (
+                    let index = 0;
+                    index < persistSelectors.length;
+                    index++
+                ) {
+                    combined[persistSelectors[index]] = true;
+                }
+
+                for (
+                    let index = 0;
+                    index < hiddenSelectors.length;
+                    index++
+                ) {
+                    combined[hiddenSelectors[index]] = true;
+                }
+
+                allSelectors = Object.keys(combined);
+            }
+        }
+    } catch (error) {
+        // Ignore localStorage parsing errors
+    }
+
+    try {
+        localStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify(allSelectors)
+        );
+    } catch (error) {
+        // Ignore localStorage write errors
+    }
+
+    return allSelectors;
+})();
+

--- a/tests/end2end/data/zapper.html
+++ b/tests/end2end/data/zapper.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>quteprocess.click_element test</title>
+    </head>
+    <body>
+        <button id='button1' onclick='console.log("button1 clicked")' onmouseover='console.log("button1 hovered")' onmouseout='console.log("button1 left")'>button1</button>
+        <button id='button2' onclick='console.log("button2 clicked")' onmouseover='console.log("button2 hovered")' onmouseout='console.log("button2 left")'>button2</button>
+    </body>
+</html>

--- a/tests/end2end/data/zapper2.html
+++ b/tests/end2end/data/zapper2.html
@@ -1,0 +1,9 @@
+<html>
+    <head>
+        <title>quteprocess.click_element test</title>
+    </head>
+    <body>
+        <button id='button1' onclick='console.log("button1 clicked")' onmouseover='console.log("button1 hovered")' onmouseout='console.log("button1 left")'>button1</button>
+        <button id='button2' onclick='console.log("button2 clicked")' onmouseover='console.log("button2 hovered")' onmouseout='console.log("button2 left")'>button2</button>
+    </body>
+</html>

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -914,10 +914,11 @@ class QuteProc(testprocess.Process):
                              .format(message))
 
     def click_element_by_id(self, element_id):
-        """Click the element with the given id by dispatching pointer/mouse
-        events targeting the element center. This sets `button` and `buttons`
-        and dispatches `pointerdown` so page handlers that rely on coordinates
-        (e.g. zapper) see the same element as `document.elementFromPoint`.
+        """Click the element with the given id.
+
+        Dispatches pointer/mouse events targeting the element center, setting
+        `button` and `buttons` and firing `pointerdown` so handlers that rely
+        on coordinates (e.g. zapper) see the correct element.
         """
         script = (
             'var _e = document.getElementById({id}); '

--- a/tests/end2end/fixtures/quteprocess.py
+++ b/tests/end2end/fixtures/quteprocess.py
@@ -913,6 +913,69 @@ class QuteProc(testprocess.Process):
             raise ValueError('Invalid response from qutebrowser: {}'
                              .format(message))
 
+    def click_element_by_id(self, element_id):
+        """Click the element with the given id by dispatching pointer/mouse
+        events targeting the element center. This sets `button` and `buttons`
+        and dispatches `pointerdown` so page handlers that rely on coordinates
+        (e.g. zapper) see the same element as `document.elementFromPoint`.
+        """
+        script = (
+            'var _e = document.getElementById({id}); '
+            'if (!_e) {{ console.log("qute:no elem"); }} '
+            'else {{ '
+            '  var rect = _e.getBoundingClientRect(), x = rect.left + rect.width / 2, y = rect.top + rect.height / 2; '
+            '  var target = document.elementFromPoint(x, y) || _e, base = {{ bubbles: true, cancelable: true, view: window, clientX: x, clientY: y }}; '
+            '  window.dispatchEvent(new PointerEvent("mousemove", base)); '
+            '  var down = {{ bubbles: true, cancelable: true, view: window, clientX: x, clientY: y, button: 0, buttons: 1, pointerId: 1, pointerType: "mouse", isPrimary: true }}; '
+            '  target.dispatchEvent(new PointerEvent("pointerdown", down)); '
+            '  target.dispatchEvent(new MouseEvent("mousedown", down)); '
+            '  setTimeout(function() {{ '
+            '    var up = {{ bubbles: true, cancelable: true, view: window, clientX: x, clientY: y, button: 0, buttons: 0, pointerId: 1, pointerType: "mouse", isPrimary: true }}; '
+            '    target.dispatchEvent(new PointerEvent("pointerup", up)); '
+            '    target.dispatchEvent(new MouseEvent("mouseup", up)); '
+            '    target.dispatchEvent(new MouseEvent("click", up)); '
+            '    console.log("qute:okay"); '
+            '  }}, 20); '
+            '}}'
+        ).format(id=repr(element_id))
+        self.send_cmd(':jseval ' + script, escape=False)
+        message = self.wait_for_js('qute:*').message
+        if 'qute:no elem' in message:
+            raise ValueError('No element with id {!r} found'.format(element_id))
+        if 'qute:okay' not in message:
+            raise ValueError('Invalid response from qutebrowser: {}'.format(message))
+
+    def get_element_outline_color(self, element_id):
+        """Get the outline color of an element by id.
+
+        Args:
+            element_id: The id of the element
+
+        Return:
+            The computed outline color (e.g., 'rgb(255, 0, 0)' or 'red')
+        """
+        script = (
+            'var _e = document.getElementById({id}); '
+            'if (!_e) {{ console.log("qute:no elem"); }} '
+            'else {{ var color = window.getComputedStyle(_e).outlineColor; console.log("qute:color " + color); }}'
+        ).format(id=repr(element_id))
+        self.send_cmd(':jseval ' + script, escape=False)
+        message = self.wait_for_js('qute:color *').message
+
+        if 'qute:no elem' in message:
+            raise ValueError('No element with id {!r} found'.format(element_id))
+        if 'qute:color ' not in message:
+            raise ValueError('Invalid response from qutebrowser: {}'
+                             .format(message))
+
+        # Extract the color value from the message
+        # Message format: '[*] qute:color rgb(255, 0, 0)'
+        parts = message.split('qute:color ', 1)
+        if len(parts) == 2:
+            return parts[1].strip()
+        else:
+            raise ValueError('Failed to parse color from: {}'.format(message))
+
     def compare_session(self, expected, *, flags="--with-private"):
         """Compare the current sessions against the given template.
 

--- a/tests/end2end/test_zapper.py
+++ b/tests/end2end/test_zapper.py
@@ -5,13 +5,14 @@
 """End-to-end tests for the zapper element-hiding tool."""
 
 import pytest
-from typing import Any, Generator
+from collections.abc import Generator
+from typing import Any
 
 pytestmark = pytest.mark.flaky(reruns=3)
 
 
 @pytest.fixture(autouse=True)
-def _zapper_cleanup(quteproc: Any) -> Generator[None, None, None]:
+def _zapper_cleanup(quteproc: Any) -> Generator[None]:
     yield
     try:
         quteproc.send_cmd(':zapper-restore')
@@ -21,7 +22,6 @@ def _zapper_cleanup(quteproc: Any) -> Generator[None, None, None]:
 
 def _element_state(quteproc: Any, element_id: str) -> str:
     """Return the state of an element."""
-
     marker = f'qute-{element_id}'
 
     script = f"""
@@ -92,7 +92,16 @@ def assert_not_visible(quteproc: Any, element_id: str) -> None:
             }} catch (e) {{ /* ignore */ }}
 
             // Fallback: after timeout, report current state
-            setTimeout(function() {{ const el = document.getElementById(id); if (!el) {{ console.log(marker + ':missing'); return; }} const style = window.getComputedStyle(el); const visible = style.display !== 'none' && style.visibility !== 'hidden' && el.offsetParent !== null; console.log(marker + (visible ? ':visible' : ':hidden')); }}, 3000);
+            setTimeout(function() {{
+                const el = document.getElementById(id);
+                if (!el) {{ console.log(marker + ':missing'); return; }}
+                const style = window.getComputedStyle(el);
+                const visible =
+                    style.display !== 'none' &&
+                    style.visibility !== 'hidden' &&
+                    el.offsetParent !== null;
+                console.log(marker + (visible ? ':visible' : ':hidden'));
+            }}, 3000);
         }})();
     """
 
@@ -190,6 +199,8 @@ def test_zapper_without_save_leave_and_back_to_site(quteproc: Any) -> None:
 
     quteproc.send_cmd(':back')
 
+    quteproc.wait_for_load_finished('data/zapper.html')
+
     assert_visible(quteproc, 'button1')
 
 
@@ -279,20 +290,27 @@ def test_all_comands_multiple_sites(quteproc: Any) -> None:
 
     quteproc.send_cmd(':back')
 
+    quteproc.wait_for_load_finished('data/zapper.html')
+
     assert_not_visible(quteproc, 'button1')
 
     quteproc.send_cmd(':forward')
 
+    quteproc.wait_for_load_finished('data/zapper2.html')
+
     assert_not_visible(quteproc, 'button2')
 
     quteproc.send_cmd(':zapper-restore')
-    
     quteproc.send_cmd(':back')
+
+    quteproc.wait_for_load_finished('data/zapper.html')
 
     quteproc.send_cmd(':zapper-restore')
 
     assert_visible(quteproc, 'button1')
 
     quteproc.send_cmd(':forward')
+
+    quteproc.wait_for_load_finished('data/zapper2.html')
 
     assert_visible(quteproc, 'button2')

--- a/tests/end2end/test_zapper.py
+++ b/tests/end2end/test_zapper.py
@@ -1,0 +1,298 @@
+# SPDX-FileCopyrightText: Freya Bruhin (The Compiler) <mail@qutebrowser.org>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""End-to-end tests for the zapper element-hiding tool."""
+
+import pytest
+from typing import Any, Generator
+
+pytestmark = pytest.mark.flaky(reruns=3)
+
+
+@pytest.fixture(autouse=True)
+def _zapper_cleanup(quteproc: Any) -> Generator[None, None, None]:
+    yield
+    try:
+        quteproc.send_cmd(':zapper-restore')
+    except Exception:
+        pass
+
+
+def _element_state(quteproc: Any, element_id: str) -> str:
+    """Return the state of an element."""
+
+    marker = f'qute-{element_id}'
+
+    script = f"""
+        (function() {{
+            const el = document.getElementById("{element_id}");
+
+            if (!el) {{
+                console.log("{marker}:missing");
+                return;
+            }}
+
+            const style = window.getComputedStyle(el);
+
+            const visible =
+                style.display !== "none" &&
+                style.visibility !== "hidden" &&
+                el.offsetParent !== null;
+
+            console.log(
+                visible
+                    ? "{marker}:visible"
+                    : "{marker}:hidden"
+            );
+        }})();
+    """
+
+    quteproc.send_cmd(':jseval ' + script, escape=False)
+
+    return quteproc.wait_for_js(f'{marker}:*').message
+
+
+def assert_visible(quteproc: Any, element_id: str) -> None:
+    message = _element_state(quteproc, element_id)
+
+    assert message.endswith(':visible'), (
+        f'{element_id} should be visible. Got: {message}'
+    )
+
+
+def assert_not_visible(quteproc: Any, element_id: str) -> None:
+
+    # Wait in-page for the element to become hidden/missing, as applying
+    # zapper restore rules can be asynchronous after reload.
+    marker = f'qute-{element_id}'
+
+    script = f"""
+        (function() {{
+            const id = "{element_id}";
+            const marker = "{marker}";
+
+            function check() {{
+                const el = document.getElementById(id);
+                if (!el) {{ console.log(marker + ':missing'); return true; }}
+                const style = window.getComputedStyle(el);
+                const visible =
+                    style.display !== 'none' &&
+                    style.visibility !== 'hidden' &&
+                    el.offsetParent !== null;
+                if (!visible) {{ console.log(marker + ':hidden'); return true; }}
+                return false;
+            }}
+
+            if (check()) return;
+
+            try {{
+                const obs = new MutationObserver(function() {{ if (check()) obs.disconnect(); }});
+                obs.observe(document, {{ attributes: true, childList: true, subtree: true }});
+            }} catch (e) {{ /* ignore */ }}
+
+            // Fallback: after timeout, report current state
+            setTimeout(function() {{ const el = document.getElementById(id); if (!el) {{ console.log(marker + ':missing'); return; }} const style = window.getComputedStyle(el); const visible = style.display !== 'none' && style.visibility !== 'hidden' && el.offsetParent !== null; console.log(marker + (visible ? ':visible' : ':hidden')); }}, 3000);
+        }})();
+    """
+
+    quteproc.send_cmd(':jseval ' + script, escape=False)
+    message = quteproc.wait_for_js(f'{marker}:*').message
+
+    assert (
+        message.endswith(':hidden') or
+        message.endswith(':missing')
+    ), f'{element_id} should not be visible. Got: {message}'
+
+
+def enable_zapper(quteproc: Any) -> None:
+    quteproc.send_cmd(':zapper')
+    quteproc.wait_for(message='Zapper enabled*')
+
+
+def disable_zapper(quteproc: Any) -> None:
+    quteproc.send_cmd(':zapper')
+    quteproc.wait_for(message='Zapper disabled*')
+
+
+def goto(quteproc: Any, path: str) -> None:
+    """Open `path` and wait for it to finish loading."""
+    quteproc.open_path(path)
+    #quteproc.wait_for_load_finished(path)
+
+
+def test_zapper_enters_mode(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+
+def test_zapper_exits_mode(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+    disable_zapper(quteproc)
+
+
+def test_zapper_toggle_mode_multiple_times(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+    disable_zapper(quteproc)
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+
+    disable_zapper(quteproc)
+
+    assert_not_visible(quteproc, 'button1')
+
+
+def test_zapper_without_save(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+
+    disable_zapper(quteproc)
+
+    assert_not_visible(quteproc, 'button1')
+
+
+def test_zapper_remove_multiple_elements(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+    quteproc.click_element_by_id('button2')
+
+    disable_zapper(quteproc)
+
+    assert_not_visible(quteproc, 'button1')
+    assert_not_visible(quteproc, 'button2')
+
+
+def test_zapper_without_save_leave_and_back_to_site(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+
+    disable_zapper(quteproc)
+
+    assert_not_visible(quteproc, 'button1')
+
+    goto(quteproc, 'data/email_address.html')
+
+    quteproc.send_cmd(':back')
+
+    assert_visible(quteproc, 'button1')
+
+
+def test_zapper_with_save_and_restore(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+
+    quteproc.send_cmd(':zapper-save')
+
+    disable_zapper(quteproc)
+
+    assert_not_visible(quteproc, 'button1')
+
+    quteproc.send_cmd(':zapper-restore')
+
+    assert_visible(quteproc, 'button1')
+
+
+def test_zapper_restore_after_reload(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+
+    quteproc.send_cmd(':zapper-save')
+
+    quteproc.send_cmd(':reload')
+    # Wait for the page to finish loading so zapper restore runs reliably
+    quteproc.wait_for_load_finished('data/zapper.html')
+
+    assert_not_visible(quteproc, 'button1')
+
+    quteproc.send_cmd(':zapper-restore')
+
+    assert_visible(quteproc, 'button1')
+
+
+def test_zapper_save_multiple_elements_and_restore(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+    quteproc.click_element_by_id('button2')
+
+    quteproc.send_cmd(':zapper-save')
+
+    disable_zapper(quteproc)
+
+    assert_not_visible(quteproc, 'button1')
+    assert_not_visible(quteproc, 'button2')
+
+    quteproc.send_cmd(':zapper-restore')
+
+    assert_visible(quteproc, 'button1')
+    assert_visible(quteproc, 'button2')
+
+
+def test_all_comands_multiple_sites(quteproc: Any) -> None:
+    goto(quteproc, 'data/zapper.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button1')
+
+    disable_zapper(quteproc)
+
+    quteproc.send_cmd(':zapper-save')
+
+    assert_not_visible(quteproc, 'button1')
+
+    goto(quteproc, 'data/zapper2.html')
+
+    enable_zapper(quteproc)
+
+    quteproc.click_element_by_id('button2')
+
+    disable_zapper(quteproc)
+
+    quteproc.send_cmd(':zapper-save')
+
+    assert_not_visible(quteproc, 'button2')
+
+    quteproc.send_cmd(':back')
+
+    assert_not_visible(quteproc, 'button1')
+
+    quteproc.send_cmd(':forward')
+
+    assert_not_visible(quteproc, 'button2')
+
+    quteproc.send_cmd(':zapper-restore')
+    
+    quteproc.send_cmd(':back')
+
+    quteproc.send_cmd(':zapper-restore')
+
+    assert_visible(quteproc, 'button1')
+
+    quteproc.send_cmd(':forward')
+
+    assert_visible(quteproc, 'button2')


### PR DESCRIPTION
## Description

Create persistent element zapper mode and add supporting commands.

The element zapper has become a widely used tool, convenient for hiding annoying/distracting elements from webpages. QuteBrowser did not have an element zapper, and this feature accounts for.

Introducing 3 new commands: 
- ":zapper" 
	- if zapper-mode disabled: toggles zapper mode, hiding all elements selected on exit;
	- if zapper-mode enabled: exits zapper mode;
- ":zapper-save" - persists zapper settings for the current url, keeping previously selected elements hidden on url reload;
- ":zapper-restore" - clears saved zapper settings for the current url. 

---
## Implementation Notes

- Adds new AbstractZapper class (browsertab.py);
- Adds new WebEngineZapper class (webenginetab.py);
- Creates new zapper.js, zapper-save.js, zapper-restore.js and zapper-load.js files ;
- On url load, checks for previously saved zapper settings; loads saved settings if there are any (webenginetab.py);
- Creates 10 tests for new zapper functionality. 

