### PR TITLE
fix(password-fill): fill username-only login forms

### DIFF
--- a/misc/userscripts/password_fill
+++ b/misc/userscripts/password_fill
@@ -26,7 +26,10 @@ Behavior:
   It will try to find a username/password entry in the configured backend
   (currently only pass) for the current website and will load that pair of
   username and password to any form on the current page that has some password
-  entry field. If multiple entries are found, a zenity menu is offered.
+  entry field. It will also fill the username into forms without a password
+  field, e.g. email-first authentication forms, if they contain a visible
+  field with an autocomplete attribute including the "username" token.
+  If multiple entries are found, a zenity menu is offered.
 
   If no entry is found, then it crops subdomains from the url if at least one
   entry is found in the backend. (In that case, it always shows a menu)
@@ -354,20 +357,62 @@ cat <<EOF
         }
         return false;
     };
+    function hasAutocompleteUsername(input) {
+        var autocomplete = input.getAttribute("autocomplete");
+        if (autocomplete === null) {
+            return false;
+        }
+        var tokens = autocomplete.split(/\s+/);
+        for (var j = 0; j < tokens.length; j++) {
+            if (tokens[j].toLowerCase() == "username") {
+                return true;
+            }
+        }
+        return false;
+    };
+    function hasUsernameField(form) {
+        var inputs = form.getElementsByTagName("input");
+        for (var j = 0; j < inputs.length; j++) {
+            var input = inputs[j];
+            if (isVisible(input) && (input.type == "text" || input.type == "email") &&
+                hasAutocompleteUsername(input)) {
+                return true;
+            }
+        }
+        return false;
+    };
+    function setValue(input, value) {
+        var setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, "value").set;
+        setter.call(input, value);
+    };
     function loadData2Form (form) {
         var inputs = form.getElementsByTagName("input");
         for (var j = 0; j < inputs.length; j++) {
             var input = inputs[j];
             if (isVisible(input) && (input.type == "text" || input.type == "email")) {
                 input.focus();
-                input.value = "$(javascript_escape "${username}")";
+                setValue(input, "$(javascript_escape "${username}")");
                 input.dispatchEvent(new Event('change'));
                 input.blur();
             }
             if (input.type == "password") {
                 input.focus();
-                input.value = "$(javascript_escape "${password}")";
+                setValue(input, "$(javascript_escape "${password}")");
                 input.dispatchEvent(new Event('change'));
+                input.blur();
+            }
+        }
+    };
+    function fillUsernameFields(form) {
+        var inputs = form.getElementsByTagName("input");
+        for (var j = 0; j < inputs.length; j++) {
+            var input = inputs[j];
+            if (isVisible(input) && (input.type == "text" || input.type == "email") &&
+                hasAutocompleteUsername(input)) {
+                input.focus();
+                setValue(input, "$(javascript_escape "${username}")");
+                input.dispatchEvent(new Event('input', { bubbles: true }));
+                input.dispatchEvent(new Event('change', { bubbles: true }));
                 input.blur();
             }
         }
@@ -377,6 +422,8 @@ cat <<EOF
     for (i = 0; i < forms.length; i++) {
         if (hasPasswordField(forms[i])) {
             loadData2Form(forms[i]);
+        } else if (hasUsernameField(forms[i])) {
+            fillUsernameFields(forms[i]);
         }
     }
 EOF


### PR DESCRIPTION
The password_fill userscript only processed forms containing a password input. This prevented it from filling username fields on login pages that collect the username before displaying the password field.

Recognize visible text and email inputs whose autocomplete attribute contains the username token in passwordless forms. Fill only those fields while preserving the existing handling of regular login forms.