### PR TITLE
Support regex-based find in page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ TODO
 /misc/nsis/include
 /misc/nsis/plugins
 /wheels
+tags

--- a/qutebrowser/browser/webengine/webenginetab.py
+++ b/qutebrowser/browser/webengine/webenginetab.py
@@ -4,13 +4,15 @@
 
 """Wrapper over a WebEngineView."""
 
+import contextlib
 import math
 import struct
 import functools
 import dataclasses
 import re
 import html as html_utils
-from typing import cast, TypeAlias
+from collections.abc import Callable
+from typing import cast, Any, TypeAlias
 
 from qutebrowser.qt.core import (pyqtSignal, pyqtSlot, Qt, QPoint, QPointF, QUrl,
                           QObject, QByteArray, QTimer)
@@ -24,7 +26,7 @@ from qutebrowser.browser.webengine import (webview, webengineelem, tabhistory,
                                            webengineinspector)
 
 from qutebrowser.utils import (usertypes, qtutils, log, javascript, utils,
-                               resources, message, jinja, debug, version, urlutils)
+                               resources, message, jinja, debug, version, urlutils, bidir_cycle)
 from qutebrowser.qt import sip, machinery
 from qutebrowser.misc import objects, miscwidgets
 
@@ -142,6 +144,8 @@ class WebEngineSearch(browsertab.AbstractSearch):
                            back yet.
     """
 
+    SEARCH_REGEX_PREFIX = r"\v"
+
     _widget: webview.WebEngineView
 
     def __init__(self, tab, parent=None):
@@ -150,6 +154,7 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._pending_searches = 0
         self.match = browsertab.SearchMatch()
         self._old_match = browsertab.SearchMatch()
+        self._search_terms: bidir_cycle.BidirectionalCycle[str] | None = None
 
     def _store_flags(self, reverse, ignore_case):
         self._flags.case_sensitive = self._is_case_sensitive(ignore_case)
@@ -212,6 +217,40 @@ class WebEngineSearch(browsertab.AbstractSearch):
         log.webview.debug(f"Active search match: {self.match}")
         self.match_changed.emit(self.match)
 
+    @classmethod
+    def _is_search_regex(cls, text: str) -> bool:
+        r"""Determine whether the provided text is a search regex or not.
+
+        Any string starting with "\v" - i.e. a single backslash followed by the character v when
+        written in the search bar - followed by at least one more character is considered a regex.
+        The \v prefix is removed from the pattern before the regex is compiled.
+        """
+        return text.startswith(cls.SEARCH_REGEX_PREFIX) and len(text) > len(cls.SEARCH_REGEX_PREFIX)
+
+    @classmethod
+    def _extract_regex_from_search(cls, text: str) -> str:
+        """Strip the search regex prefix from the provided text."""
+        assert cls._is_search_regex(text), f"'{text}' is not a valid search regex"
+        return text[len(cls.SEARCH_REGEX_PREFIX):]
+
+    def _regex_search(
+        self,
+        html: str,
+        *,
+        regex: re.Pattern[str],
+        flags: _FindFlags,
+        result_cb: Callable[[Any], None] | None
+    ) -> None:
+        """Gather character sequences matching the provided regex and commence the search."""
+        matches = regex.findall(" ".join(html.split("\n")))
+        if not matches:
+            if result_cb is not None:
+                result_cb(browsertab.SearchNavigationResult.not_found)
+            return
+
+        self._search_terms = bidir_cycle.BidirectionalCycle[str](matches, backward=flags.backward)
+        self._find(next(self._search_terms), flags, result_cb, 'search')
+
     def search(self, text, *, ignore_case=usertypes.IgnoreCase.never,
                reverse=False, result_cb=None):
         # Don't go to next entry on duplicate search
@@ -225,6 +264,24 @@ class WebEngineSearch(browsertab.AbstractSearch):
         self._store_flags(reverse, ignore_case)
         self.match.reset()
 
+        if self._is_search_regex(text):
+            # If the text can be compiled to a re.Pattern, perform a regex search. Otherwise,
+            # fall back on a standard one.
+            with contextlib.suppress(re.error):
+                regex = re.compile(self._extract_regex_from_search(text))
+                bound = functools.partial(
+                    self._regex_search,
+                    regex=regex,
+                    flags=self._flags,
+                    result_cb=result_cb
+                )
+
+                # Get the plain HTML to gather search terms
+                self._widget.page().toPlainText(bound)
+                return
+
+        # Not a regex, only ever going to be searching for `text`
+        self._search_terms = bidir_cycle.BidirectionalCycle[str]([text], backward=self._flags.backward)
         self._find(text, self._flags, result_cb, 'search')
 
     def clear(self):
@@ -264,7 +321,9 @@ class WebEngineSearch(browsertab.AbstractSearch):
             return
 
         cb = functools.partial(self._prev_next_cb, going_up=going_up, callback=callback)
-        self._find(self.text, flags, cb, 'prev_result')
+        assert self._search_terms is not None, "Search terms not populated"
+        self._search_terms.backward = going_up
+        self._find(next(self._search_terms), flags, cb, 'prev_result')
 
     def next_result(self, *, wrap=False, callback=None):
         going_up = self._flags.backward
@@ -277,8 +336,10 @@ class WebEngineSearch(browsertab.AbstractSearch):
                 callback(res)
             return
 
+        assert self._search_terms is not None, "Search terms not populated"
+        self._search_terms.backward = going_up
         cb = functools.partial(self._prev_next_cb, going_up=going_up, callback=callback)
-        self._find(self.text, self._flags, cb, 'next_result')
+        self._find(next(self._search_terms), self._flags, cb, 'next_result')
 
 
 class WebEngineCaret(browsertab.AbstractCaret):

--- a/qutebrowser/utils/bidir_cycle.py
+++ b/qutebrowser/utils/bidir_cycle.py
@@ -1,0 +1,78 @@
+# SPDX-FileCopyrightText: Vilhelm Engström <vilhelm.engstrom@tuta.io>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Bidirectional itertools.cycle-like adapter."""
+
+from collections.abc import Sequence
+from typing import Generic, TypeVar
+
+_T = TypeVar("_T")
+
+
+class BidirectionalCycle(Generic[_T]):
+
+    """Simple adapter inspired by itertools.cycle allowing bidirectional iteration.
+
+    Calling :func:`next` on an instance yields the next item in the cycle. The
+    direction is determined by :attr:`backward`.
+
+    .. code-block:: python
+
+        cycle = BidrectionalCycle[str](['a', 'b', 'c', 'd'], backward=False)
+
+        next(cycle)  # a
+        next(cycle)  # b
+
+        cycle.backward = True
+        next(cycle)  # a
+        next(cycle)  # d
+        next(cycle)  # c
+        next(cycle)  # b
+        next(cycle)  # a
+        next(cycle)  # d
+
+        cycle.backward = False
+        next(cycle)  # a
+        # etc.
+    """
+
+    def __init__(self, items: Sequence[_T], *, backward: bool = False) -> None:
+        self._items = items
+        self._idx = 0 if backward else len(self._items) - 1
+        self._backward = backward
+
+    @property
+    def backward(self) -> bool:
+        """Check whether the current direction is backwards."""
+        return self._backward
+
+    @backward.setter
+    def backward(self, backward: bool) -> None:
+        """Set iteration direction.
+
+        :param backward: `True` to enabled backward iteration, `False` to disable
+        :type backward: bool
+        """
+        assert isinstance(backward, bool)
+        self._backward = backward
+
+    def _next_forward(self) -> _T:
+        """Get the next item and advance adapter index."""
+        self._idx = (self._idx + 1) % len(self._items)
+        return self._items[self._idx]
+
+    def _next_backward(self) -> _T:
+        """Revert adapter index and get the last item."""
+        self._idx -= 1
+        if self._idx < 0:
+            self._idx = len(self._items) - 1
+
+        return self._items[self._idx]
+
+    def __next__(self) -> _T:
+        """Get then next item."""
+        if self._backward:
+            return self._next_backward()
+
+        return self._next_forward()

