### PR TITLE
fix: link_pyqt.py excluding QtWebProcess.exe files and QtWebEngine resources on Windows

### DIFF
--- a/scripts/link_pyqt.py
+++ b/scripts/link_pyqt.py
@@ -52,7 +52,7 @@ def verbose_copy(src, dst, *, follow_symlinks=True):
 
 def get_ignored_files(directory, files):
     """Get the files which should be ignored for link_pyqt() on Windows."""
-    needed_exts = ('.py', '.dll', '.pyd', '.so')
+    needed_exts = ('.py', '.dll', '.pyd', '.so', '.exe', '.pak', '.dat', '.bin')
     ignored_dirs = ('examples', 'qml', 'uic', 'doc')
     filtered = []
     for f in files:


### PR DESCRIPTION
On Windows, `scripts/link_pyqt.py` is supposed to copy the system-wide PyQt installation into the tox virtualenv (via get_ignored_files / copy_or_link). However, .exe files are never actually copied, because needed_exts never correctly matches the `.exe` extension. This means QtWebEngineProcess.exe and the resources/ directory never get linked into the tox venv on Windows, which breaks any test or usage that spins up QtWebEngine, you get errors about the WebEngine process failing to start, or missing resource files, with no indication that the cause is an incomplete copy.

So, the script now has the required file extension additions (.exe, .pak, .dat, .bin) which lets it fully copy the required files like the `QtWebEngineProcess.exe` into the .tox directory.
