### PR TITLE
Fix docstring Args entries that name a parameter the function does not take

### DIFF
--- a/qutebrowser/browser/commands.py
+++ b/qutebrowser/browser/commands.py
@@ -222,7 +222,6 @@ class CommandDispatcher:
             next_: Force selecting the tab after the current tab.
             opposite: Force selecting the tab in the opposite direction of
                       what's configured in 'tabs.select_on_remove'.
-            count: The tab index to close, or None
         """
         tabbar = self._tabbed_browser.widget.tabBar()
         selection_override = self._get_selection_override(prev, next_,

--- a/qutebrowser/browser/downloads.py
+++ b/qutebrowser/browser/downloads.py
@@ -1097,8 +1097,7 @@ class DownloadModel(QAbstractListModel):
         """Called when a downloader's data changed.
 
         Args:
-            start: The first changed index as int.
-            end: The last changed index as int, or -1 for all indices.
+            idx: The changed index as int.
             webengine: If given, the QtNetwork download length is added to the
                       index.
         """

--- a/qutebrowser/browser/eventfilter.py
+++ b/qutebrowser/browser/eventfilter.py
@@ -144,7 +144,7 @@ class TabEventFilter(QObject):
         """Handle releasing of a mouse button.
 
         Args:
-            e: The QMouseEvent.
+            _e: The QMouseEvent.
 
         Return:
             True if the event should be filtered, False otherwise.

--- a/qutebrowser/commands/parser.py
+++ b/qutebrowser/commands/parser.py
@@ -46,7 +46,6 @@ class CommandParser:
 
         Args:
             text: The text to parse.
-            aliases: A map of aliases to commands.
             default : Default value to return when alias was not found.
 
         Return:

--- a/qutebrowser/completion/completer.py
+++ b/qutebrowser/completion/completer.py
@@ -276,7 +276,7 @@ class Completer(QObject):
         """Change the part we're currently completing in the commandline.
 
         Args:
-            text: The text to set (string) for the token under the cursor.
+            newtext: The text to set (string) for the token under the cursor.
             before: Commandline tokens before the token under the cursor.
             after: Commandline tokens after the token under the cursor.
             immediate: True if the text should be completed immediately

--- a/qutebrowser/completion/models/completionmodel.py
+++ b/qutebrowser/completion/models/completionmodel.py
@@ -43,7 +43,7 @@ class CompletionModel(QAbstractItemModel):
         """Return the category pointed to by the given index.
 
         Args:
-            idx: A QModelIndex
+            index: A QModelIndex
         Returns:
             A category if the index points at one, else None
         """

--- a/qutebrowser/components/hostblock.py
+++ b/qutebrowser/components/hostblock.py
@@ -143,7 +143,7 @@ class HostBlocker:
         """Read hosts from the given line.
 
         Args:
-            line: The bytes object to read.
+            raw_line: The bytes object to read.
 
         Returns:
             A set containing valid hosts found

--- a/qutebrowser/keyinput/basekeyparser.py
+++ b/qutebrowser/keyinput/basekeyparser.py
@@ -195,7 +195,7 @@ class BaseKeyParser(QObject):
         """Log a message to the debug log if logging is active.
 
         Args:
-            message: The message to log.
+            msg: The message to log.
         """
         if self._do_log:
             prefix = '{} for mode {}: '.format(self.__class__.__name__,

--- a/qutebrowser/mainwindow/tabbedbrowser.py
+++ b/qutebrowser/mainwindow/tabbedbrowser.py
@@ -302,7 +302,6 @@ class TabbedBrowser(QWidget):
         """Change the window title to match the current tab.
 
         Args:
-            idx: The tab index to update.
             field: A field name which was updated. If given, the title
                    is only set if the given field is in the template.
         """

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -220,9 +220,6 @@ class _CrashDialog(QDialog):
         """Gather crash information to display.
 
         Args:
-            pages: A list of lists of the open pages (URLs as strings)
-            cmdhist: A list with the command history (as strings)
-            exc: An exception tuple (type, value, traceback)
         """
         try:
             launch_time = objects.qapp.launch_time.ctime()

--- a/qutebrowser/misc/crashdialog.py
+++ b/qutebrowser/misc/crashdialog.py
@@ -217,10 +217,7 @@ class _CrashDialog(QDialog):
         self._vbox.addWidget(info_label)
 
     def _gather_crash_info(self):
-        """Gather crash information to display.
-
-        Args:
-        """
+        """Gather crash information to display."""
         try:
             launch_time = objects.qapp.launch_time.ctime()
             crash_time = datetime.datetime.now().ctime()

--- a/qutebrowser/utils/urlutils.py
+++ b/qutebrowser/utils/urlutils.py
@@ -206,7 +206,7 @@ def _is_url_dns(urlstr: str) -> bool:
     """Check if a URL is really a URL via DNS.
 
     Args:
-        url: The URL to check for as a string.
+        urlstr: The URL to check for as a string.
 
     Return:
         True if the URL really is a URL, False otherwise.


### PR DESCRIPTION
Fourteen `Args:` entries name a parameter the function does not take. Docstrings only.

Seven renames:

| Where | Documented | Actual |
|---|---|---|
| `EventFilter._handle_mouse_release` | `e` | `_e` |
| `Completer._change_completed_part` | `text` | `newtext` |
| `CompletionModel._cat_from_idx` | `idx` | `index` |
| `HostBlocker._read_hosts_line` | `line` | `raw_line` |
| `BaseKeyParser._debug_log` | `message` | `msg` |
| `_is_url_dns` | `url` | `urlstr` |
| `DownloadModel._on_data_changed` | `start` + `end` | `idx` |

The last one had two entries where the signature has one: `start`/`end` are from a version that took a range.

The rest document an argument that is gone: `count` in `_tab_close` (the helper does not take it — the `tab-close` command does), `aliases` in `_get_alias`, `idx` in `_update_window_title`, and `pages`, `cmdhist` and `exc` in `_gather_crash_info`, which takes only `self`.

I left two groups alone, since both look like house convention rather than mistakes:

- Class docstrings that list attributes under `Args:` — `GUIProcess`, `SocketError`, `ListenError`, `LineParser`, `NeighborList`. Their `__init__` arguments are documented separately in the constructor.
- The `count` entries on the `@cmdutils.register` commands in `misccommands.py`. `count` is the argument the *command* takes; `cmdutils.Value.count_tab` turns it into `tab` before the Python function sees it, and the command help is built from that docstring.

Everything here was opened and read against the code first.
