### PR TITLE
feat: ability to enable push notifications

### DIFF
--- a/doc/changelog.asciidoc
+++ b/doc/changelog.asciidoc
@@ -24,6 +24,8 @@ Added
 
 - New `:quickmark-reload` and `:bookmark-reload` commands to reload
   quick-/bookmarks from disk (#8845).
+- New `content.push_service.enabled` setting to allow websites to use the
+  Push API via QtWebEngine (#7533).
 
 Changed
 ~~~~~~~

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -197,6 +197,7 @@
 |<<content.private_browsing,content.private_browsing>>|Open new windows in private browsing mode which does not record visited pages.
 |<<content.proxy,content.proxy>>|Proxy to use.
 |<<content.proxy_dns_requests,content.proxy_dns_requests>>|Send DNS requests over the configured proxy.
+|<<content.push_service.enabled,content.push_service.enabled>>|Allow websites to use the Push API (via QtWebEngine's push service).
 |<<content.register_protocol_handler,content.register_protocol_handler>>|Allow websites to register protocol handlers via `navigator.registerProtocolHandler`.
 |<<content.site_specific_quirks.enabled,content.site_specific_quirks.enabled>>|Enable quirks (such as faked user agent headers) needed to get specific sites to work properly.
 |<<content.site_specific_quirks.skip,content.site_specific_quirks.skip>>|Disable a list of named quirks.
@@ -2732,6 +2733,19 @@ This setting is only available with the QtWebKit backend.
 Type: <<types,Bool>>
 
 Default: +pass:[true]+
+
+[[content.push_service.enabled]]
+=== content.push_service.enabled
+Allow websites to use the Push API (via QtWebEngine's push service).
+This is only applied to the default profile at startup, so changing it requires a restart. It is never enabled for private (off-the-record) windows.
+
+This setting requires a restart.
+
+This setting is only available with the QtWebEngine backend.
+
+Type: <<types,Bool>>
+
+Default: +pass:[false]+
 
 [[content.register_protocol_handler]]
 === content.register_protocol_handler

--- a/doc/help/settings.asciidoc
+++ b/doc/help/settings.asciidoc
@@ -2737,9 +2737,7 @@ Default: +pass:[true]+
 [[content.push_service.enabled]]
 === content.push_service.enabled
 Allow websites to use the Push API (via QtWebEngine's push service).
-This is only applied to the default profile at startup, so changing it requires a restart. It is never enabled for private (off-the-record) windows.
-
-This setting requires a restart.
+This is never enabled for private (off-the-record) windows.
 
 This setting is only available with the QtWebEngine backend.
 

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -337,8 +337,7 @@ class ProfileSetter:
     def set_push_service(self):
         """Enable/disable the push service for the profile.
 
-        This is applied at profile construction time only (hence restart: true),
-        and never enabled for private (off-the-record) profiles.
+        Never enabled for private (off-the-record) profiles.
         """
         if self._profile.isOffTheRecord():
             return

--- a/qutebrowser/browser/webengine/webenginesettings.py
+++ b/qutebrowser/browser/webengine/webenginesettings.py
@@ -265,6 +265,7 @@ class ProfileSetter:
         self._name_to_method = {
             'content.cache.size': self.set_http_cache_size,
             'content.cookies.store': self.set_persistent_cookie_policy,
+            'content.push_service.enabled': self.set_push_service,
             'spellcheck.languages': self.set_dictionary_language,
             'content.headers.user_agent': self.set_http_headers,
             'content.headers.accept_language': self.set_http_headers,
@@ -284,6 +285,7 @@ class ProfileSetter:
         self.set_http_cache_size()
         self._set_hardcoded_settings()
         self.set_persistent_cookie_policy()
+        self.set_push_service()
         self.set_dictionary_language()
         self.disable_persistent_permissions_policy()
 
@@ -331,6 +333,22 @@ class ProfileSetter:
         else:
             value = QWebEngineProfile.PersistentCookiesPolicy.NoPersistentCookies
         self._profile.setPersistentCookiesPolicy(value)
+
+    def set_push_service(self):
+        """Enable/disable the push service for the profile.
+
+        This is applied at profile construction time only (hence restart: true),
+        and never enabled for private (off-the-record) profiles.
+        """
+        if self._profile.isOffTheRecord():
+            return
+        if machinery.IS_QT6:  # for mypy
+            try:
+                self._profile.setPushServiceEnabled(
+                    config.val.content.push_service.enabled)
+            except AttributeError:
+                # New in QtWebEngine 6.5
+                pass
 
     def set_dictionary_language(self):
         """Load the given dictionaries."""

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1196,6 +1196,18 @@ content.notifications.show_origin:
 
     Note that with the `qt` presenter, origins are never shown.
 
+content.push_service.enabled:
+  default: false
+  type: Bool
+  restart: true
+  backend: QtWebEngine
+  desc: >-
+    Allow websites to use the Push API (via QtWebEngine's push service).
+
+    This is only applied to the default profile at startup, so changing it
+    requires a restart. It is never enabled for private (off-the-record)
+    windows.
+
 content.pdfjs:
   default: false
   type: Bool

--- a/qutebrowser/config/configdata.yml
+++ b/qutebrowser/config/configdata.yml
@@ -1199,14 +1199,11 @@ content.notifications.show_origin:
 content.push_service.enabled:
   default: false
   type: Bool
-  restart: true
   backend: QtWebEngine
   desc: >-
     Allow websites to use the Push API (via QtWebEngine's push service).
 
-    This is only applied to the default profile at startup, so changing it
-    requires a restart. It is never enabled for private (off-the-record)
-    windows.
+    This is never enabled for private (off-the-record) windows.
 
 content.pdfjs:
   default: false

--- a/tests/unit/browser/webengine/test_webenginesettings.py
+++ b/tests/unit/browser/webengine/test_webenginesettings.py
@@ -148,6 +148,29 @@ def test_spell_check_disabled(config_stub, monkeypatch, global_settings,
         assert not profile.isSpellCheckEnabled()
 
 
+push_service_available = hasattr(QWebEngineProfile, 'setPushServiceEnabled')
+
+
+@pytest.mark.skipif(not push_service_available,
+                    reason="setPushServiceEnabled is new in QtWebEngine 6.5")
+@pytest.mark.parametrize('value', [True, False])
+def test_push_service(config_stub, default_profile, value):
+    """Push service should follow the config value on the default profile."""
+    config_stub.val.content.push_service.enabled = value
+    default_profile.setter.set_push_service()
+    assert default_profile.isPushServiceEnabled() == value
+
+
+@pytest.mark.skipif(not push_service_available,
+                    reason="setPushServiceEnabled is new in QtWebEngine 6.5")
+def test_push_service_private_profile(config_stub, private_profile):
+    """Push service should never be enabled on an off-the-record profile."""
+    assert private_profile.isOffTheRecord()
+    config_stub.val.content.push_service.enabled = True
+    private_profile.setter.set_push_service()
+    assert not private_profile.isPushServiceEnabled()
+
+
 def test_parsed_user_agent(qapp):
     webenginesettings.init_user_agent()
     parsed = webenginesettings.parsed_user_agent


### PR DESCRIPTION
QtWebEngine exposes a Push API through `QWebEngineProfile.setPushServiceEnabled()` (added in QtWebEngine 6.5), but qutebrowser never enabled it, so the Push API was unavailable to websites. This adds a proper, privacy-conservative config setting to opt in.

This can now be enabled by configuring `content.push_service.enabled`. Default value is `false`.

Ref: https://github.com/qutebrowser/qutebrowser/issues/7533