--- a/tests/unit/utils/test_bidir_cycle.py
+++ b/tests/unit/utils/test_bidir_cycle.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: Vilhelm Engström <vilhelm.engstrom@tuta.io>
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""Tests for qutebrowser.utils.bidir_cycle."""
+
+import pytest
+
+from qutebrowser.utils.bidir_cycle import BidirectionalCycle
+
+
+@pytest.mark.parametrize('seq', [['a', 'b', 'c', 'd'], list(range(33))])
+def test_foward_iteration(seq: list[str] | list[int]) -> None:
+    cycle = BidirectionalCycle[type(seq[0])](seq, backward=False)
+
+    for item in seq:
+        assert next(cycle) == item
+
+    # Verify wrapping
+    assert next(cycle) == seq[0]
+    assert next(cycle) == seq[1]
+
+
+@pytest.mark.parametrize('seq', [['a', 'b', 'c', 'd', 'E'], list(range(112))])
+def test_backward_iteration(seq: list[str] | list[int]) -> None:
+    cycle = BidirectionalCycle[type(seq[0])](seq, backward=True)
+
+    for item in reversed(seq):
+        assert next(cycle) == item
+
+    # Verify wrapping
+    assert next(cycle) == seq[-1]
+    assert next(cycle) == seq[-2]
+
+
+@pytest.mark.parametrize('seq', [['a', 'b', 'c', 'd', 'E'], list(range(23))])
+def test_mixed_iteration(seq: list[str] | list[int]) -> None:
+    cycle = BidirectionalCycle[type(seq[0])](seq, backward=False)
+
+    assert next(cycle) == seq[0]
+    assert next(cycle) == seq[1]
+
+    cycle.backward = True
+    assert next(cycle) == seq[0]
+    assert next(cycle) == seq[-1]
+    assert next(cycle) == seq[-2]
+
+    cycle.backward = False
+    assert next(cycle) == seq[-1]
+    assert next(cycle) == seq[0]
+
+    cycle.backward = True
+    assert next(cycle) == seq[-1]
+
+    cycle.backward = False
+    assert next(cycle) == seq[0]


### PR DESCRIPTION
This PR introduces regex support for the `/` and `?` commands. 

Rather than passing the regex to `WebEnginePage.findText`, the pattern is used to generate a sequence containing all strings on the webpage that match the regex. The first matching string is passed to `WebEnginePage.findText` once the search is started. Invoking `WebEngineSearch.next_result` passes the next entry in the match sequence to `WebEnginePage.findText`. Analogously, `WebEngineSearch.prev_result` invokes `WebEnginePage.findText` with the 
*previous* entry in the match sequence. Naturally, the matches sequence wraps both forwards and backwards.

Since generating the match sequence requires that the HTML be loaded into memory all at once, regex searches are made opt in and enabled by prefixing the pattern with `\v`, inspired by how very magic mode is enabled in Vim. The prefix is stripped from the string before passing it to `re.compile`. 

Feel free to critique this in whatever fashion you wish. Given that I haven't worked with Qutebrowser before, I'm bound to have missed at least something. 

This PR is partially related to the first bullet point in https://github.com/qutebrowser/qutebrowser/issues/5652 but is insufficient to close the issue.

### What I Would Appreciate Input On

* Should a string starting with `\v` not compile as a regex - say, for example, `\v[asd` - the browser falls back on searching for the string verbatim. Is this an appropriate behavior or should we simply discard such inputs?
* These changes make it cumbersome to search for strings that actually start with `\v`. While `\v\\vsomething` should match `\vsomething` in the page, that's certainly not the first approach I would have thought of as a user. Would it be better to allow users to escape the regex search via e.g. `\\v` at the start of the line?

### What I Don't Like

* Using the `\v` prefix for regexes will likely confuse those who know how Vim's very magic mode works. That'd admittedly be like 3 people in total, and I'm definitely not one of them, but still. If anyone has a suggestion for a more appropriate prefix I'm all ears.
* Search terms are collected starting at the top of the page. This has no adverse effects vis-à-vis the current behavior given that searches start at the top anyway but would cause an additional hurdle if wanting to address the second bullet point in https://github.com/qutebrowser/qutebrowser/issues/5652.
* Using regex searches on **VERY** large pages might exhaust the system memory. I've been testing it on [infinitehomepage.com](https://infinitehomepage.com/) after first having scrolled to the bottom for a relatively long time to generate more content. Even on that page, I have been unable to reliably tell the memory usage spikes caused by regex searches apart from normal fluctuations caused by having Firefox open in the background, so it's *probably* fine but I can't say for sure.
* This will likely misbehave on pages that generate HTML dynamically seeing as the match sequence is generated when the search is initiated. To work around this, we'd need to either regenerate the match list following every call to `WebEnginePage.findText` or,  more appropriately, use some sort of reload hook.

### Demo

The following gif illustrates how regex patterns are ignored unless prefixed by `\v` as well as a regex-based search in action.

<img width="1885" height="997" alt="regex_search" src="https://github.com/user-attachments/assets/7de67e6f-35ed-4198-890b-359ed46a8129" />

